### PR TITLE
ci: fix Docker image publish + add on-demand docker-publish workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,71 @@
+name: Publish Docker image
+
+# On-demand build + push of the scratch/static-musl image for an already-released
+# `v*` version. Decoupled from the tag-release flow so the image can be (re)built
+# without re-publishing crates.io / the GitHub release. Pulls the static musl
+# binary from the published GitHub release, so no cross-compile is needed here.
+on:
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Released version to package, without the leading v (e.g. 1.0.0)."
+        type: string
+        required: true
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  publish-image:
+    name: Build & push scratch image
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Download released musl binary
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          gh release download "v${VERSION}" \
+            --repo "${{ github.repository }}" \
+            --pattern "snapdir-${VERSION}-x86_64-unknown-linux-musl.tar.xz"
+          tar -xJf "snapdir-${VERSION}-x86_64-unknown-linux-musl.tar.xz"
+          mkdir -p release-bin
+          cp "snapdir-${VERSION}-x86_64-unknown-linux-musl/snapdir" release-bin/snapdir
+
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}},value=${{ inputs.version }}
+            type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version }}
+            type=semver,pattern={{major}},value=${{ inputs.version }}
+            type=raw,value=latest,enable=${{ !contains(inputs.version, '-') }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push (scratch, static musl)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: packaging/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BIN=release-bin/snapdir

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -270,9 +270,12 @@ jobs:
           version="${GITHUB_REF_NAME#v}"
           archive="dist/${BIN_NAME}-${version}-x86_64-unknown-linux-musl.tar.xz"
           tar -C dist -xJf "${archive}"
-          mkdir -p target/x86_64-unknown-linux-musl/dist
+          # Stage outside target/ — the repo .dockerignore excludes target/ (kept small
+          # for the from-source root Dockerfile), which would otherwise hide the binary
+          # from the packaging/Dockerfile COPY.
+          mkdir -p release-bin
           cp "dist/${BIN_NAME}-${version}-x86_64-unknown-linux-musl/${BIN_NAME}" \
-            target/x86_64-unknown-linux-musl/dist/snapdir
+            release-bin/snapdir
 
       - name: Docker meta
         id: meta
@@ -304,7 +307,7 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |
-            BIN=target/x86_64-unknown-linux-musl/dist/snapdir
+            BIN=release-bin/snapdir
 
   # ---------------------------------------------------------------------------
   # 5. Publish library crates to crates.io (core -> catalog/stores -> cli).


### PR DESCRIPTION
**Fix:** the v1.0.0 release's Docker job failed because it staged the binary under `target/`, which the repo `.dockerignore` excludes (needed small for the from-source root Dockerfile) — so `packaging/Dockerfile`'s `COPY` couldn't find it. Now staged at `release-bin/`. Dry-runs always skipped docker, so this was latent.

**Add:** `docker-publish.yml` — an on-demand `workflow_dispatch` that pulls a released musl binary and builds+pushes the scratch image to GHCR. Lets us publish the **1.0.0** image now (crates.io + GitHub release already shipped) without re-tagging.