### PR TITLE
docs: easier onboarding README + tested local/S3/GCS sync example

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,59 +4,83 @@ Content-addressable directory snapshots: hash a directory into a deterministic I
 
 `snapdir` snapshots a directory by content. Every snapshot is a BLAKE3 manifest — one line per file/dir as `TYPE PERMISSIONS CHECKSUM SIZE PATH`, sorted by path, with directory checksums computed as a merkle hash of their children. The **snapshot ID** is the BLAKE3 of the manifest text, so identical content produces an identical ID on any machine. Objects and manifests are stored at content-addressed sharded keys, so identical files and snapshots are stored once and interoperate across stores.
 
-Single static binary, zero runtime dependencies. v1.0.0.
-
-## Quick start
-
-```sh
-# Hash a directory: print its manifest and its deterministic snapshot ID
-snapdir manifest ./mydir
-snapdir id ./mydir
-
-# Push a snapshot to S3 (objects + manifest, deduplicated, skip-if-present)
-snapdir push --store s3://my-bucket/snapshots ./mydir
-
-# Pull it back anywhere; objects are re-hashed and verified on fetch
-snapdir pull --store s3://my-bucket/snapshots --id <snapshot-id> ./restored
-
-# Verify a stored snapshot is byte-for-byte intact (re-hash every object)
-snapdir verify --store s3://my-bucket/snapshots --id <snapshot-id>
-```
-
-`./restored` re-manifests to the same snapshot ID, with permissions restored.
+A single static binary with **zero runtime dependencies** — all hashing and storage is in-process; nothing to install alongside it.
 
 ## Install
 
-A single, statically-linked binary with **no runtime dependencies** — nothing else to install; all hashing and storage is in-process.
-
 ```sh
-# Prebuilt release archives (cargo-dist; static musl + per-platform builds)
-# https://github.com/bermi/snapdir/releases
-
-# From source
-cargo install --git https://github.com/bermi/snapdir snapdir-cli
+# crates.io — installs the `snapdir` binary
+cargo install snapdir-cli
 ```
 
-### Docker
-
-The published image is built `FROM scratch`: it contains the fully-static musl `snapdir` binary and the bundled CA roots (`ca-certificates.crt`) for HTTPS to S3/B2/GCS — and **nothing else**. There is no libc, no shell, and no other runtime executables in the image.
+Other ways:
 
 ```sh
-# Run the published image
-docker run --rm ghcr.io/bermi/snapdir manifest /data
+# Prebuilt release archives (static musl + per-platform builds)
+#   https://github.com/snapdir/snapdir/releases
 
-# Or build the same scratch image from a clean checkout (no build-args needed)
-docker build -t snapdir .
+# Run the published container image (FROM scratch: just the static binary + CA roots)
+docker run --rm ghcr.io/snapdir/snapdir version
+
+# As a Rust library
+cargo add snapdir-core
 ```
 
-## Use cases
+## Quick start — 60 seconds, no setup
 
-- Reproducible build/dataset artifacts addressed by content hash.
-- Deduplicated backup and restore to object storage from a single binary.
-- Content distribution with end-to-end integrity — don't trust the store; `verify` re-hashes every object.
-- Dataset and model versioning by deterministic snapshot ID.
-- CI artifact caching keyed by directory content.
-- Cross-cloud replication (S3↔B2↔GCS) without re-uploading unchanged data.
+No cloud account needed: snapshot a directory and round-trip it through a **local** store.
+
+```sh
+# A directory to snapshot
+mkdir -p demo && echo hello > demo/a.txt
+
+# Its content has a deterministic ID — same content, same ID, on any machine
+snapdir id ./demo
+
+# Push it to a store. Here the store is just a local directory.
+# `push` prints the snapshot ID.
+id=$(snapdir push --store "file://$PWD/store" ./demo)
+
+# Pull it back somewhere else; every object is re-hashed and verified on fetch
+snapdir pull --store "file://$PWD/store" --id "$id" ./restored
+
+snapdir id ./restored   # prints the same $id — byte-for-byte identical
+```
+
+Swap `file://$PWD/store` for `s3://…`, `gs://…`, or `b2://…` and the exact same commands push to the cloud.
+
+## Sync a directory across local, S3 & GCS
+
+snapdir keeps a directory in sync across backends **by content**: the same snapshot lands under the same content-addressed keys everywhere, unchanged data is never re-uploaded, and every restore is verified. (It's snapshot-based, not a live-sync daemon — re-run `push` to publish a new version.)
+
+```sh
+# Snapshot once; push to S3 and to a local mirror (push prints the id)
+id=$(snapdir push --store s3://my-bucket/snaps ./project)
+snapdir push --store "file://$PWD/mirror" ./project
+
+# Replicate S3 → GCS without the original directory: pull from S3, push to GCS
+snapdir pull --store s3://my-bucket/snaps --id "$id" /tmp/from-s3
+snapdir push --store gs://my-bucket/snaps /tmp/from-s3
+
+# Pull from ANY backend, anywhere — byte-for-byte verified on fetch
+snapdir pull --store gs://my-bucket/snaps --id "$id" ./restored
+
+# Change a file and re-push: a new snapshot, only the changed object uploads
+echo "an edit" >> ./project/a.txt
+snapdir push --store s3://my-bucket/snaps ./project   # new id; unchanged objects skipped
+```
+
+A runnable, self-checking version — pushes to local + S3 + GCS, replicates S3→GCS, pulls from each and asserts the restores match — is in **[`examples/sync-local-s3-gcs.sh`](examples/sync-local-s3-gcs.sh)**. It runs with **zero cloud setup** (all `file://`), or against real clouds when you point it at them:
+
+```sh
+# all-local, no credentials:
+examples/sync-local-s3-gcs.sh
+
+# against real buckets (S3 via the AWS chain, GCS via ADC):
+SNAPDIR_S3_TEST_STORE=s3://my-bucket/snaps \
+SNAPDIR_GCS_TEST_STORE=gs://my-bucket/snaps \
+examples/sync-local-s3-gcs.sh
+```
 
 ## How it works
 
@@ -87,6 +111,15 @@ Pick a backend by `--store` URI scheme:
 
 Cloud backends use native SDKs and standard credential chains — no bespoke env vars, no CLI shell-outs. Any other scheme dispatches to a `snapdir-<scheme>-store` binary on `PATH`.
 
+## Use cases
+
+- Reproducible build/dataset artifacts addressed by content hash.
+- Deduplicated backup and restore to object storage from a single binary.
+- Content distribution with end-to-end integrity — don't trust the store; `verify` re-hashes every object.
+- Dataset and model versioning by deterministic snapshot ID.
+- CI artifact caching keyed by directory content.
+- Cross-cloud replication (S3↔B2↔GCS) without re-uploading unchanged data.
+
 ## Compared to
 
 - **`git`** — snapshots arbitrary directories with no working copy, index, or commit history to carry around.
@@ -96,7 +129,7 @@ Cloud backends use native SDKs and standard credential chains — no bespoke env
 
 ## Status & links
 
-- v1.0.0. 14 subcommands: `manifest id stage push fetch pull checkout verify verify-cache flush-cache locations ancestors revisions defaults`.
+- **v1.0.0.** 14 subcommands: `manifest id stage push fetch pull checkout verify verify-cache flush-cache locations ancestors revisions defaults`.
 - An embedded redb catalog tracks where snapshots live (`locations` / `ancestors` / `revisions`).
 - Changelog: [docs/rust-port/CHANGELOG.md](docs/rust-port/CHANGELOG.md)
 - Migrating from the earlier version: [docs/rust-port/migration.md](docs/rust-port/migration.md)

--- a/examples/sync-local-s3-gcs.sh
+++ b/examples/sync-local-s3-gcs.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+#
+# Keep a directory in sync across a local filesystem store, S3, and GCS using
+# snapdir's content-addressed snapshots.
+#
+# snapdir is snapshot-based, not a live-sync daemon: every backend ends up with the
+# SAME snapshot — same snapshot ID, same content-addressed object keys — so
+# unchanged data is never re-uploaded, stores written by one machine are readable
+# by any other, and every restore is re-hashed and verified on fetch.
+#
+# This script:
+#   1. snapshots a sample directory,
+#   2. pushes it to a LOCAL store and to S3,
+#   3. replicates S3 -> GCS *without the source directory* (fetch + push),
+#   4. pulls from every backend into a separate dir and asserts each restore
+#      re-hashes to the same snapshot ID (byte-for-byte identical),
+#   5. edits a file and re-pushes to show a new snapshot (only the changed object
+#      uploads; everything else is skipped).
+#
+# Usage:
+#   examples/sync-local-s3-gcs.sh [S3_STORE_URI] [GCS_STORE_URI]
+#
+# Store URIs resolve in this order: positional args, then the env vars
+# SNAPDIR_S3_TEST_STORE / SNAPDIR_GCS_TEST_STORE, else a local file:// store — so
+# the script runs end-to-end with zero cloud setup, and against real clouds when
+# you point it at them, e.g.:
+#
+#   SNAPDIR_S3_TEST_STORE=s3://my-bucket/snapdir \
+#   SNAPDIR_GCS_TEST_STORE=gs://my-bucket/snapdir \
+#   examples/sync-local-s3-gcs.sh
+#
+# Auth: S3 uses the standard AWS chain (env / profile / SSO / instance metadata);
+# GCS uses Application Default Credentials (`gcloud auth application-default login`).
+# Each backend gets a unique per-run subpath; the script cleans up after itself.
+
+set -euo pipefail
+
+snapdir="${SNAPDIR_BIN:-snapdir}"
+run="run-$$-${RANDOM}"
+
+work="$(mktemp -d)"
+cleanup() { rm -rf "$work"; }
+trap cleanup EXIT
+export SNAPDIR_CACHE_DIR="$work/cache"
+
+# Resolve the three store URIs (unique subpath per run so reruns never collide).
+local_store="file://$work/local-store/$run"
+s3_store="${1:-${SNAPDIR_S3_TEST_STORE:-file://$work/s3-fallback}}/$run"
+gcs_store="${2:-${SNAPDIR_GCS_TEST_STORE:-file://$work/gcs-fallback}}/$run"
+
+ok()   { printf '  \033[32m✓\033[0m %s\n' "$*"; }
+step() { printf '\n\033[1m%s\033[0m\n' "$*"; }
+die()  { printf '  \033[31m✗ %s\033[0m\n' "$*" >&2; exit 1; }
+
+step "Stores"
+echo "  local : $local_store"
+echo "  s3    : $s3_store"
+echo "  gcs   : $gcs_store"
+
+# 1. A sample directory.
+src="$work/project"
+mkdir -p "$src/data"
+echo "hello"        > "$src/README.md"
+echo "row,value"    > "$src/data/table.csv"
+printf '\x00\x01\x02binary' > "$src/data/blob.bin"
+
+step "1. Snapshot the directory"
+id="$("$snapdir" id "$src")"
+ok "snapshot id = $id"
+
+# 2. Push to local + S3 (push prints the snapshot id on stdout).
+step "2. Push to local + S3"
+for pair in "local|$local_store" "s3|$s3_store"; do
+  name="${pair%%|*}"; uri="${pair#*|}"
+  got="$("$snapdir" push --store "$uri" "$src")"
+  [ "$got" = "$id" ] || die "push to $name returned '$got' (expected $id)"
+  ok "pushed to $name → $got"
+done
+
+# 3. Replicate S3 -> GCS without the original source dir: pull the snapshot from S3
+#    into a throwaway checkout, then push that checkout to GCS.
+step "3. Replicate S3 → GCS (no original source directory)"
+"$snapdir" flush-cache >/dev/null 2>&1 || true   # prove the objects really come from S3
+mirror="$work/from-s3"
+"$snapdir" pull --store "$s3_store" --id "$id" "$mirror" >/dev/null
+ok "pulled $id from S3 into a temp checkout"
+got="$("$snapdir" push --store "$gcs_store" "$mirror")"
+[ "$got" = "$id" ] || die "replicate to GCS returned '$got' (expected $id)"
+ok "pushed $id to GCS"
+
+# 4. Pull from every backend into a separate dir and verify byte-for-byte.
+step "4. Pull from every backend and verify"
+for pair in "local|$local_store" "s3|$s3_store" "gcs|$gcs_store"; do
+  name="${pair%%|*}"; uri="${pair#*|}"
+  dest="$work/restored-$name"
+  "$snapdir" pull --store "$uri" --id "$id" "$dest" >/dev/null
+  rid="$("$snapdir" id "$dest")"
+  [ "$rid" = "$id" ] || die "restore from $name re-hashes to $rid (expected $id)"
+  ok "pulled from $name → verified identical ($rid)"
+done
+
+# 5. Edit a file and re-push: a new snapshot, only the changed object uploads.
+step "5. Edit a file and re-push (content-addressed dedup)"
+echo "an edit" >> "$src/README.md"
+new_id="$("$snapdir" id "$src")"
+[ "$new_id" != "$id" ] || die "editing a file should change the snapshot id"
+got="$("$snapdir" push --store "$s3_store" "$src")"
+[ "$got" = "$new_id" ] || die "re-push returned '$got' (expected $new_id)"
+ok "new snapshot $new_id pushed to S3 (unchanged objects were skipped)"
+
+step "Done — local, S3 and GCS all hold snapshot $id, byte-for-byte."


### PR DESCRIPTION
Makes first-time onboarding frictionless and adds the cross-cloud sync example.

- **Install** leads with the crates.io one-liner `cargo install snapdir-cli`; all URLs corrected to `snapdir/snapdir` (+ `ghcr.io/snapdir/snapdir`, `cargo add snapdir-core`).
- **Quick start** is a 60-second, **zero-setup local** round-trip (`file://` store).
- **Sync a directory across local, S3 & GCS** section + a runnable, self-checking [`examples/sync-local-s3-gcs.sh`](examples/sync-local-s3-gcs.sh) (push to local+S3 → replicate S3→GCS → pull from each and assert byte-identical). **Verified live against real S3 + GCS**; falls back to `file://` for a no-cloud run.