### PR TITLE
Concurrent transfers + bandwidth control, and post-1.0 correctness fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3421,6 +3421,7 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-storage",
  "http 1.4.1",
+ "rayon",
  "rustls",
  "snapdir-core",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3362,7 +3362,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-benches"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "criterion",
  "snapdir-core",
@@ -3371,7 +3371,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-catalog"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "redb",
  "serde",
@@ -3381,7 +3381,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-cli"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3398,7 +3398,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-core"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "blake3",
  "md-5",
@@ -3410,7 +3410,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-stores"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,6 +1334,7 @@ checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
 dependencies = [
  "futures-channel",
  "futures-core",
+ "futures-executor",
  "futures-io",
  "futures-sink",
  "futures-task",
@@ -1402,6 +1403,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -3415,6 +3417,7 @@ dependencies = [
  "aws-smithy-http-client",
  "aws-smithy-runtime-api",
  "bytes",
+ "futures",
  "google-cloud-gax",
  "google-cloud-storage",
  "http 1.4.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 rust-version = "1.91.1"
 authors = ["Bermi Ferrer <bermi@bermilabs.com>"]
@@ -22,9 +22,9 @@ categories = ["command-line-utilities", "filesystem"]
 
 [workspace.dependencies]
 # Internal crates
-snapdir-core = { path = "crates/snapdir-core", version = "1.0.1" }
-snapdir-catalog = { path = "crates/snapdir-catalog", version = "1.0.1" }
-snapdir-stores = { path = "crates/snapdir-stores", version = "1.0.1" }
+snapdir-core = { path = "crates/snapdir-core", version = "1.1.0" }
+snapdir-catalog = { path = "crates/snapdir-catalog", version = "1.1.0" }
+snapdir-stores = { path = "crates/snapdir-stores", version = "1.1.0" }
 
 # Errors: thiserror in libs, anyhow (+ context) in the bin.
 thiserror = "2"

--- a/crates/snapdir-cli/src/cli.rs
+++ b/crates/snapdir-cli/src/cli.rs
@@ -28,7 +28,7 @@ use snapdir_core::{
     Sha256Hasher, Store, WalkOptions,
 };
 use snapdir_stores::{
-    resolve_adapter, Adapter, B2Store, ExternalStore, FileStore, GcsStore, S3Store,
+    resolve_adapter, Adapter, B2Store, ExternalStore, FileStore, GcsStore, S3Store, TransferConfig,
 };
 
 /// Content-addressable directory snapshots.
@@ -136,6 +136,20 @@ pub struct GlobalArgs {
     /// Context (directory or store) for catalog queries.
     #[arg(long, global = true, value_name = "DIR|STORE")]
     pub location: Option<String>,
+
+    /// Max concurrent object transfers (0/auto = number of CPUs, capped).
+    #[arg(
+        long,
+        short = 'j',
+        global = true,
+        value_name = "N",
+        env = "SNAPDIR_JOBS"
+    )]
+    pub jobs: Option<usize>,
+
+    /// Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers).
+    #[arg(long, global = true, value_name = "RATE", env = "SNAPDIR_LIMIT_RATE")]
+    pub limit_rate: Option<String>,
 }
 
 /// The `snapdir` subcommands, matching the Bash orchestrator one-for-one.
@@ -440,7 +454,7 @@ impl Cli {
         // so `push --id` silently snapshotted the CWD instead of honoring `--id`.
         if path.is_none() && self.globals.id.is_some() {
             let id = self.require_id()?;
-            let cache = self.cache_store();
+            let cache = self.cache_store()?;
             let manifest = cache.get_manifest(id).with_context(|| {
                 format!("manifest {id} not found in the local cache; stage or fetch it first")
             })?;
@@ -520,7 +534,7 @@ impl Cli {
         // id there is nothing to look up, so we fall through and let the
         // original store-resolution path surface the canonical "missing --store
         // option" error first (preserving the frozen CLI error precedence).
-        let cache = self.cache_store();
+        let cache = self.cache_store()?;
         if let Some(id) = self.globals.id.as_deref() {
             if cache.get_manifest(id).is_ok() {
                 if self.globals.verbose {
@@ -580,7 +594,7 @@ impl Cli {
             );
             return Ok(());
         }
-        let cache = self.cache_store();
+        let cache = self.cache_store()?;
         let manifest = cache.get_manifest(id).with_context(|| {
             format!("manifest {id} not found locally; did you forget to fetch it?")
         })?;
@@ -650,7 +664,7 @@ impl Cli {
             eprintln!("dry-run: would stage {id} into the local cache (no writes performed)");
             return Ok(());
         }
-        let cache = self.cache_store();
+        let cache = self.cache_store()?;
         cache
             .push(&manifest, &root)
             .with_context(|| format!("staging snapshot {id} into the local cache"))?;
@@ -858,13 +872,38 @@ impl Cli {
             .as_deref()
             .context("missing --store option")?;
         let adapter = resolve_adapter(store_url).context("resolving --store protocol")?;
-        store_for_adapter(&adapter, store_url)
+        let config = self.transfer_config()?;
+        store_for_adapter(&adapter, store_url, config)
+    }
+
+    /// Builds the [`TransferConfig`] from the global `--jobs` / `--limit-rate`
+    /// flags. `--jobs` unset or `0` falls back to the stores' auto-detected
+    /// default concurrency; `--limit-rate` unset means unlimited bandwidth.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `--limit-rate` cannot be parsed as a byte rate.
+    fn transfer_config(&self) -> Result<TransferConfig> {
+        let max_bytes_per_sec = match self.globals.limit_rate.as_deref() {
+            Some(rate) => Some(parse_rate(rate)?),
+            None => None,
+        };
+        let concurrency = match self.globals.jobs {
+            Some(n) if n > 0 => n,
+            // Unset or 0 => auto (the stores' default).
+            _ => TransferConfig::default().concurrency.get(),
+        };
+        Ok(TransferConfig::new(concurrency, max_bytes_per_sec))
     }
 
     /// The local cache as a `file://`-shaped store, rooted at the resolved cache
     /// directory. The cache uses the identical sharded layout as a `FileStore`.
-    fn cache_store(&self) -> FileStore {
-        FileStore::from_root(self.cache_dir())
+    /// Cache copies honor `--jobs` / `--limit-rate` via the [`TransferConfig`].
+    fn cache_store(&self) -> Result<FileStore> {
+        Ok(FileStore::from_root_with_config(
+            self.cache_dir(),
+            self.transfer_config()?,
+        ))
     }
 
     /// Resolves the cache directory: `--cache-dir`, else
@@ -961,12 +1000,16 @@ impl Cli {
 /// Kept as a free function (decoupled from `--store` parsing) so the
 /// scheme→store routing is exercised independently of CLI argument plumbing;
 /// the pure scheme→adapter decision itself lives in [`resolve_adapter`].
-fn store_for_adapter(adapter: &Adapter, store_url: &str) -> Result<Box<dyn Store>> {
+fn store_for_adapter(
+    adapter: &Adapter,
+    store_url: &str,
+    config: TransferConfig,
+) -> Result<Box<dyn Store>> {
     match adapter {
-        Adapter::File => Ok(Box::new(FileStore::new(store_url))),
+        Adapter::File => Ok(Box::new(FileStore::new_with_config(store_url, config))),
         Adapter::S3 => {
             let endpoint = std::env::var("SNAPDIR_S3_STORE_ENDPOINT_URL").ok();
-            let store = S3Store::connect(store_url, endpoint.as_deref())
+            let store = S3Store::connect_with(store_url, endpoint.as_deref(), config)
                 .with_context(|| format!("connecting to S3 store {store_url}"))?;
             Ok(Box::new(store))
         }
@@ -975,12 +1018,13 @@ fn store_for_adapter(adapter: &Adapter, store_url: &str) -> Result<Box<dyn Store
             let region = std::env::var("SNAPDIR_B2_REGION")
                 .or_else(|_| std::env::var("AWS_REGION"))
                 .ok();
-            let store = B2Store::connect(store_url, endpoint.as_deref(), region.as_deref())
-                .with_context(|| format!("connecting to B2 store {store_url}"))?;
+            let store =
+                B2Store::connect_with(store_url, endpoint.as_deref(), region.as_deref(), config)
+                    .with_context(|| format!("connecting to B2 store {store_url}"))?;
             Ok(Box::new(store))
         }
         Adapter::Gcs => {
-            let store = GcsStore::connect(store_url)
+            let store = GcsStore::connect_with(store_url, config)
                 .with_context(|| format!("connecting to GCS store {store_url}"))?;
             Ok(Box::new(store))
         }
@@ -990,6 +1034,59 @@ fn store_for_adapter(adapter: &Adapter, store_url: &str) -> Result<Box<dyn Store
             Ok(Box::new(store))
         }
     }
+}
+
+/// Parses a wget-style byte-rate string into bytes/second.
+///
+/// Accepts a bare integer (bytes), or a number with a binary-multiple suffix.
+/// Suffixes are case-insensitive and the trailing `i`/`B` letters are optional:
+/// `K`/`KB`/`KiB` = 1024, `M`/`MB`/`MiB` = 1024², `G`/`GB`/`GiB` = 1024³.
+/// Fractional values are supported (`1.5M` = 1572864). Surrounding whitespace
+/// is ignored.
+///
+/// # Errors
+///
+/// Returns an error for empty input, an unrecognized suffix, a non-numeric
+/// mantissa, or a negative value.
+fn parse_rate(s: &str) -> Result<u64> {
+    let trimmed = s.trim();
+    anyhow::ensure!(!trimmed.is_empty(), "empty --limit-rate value");
+
+    // Split the numeric mantissa from the (optional) unit suffix.
+    let split = trimmed
+        .find(|c: char| !(c.is_ascii_digit() || c == '.'))
+        .unwrap_or(trimmed.len());
+    let (num, suffix) = trimmed.split_at(split);
+    anyhow::ensure!(
+        !num.is_empty(),
+        "invalid --limit-rate '{s}': expected a number, optionally followed by K/M/G"
+    );
+
+    let value: f64 = num
+        .parse()
+        .with_context(|| format!("invalid --limit-rate '{s}': '{num}' is not a number"))?;
+    anyhow::ensure!(
+        value.is_finite() && value >= 0.0,
+        "invalid --limit-rate '{s}': must be a non-negative number"
+    );
+
+    // Normalize the suffix: strip an optional 'i' and an optional 'b'
+    // (case-insensitive) so K/KB/KiB all collapse to the same multiplier.
+    let unit = suffix.trim().to_ascii_lowercase();
+    let unit = unit.strip_suffix('b').unwrap_or(&unit);
+    let unit = unit.strip_suffix('i').unwrap_or(unit);
+    let multiplier: f64 = match unit {
+        "" => 1.0,
+        "k" => 1024.0,
+        "m" => 1024.0 * 1024.0,
+        "g" => 1024.0 * 1024.0 * 1024.0,
+        other => {
+            anyhow::bail!("invalid --limit-rate '{s}': unknown unit '{other}' (use K, M, or G)")
+        }
+    };
+
+    #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
+    Ok((value * multiplier) as u64)
 }
 
 /// Reformats a `SNAPDIR*` environment variable into the oracle's `defaults`
@@ -1208,7 +1305,12 @@ mod tests {
         // store is usable behind the trait object (a non-existent id is absent,
         // not an error other than ManifestNotFound semantics surfacing later).
         let adapter = resolve_adapter("file:///tmp/snapdir-routing-test").unwrap();
-        let store = store_for_adapter(&adapter, "file:///tmp/snapdir-routing-test").unwrap();
+        let store = store_for_adapter(
+            &adapter,
+            "file:///tmp/snapdir-routing-test",
+            TransferConfig::default(),
+        )
+        .unwrap();
         // get_manifest on a missing id must not panic; it returns an Err.
         assert!(store.get_manifest("0".repeat(64).as_str()).is_err());
     }
@@ -1222,12 +1324,99 @@ mod tests {
         let store = ExternalStore::new("xyz://bucket/base").unwrap();
         assert_eq!(store.binary(), Path::new("snapdir-xyz-store"));
         // store_for_adapter routes the same scheme through the shim.
-        let routed = store_for_adapter(&adapter, "xyz://bucket/base");
+        let routed = store_for_adapter(&adapter, "xyz://bucket/base", TransferConfig::default());
         assert!(routed.is_ok());
     }
 
     #[test]
     fn remote_store_routing_rejects_invalid_protocol() {
         assert!(resolve_adapter("NotAScheme://x").is_err());
+    }
+
+    /// Builds a `Cli` from args, forcing the transfer-tuning env vars unset so
+    /// the parse reflects ONLY the explicit flags (clap's `env` would otherwise
+    /// let a leaked `SNAPDIR_JOBS` / `SNAPDIR_LIMIT_RATE` perturb the result).
+    fn cli_with(args: &[&str]) -> Cli {
+        // SAFETY: tests in this module that touch these vars run in-process;
+        // we remove them before parsing so the flags alone drive the config.
+        unsafe {
+            std::env::remove_var("SNAPDIR_JOBS");
+            std::env::remove_var("SNAPDIR_LIMIT_RATE");
+        }
+        let mut full = vec!["snapdir"];
+        full.extend_from_slice(args);
+        // `defaults` is a no-arg subcommand, satisfying the required subcommand.
+        full.push("defaults");
+        Cli::try_parse_from(full).expect("parse cli")
+    }
+
+    #[test]
+    fn transfer_flags_parse_rate() {
+        assert_eq!(parse_rate("10M").unwrap(), 10_485_760);
+        assert_eq!(parse_rate("512K").unwrap(), 524_288);
+        assert_eq!(parse_rate("1G").unwrap(), 1_073_741_824);
+        assert_eq!(parse_rate("1GiB").unwrap(), 1_073_741_824);
+        assert_eq!(parse_rate("1GB").unwrap(), 1_073_741_824);
+        assert_eq!(parse_rate("1000").unwrap(), 1000);
+        assert_eq!(parse_rate("1.5M").unwrap(), 1_572_864);
+        assert_eq!(parse_rate("  2k ").unwrap(), 2048);
+        assert_eq!(parse_rate("1kib").unwrap(), 1024);
+
+        for bad in ["10X", "abc", "", "   ", "M", "1.2.3", "-5M"] {
+            assert!(parse_rate(bad).is_err(), "expected {bad:?} to be rejected");
+        }
+    }
+
+    #[test]
+    fn transfer_flags_jobs_explicit() {
+        let cfg = cli_with(&["--jobs", "4"]).transfer_config().unwrap();
+        assert_eq!(cfg.concurrency.get(), 4);
+        assert_eq!(cfg.max_bytes_per_sec, None);
+    }
+
+    #[test]
+    fn transfer_flags_jobs_one_is_sequential() {
+        let cfg = cli_with(&["--jobs", "1"]).transfer_config().unwrap();
+        assert_eq!(cfg.concurrency.get(), 1);
+    }
+
+    #[test]
+    fn transfer_flags_jobs_unset_is_auto() {
+        let cfg = cli_with(&[]).transfer_config().unwrap();
+        assert!(cfg.concurrency.get() >= 1 && cfg.concurrency.get() <= 16);
+        assert_eq!(
+            cfg.concurrency.get(),
+            TransferConfig::default().concurrency.get()
+        );
+    }
+
+    #[test]
+    fn transfer_flags_jobs_zero_is_auto() {
+        let cfg = cli_with(&["--jobs", "0"]).transfer_config().unwrap();
+        assert!(cfg.concurrency.get() >= 1 && cfg.concurrency.get() <= 16);
+        assert_eq!(
+            cfg.concurrency.get(),
+            TransferConfig::default().concurrency.get()
+        );
+    }
+
+    #[test]
+    fn transfer_flags_limit_rate_threads_into_config() {
+        let cfg = cli_with(&["--limit-rate", "1M"]).transfer_config().unwrap();
+        assert_eq!(cfg.max_bytes_per_sec, Some(1_048_576));
+
+        // The short `-j` alias works and pairs with --limit-rate.
+        let cfg = cli_with(&["-j", "2", "--limit-rate", "512K"])
+            .transfer_config()
+            .unwrap();
+        assert_eq!(cfg.concurrency.get(), 2);
+        assert_eq!(cfg.max_bytes_per_sec, Some(524_288));
+    }
+
+    #[test]
+    fn transfer_flags_bad_limit_rate_errors() {
+        assert!(cli_with(&["--limit-rate", "nope"])
+            .transfer_config()
+            .is_err());
     }
 }

--- a/crates/snapdir-cli/src/cli.rs
+++ b/crates/snapdir-cli/src/cli.rs
@@ -24,8 +24,8 @@ use snapdir_catalog::{
 };
 use snapdir_core::{
     cache, expand_excludes, snapshot_id, walk, Blake3Hasher, Blake3KeyedHasher, ExcludeMatcher,
-    FollowMode, Hasher, Manifest, ManifestEntry, Md5Hasher, PathMode, PathType, Sha256Hasher,
-    Store, WalkOptions,
+    ExpandedExclude, FollowMode, Hasher, Manifest, ManifestEntry, Md5Hasher, PathMode, PathType,
+    Sha256Hasher, Store, WalkOptions,
 };
 use snapdir_stores::{
     resolve_adapter, Adapter, B2Store, ExternalStore, FileStore, GcsStore, S3Store,
@@ -78,12 +78,32 @@ pub struct GlobalArgs {
     pub id: Option<String>,
 
     /// Exclude paths matching PATTERN.
-    #[arg(long, global = true, value_name = "PATTERN")]
-    pub exclude: Option<String>,
+    // Accepts both repeated occurrences (`--exclude a --exclude b`) and
+    // comma-delimited values (`--exclude a,b`); the collected patterns are
+    // OR-combined (a path is excluded if it matches ANY pattern). The doc
+    // comment is kept to a single line so `--help` output is byte-stable.
+    #[arg(
+        long,
+        global = true,
+        value_name = "PATTERN",
+        action = clap::ArgAction::Append,
+        value_delimiter = ','
+    )]
+    pub exclude: Vec<String>,
 
     /// Only include paths matching PATTERN.
-    #[arg(long, global = true, value_name = "PATTERN")]
-    pub paths: Option<String>,
+    // Accepts both repeated occurrences and comma-delimited values, matching
+    // `--exclude`'s arity. NOTE: this flag is currently UNWIRED — no `--paths`
+    // filtering is performed yet (wiring it is out of scope for this gate).
+    // Single-line doc comment keeps `--help` byte-stable.
+    #[arg(
+        long,
+        global = true,
+        value_name = "PATTERN",
+        action = clap::ArgAction::Append,
+        value_delimiter = ','
+    )]
+    pub paths: Vec<String>,
 
     /// Use symlinks instead of copies.
     #[arg(long, global = true)]
@@ -137,8 +157,15 @@ pub enum Command {
 
         /// Exclude paths matching the extended-regex PATTERN
         /// (supports the `%system%` / `%common%` macros).
-        #[arg(long, value_name = "PATTERN")]
-        exclude: Option<String>,
+        // Accepts both repeated occurrences and comma-delimited values,
+        // OR-combined (a path is excluded if it matches ANY pattern).
+        #[arg(
+            long,
+            value_name = "PATTERN",
+            action = clap::ArgAction::Append,
+            value_delimiter = ','
+        )]
+        exclude: Vec<String>,
 
         /// Directory to describe.
         path: Option<PathBuf>,
@@ -242,7 +269,13 @@ impl Cli {
                 exclude,
                 path,
             } => {
-                let exclude = exclude.as_deref().or(self.globals.exclude.as_deref());
+                // Precedence: the subcommand's `--exclude` list overrides the
+                // global one when non-empty, else fall back to the global list.
+                let exclude: &[String] = if exclude.is_empty() {
+                    &self.globals.exclude
+                } else {
+                    exclude
+                };
                 let manifest = self.build_manifest(
                     path.as_deref(),
                     *absolute,
@@ -272,8 +305,13 @@ impl Cli {
                 // b3sum of the comment-stripped manifest text. The wrapper
                 // walks with the default checksum (b3sum) and default
                 // path/follow modes; the id is checksum-mode independent here.
-                let exclude = self.globals.exclude.as_deref();
-                let manifest = self.build_manifest(path.as_deref(), false, false, None, exclude)?;
+                let manifest = self.build_manifest(
+                    path.as_deref(),
+                    false,
+                    false,
+                    None,
+                    &self.globals.exclude,
+                )?;
                 let id = snapshot_id(&manifest, &Blake3Hasher::new());
                 println!("{id}");
                 Ok(())
@@ -425,8 +463,7 @@ impl Cli {
 
         // Push always uses the default checksum surface (b3sum / keyed-b3sum),
         // relative paths, follow symlinks — the same wiring `snapdir id` uses.
-        let manifest =
-            self.build_manifest(path, false, false, None, self.globals.exclude.as_deref())?;
+        let manifest = self.build_manifest(path, false, false, None, &self.globals.exclude)?;
         let root = resolve_root(path).context("resolving push path")?;
         let id = snapshot_id(&manifest, &Blake3Hasher::new());
         store
@@ -542,8 +579,7 @@ impl Cli {
     fn run_stage(&self, path: Option<&Path>) -> Result<()> {
         // Stage uses the same default checksum surface as `push`/`id`: b3sum
         // (or keyed-b3sum), relative paths, follow symlinks.
-        let manifest =
-            self.build_manifest(path, false, false, None, self.globals.exclude.as_deref())?;
+        let manifest = self.build_manifest(path, false, false, None, &self.globals.exclude)?;
         let root = resolve_root(path).context("resolving stage path")?;
         let id = snapshot_id(&manifest, &Blake3Hasher::new());
         let cache = self.cache_store();
@@ -770,23 +806,29 @@ impl Cli {
         absolute: bool,
         no_follow: bool,
         checksum_bin: Option<&str>,
-        exclude: Option<&str>,
+        exclude: &[String],
     ) -> Result<Manifest> {
         let root = resolve_root(path).context("resolving manifest path")?;
 
-        // Expand the exclude pattern. `%system%` forces no-follow; the runtime
-        // `$HOME/.cache/` + cache-dir values come from the CLI (core is
-        // env-pure). When no `--exclude` is given there is no filtering.
+        // Expand the exclude patterns. Each `--exclude` value is expanded
+        // independently — `%system%` / `%common%` macros must be expanded
+        // per-pattern, never on a raw `|`-joined string (that would split the
+        // macro tokens apart) — then OR-combined into a single ERE so a path is
+        // excluded if it matches ANY pattern. `%system%` forces no-follow; the
+        // runtime `$HOME/.cache/` + cache-dir values come from the CLI (core is
+        // env-pure). An empty list means no filtering. A single pattern is
+        // byte-identical to the previous single-pattern path: one expansion,
+        // wrapped in a `(?:…)` group, with no extra alternation.
         let (home_cache, cache_dir) = exclude_runtime_paths(self.globals.cache_dir.as_deref());
-        let expanded = expand_excludes(exclude.unwrap_or(""), &home_cache, &cache_dir);
-        let matcher = match &expanded.pattern {
+        let combined = combine_excludes(exclude, &home_cache, &cache_dir);
+        let matcher = match &combined.pattern {
             Some(pattern) => {
                 Some(ExcludeMatcher::new(pattern).context("compiling --exclude pattern")?)
             }
             None => None,
         };
 
-        let follow = if no_follow || expanded.forces_no_follow {
+        let follow = if no_follow || combined.forces_no_follow {
             FollowMode::NoFollow
         } else {
             FollowMode::Follow
@@ -986,6 +1028,42 @@ fn resolve_root(path: Option<&Path>) -> Result<PathBuf> {
     }
     let cwd = std::env::current_dir().context("getting current directory")?;
     Ok(cwd.join(raw))
+}
+
+/// OR-combines a list of `--exclude` patterns into a single expanded
+/// extended-regex, expanding the `%system%` / `%common%` macros **per pattern**.
+///
+/// The macros (e.g. `%system%`) expand to parenthesized alternations that
+/// embed `|` and `^` anchors, so the raw patterns must NOT be `|`-joined before
+/// expansion — that would split a macro token across an alternation boundary.
+/// Instead each pattern is run through [`expand_excludes`] on its own, each
+/// expanded result is wrapped in a non-capturing group `(?:…)`, and the groups
+/// are joined with `|`. `forces_no_follow` is the OR of every pattern's flag
+/// (any `%system%` anywhere forces no-follow).
+///
+/// An empty list yields `pattern: None` (no filtering), exactly as before. A
+/// single pattern produces `(?:<expansion>)`, which matches identically to the
+/// bare `<expansion>` the previous single-pattern path compiled — the
+/// non-capturing group changes grouping only, never the matched set.
+fn combine_excludes(patterns: &[String], home_cache: &str, cache_dir: &str) -> ExpandedExclude {
+    let mut groups: Vec<String> = Vec::new();
+    let mut forces_no_follow = false;
+    for pattern in patterns {
+        let expanded = expand_excludes(pattern, home_cache, cache_dir);
+        forces_no_follow |= expanded.forces_no_follow;
+        if let Some(ere) = expanded.pattern {
+            groups.push(format!("(?:{ere})"));
+        }
+    }
+    let pattern = if groups.is_empty() {
+        None
+    } else {
+        Some(groups.join("|"))
+    };
+    ExpandedExclude {
+        pattern,
+        forces_no_follow,
+    }
 }
 
 /// Resolves the runtime values the `%system%` macro interpolates: the

--- a/crates/snapdir-cli/src/cli.rs
+++ b/crates/snapdir-cli/src/cli.rs
@@ -444,6 +444,20 @@ impl Cli {
             let manifest = cache.get_manifest(id).with_context(|| {
                 format!("manifest {id} not found in the local cache; stage or fetch it first")
             })?;
+            let store_url = self
+                .globals
+                .store
+                .as_deref()
+                .context("missing --store option")?;
+            // Under --dryrun: the id is a pure read-only lookup, so still print
+            // it to stdout (the scriptable id-on-stdout contract). Skip the
+            // scratch materialize (it's discarded), the store push, and the
+            // catalog log — those are the only persistent writes.
+            if self.globals.dryrun {
+                println!("{id}");
+                eprintln!("dry-run: would push {id} to {store_url} (no writes performed)");
+                return Ok(());
+            }
             let scratch = ScratchDir::new("push")?;
             cache
                 .fetch_files(&manifest, scratch.path())
@@ -452,11 +466,6 @@ impl Cli {
                 .push(&manifest, scratch.path())
                 .with_context(|| format!("pushing snapshot {id} to store"))?;
             println!("{id}");
-            let store_url = self
-                .globals
-                .store
-                .as_deref()
-                .context("missing --store option")?;
             self.log_event("push", id, store_url)?;
             return Ok(());
         }
@@ -466,6 +475,19 @@ impl Cli {
         let manifest = self.build_manifest(path, false, false, None, &self.globals.exclude)?;
         let root = resolve_root(path).context("resolving push path")?;
         let id = snapshot_id(&manifest, &Blake3Hasher::new());
+        let store_url = self
+            .globals
+            .store
+            .as_deref()
+            .context("missing --store option")?;
+        // Under --dryrun: the snapshot id is a pure read-only computation, so
+        // still print it to stdout. Skip the store push and the catalog log —
+        // the only persistent writes here.
+        if self.globals.dryrun {
+            println!("{id}");
+            eprintln!("dry-run: would push {id} to {store_url} (no writes performed)");
+            return Ok(());
+        }
         store
             .push(&manifest, &root)
             .with_context(|| format!("pushing snapshot {id} to store"))?;
@@ -475,11 +497,6 @@ impl Cli {
         // `revisions`/`ancestors` see it. Best-effort and only when the catalog
         // is enabled (`--catalog` / `SNAPDIR_CATALOG`), exactly like the oracle's
         // `_snapdir_log_event` no-op when no catalog adapter is configured.
-        let store_url = self
-            .globals
-            .store
-            .as_deref()
-            .context("missing --store option")?;
         self.log_event("push", &id, store_url)?;
         Ok(())
     }
@@ -494,6 +511,14 @@ impl Cli {
         let manifest = store
             .get_manifest(id)
             .with_context(|| format!("fetching manifest {id} from store"))?;
+
+        // Under --dryrun: the manifest read is fine, but skip materializing the
+        // scratch tree (discarded) and the cache write — the only persistent
+        // write in fetch.
+        if self.globals.dryrun {
+            eprintln!("dry-run: would fetch {id} into the local cache (no writes performed)");
+            return Ok(());
+        }
 
         // Materialize the verified objects into a scratch tree, then push that
         // tree into the cache store. This reuses the store's verify/atomic
@@ -518,11 +543,24 @@ impl Cli {
     /// permissions so the checked-out tree re-manifests to the same snapshot id.
     fn run_checkout(&self, dir: Option<&Path>) -> Result<()> {
         let id = self.require_id()?;
+        let dest = resolve_root(dir).context("resolving checkout destination")?;
+        // Under --dryrun: skip materializing the destination tree and restoring
+        // permissions — both write to the destination. The notice is emitted
+        // before the cache manifest read so `pull --dryrun` (whose `fetch` leg
+        // is itself a dry no-op and therefore leaves the cache unpopulated)
+        // composes into a clean, write-free no-op rather than failing on a
+        // missing cached manifest.
+        if self.globals.dryrun {
+            eprintln!(
+                "dry-run: would check out {id} to {} (no writes performed)",
+                dest.display()
+            );
+            return Ok(());
+        }
         let cache = self.cache_store();
         let manifest = cache.get_manifest(id).with_context(|| {
             format!("manifest {id} not found locally; did you forget to fetch it?")
         })?;
-        let dest = resolve_root(dir).context("resolving checkout destination")?;
         cache
             .fetch_files(&manifest, &dest)
             .with_context(|| format!("checking out snapshot {id} to {}", dest.display()))?;
@@ -582,6 +620,13 @@ impl Cli {
         let manifest = self.build_manifest(path, false, false, None, &self.globals.exclude)?;
         let root = resolve_root(path).context("resolving stage path")?;
         let id = snapshot_id(&manifest, &Blake3Hasher::new());
+        // Under --dryrun: the id is a pure read-only computation, so still print
+        // it to stdout. Skip the cache write and the catalog log.
+        if self.globals.dryrun {
+            println!("{id}");
+            eprintln!("dry-run: would stage {id} into the local cache (no writes performed)");
+            return Ok(());
+        }
         let cache = self.cache_store();
         cache
             .push(&manifest, &root)
@@ -606,13 +651,21 @@ impl Cli {
     /// whether or not it was purged.
     fn run_verify_cache(&self) -> Result<()> {
         let cache_dir = self.cache_dir();
-        let report = cache::verify_cache(&cache_dir, self.globals.purge, &Blake3Hasher::new())
+        // `--purge` is FS-mutating (it deletes corrupt objects), so under
+        // --dryrun never purge — pass `false` so the verification is read-only —
+        // while still emitting the corruption report and preserving the
+        // non-zero exit below.
+        let purge = self.globals.purge && !self.globals.dryrun;
+        if self.globals.purge && self.globals.dryrun {
+            eprintln!("dry-run: would purge corrupt objects from the cache (no writes performed)");
+        }
+        let report = cache::verify_cache(&cache_dir, purge, &Blake3Hasher::new())
             .with_context(|| format!("verifying cache at {}", cache_dir.display()))?;
 
         for checksum in &report.corrupt {
             eprintln!("Checksum mismatch for {checksum}");
         }
-        if self.globals.purge && self.globals.verbose {
+        if purge && self.globals.verbose {
             for checksum in &report.purged {
                 eprintln!("purged {checksum}");
             }
@@ -632,6 +685,15 @@ impl Cli {
     /// (objects + manifests). Idempotent on an already-empty / missing cache.
     fn run_flush_cache(&self) -> Result<()> {
         let cache_dir = self.cache_dir();
+        // Under --dryrun: skip the destructive flush (it deletes every cached
+        // object + manifest).
+        if self.globals.dryrun {
+            eprintln!(
+                "dry-run: would flush the cache at {} (no writes performed)",
+                cache_dir.display()
+            );
+            return Ok(());
+        }
         cache::flush_cache(&cache_dir)
             .with_context(|| format!("flushing cache at {}", cache_dir.display()))?;
         Ok(())

--- a/crates/snapdir-cli/src/cli.rs
+++ b/crates/snapdir-cli/src/cli.rs
@@ -506,6 +506,30 @@ impl Cli {
     /// each object's BLAKE3), then file the manifest+objects into the local
     /// cache so a later `checkout` can reconstruct the tree offline.
     fn run_fetch(&self) -> Result<()> {
+        // Fast path: if the local cache already holds the manifest, the whole
+        // snapshot is cached. By snapdir's manifest-written-last invariant a
+        // present manifest implies every object it references is present (the
+        // same invariant `FileStore::push`'s skip-if-manifest-present relies
+        // on), and `get_manifest` re-verifies the cached manifest hashes back
+        // to `id`, so this is a sound integrity gate. Skipping here means a
+        // repeat `fetch`/`pull` of the same id performs ZERO store reads — no
+        // network round-trip to re-download objects already on disk. The early
+        // return is itself write-free, so it composes cleanly with `--dryrun`.
+        //
+        // We only consult the cache when an `--id` is actually present; with no
+        // id there is nothing to look up, so we fall through and let the
+        // original store-resolution path surface the canonical "missing --store
+        // option" error first (preserving the frozen CLI error precedence).
+        let cache = self.cache_store();
+        if let Some(id) = self.globals.id.as_deref() {
+            if cache.get_manifest(id).is_ok() {
+                if self.globals.verbose {
+                    eprintln!("CACHED: {id}");
+                }
+                return Ok(());
+            }
+        }
+
         let store = self.resolve_store()?;
         let id = self.require_id()?;
         let manifest = store
@@ -528,7 +552,6 @@ impl Cli {
             .fetch_files(&manifest, scratch.path())
             .with_context(|| format!("fetching objects for snapshot {id}"))?;
 
-        let cache = self.cache_store();
         cache
             .push(&manifest, scratch.path())
             .with_context(|| format!("saving snapshot {id} to the local cache"))?;

--- a/crates/snapdir-cli/src/cli.rs
+++ b/crates/snapdir-cli/src/cli.rs
@@ -440,6 +440,7 @@ impl Cli {
     /// and push its objects (objects-before-manifest, skip-if-present) to the
     /// resolved store. Prints the resulting snapshot id, matching the oracle.
     fn run_push(&self, path: Option<&Path>) -> Result<()> {
+        self.log_transfer_config();
         let store = self.resolve_store()?;
 
         // `snapdir push --store … --id <id>` with no PATH: push a *staged* (or
@@ -520,6 +521,14 @@ impl Cli {
     /// each object's BLAKE3), then file the manifest+objects into the local
     /// cache so a later `checkout` can reconstruct the tree offline.
     fn run_fetch(&self) -> Result<()> {
+        self.log_transfer_config();
+        self.fetch_inner()
+    }
+
+    /// `fetch` body without the verbose transfer-config banner. `run_pull`
+    /// composes `fetch_inner` + `checkout_inner` so the banner prints exactly
+    /// once (from `run_pull`), not once per leg.
+    fn fetch_inner(&self) -> Result<()> {
         // Fast path: if the local cache already holds the manifest, the whole
         // snapshot is cached. By snapdir's manifest-written-last invariant a
         // present manifest implies every object it references is present (the
@@ -579,6 +588,13 @@ impl Cli {
     /// cache, materialize the tree at `<dest>`, and restore each entry's
     /// permissions so the checked-out tree re-manifests to the same snapshot id.
     fn run_checkout(&self, dir: Option<&Path>) -> Result<()> {
+        self.log_transfer_config();
+        self.checkout_inner(dir)
+    }
+
+    /// `checkout` body without the verbose transfer-config banner (see
+    /// [`Self::fetch_inner`]).
+    fn checkout_inner(&self, dir: Option<&Path>) -> Result<()> {
         let id = self.require_id()?;
         let dest = resolve_root(dir).context("resolving checkout destination")?;
         // Under --dryrun: skip materializing the destination tree and restoring
@@ -607,8 +623,12 @@ impl Cli {
 
     /// `snapdir pull` = fetch + checkout.
     fn run_pull(&self, path: Option<&Path>) -> Result<()> {
-        self.run_fetch()?;
-        self.run_checkout(path)
+        // Banner ONCE for the whole pull, then run the two legs without their
+        // own banners (`fetch_inner`/`checkout_inner`) so `pull --verbose`
+        // emits exactly one transfer-config line.
+        self.log_transfer_config();
+        self.fetch_inner()?;
+        self.checkout_inner(path)
     }
 
     /// `snapdir verify --id <id>`: confirm the snapshot in the store is intact —
@@ -652,6 +672,7 @@ impl Cli {
     /// core/stores code. The resulting on-disk keys are exactly what
     /// `verify-cache` later checks (`stage` then `verify-cache` round-trips).
     fn run_stage(&self, path: Option<&Path>) -> Result<()> {
+        self.log_transfer_config();
         // Stage uses the same default checksum surface as `push`/`id`: b3sum
         // (or keyed-b3sum), relative paths, follow symlinks.
         let manifest = self.build_manifest(path, false, false, None, &self.globals.exclude)?;
@@ -894,6 +915,29 @@ impl Cli {
             _ => TransferConfig::default().concurrency.get(),
         };
         Ok(TransferConfig::new(concurrency, max_bytes_per_sec))
+    }
+
+    /// Field observability for the transfer commands: under `--verbose`, print
+    /// the *effective* transfer concurrency (and `--limit-rate`, if set) ONCE to
+    /// stderr so an operator can confirm in the field that concurrent transfers +
+    /// bandwidth limiting are actually in effect. Stdout is untouched (the
+    /// scriptable id-on-stdout contract stays byte-stable); the deterministic
+    /// concurrency proof is the unit test, this is just field observability.
+    fn log_transfer_config(&self) {
+        if !self.globals.verbose {
+            return;
+        }
+        // A bad --limit-rate would already have failed transfer_config() in the
+        // command body; here we only render for humans, so on the off chance the
+        // config can't resolve we simply skip the diagnostic rather than abort.
+        let Ok(config) = self.transfer_config() else {
+            return;
+        };
+        let concurrency = config.concurrency.get();
+        match self.globals.limit_rate.as_deref() {
+            Some(rate) => eprintln!("transfers: {concurrency} concurrent, limit {rate}"),
+            None => eprintln!("transfers: {concurrency} concurrent"),
+        }
     }
 
     /// The local cache as a `file://`-shaped store, rooted at the resolved cache

--- a/crates/snapdir-cli/tests/cmd/help-ancestors.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-ancestors.trycmd
@@ -19,6 +19,8 @@ Options:
       --verbose               Enable verbose output
       --debug                 Enable debug output
       --location <DIR|STORE>  Context (directory or store) for catalog queries
+  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
+      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
   -h, --help                  Print help
   -V, --version               Print version
 

--- a/crates/snapdir-cli/tests/cmd/help-checkout.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-checkout.trycmd
@@ -22,6 +22,8 @@ Options:
       --verbose               Enable verbose output
       --debug                 Enable debug output
       --location <DIR|STORE>  Context (directory or store) for catalog queries
+  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
+      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
   -h, --help                  Print help
   -V, --version               Print version
 

--- a/crates/snapdir-cli/tests/cmd/help-defaults.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-defaults.trycmd
@@ -19,6 +19,8 @@ Options:
       --verbose               Enable verbose output
       --debug                 Enable debug output
       --location <DIR|STORE>  Context (directory or store) for catalog queries
+  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
+      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
   -h, --help                  Print help
   -V, --version               Print version
 

--- a/crates/snapdir-cli/tests/cmd/help-fetch.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-fetch.trycmd
@@ -19,6 +19,8 @@ Options:
       --verbose               Enable verbose output
       --debug                 Enable debug output
       --location <DIR|STORE>  Context (directory or store) for catalog queries
+  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
+      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
   -h, --help                  Print help
   -V, --version               Print version
 

--- a/crates/snapdir-cli/tests/cmd/help-flush-cache.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-flush-cache.trycmd
@@ -19,6 +19,8 @@ Options:
       --verbose               Enable verbose output
       --debug                 Enable debug output
       --location <DIR|STORE>  Context (directory or store) for catalog queries
+  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
+      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
   -h, --help                  Print help
   -V, --version               Print version
 

--- a/crates/snapdir-cli/tests/cmd/help-id.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-id.trycmd
@@ -22,6 +22,8 @@ Options:
       --verbose               Enable verbose output
       --debug                 Enable debug output
       --location <DIR|STORE>  Context (directory or store) for catalog queries
+  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
+      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
   -h, --help                  Print help
   -V, --version               Print version
 

--- a/crates/snapdir-cli/tests/cmd/help-locations.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-locations.trycmd
@@ -19,6 +19,8 @@ Options:
       --verbose               Enable verbose output
       --debug                 Enable debug output
       --location <DIR|STORE>  Context (directory or store) for catalog queries
+  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
+      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
   -h, --help                  Print help
   -V, --version               Print version
 

--- a/crates/snapdir-cli/tests/cmd/help-manifest.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-manifest.trycmd
@@ -25,6 +25,8 @@ Options:
       --verbose               Enable verbose output
       --debug                 Enable debug output
       --location <DIR|STORE>  Context (directory or store) for catalog queries
+  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
+      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
   -h, --help                  Print help
   -V, --version               Print version
 

--- a/crates/snapdir-cli/tests/cmd/help-pull.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-pull.trycmd
@@ -22,6 +22,8 @@ Options:
       --verbose               Enable verbose output
       --debug                 Enable debug output
       --location <DIR|STORE>  Context (directory or store) for catalog queries
+  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
+      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
   -h, --help                  Print help
   -V, --version               Print version
 

--- a/crates/snapdir-cli/tests/cmd/help-push.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-push.trycmd
@@ -22,6 +22,8 @@ Options:
       --verbose               Enable verbose output
       --debug                 Enable debug output
       --location <DIR|STORE>  Context (directory or store) for catalog queries
+  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
+      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
   -h, --help                  Print help
   -V, --version               Print version
 

--- a/crates/snapdir-cli/tests/cmd/help-revisions.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-revisions.trycmd
@@ -19,6 +19,8 @@ Options:
       --verbose               Enable verbose output
       --debug                 Enable debug output
       --location <DIR|STORE>  Context (directory or store) for catalog queries
+  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
+      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
   -h, --help                  Print help
   -V, --version               Print version
 

--- a/crates/snapdir-cli/tests/cmd/help-stage.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-stage.trycmd
@@ -22,6 +22,8 @@ Options:
       --verbose               Enable verbose output
       --debug                 Enable debug output
       --location <DIR|STORE>  Context (directory or store) for catalog queries
+  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
+      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
   -h, --help                  Print help
   -V, --version               Print version
 

--- a/crates/snapdir-cli/tests/cmd/help-verify-cache.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-verify-cache.trycmd
@@ -19,6 +19,8 @@ Options:
       --verbose               Enable verbose output
       --debug                 Enable debug output
       --location <DIR|STORE>  Context (directory or store) for catalog queries
+  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
+      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
   -h, --help                  Print help
   -V, --version               Print version
 

--- a/crates/snapdir-cli/tests/cmd/help-verify.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-verify.trycmd
@@ -19,6 +19,8 @@ Options:
       --verbose               Enable verbose output
       --debug                 Enable debug output
       --location <DIR|STORE>  Context (directory or store) for catalog queries
+  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
+      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
   -h, --help                  Print help
   -V, --version               Print version
 

--- a/crates/snapdir-cli/tests/cmd/help.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help.trycmd
@@ -37,6 +37,8 @@ Options:
       --verbose               Enable verbose output
       --debug                 Enable debug output
       --location <DIR|STORE>  Context (directory or store) for catalog queries
+  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
+      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
   -h, --help                  Print help
   -V, --version               Print version
 

--- a/crates/snapdir-cli/tests/dryrun.rs
+++ b/crates/snapdir-cli/tests/dryrun.rs
@@ -1,0 +1,253 @@
+//! Integration tests for the global `--dryrun` flag.
+//!
+//! `--dryrun` must make every store/FS-mutating command a no-op-writes mode:
+//! zero persistent writes (no store objects/manifests, no cache writes, no
+//! destination files, no cache flush, no catalog events) while still printing
+//! the intended action and the pure-computation snapshot id. These tests assert
+//! the hard invariant — ZERO writes — for each guarded command, and confirm a
+//! successful (exit 0) run. Every test fn name contains `dryrun` so
+//! `cargo test -p snapdir-cli --locked dryrun` selects them.
+//!
+//! Mirrors the `file://` store + cache-dir setup pattern from
+//! `tests/store_roundtrip.rs`.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Path to the compiled `snapdir` binary under test.
+fn snapdir_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_snapdir")
+}
+
+/// Creates a unique temp directory and returns its path.
+fn temp_dir(tag: &str) -> PathBuf {
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "snapdir-cli-dryrun-{tag}-{}-{:?}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// Runs the `snapdir` binary, asserting success and returning trimmed stdout.
+fn run_snapdir(args: &[&str], cache: &Path) -> String {
+    let output = Command::new(snapdir_bin())
+        .args(args)
+        .env("SNAPDIR_CACHE_DIR", cache)
+        .output()
+        .expect("run snapdir");
+    assert!(
+        output.status.success(),
+        "snapdir {args:?} exited with {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout)
+        .expect("stdout is UTF-8")
+        .trim_end()
+        .to_owned()
+}
+
+/// Builds a small, deterministic source tree under `src`.
+fn build_src_tree(src: &Path) {
+    fs::write(src.join("a.txt"), b"hello").unwrap();
+    fs::set_permissions(src.join("a.txt"), fs::Permissions::from_mode(0o644)).unwrap();
+    fs::create_dir(src.join("sub")).unwrap();
+    fs::set_permissions(src.join("sub"), fs::Permissions::from_mode(0o755)).unwrap();
+    fs::write(src.join("sub").join("b.txt"), b"world!!").unwrap();
+    fs::set_permissions(
+        src.join("sub").join("b.txt"),
+        fs::Permissions::from_mode(0o600),
+    )
+    .unwrap();
+    fs::set_permissions(src, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+/// Counts the regular files anywhere under `dir` (recursively). A
+/// content-addressable store/cache materializes objects + manifests as files,
+/// so a count of zero means nothing was persisted.
+fn count_files(dir: &Path) -> usize {
+    let mut total = 0;
+    if !dir.exists() {
+        return 0;
+    }
+    for entry in fs::read_dir(dir).expect("read_dir") {
+        let entry = entry.expect("dir entry");
+        let path = entry.path();
+        if path.is_dir() {
+            total += count_files(&path);
+        } else {
+            total += 1;
+        }
+    }
+    total
+}
+
+/// `push --dryrun` against an empty `file://` store must leave the store empty:
+/// no `.objects`/`.manifests` entries are written.
+#[test]
+fn dryrun_push_writes_nothing() {
+    let src = temp_dir("push-src");
+    let store = temp_dir("push-store");
+    let cache = temp_dir("push-cache");
+
+    build_src_tree(&src);
+    let store_url = format!("file://{}", store.display());
+    let src_str = src.to_string_lossy().into_owned();
+
+    // The id is a pure computation and must still be printed to stdout.
+    let id = run_snapdir(
+        &["push", "--dryrun", "--store", &store_url, &src_str],
+        &cache,
+    );
+    assert_eq!(id.len(), 64, "push --dryrun must still print the id");
+
+    assert!(
+        !store.join(".objects").exists(),
+        "push --dryrun must not write any objects"
+    );
+    assert!(
+        !store.join(".manifests").exists(),
+        "push --dryrun must not write any manifests"
+    );
+    assert_eq!(
+        count_files(&store),
+        0,
+        "store must remain empty after dryrun"
+    );
+    // And the cache must not be written to either.
+    assert_eq!(
+        count_files(&cache),
+        0,
+        "cache must remain empty after dryrun"
+    );
+
+    for dir in [&src, &store, &cache] {
+        fs::remove_dir_all(dir).ok();
+    }
+}
+
+/// `stage --dryrun` with an empty cache must leave the cache empty.
+#[test]
+fn dryrun_stage_writes_nothing() {
+    let src = temp_dir("stage-src");
+    let cache = temp_dir("stage-cache");
+
+    build_src_tree(&src);
+    let src_str = src.to_string_lossy().into_owned();
+
+    let id = run_snapdir(&["stage", "--dryrun", &src_str], &cache);
+    assert_eq!(id.len(), 64, "stage --dryrun must still print the id");
+
+    assert_eq!(
+        count_files(&cache),
+        0,
+        "stage --dryrun must not write anything to the cache"
+    );
+
+    for dir in [&src, &cache] {
+        fs::remove_dir_all(dir).ok();
+    }
+}
+
+/// `flush-cache --dryrun` must NOT empty a populated cache.
+#[test]
+fn dryrun_flush_cache_keeps_objects() {
+    let src = temp_dir("flush-src");
+    let cache = temp_dir("flush-cache");
+
+    build_src_tree(&src);
+    let src_str = src.to_string_lossy().into_owned();
+
+    // Real (non-dryrun) stage to populate the cache.
+    run_snapdir(&["stage", &src_str], &cache);
+    let before = count_files(&cache);
+    assert!(before > 0, "real stage must populate the cache");
+
+    // Dry-run flush must be a no-op.
+    run_snapdir(&["flush-cache", "--dryrun"], &cache);
+    let after = count_files(&cache);
+    assert_eq!(
+        after, before,
+        "flush-cache --dryrun must leave the cache unchanged"
+    );
+
+    for dir in [&src, &cache] {
+        fs::remove_dir_all(dir).ok();
+    }
+}
+
+/// `checkout --dryrun` with a populated cache must leave the destination empty.
+#[test]
+fn dryrun_checkout_writes_nothing() {
+    let src = temp_dir("co-src");
+    let cache = temp_dir("co-cache");
+    let dest = temp_dir("co-dest");
+
+    build_src_tree(&src);
+    let src_str = src.to_string_lossy().into_owned();
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    // Real stage so the snapshot is available for checkout from the cache.
+    let id = run_snapdir(&["stage", &src_str], &cache);
+
+    // Dry-run checkout must not materialize anything at the destination.
+    run_snapdir(&["checkout", "--dryrun", "--id", &id, &dest_str], &cache);
+    assert_eq!(
+        count_files(&dest),
+        0,
+        "checkout --dryrun must not write any files to the destination"
+    );
+
+    for dir in [&src, &cache, &dest] {
+        fs::remove_dir_all(dir).ok();
+    }
+}
+
+/// `pull --dryrun` (= fetch + checkout) must write neither the cache nor the
+/// destination.
+#[test]
+fn dryrun_pull_writes_nothing() {
+    let src = temp_dir("pull-src");
+    let store = temp_dir("pull-store");
+    let pushcache = temp_dir("pull-pushcache");
+    let cache = temp_dir("pull-cache");
+    let dest = temp_dir("pull-dest");
+
+    build_src_tree(&src);
+    let store_url = format!("file://{}", store.display());
+    let src_str = src.to_string_lossy().into_owned();
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    // Real push to populate the store (uses a throwaway cache).
+    let id = run_snapdir(&["push", "--store", &store_url, &src_str], &pushcache);
+
+    // Dry-run pull from the store into a fresh, empty cache + dest.
+    run_snapdir(
+        &[
+            "pull", "--dryrun", "--store", &store_url, "--id", &id, &dest_str,
+        ],
+        &cache,
+    );
+    assert_eq!(
+        count_files(&cache),
+        0,
+        "pull --dryrun must not write to the cache"
+    );
+    assert_eq!(
+        count_files(&dest),
+        0,
+        "pull --dryrun must not write to the destination"
+    );
+
+    for dir in [&src, &store, &pushcache, &cache, &dest] {
+        fs::remove_dir_all(dir).ok();
+    }
+}

--- a/crates/snapdir-cli/tests/e2e.rs
+++ b/crates/snapdir-cli/tests/e2e.rs
@@ -272,3 +272,275 @@ fn checkout_unknown_id_fails() {
         .assert()
         .failure();
 }
+
+// ---------------------------------------------------------------------------
+// pull-push-correctness-suite: binary-level regression tests for the four
+// correctness properties the operator was worried about. These build on top of
+// the existing round-trip tests above; each is hermetic (temp `file://` store +
+// temp cache, both removed on drop).
+// ---------------------------------------------------------------------------
+
+/// Recursively counts the regular files anywhere under `dir` (0 if absent). A
+/// content-addressable store/cache/destination materializes its state as files,
+/// so a count of zero means nothing was written.
+fn count_files(dir: &Path) -> usize {
+    let mut total = 0;
+    if !dir.exists() {
+        return 0;
+    }
+    for entry in std::fs::read_dir(dir).expect("read_dir") {
+        let path = entry.expect("dir entry").path();
+        if path.is_dir() {
+            total += count_files(&path);
+        } else {
+            total += 1;
+        }
+    }
+    total
+}
+
+/// Scenario 1 — **push → pull → pull idempotency.** Pulling the same id into
+/// the SAME destination twice must be a stable no-op: both pulls exit 0, and
+/// after each the destination re-manifests to the source id (contents +
+/// permissions intact). This complements `fetch_cached_skips_store_objects`
+/// (which proves the 2nd pull needs no store objects); here we focus on the
+/// positive idempotency / destination stability across repeated pulls.
+#[test]
+fn push_pull_pull_is_idempotent() {
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let store = TempDir::new().unwrap();
+    let dest = TempDir::new().unwrap();
+    build_tree(&src);
+
+    let src_str = src.path().to_string_lossy().into_owned();
+    let dest_str = dest.path().to_string_lossy().into_owned();
+    let store_url = format!("file://{}", store.path().display());
+
+    let src_id = stdout_ok(cache.path(), &["push", "--store", &store_url, &src_str]);
+
+    // Pull #1 into the destination.
+    snapdir(cache.path())
+        .args(["pull", "--store", &store_url, "--id", &src_id, &dest_str])
+        .assert()
+        .success();
+    dest.child("a.txt").assert("hello");
+    dest.child("sub/b.txt").assert("world!!");
+    assert_eq!(
+        stdout_ok(cache.path(), &["id", &dest_str]),
+        src_id,
+        "first pull must reproduce the source id"
+    );
+
+    // Pull #2 into the SAME destination — must be a stable, idempotent no-op.
+    snapdir(cache.path())
+        .args(["pull", "--store", &store_url, "--id", &src_id, &dest_str])
+        .assert()
+        .success();
+    dest.child("a.txt").assert("hello");
+    dest.child("sub/b.txt").assert("world!!");
+    assert_eq!(
+        stdout_ok(cache.path(), &["id", &dest_str]),
+        src_id,
+        "repeated pull must leave the destination re-manifesting to the same id"
+    );
+}
+
+/// Scenario 2 — **--dryrun makes no writes (e2e level).** A `push --dryrun`
+/// against an empty `file://` store must leave the store empty (no `.objects`,
+/// no `.manifests`), and a `pull --dryrun` into a fresh destination must leave
+/// that destination empty. Intentionally overlaps `tests/dryrun.rs` so THIS
+/// gate's verification — which runs only e2e + `store_roundtrip` — exercises the
+/// dry-run invariant.
+#[test]
+fn dryrun_push_leaves_store_empty_e2e() {
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let store = TempDir::new().unwrap();
+    build_tree(&src);
+
+    let src_str = src.path().to_string_lossy().into_owned();
+    let store_url = format!("file://{}", store.path().display());
+
+    // push --dryrun: still prints the (pure-computation) id, writes nothing.
+    let id = stdout_ok(
+        cache.path(),
+        &["push", "--dryrun", "--store", &store_url, &src_str],
+    );
+    assert_eq!(id.len(), 64, "push --dryrun must still print the id");
+    assert!(
+        !store.path().join(".objects").exists(),
+        "push --dryrun must not create any store objects"
+    );
+    assert!(
+        !store.path().join(".manifests").exists(),
+        "push --dryrun must not create any store manifests"
+    );
+    assert_eq!(
+        count_files(store.path()),
+        0,
+        "store must remain empty after push --dryrun"
+    );
+
+    // A real push so a dryrun pull has something to (not) materialize.
+    let realstore = TempDir::new().unwrap();
+    let real_url = format!("file://{}", realstore.path().display());
+    let pushcache = TempDir::new().unwrap();
+    let real_id = stdout_ok(pushcache.path(), &["push", "--store", &real_url, &src_str]);
+
+    // pull --dryrun into a fresh dest + fresh cache must leave both empty.
+    let dest = TempDir::new().unwrap();
+    let pullcache = TempDir::new().unwrap();
+    let dest_str = dest.path().to_string_lossy().into_owned();
+    snapdir(pullcache.path())
+        .args([
+            "pull", "--dryrun", "--store", &real_url, "--id", &real_id, &dest_str,
+        ])
+        .assert()
+        .success();
+    assert_eq!(
+        count_files(dest.path()),
+        0,
+        "pull --dryrun must not materialize any destination files"
+    );
+    assert_eq!(
+        count_files(pullcache.path()),
+        0,
+        "pull --dryrun must not write to the cache"
+    );
+}
+
+/// Scenario 3 — **corrupted local file is detected and repaired on pull.**
+/// After a push + pull populates the cache and the destination, overwrite one
+/// destination file with wrong bytes. A second pull into the SAME destination
+/// must repair it: the destination re-manifests to the source id and the
+/// corrupted file's contents are restored. The 2nd pull's fetch leg is a
+/// cache-hit no-op (manifest already cached); the checkout leg notices the
+/// corrupt file's local checksum no longer matches and rewrites it from the
+/// cache — so the repair works offline. We prove offline by amputating the
+/// store's `.objects` before the repairing pull.
+#[test]
+fn pull_repairs_corrupted_dest_file() {
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let store = TempDir::new().unwrap();
+    let dest = TempDir::new().unwrap();
+    build_tree(&src);
+
+    let src_str = src.path().to_string_lossy().into_owned();
+    let dest_str = dest.path().to_string_lossy().into_owned();
+    let store_url = format!("file://{}", store.path().display());
+
+    let src_id = stdout_ok(cache.path(), &["push", "--store", &store_url, &src_str]);
+
+    // Pull #1 populates the cache and the destination.
+    snapdir(cache.path())
+        .args(["pull", "--store", &store_url, "--id", &src_id, &dest_str])
+        .assert()
+        .success();
+    dest.child("a.txt").assert("hello");
+    assert_eq!(stdout_ok(cache.path(), &["id", &dest_str]), src_id);
+
+    // Corrupt a destination file in place (wrong bytes, wrong length).
+    dest.child("a.txt")
+        .write_str("CORRUPTED-WRONG-BYTES")
+        .unwrap();
+    assert_ne!(
+        stdout_ok(cache.path(), &["id", &dest_str]),
+        src_id,
+        "corrupting the file must change the re-manifested id"
+    );
+
+    // Amputate the store's objects to prove the repair is served from the
+    // cache (offline) and not by re-reading the store.
+    let objects = store.path().join(".objects");
+    assert!(objects.exists(), "store must have an .objects subtree");
+    std::fs::remove_dir_all(&objects).expect("remove store .objects subtree");
+
+    // Pull #2 into the SAME destination must repair the corrupted file.
+    snapdir(cache.path())
+        .args(["pull", "--store", &store_url, "--id", &src_id, &dest_str])
+        .assert()
+        .success();
+    dest.child("a.txt").assert("hello");
+    dest.child("sub/b.txt").assert("world!!");
+    assert_eq!(
+        stdout_ok(cache.path(), &["id", &dest_str]),
+        src_id,
+        "repairing pull must restore the destination to the source id"
+    );
+}
+
+/// Scenario 4 — **multi/comma --exclude drops paths from the manifest.** Build
+/// a tree with excludable `node_modules/x` and `coverage/y`. The comma form
+/// (`--exclude node_modules,coverage`) and the repeated form (`--exclude
+/// node_modules --exclude coverage`) must both omit those paths from the
+/// manifest stdout AND produce identical output, while a plain `manifest` (no
+/// exclude) includes them.
+///
+/// (The exclude regex matches against the *absolute* scan path, so the chosen
+/// exclude tokens must not appear in the temp-dir prefix — e.g. `tmp` would
+/// also match `/tmp/...` and nuke the whole walk. `node_modules`/`coverage` are
+/// safe distinctive names.)
+#[test]
+fn manifest_multi_exclude_drops_paths_e2e() {
+    let src = TempDir::new().unwrap();
+    build_tree(&src);
+    // Add excludable subtrees on top of the known tree.
+    src.child("node_modules/x").write_str("dep").unwrap();
+    src.child("coverage/y").write_str("scratch").unwrap();
+    let src_str = src.path().to_string_lossy().into_owned();
+
+    // The cache dir is irrelevant for `manifest` (pure computation) but the
+    // harness pins it; reuse a temp cache so we never touch the real $HOME.
+    let cache = TempDir::new().unwrap();
+
+    // Plain manifest includes both excludable subtrees.
+    let plain = stdout_ok(cache.path(), &["manifest", &src_str]);
+    assert!(
+        plain.contains("node_modules"),
+        "plain manifest should include node_modules:\n{plain}"
+    );
+    assert!(
+        plain.contains("coverage"),
+        "plain manifest should include coverage:\n{plain}"
+    );
+
+    // Comma form and repeated form.
+    let comma = stdout_ok(
+        cache.path(),
+        &["manifest", "--exclude", "node_modules,coverage", &src_str],
+    );
+    let repeated = stdout_ok(
+        cache.path(),
+        &[
+            "manifest",
+            "--exclude",
+            "node_modules",
+            "--exclude",
+            "coverage",
+            &src_str,
+        ],
+    );
+
+    for (label, out) in [("comma", &comma), ("repeated", &repeated)] {
+        assert!(
+            !out.contains("node_modules"),
+            "{label} --exclude must drop node_modules:\n{out}"
+        );
+        assert!(
+            !out.contains("coverage"),
+            "{label} --exclude must drop coverage:\n{out}"
+        );
+        // The non-excluded known tree files must survive.
+        assert!(
+            out.contains("./a.txt") && out.contains("./sub/b.txt"),
+            "{label} --exclude must keep the non-excluded files:\n{out}"
+        );
+    }
+
+    assert_eq!(
+        comma, repeated,
+        "comma and repeated --exclude forms must produce identical manifests"
+    );
+}

--- a/crates/snapdir-cli/tests/e2e.rs
+++ b/crates/snapdir-cli/tests/e2e.rs
@@ -193,6 +193,64 @@ fn pull_is_fetch_plus_checkout() {
     assert_eq!(stdout_ok(cache.path(), &["id", &dest_str]), src_id);
 }
 
+/// A repeat `pull`/`fetch` of an already-cached id must perform ZERO store
+/// object reads: the cache holds the manifest, and the manifest-written-last
+/// invariant means it holds every referenced object too. We prove "no store
+/// reads" the only honest way — by *deleting the store's `.objects` subtree*
+/// (keeping `.manifests`) after the first pull, then pulling the SAME id again.
+/// If the fetch leg still materialized objects from the store, the second pull
+/// would fail with `object not found`; instead it must succeed, and its
+/// destination must re-manifest to the same id (correctness, not a silent skip).
+#[test]
+fn fetch_cached_skips_store_objects() {
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let store = TempDir::new().unwrap();
+    let dest = TempDir::new().unwrap();
+    let dest2 = TempDir::new().unwrap();
+    build_tree(&src);
+
+    let src_str = src.path().to_string_lossy().into_owned();
+    let dest_str = dest.path().to_string_lossy().into_owned();
+    let redest_str = dest2.path().to_string_lossy().into_owned();
+    let store_url = format!("file://{}", store.path().display());
+
+    // push, then pull #1 — populates BOTH the cache and the first destination.
+    let src_id = stdout_ok(cache.path(), &["push", "--store", &store_url, &src_str]);
+    snapdir(cache.path())
+        .args(["pull", "--store", &store_url, "--id", &src_id, &dest_str])
+        .assert()
+        .success();
+    assert_eq!(stdout_ok(cache.path(), &["id", &dest_str]), src_id);
+
+    // Amputate the store's objects (keep the manifest). Any store object read
+    // now fails — so a fetch that hits the store cannot succeed.
+    let objects = store.path().join(".objects");
+    assert!(objects.exists(), "store must have an .objects subtree");
+    std::fs::remove_dir_all(&objects).expect("remove store .objects subtree");
+    assert!(store.path().join(".manifests").exists(), "manifest kept");
+
+    // pull #2 of the SAME id into a fresh destination must SUCCEED purely from
+    // the cache (zero store object reads), and re-manifest to the same id.
+    snapdir(cache.path())
+        .args(["pull", "--store", &store_url, "--id", &src_id, &redest_str])
+        .assert()
+        .success();
+    dest2.child("a.txt").assert("hello");
+    dest2.child("sub/b.txt").assert("world!!");
+    assert_eq!(
+        stdout_ok(cache.path(), &["id", &redest_str]),
+        src_id,
+        "cache-served pull must reproduce the source id"
+    );
+
+    // A bare `fetch` of the cached id is likewise a no-op success.
+    snapdir(cache.path())
+        .args(["fetch", "--store", &store_url, "--id", &src_id])
+        .assert()
+        .success();
+}
+
 #[test]
 fn fetch_without_store_fails_with_clear_message() {
     let cache = TempDir::new().unwrap();

--- a/crates/snapdir-cli/tests/e2e.rs
+++ b/crates/snapdir-cli/tests/e2e.rs
@@ -531,6 +531,196 @@ fn pull_repairs_corrupted_dest_file() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// transfer-concurrency-verification (phase 13): end-to-end proof that
+// `--jobs` / `--limit-rate` are wired through the binary and that concurrency
+// does not change the materialized result. All hermetic via a temp `file://`
+// store (the aggregate `RateLimiter` is network-only; `FileStore` does NOT throttle
+// local copies, so the deterministic throttle proof lives in transfer-config's
+// `RateLimiter` timing unit test, not here). These tests prove flag acceptance,
+// threading, and byte-identical correctness through the concurrent `FileStore`
+// path. Fn names start with `transfer_concurrency` so
+// `cargo test -p snapdir-cli --locked transfer_concurrency` selects them.
+// ---------------------------------------------------------------------------
+
+/// Builds a *multi-file* tree (several files + nested dirs) with deterministic
+/// permissions so a concurrent push/pull has real fan-out to exercise, and a
+/// checked-out copy must restore contents + perms to re-manifest to the same id.
+fn build_multi_tree(dir: &TempDir) {
+    let files = [
+        ("top1.txt", "alpha", 0o644),
+        ("top2.bin", "bravo-bravo", 0o600),
+        ("dir_a/a1.txt", "charlie", 0o644),
+        ("dir_a/a2.txt", "delta-delta-delta", 0o640),
+        ("dir_a/nested/deep.txt", "echo!!", 0o644),
+        ("dir_b/b1.txt", "foxtrot", 0o600),
+        ("dir_b/b2.txt", "golf", 0o644),
+        ("dir_b/sub/c/leaf.dat", "hotel-hotel", 0o644),
+    ];
+    for (rel, body, mode) in files {
+        dir.child(rel).write_str(body).unwrap();
+        std::fs::set_permissions(dir.child(rel).path(), PermissionsExt::from_mode(mode)).unwrap();
+    }
+    // Pin a couple of directory modes so directory perms are part of the id too.
+    for d in ["dir_a", "dir_a/nested", "dir_b", "dir_b/sub", "dir_b/sub/c"] {
+        std::fs::set_permissions(dir.child(d).path(), PermissionsExt::from_mode(0o755)).unwrap();
+    }
+    std::fs::set_permissions(dir.path(), PermissionsExt::from_mode(0o755)).unwrap();
+}
+
+/// `push --jobs 4` a multi-file tree to a `file://` store, then `pull --jobs 4`
+/// into a fresh dest: exit 0, the pushed id equals the source id, and the pulled
+/// tree re-manifests to the same id (byte-identical materialization through the
+/// concurrent `FileStore` path).
+#[test]
+fn transfer_concurrency_jobs4_roundtrip() {
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let store = TempDir::new().unwrap();
+    let dest = TempDir::new().unwrap();
+    build_multi_tree(&src);
+
+    let src_str = src.path().to_string_lossy().into_owned();
+    let dest_str = dest.path().to_string_lossy().into_owned();
+    let store_url = format!("file://{}", store.path().display());
+
+    let src_id = stdout_ok(cache.path(), &["id", &src_str]);
+
+    let pushed = stdout_ok(
+        cache.path(),
+        &["push", "--store", &store_url, "--jobs", "4", &src_str],
+    );
+    assert_eq!(pushed, src_id, "push --jobs 4 must print the source id");
+
+    snapdir(cache.path())
+        .args([
+            "pull", "--store", &store_url, "--id", &src_id, "--jobs", "4", &dest_str,
+        ])
+        .assert()
+        .success();
+
+    dest.child("dir_a/nested/deep.txt").assert("echo!!");
+    dest.child("dir_b/sub/c/leaf.dat").assert("hotel-hotel");
+    assert_eq!(
+        stdout_ok(cache.path(), &["id", &dest_str]),
+        src_id,
+        "tree pulled with --jobs 4 must re-manifest to the source id"
+    );
+}
+
+/// Same round-trip with `--jobs 1` (the sequential path): identical id/result.
+/// Also asserts the `--jobs 1` and `--jobs 4` runs produce the SAME snapshot id,
+/// proving concurrency does not change the output.
+#[test]
+fn transfer_concurrency_jobs1_roundtrip() {
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let store = TempDir::new().unwrap();
+    let dest = TempDir::new().unwrap();
+    build_multi_tree(&src);
+
+    let src_str = src.path().to_string_lossy().into_owned();
+    let dest_str = dest.path().to_string_lossy().into_owned();
+    let store_url = format!("file://{}", store.path().display());
+
+    let src_id = stdout_ok(cache.path(), &["id", &src_str]);
+
+    let pushed = stdout_ok(
+        cache.path(),
+        &["push", "--store", &store_url, "--jobs", "1", &src_str],
+    );
+    assert_eq!(pushed, src_id, "push --jobs 1 must print the source id");
+
+    snapdir(cache.path())
+        .args([
+            "pull", "--store", &store_url, "--id", &src_id, "--jobs", "1", &dest_str,
+        ])
+        .assert()
+        .success();
+
+    dest.child("dir_a/a2.txt").assert("delta-delta-delta");
+    dest.child("dir_b/b1.txt").assert("foxtrot");
+    let dest_id = stdout_ok(cache.path(), &["id", &dest_str]);
+    assert_eq!(
+        dest_id, src_id,
+        "tree pulled with --jobs 1 must re-manifest to the source id"
+    );
+
+    // Push the same tree to a SECOND store with --jobs 4; the printed id must
+    // match the --jobs 1 push — concurrency must not change the snapshot id.
+    let parallel_store = TempDir::new().unwrap();
+    let parallel_url = format!("file://{}", parallel_store.path().display());
+    let pushed4 = stdout_ok(
+        cache.path(),
+        &["push", "--store", &parallel_url, "--jobs", "4", &src_str],
+    );
+    assert_eq!(
+        pushed4, pushed,
+        "--jobs 4 and --jobs 1 pushes must yield the same snapshot id"
+    );
+}
+
+/// `push --jobs 2 --limit-rate 1M` + `pull --limit-rate 512K` round-trip to a
+/// `file://` store succeeds and re-manifests to the same id. This proves the
+/// flag parses, threads into `TransferConfig`, and does not break correctness.
+/// There is NO timing assertion: `FileStore` does not throttle local copies (the
+/// `RateLimiter` is network-only; its deterministic timing proof lives in
+/// transfer-config's `RateLimiter` unit test).
+#[test]
+fn transfer_concurrency_limit_rate_accepted() {
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let store = TempDir::new().unwrap();
+    let dest = TempDir::new().unwrap();
+    build_multi_tree(&src);
+
+    let src_str = src.path().to_string_lossy().into_owned();
+    let dest_str = dest.path().to_string_lossy().into_owned();
+    let store_url = format!("file://{}", store.path().display());
+
+    let src_id = stdout_ok(cache.path(), &["id", &src_str]);
+
+    let pushed = stdout_ok(
+        cache.path(),
+        &[
+            "push",
+            "--store",
+            &store_url,
+            "--jobs",
+            "2",
+            "--limit-rate",
+            "1M",
+            &src_str,
+        ],
+    );
+    assert_eq!(
+        pushed, src_id,
+        "push --jobs 2 --limit-rate 1M must print the source id"
+    );
+
+    snapdir(cache.path())
+        .args([
+            "pull",
+            "--store",
+            &store_url,
+            "--id",
+            &src_id,
+            "--limit-rate",
+            "512K",
+            &dest_str,
+        ])
+        .assert()
+        .success();
+
+    dest.child("top1.txt").assert("alpha");
+    dest.child("dir_b/sub/c/leaf.dat").assert("hotel-hotel");
+    assert_eq!(
+        stdout_ok(cache.path(), &["id", &dest_str]),
+        src_id,
+        "tree pulled with --limit-rate must re-manifest to the source id"
+    );
+}
+
 /// Scenario 4 — **multi/comma --exclude drops paths from the manifest.** Build
 /// a tree with excludable `node_modules/x` and `coverage/y`. The comma form
 /// (`--exclude node_modules,coverage`) and the repeated form (`--exclude

--- a/crates/snapdir-cli/tests/e2e.rs
+++ b/crates/snapdir-cli/tests/e2e.rs
@@ -193,6 +193,66 @@ fn pull_is_fetch_plus_checkout() {
     assert_eq!(stdout_ok(cache.path(), &["id", &dest_str]), src_id);
 }
 
+/// The transfer-tuning flags (`--jobs` / `--limit-rate`) are accepted on a real
+/// `push` then `pull` round-trip to a `file://` store and do not change the
+/// outcome: the pushed id equals the source id and the pulled tree re-manifests
+/// to it. This exercises the full flag → `TransferConfig` → store threading.
+#[test]
+fn transfer_flags_push_pull_roundtrip() {
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let store = TempDir::new().unwrap();
+    let dest = TempDir::new().unwrap();
+    build_tree(&src);
+
+    let src_str = src.path().to_string_lossy().into_owned();
+    let dest_str = dest.path().to_string_lossy().into_owned();
+    let store_url = format!("file://{}", store.path().display());
+
+    let src_id = stdout_ok(cache.path(), &["id", &src_str]);
+
+    // push with concurrency + bandwidth caps set explicitly.
+    let pushed = stdout_ok(
+        cache.path(),
+        &[
+            "push",
+            "--store",
+            &store_url,
+            "--jobs",
+            "2",
+            "--limit-rate",
+            "1M",
+            &src_str,
+        ],
+    );
+    assert_eq!(pushed, src_id, "push with transfer flags must print the id");
+
+    // pull with the short `-j` alias and a sequential cap.
+    snapdir(cache.path())
+        .args([
+            "pull",
+            "--store",
+            &store_url,
+            "--id",
+            &src_id,
+            "-j",
+            "1",
+            "--limit-rate",
+            "512K",
+            &dest_str,
+        ])
+        .assert()
+        .success();
+
+    dest.child("a.txt").assert("hello");
+    dest.child("sub/b.txt").assert("world!!");
+    assert_eq!(
+        stdout_ok(cache.path(), &["id", &dest_str]),
+        src_id,
+        "tree pulled with transfer flags must re-manifest to the source id"
+    );
+}
+
 /// A repeat `pull`/`fetch` of an already-cached id must perform ZERO store
 /// object reads: the cache holds the manifest, and the manifest-written-last
 /// invariant means it holds every referenced object too. We prove "no store

--- a/crates/snapdir-cli/tests/e2e.rs
+++ b/crates/snapdir-cli/tests/e2e.rs
@@ -794,3 +794,159 @@ fn manifest_multi_exclude_drops_paths_e2e() {
         "comma and repeated --exclude forms must produce identical manifests"
     );
 }
+
+/// `--verbose push --jobs N` prints the effective transfer concurrency to
+/// stderr ONCE, while stdout stays exactly the snapshot id (byte-stable).
+#[test]
+fn verbose_jobs_push_reports_concurrency() {
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let store = TempDir::new().unwrap();
+    build_tree(&src);
+
+    let src_str = src.path().to_string_lossy().into_owned();
+    let store_url = format!("file://{}", store.path().display());
+
+    let src_id = stdout_ok(cache.path(), &["id", &src_str]);
+
+    let out = snapdir(cache.path())
+        .args([
+            "push",
+            "--jobs",
+            "3",
+            "--verbose",
+            "--store",
+            &store_url,
+            &src_str,
+        ])
+        .output()
+        .expect("run snapdir");
+    assert!(out.status.success(), "verbose push must succeed");
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert_eq!(
+        stdout.trim_end(),
+        src_id,
+        "stdout must remain exactly the snapshot id"
+    );
+
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("transfers: 3 concurrent"),
+        "stderr must report effective concurrency:\n{stderr}"
+    );
+    assert_eq!(
+        stderr.matches("transfers:").count(),
+        1,
+        "the transfer-config banner must print exactly once:\n{stderr}"
+    );
+}
+
+/// `--verbose push --jobs N --limit-rate R` reports both the concurrency and the
+/// rate limit on stderr.
+#[test]
+fn verbose_jobs_limit_rate_reported() {
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let store = TempDir::new().unwrap();
+    build_tree(&src);
+
+    let src_str = src.path().to_string_lossy().into_owned();
+    let store_url = format!("file://{}", store.path().display());
+
+    let out = snapdir(cache.path())
+        .args([
+            "push",
+            "--jobs",
+            "2",
+            "--limit-rate",
+            "1M",
+            "--verbose",
+            "--store",
+            &store_url,
+            &src_str,
+        ])
+        .output()
+        .expect("run snapdir");
+    assert!(out.status.success(), "verbose limited push must succeed");
+
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("2 concurrent") && stderr.contains("limit 1M"),
+        "stderr must report concurrency AND the limit rate:\n{stderr}"
+    );
+}
+
+/// Without `--verbose`, the transfer-config banner is silent and stdout is still
+/// exactly the snapshot id.
+#[test]
+fn verbose_jobs_silent_without_verbose() {
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let store = TempDir::new().unwrap();
+    build_tree(&src);
+
+    let src_str = src.path().to_string_lossy().into_owned();
+    let store_url = format!("file://{}", store.path().display());
+
+    let src_id = stdout_ok(cache.path(), &["id", &src_str]);
+
+    let out = snapdir(cache.path())
+        .args(["push", "--jobs", "3", "--store", &store_url, &src_str])
+        .output()
+        .expect("run snapdir");
+    assert!(out.status.success(), "non-verbose push must succeed");
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert_eq!(stdout.trim_end(), src_id, "stdout must be the snapshot id");
+
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        !stderr.contains("concurrent") && !stderr.contains("transfers:"),
+        "non-verbose run must not emit the transfer-config banner:\n{stderr}"
+    );
+}
+
+/// `pull --jobs N --verbose` (fetch + checkout) emits the transfer-config banner
+/// exactly ONCE, not once per leg.
+#[test]
+fn verbose_jobs_pull_reports_once() {
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let store = TempDir::new().unwrap();
+    let dest = TempDir::new().unwrap();
+    build_tree(&src);
+
+    let src_str = src.path().to_string_lossy().into_owned();
+    let dest_str = dest.path().to_string_lossy().into_owned();
+    let store_url = format!("file://{}", store.path().display());
+
+    let src_id = stdout_ok(cache.path(), &["push", "--store", &store_url, &src_str]);
+
+    let out = snapdir(cache.path())
+        .args([
+            "pull",
+            "--jobs",
+            "4",
+            "--verbose",
+            "--store",
+            &store_url,
+            "--id",
+            &src_id,
+            &dest_str,
+        ])
+        .output()
+        .expect("run snapdir");
+    assert!(out.status.success(), "verbose pull must succeed");
+
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains("transfers: 4 concurrent"),
+        "pull --verbose must report concurrency:\n{stderr}"
+    );
+    assert_eq!(
+        stderr.matches("transfers:").count(),
+        1,
+        "pull must print the transfer-config banner exactly once:\n{stderr}"
+    );
+}

--- a/crates/snapdir-cli/tests/list_options.rs
+++ b/crates/snapdir-cli/tests/list_options.rs
@@ -1,0 +1,197 @@
+//! Integration tests for the multi-value list CLI options (`--exclude`).
+//!
+//! Gate `cli-list-options-multi` (phase 12): `--exclude` accepts BOTH repeated
+//! occurrences (`--exclude a --exclude b`) AND comma-delimited values
+//! (`--exclude a,b`), OR-combined (a path is dropped if it matches ANY
+//! pattern). These drive the compiled `snapdir manifest` binary over a known
+//! scratch tree and assert which `PATH` lines survive in stdout.
+//!
+//! Every test fn is named with `list_options` so
+//! `cargo test -p snapdir-cli --locked list_options` selects exactly this file.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use assert_cmd::Command;
+
+/// Path to the compiled `snapdir` binary under test.
+fn snapdir_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_snapdir")
+}
+
+/// Creates a unique temp directory for a test tree and returns its path.
+fn temp_tree(tag: &str) -> PathBuf {
+    let mut dir = std::env::temp_dir();
+    let unique = format!(
+        "snapdir-cli-list-{tag}-{}-{:?}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    dir.push(unique);
+    fs::create_dir_all(&dir).expect("create temp tree");
+    dir
+}
+
+/// Builds a scratch tree with several distinctly-named files/dirs so excludes
+/// can be checked independently:
+///
+/// ```text
+/// <root>/alpha.txt
+/// <root>/beta.txt
+/// <root>/gamma.txt
+/// <root>/keep.txt
+/// ```
+fn build_tree(root: &Path) {
+    fs::write(root.join("alpha.txt"), b"a").unwrap();
+    fs::write(root.join("beta.txt"), b"b").unwrap();
+    fs::write(root.join("gamma.txt"), b"g").unwrap();
+    fs::write(root.join("keep.txt"), b"k").unwrap();
+}
+
+/// Runs `snapdir manifest <args> <root>` and returns stdout as a String.
+fn manifest_stdout(root: &Path, args: &[&str]) -> String {
+    let mut cmd = Command::new(snapdir_bin());
+    cmd.arg("manifest");
+    cmd.args(args);
+    cmd.arg(root.to_string_lossy().into_owned());
+    let out = cmd.output().expect("run snapdir manifest");
+    assert!(
+        out.status.success(),
+        "snapdir manifest failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    String::from_utf8(out.stdout).expect("utf8 stdout")
+}
+
+/// Asserts that `stdout` mentions exactly the expected file basenames among
+/// `alpha beta gamma keep` (each as a `./<name>` PATH).
+fn assert_present(stdout: &str, present: &[&str], absent: &[&str]) {
+    for name in present {
+        assert!(
+            stdout.contains(&format!("./{name}")),
+            "expected {name} present in:\n{stdout}"
+        );
+    }
+    for name in absent {
+        assert!(
+            !stdout.contains(&format!("./{name}")),
+            "expected {name} absent in:\n{stdout}"
+        );
+    }
+}
+
+#[test]
+fn list_options_single_exclude_unchanged() {
+    // A single `--exclude` must behave exactly as before: drop only alpha.
+    let root = temp_tree("single");
+    build_tree(&root);
+    let out = manifest_stdout(&root, &["--exclude", "alpha"]);
+    assert_present(&out, &["beta.txt", "gamma.txt", "keep.txt"], &["alpha.txt"]);
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn list_options_repeated_exclude() {
+    // Repeated `--exclude a --exclude b` OR-combines: drop alpha AND beta.
+    let root = temp_tree("repeated");
+    build_tree(&root);
+    let out = manifest_stdout(&root, &["--exclude", "alpha", "--exclude", "beta"]);
+    assert_present(&out, &["gamma.txt", "keep.txt"], &["alpha.txt", "beta.txt"]);
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn list_options_comma_delimited() {
+    // A comma list `--exclude a,b` drops the same set as the repeated form.
+    let root = temp_tree("comma");
+    build_tree(&root);
+    let out = manifest_stdout(&root, &["--exclude", "alpha,beta"]);
+    assert_present(&out, &["gamma.txt", "keep.txt"], &["alpha.txt", "beta.txt"]);
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn list_options_mixed_comma_and_repeated() {
+    // Mixed `--exclude a,b --exclude c` OR-combines all three.
+    let root = temp_tree("mixed");
+    build_tree(&root);
+    let out = manifest_stdout(&root, &["--exclude", "alpha,beta", "--exclude", "gamma"]);
+    assert_present(&out, &["keep.txt"], &["alpha.txt", "beta.txt", "gamma.txt"]);
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn list_options_repeated_and_comma_match_same_set() {
+    // The comma form and the repeated form must drop the identical path set.
+    let root_a = temp_tree("eq-a");
+    let root_b = temp_tree("eq-b");
+    build_tree(&root_a);
+    build_tree(&root_b);
+    let comma = manifest_stdout(&root_a, &["--exclude", "alpha,gamma"]);
+    let repeated = manifest_stdout(&root_b, &["--exclude", "alpha", "--exclude", "gamma"]);
+    // Compare the surviving basenames (the absolute root differs between trees,
+    // but the `./`-relative PATHs are identical for the same exclude set).
+    assert_present(
+        &comma,
+        &["beta.txt", "keep.txt"],
+        &["alpha.txt", "gamma.txt"],
+    );
+    assert_present(
+        &repeated,
+        &["beta.txt", "keep.txt"],
+        &["alpha.txt", "gamma.txt"],
+    );
+    fs::remove_dir_all(&root_a).ok();
+    fs::remove_dir_all(&root_b).ok();
+}
+
+#[test]
+fn list_options_macro_combined_with_literal() {
+    // A `%common%` macro combined with a literal pattern proves per-pattern
+    // macro expansion: the macro expands to the common dir set (which includes
+    // `node_modules`) and still OR-combines with the literal `alpha`.
+    // `%common%` expands to `(/(…|node_modules|…)($|/))`, so a `node_modules/`
+    // subdir is dropped; `alpha.txt` is dropped by the literal; everything else
+    // survives. If the raw patterns were `|`-joined before expansion the macro
+    // token would be corrupted and `node_modules` would NOT be excluded.
+    let root = temp_tree("macro");
+    build_tree(&root);
+    fs::create_dir(root.join("node_modules")).unwrap();
+    fs::write(root.join("node_modules").join("pkg.txt"), b"p").unwrap();
+
+    let out = manifest_stdout(&root, &["--exclude", "%common%", "--exclude", "alpha"]);
+    // alpha dropped by the literal; the node_modules subtree dropped by %common%.
+    assert_present(&out, &["beta.txt", "gamma.txt", "keep.txt"], &["alpha.txt"]);
+    assert!(
+        !out.contains("node_modules"),
+        "node_modules excluded by %common% in:\n{out}"
+    );
+    fs::remove_dir_all(&root).ok();
+}
+
+#[test]
+fn list_options_subcommand_overrides_global_exclude() {
+    // Precedence: the `manifest` subcommand's `--exclude` (placed after the
+    // subcommand) overrides the global `--exclude` (placed before it). Here the
+    // global drops alpha, but the subcommand list (gamma) takes over, so alpha
+    // survives and gamma is dropped.
+    let root = temp_tree("precedence");
+    build_tree(&root);
+    let mut cmd = Command::new(snapdir_bin());
+    cmd.arg("--exclude").arg("alpha"); // global (before subcommand)
+    cmd.arg("manifest");
+    cmd.arg("--exclude").arg("gamma"); // subcommand override
+    cmd.arg(root.to_string_lossy().into_owned());
+    let out = cmd.output().expect("run snapdir manifest");
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    assert_present(
+        &stdout,
+        &["alpha.txt", "beta.txt", "keep.txt"],
+        &["gamma.txt"],
+    );
+    fs::remove_dir_all(&root).ok();
+}

--- a/crates/snapdir-stores/Cargo.toml
+++ b/crates/snapdir-stores/Cargo.toml
@@ -61,6 +61,14 @@ tokio = { version = "1", default-features = false, features = [
 # dependency-age cooldown (utils/ci/check-crate-age.sh).
 futures = "0.3"
 
+# `rayon` drives the LOCAL `FileStore` object copies (push/fetch_files) across a
+# bounded thread pool sized by `TransferConfig::concurrency`. Local copies have
+# no network bandwidth concern, so the async `run_concurrent`/RateLimiter path
+# (used by the network stores) does not apply here — only the concurrency cap.
+# Ancient/stable 1.x line, already in the lock graph transitively, so it
+# satisfies the dependency-age cooldown (utils/ci/check-crate-age.sh).
+rayon = "1"
+
 # --- GCS store (gs://) ------------------------------------------------------
 # CRITICAL TLS constraint (same as the S3 store): the shipped binary statically
 # links on musl, so the workspace standardizes on the `ring` rustls provider and

--- a/crates/snapdir-stores/Cargo.toml
+++ b/crates/snapdir-stores/Cargo.toml
@@ -48,7 +48,18 @@ aws-smithy-runtime-api = { version = "1", features = ["client", "http-1x"] }
 aws-smithy-http-client = { version = "1", default-features = false, features = [
     "rustls-ring",
 ] }
-tokio = { version = "1", default-features = false, features = ["rt-multi-thread"] }
+tokio = { version = "1", default-features = false, features = [
+    "rt-multi-thread",
+    "time",
+    "sync",
+] }
+
+# --- Transfer engine (concurrency + rate limiting) --------------------------
+# `futures` provides the bounded-concurrency stream combinator
+# (`buffer_unordered` / `try_collect`) used by `run_concurrent`. Ancient/stable
+# 0.3 line — already in the lock graph transitively, so it satisfies the
+# dependency-age cooldown (utils/ci/check-crate-age.sh).
+futures = "0.3"
 
 # --- GCS store (gs://) ------------------------------------------------------
 # CRITICAL TLS constraint (same as the S3 store): the shipped binary statically

--- a/crates/snapdir-stores/src/b2_store.rs
+++ b/crates/snapdir-stores/src/b2_store.rs
@@ -55,6 +55,7 @@ use snapdir_core::manifest::Manifest;
 use snapdir_core::store::{Store, StoreError};
 
 use crate::s3_store::{S3Location, S3Store};
+use crate::transfer::TransferConfig;
 
 /// The default Backblaze B2 region used when none is configured. Backblaze
 /// requires a region in the S3-compatible endpoint host; `us-west-004` is a
@@ -97,10 +98,29 @@ impl B2Store {
         endpoint_url: Option<&str>,
         region: Option<&str>,
     ) -> Result<Self, StoreError> {
+        Self::connect_with(store_url, endpoint_url, region, TransferConfig::default())
+    }
+
+    /// Like [`connect`](Self::connect), but carries a [`TransferConfig`] for
+    /// concurrency / bandwidth control. The config lives on the wrapped
+    /// [`S3Store`]; [`connect`](Self::connect) delegates here with
+    /// [`TransferConfig::default`].
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Backend`] if the tokio runtime cannot be created or the
+    /// AWS configuration cannot be loaded (propagated from
+    /// [`S3Store::connect_with`]).
+    pub fn connect_with(
+        store_url: &str,
+        endpoint_url: Option<&str>,
+        region: Option<&str>,
+        config: TransferConfig,
+    ) -> Result<Self, StoreError> {
         let endpoint = resolve_endpoint(endpoint_url, region);
         // S3Store::connect parses the URL with S3Location::parse, which derives
         // bucket/prefix identically for b2:// and s3:// (oracle cut -f3 / -f4-).
-        let inner = S3Store::connect(store_url, Some(endpoint.as_str()))?;
+        let inner = S3Store::connect_with(store_url, Some(endpoint.as_str()), config)?;
         Ok(Self { inner })
     }
 
@@ -115,6 +135,14 @@ impl B2Store {
     #[must_use]
     pub fn location(&self) -> &S3Location {
         self.inner.location()
+    }
+
+    /// The [`TransferConfig`] (concurrency / bandwidth) this store was built
+    /// with, carried on the wrapped [`S3Store`]. Consumed by the transfer loops
+    /// in later gates.
+    #[must_use]
+    pub fn transfer_config(&self) -> &TransferConfig {
+        self.inner.transfer_config()
     }
 }
 

--- a/crates/snapdir-stores/src/fetch.rs
+++ b/crates/snapdir-stores/src/fetch.rs
@@ -1,0 +1,392 @@
+//! Shared concurrent fetch orchestrator for object-store backends.
+//!
+//! `S3Store::fetch_files` and `GcsStore::fetch_files` are byte-identical except
+//! for the single per-object download call. [`fetch_files_concurrent`] factors
+//! out that loop so both backends download objects concurrently (bounded by the
+//! store's [`TransferConfig`] concurrency, throttled by a shared
+//! [`RateLimiter`]) while each backend injects only its own download closure.
+//!
+//! The orchestrator preserves every Bash/Phase-12 invariant of the original
+//! sequential loops:
+//!
+//! - **Skip-if-present-and-verified (Phase-12 pull-skip-existing):** a present
+//!   destination file whose content already hashes to the manifest checksum is
+//!   short-circuited *before any download* — the injected `download` closure is
+//!   never called for it, so a fully-materialized tree does zero downloads.
+//! - **Directories first, parents pre-created:** every `Directory` entry and
+//!   every to-download `File` entry's parent directory is created in a
+//!   sequential first pass, so the concurrent writers never race on
+//!   `create_dir_all`.
+//! - **Per-object verify + atomic write:** the `download` closure returns bytes
+//!   already BLAKE3-verified against the entry checksum (each backend's
+//!   `fetch_verified`, with its retry budget), then [`write_atomic`] renames a
+//!   temp sibling into place. Distinct entries are content-addressed to distinct
+//!   targets, so concurrent writes never collide.
+//! - **First error wins:** [`run_concurrent`] propagates the first download or
+//!   write error and cancels the rest.
+
+use std::path::Path;
+
+use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
+use snapdir_core::merkle::Blake3Hasher;
+use snapdir_core::store::StoreError;
+
+use crate::transfer::{run_concurrent, RateLimiter, TransferConfig};
+use crate::util::file_present_and_verified;
+
+/// Strips a leading `./` and a trailing `/` from a manifest path so the
+/// remainder can be joined onto a destination root (shared with the backends).
+fn strip_leading_dot_slash(path: &str) -> &str {
+    let trimmed = path.strip_prefix("./").unwrap_or(path);
+    trimmed.strip_suffix('/').unwrap_or(trimmed)
+}
+
+/// Writes `bytes` to `target` via a temp sibling + atomic rename (same fs).
+///
+/// Shared by the concurrent fetch tasks: each entry has a unique
+/// (content-addressed) target, so the per-write temp name only needs to be
+/// unique within a single target's directory, which the atomic counter + pid
+/// guarantee.
+pub(crate) fn write_atomic(target: &Path, bytes: &[u8]) -> Result<(), StoreError> {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    if let Some(parent) = target.parent() {
+        std::fs::create_dir_all(parent)?;
+    }
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let file_name = target
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let tmp = match target.parent() {
+        Some(parent) => parent.join(format!("{file_name}.{pid}.{n}.tmp")),
+        None => std::path::PathBuf::from(format!("{file_name}.{pid}.{n}.tmp")),
+    };
+    std::fs::write(&tmp, bytes)?;
+    std::fs::rename(&tmp, target)?;
+    Ok(())
+}
+
+/// Materializes `manifest` under `dest`, downloading the missing file objects
+/// concurrently.
+///
+/// `download` is the per-object download closure each backend injects: given a
+/// [`ManifestEntry`], it returns its already-verified object bytes (e.g.
+/// `S3Store::fetch_verified` / `GcsStore::fetch_verified`, which apply the
+/// per-object BLAKE3 verify + retry budget). The orchestrator owns the
+/// skip-present short-circuit, directory creation, rate limiting, bounded
+/// concurrency, and the atomic write.
+///
+/// # Errors
+///
+/// Propagates the first [`StoreError`] from directory creation, a `download`
+/// call, or an atomic write; remaining in-flight downloads are cancelled.
+pub(crate) async fn fetch_files_concurrent<'a, F, Fut>(
+    manifest: &'a Manifest,
+    dest: &Path,
+    config: &TransferConfig,
+    rate_limiter: &RateLimiter,
+    download: F,
+) -> Result<(), StoreError>
+where
+    F: Fn(&'a ManifestEntry) -> Fut,
+    Fut: std::future::Future<Output = Result<Vec<u8>, StoreError>>,
+{
+    let hasher = Blake3Hasher::new();
+
+    // First pass (sequential): create every directory, pre-create the parent of
+    // every file, and collect the file entries that still need downloading.
+    // Skip-if-present-and-verified short-circuits here, BEFORE any download.
+    let mut to_download: Vec<(&ManifestEntry, std::path::PathBuf)> = Vec::new();
+    for entry in manifest.entries() {
+        let rel = strip_leading_dot_slash(&entry.path);
+        let target = dest.join(rel);
+        match entry.path_type {
+            PathType::Directory => {
+                std::fs::create_dir_all(&target)?;
+            }
+            PathType::File => {
+                // A present, checksum-matching destination needs no download.
+                if file_present_and_verified(&target, &entry.checksum, &hasher) {
+                    continue;
+                }
+                if let Some(parent) = target.parent() {
+                    std::fs::create_dir_all(parent)?;
+                }
+                to_download.push((entry, target));
+            }
+        }
+    }
+
+    // Concurrent pass: download + atomically write each missing object, bounded
+    // by `config.concurrency` and throttled by the shared rate limiter.
+    run_concurrent(to_download, config.concurrency, |(entry, target)| {
+        let download = &download;
+        let rate_limiter = &rate_limiter;
+        async move {
+            // Throttle by the manifest-declared object size before fetching.
+            rate_limiter.acquire(entry.size).await;
+            let bytes = download(entry).await?;
+            write_atomic(&target, &bytes)?;
+            Ok(())
+        }
+    })
+    .await?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snapdir_core::merkle::Hasher;
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    /// Builds a multi-thread tokio runtime with time enabled, so the concurrent
+    /// downloads can genuinely overlap and the high-water mark is meaningful.
+    fn runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(4)
+            .enable_time()
+            .build()
+            .expect("build tokio runtime")
+    }
+
+    /// A tiny temp-dir helper so tests don't pull in a dev-dependency. Creates a
+    /// unique directory under the system temp dir and removes it on drop.
+    struct TempDir {
+        path: std::path::PathBuf,
+    }
+
+    impl TempDir {
+        fn new() -> Self {
+            static COUNTER: AtomicUsize = AtomicUsize::new(0);
+            let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path =
+                std::env::temp_dir().join(format!("snapdir-fetch-test-{}-{n}", std::process::id()));
+            std::fs::create_dir_all(&path).expect("create temp dir");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    /// BLAKE3 hex of `bytes`, used both to build manifest entries and to
+    /// pre-seed already-present destination files in the skip test.
+    fn checksum_of(bytes: &[u8]) -> String {
+        Blake3Hasher::new().hash_hex(bytes)
+    }
+
+    /// Builds a tiny manifest: a root dir entry plus one `File` entry per
+    /// `(rel_path, contents)`, with each file's checksum/size derived from its
+    /// contents so the skip-present check and rate-limit accounting are real.
+    fn manifest_for(files: &[(&str, &[u8])]) -> Manifest {
+        let mut m = Manifest::new();
+        m.push(ManifestEntry::new(
+            PathType::Directory,
+            "700",
+            "0".repeat(64),
+            0,
+            "./",
+        ));
+        for (path, contents) in files {
+            m.push(ManifestEntry::new(
+                PathType::File,
+                "600",
+                checksum_of(contents),
+                contents.len() as u64,
+                format!("./{path}"),
+            ));
+        }
+        Manifest::from_entries(m.entries().to_vec())
+    }
+
+    /// A fake download closure factory: returns canned bytes keyed by checksum,
+    /// records which checksums were requested, and tracks the high-water mark of
+    /// concurrently in-flight downloads.
+    struct FakeDownloader {
+        /// checksum -> canned bytes to return.
+        contents: HashMap<String, Vec<u8>>,
+        /// Checksums for which the closure was invoked (in call order).
+        called: Mutex<Vec<String>>,
+        /// Currently in-flight downloads.
+        in_flight: AtomicUsize,
+        /// Peak simultaneous in-flight downloads.
+        high_water: AtomicUsize,
+    }
+
+    impl FakeDownloader {
+        fn new(files: &[(&str, &[u8])]) -> Arc<Self> {
+            let contents = files
+                .iter()
+                .map(|(_, c)| (checksum_of(c), c.to_vec()))
+                .collect();
+            Arc::new(Self {
+                contents,
+                called: Mutex::new(Vec::new()),
+                in_flight: AtomicUsize::new(0),
+                high_water: AtomicUsize::new(0),
+            })
+        }
+
+        async fn download(&self, entry: &ManifestEntry) -> Result<Vec<u8>, StoreError> {
+            self.called.lock().unwrap().push(entry.checksum.clone());
+            let cur = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.high_water.fetch_max(cur, Ordering::SeqCst);
+            // Hold the slot briefly so concurrent calls actually overlap.
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            self.in_flight.fetch_sub(1, Ordering::SeqCst);
+            self.contents
+                .get(&entry.checksum)
+                .cloned()
+                .ok_or_else(|| StoreError::ObjectNotFound {
+                    checksum: entry.checksum.clone(),
+                })
+        }
+    }
+
+    #[test]
+    fn concurrent_download_orchestrator_materializes_all() {
+        let files: &[(&str, &[u8])] = &[
+            ("a.txt", b"alpha" as &[u8]),
+            ("nested/b.txt", b"bravo"),
+            ("nested/deep/c.txt", b"charlie"),
+            ("d.txt", b"delta"),
+        ];
+        let manifest = manifest_for(files);
+
+        for concurrency in [1usize, 4] {
+            let dest = TempDir::new();
+            let fake = FakeDownloader::new(files);
+            let cfg = TransferConfig::new(concurrency, None);
+            let limiter = RateLimiter::new(None);
+
+            let rt = runtime();
+            let fake_ref = Arc::clone(&fake);
+            rt.block_on(async {
+                fetch_files_concurrent(&manifest, dest.path(), &cfg, &limiter, |entry| {
+                    let fake = Arc::clone(&fake_ref);
+                    async move { fake.download(entry).await }
+                })
+                .await
+            })
+            .expect("orchestrator must succeed");
+
+            // Every file landed at the right path with the right bytes.
+            for (path, contents) in files {
+                let got = std::fs::read(dest.path().join(path))
+                    .unwrap_or_else(|e| panic!("missing {path}: {e}"));
+                assert_eq!(&got, contents, "wrong bytes for {path}");
+            }
+            // Directory was created.
+            assert!(dest.path().join("nested/deep").is_dir());
+
+            // High-water mark == min(concurrency, n) for >1, == 1 at concurrency 1.
+            let hw = fake.high_water.load(Ordering::SeqCst);
+            let expected = concurrency.min(files.len());
+            assert_eq!(
+                hw, expected,
+                "concurrency={concurrency}: peak in-flight {hw} != expected {expected}"
+            );
+        }
+    }
+
+    #[test]
+    fn concurrent_download_skips_present_and_verified() {
+        let files: &[(&str, &[u8])] = &[
+            ("present.txt", b"already-here" as &[u8]),
+            ("missing.txt", b"needs-download"),
+        ];
+        let manifest = manifest_for(files);
+
+        let dest = TempDir::new();
+        // Pre-create `present.txt` with the exact verified contents.
+        std::fs::write(dest.path().join("present.txt"), b"already-here").unwrap();
+
+        let fake = FakeDownloader::new(files);
+        let cfg = TransferConfig::new(4, None);
+        let limiter = RateLimiter::new(None);
+
+        let rt = runtime();
+        let fake_ref = Arc::clone(&fake);
+        rt.block_on(async {
+            fetch_files_concurrent(&manifest, dest.path(), &cfg, &limiter, |entry| {
+                let fake = Arc::clone(&fake_ref);
+                async move { fake.download(entry).await }
+            })
+            .await
+        })
+        .expect("orchestrator must succeed");
+
+        // The present+verified file triggered ZERO downloads; only the missing
+        // file's checksum was requested.
+        let called = fake.called.lock().unwrap().clone();
+        let present_sum = checksum_of(b"already-here");
+        let missing_sum = checksum_of(b"needs-download");
+        assert!(
+            !called.contains(&present_sum),
+            "present+verified file must not be downloaded"
+        );
+        assert_eq!(
+            called,
+            vec![missing_sum],
+            "only the missing file should be downloaded"
+        );
+
+        // The missing file was still materialized.
+        assert_eq!(
+            std::fs::read(dest.path().join("missing.txt")).unwrap(),
+            b"needs-download"
+        );
+    }
+
+    #[test]
+    fn concurrent_download_propagates_error() {
+        let files: &[(&str, &[u8])] = &[
+            ("ok1.txt", b"one" as &[u8]),
+            ("boom.txt", b"two"),
+            ("ok2.txt", b"three"),
+        ];
+        let manifest = manifest_for(files);
+        let boom_sum = checksum_of(b"two");
+
+        let dest = TempDir::new();
+        let cfg = TransferConfig::new(4, None);
+        let limiter = RateLimiter::new(None);
+
+        let rt = runtime();
+        let boom = boom_sum.clone();
+        let result = rt.block_on(async {
+            fetch_files_concurrent(&manifest, dest.path(), &cfg, &limiter, |entry| {
+                let boom = boom.clone();
+                async move {
+                    if entry.checksum == boom {
+                        return Err(StoreError::Backend {
+                            message: "download blew up".to_owned(),
+                            source: None,
+                        });
+                    }
+                    Ok(b"unused".to_vec())
+                }
+            })
+            .await
+        });
+
+        let err = result.expect_err("the failing download must surface");
+        assert!(
+            matches!(err, StoreError::Backend { ref message, .. } if message == "download blew up"),
+            "unexpected error: {err:?}"
+        );
+    }
+}

--- a/crates/snapdir-stores/src/file_store.rs
+++ b/crates/snapdir-stores/src/file_store.rs
@@ -37,6 +37,8 @@ use snapdir_core::manifest::{Manifest, PathType};
 use snapdir_core::merkle::{Blake3Hasher, Hasher};
 use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
 
+use crate::util::{file_present_and_verified, hash_file};
+
 /// Number of times the oracle retries a persist whose copied bytes fail their
 /// checksum but whose source still verifies (`_SNAPDIR_FILE_STORE_RETRIES`).
 const MAX_PERSIST_RETRIES: u32 = 5;
@@ -131,6 +133,15 @@ impl Store for FileStore {
                     fs::create_dir_all(&target)?;
                 }
                 PathType::File => {
+                    // Skip-if-present-and-verified: a destination file that
+                    // already exists and whose content hashes to the manifest's
+                    // checksum needs no copy — and critically no object read at
+                    // all (so a populated dest succeeds even if the store object
+                    // is gone). A mismatching/corrupt local file falls through
+                    // and is repaired by the persist below.
+                    if file_present_and_verified(&target, &entry.checksum, &hasher) {
+                        continue;
+                    }
                     if let Some(parent) = target.parent() {
                         fs::create_dir_all(parent)?;
                     }
@@ -277,12 +288,6 @@ fn write_manifest(
 fn copy_file(source: &Path, target: &Path) -> Result<(), StoreError> {
     fs::copy(source, target)?;
     Ok(())
-}
-
-/// Hashes a file's full byte content with `hasher`.
-fn hash_file(path: &Path, hasher: &impl Hasher) -> Result<String, StoreError> {
-    let bytes = fs::read(path)?;
-    Ok(hasher.hash_hex(&bytes))
 }
 
 /// Builds a unique temp sibling path for `target` (same directory, so the
@@ -642,6 +647,117 @@ mod tests {
         }
         // The corrupt object must NOT have been materialized at the dest.
         assert!(!dest_dir.path().join("foo").exists());
+    }
+
+    #[test]
+    fn fetch_skip_present_verified() {
+        // Push a tree, fetch it (populating dest), then DELETE the store's whole
+        // `.objects` tree so any object read would now fail with ObjectNotFound.
+        // A second fetch into the SAME dest must still return Ok — proving every
+        // file was skipped via local checksum match (ZERO object reads).
+        let store_dir = TempDir::new("store");
+        let src_dir = TempDir::new("src");
+        let dest_dir = TempDir::new("dest");
+        let (manifest, id) = make_foo_bar_source(src_dir.path());
+
+        let store = FileStore::from_root(store_dir.path());
+        store.push(&manifest, src_dir.path()).expect("push");
+
+        let fetched = store.get_manifest(&id).expect("get manifest");
+        store
+            .fetch_files(&fetched, dest_dir.path())
+            .expect("first fetch populates dest");
+        assert_eq!(fs::read(dest_dir.path().join("foo")).unwrap(), b"foo\n");
+        assert_eq!(fs::read(dest_dir.path().join("bar")).unwrap(), b"bar\n");
+
+        // Nuke every object in the store. Any read of an object now fails.
+        let objects = store_dir.path().join(".objects");
+        fs::remove_dir_all(&objects).expect("remove .objects tree");
+        assert!(!objects.exists());
+
+        // Second fetch into the populated dest must succeed without reading a
+        // single (now-missing) object.
+        store
+            .fetch_files(&fetched, dest_dir.path())
+            .expect("second fetch skips every present+verified file (no object reads)");
+
+        // Dest contents intact.
+        assert_eq!(fs::read(dest_dir.path().join("foo")).unwrap(), b"foo\n");
+        assert_eq!(fs::read(dest_dir.path().join("bar")).unwrap(), b"bar\n");
+    }
+
+    #[test]
+    fn file_store_fetch_repairs_corrupt_dest_and_skips_intact() {
+        // With store objects present: corrupt one dest file. The corrupted file
+        // is re-fetched (repaired) to match its checksum again, while an
+        // unrelated already-correct dest file is still skipped.
+        let store_dir = TempDir::new("store");
+        let src_dir = TempDir::new("src");
+        let dest_dir = TempDir::new("dest");
+        let (manifest, id) = make_foo_bar_source(src_dir.path());
+
+        let store = FileStore::from_root(store_dir.path());
+        store.push(&manifest, src_dir.path()).expect("push");
+        let fetched = store.get_manifest(&id).expect("get manifest");
+        store
+            .fetch_files(&fetched, dest_dir.path())
+            .expect("first fetch populates dest");
+
+        // Corrupt `foo` in the dest; leave `bar` correct.
+        fs::write(dest_dir.path().join("foo"), b"WRONG\n").unwrap();
+        // Remove `bar`'s store object so it CANNOT be re-fetched; the only way a
+        // second fetch can succeed is if `bar` is skipped (present + verified).
+        let bar_entry = manifest
+            .entries()
+            .iter()
+            .find(|e| e.path == "./bar")
+            .unwrap();
+        let bar_obj = store_dir.path().join(object_path(&bar_entry.checksum));
+        fs::remove_file(&bar_obj).unwrap();
+
+        store
+            .fetch_files(&fetched, dest_dir.path())
+            .expect("repair corrupt foo, skip intact bar");
+
+        // foo repaired back to its checksummed content; bar untouched.
+        assert_eq!(fs::read(dest_dir.path().join("foo")).unwrap(), b"foo\n");
+        assert_eq!(fs::read(dest_dir.path().join("bar")).unwrap(), b"bar\n");
+    }
+
+    #[test]
+    fn file_store_fetch_mismatch_then_missing_object_errors() {
+        // Confirms the skip is checksum-gated, not mere existence: corrupt a
+        // dest file AND remove its store object → fetch cannot repair and errors
+        // ObjectNotFound (it did not blindly skip the present-but-wrong file).
+        let store_dir = TempDir::new("store");
+        let src_dir = TempDir::new("src");
+        let dest_dir = TempDir::new("dest");
+        let (manifest, id) = make_foo_bar_source(src_dir.path());
+
+        let store = FileStore::from_root(store_dir.path());
+        store.push(&manifest, src_dir.path()).expect("push");
+        let fetched = store.get_manifest(&id).expect("get manifest");
+        store
+            .fetch_files(&fetched, dest_dir.path())
+            .expect("first fetch populates dest");
+
+        let foo_entry = manifest
+            .entries()
+            .iter()
+            .find(|e| e.path == "./foo")
+            .unwrap();
+        // Corrupt the dest file so the skip gate fails for it...
+        fs::write(dest_dir.path().join("foo"), b"WRONG\n").unwrap();
+        // ...and remove its store object so it cannot be repaired.
+        let foo_obj = store_dir.path().join(object_path(&foo_entry.checksum));
+        fs::remove_file(&foo_obj).unwrap();
+
+        match store.fetch_files(&fetched, dest_dir.path()) {
+            Err(StoreError::ObjectNotFound { checksum }) => {
+                assert_eq!(checksum, foo_entry.checksum);
+            }
+            other => panic!("expected ObjectNotFound (cannot repair), got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/snapdir-stores/src/file_store.rs
+++ b/crates/snapdir-stores/src/file_store.rs
@@ -37,6 +37,7 @@ use snapdir_core::manifest::{Manifest, PathType};
 use snapdir_core::merkle::{Blake3Hasher, Hasher};
 use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
 
+use crate::transfer::TransferConfig;
 use crate::util::{file_present_and_verified, hash_file};
 
 /// Number of times the oracle retries a persist whose copied bytes fail their
@@ -51,6 +52,7 @@ const MAX_PERSIST_RETRIES: u32 = 5;
 #[derive(Debug, Clone)]
 pub struct FileStore {
     root: PathBuf,
+    config: TransferConfig,
 }
 
 impl FileStore {
@@ -66,16 +68,41 @@ impl FileStore {
         Self::from_root(parse_store_dir(store))
     }
 
+    /// Like [`new`](Self::new), but carries a [`TransferConfig`] for
+    /// concurrency / bandwidth control.
+    #[must_use]
+    pub fn new_with_config(store: &str, config: TransferConfig) -> Self {
+        Self::from_root_with_config(parse_store_dir(store), config)
+    }
+
     /// Builds a store rooted at an already-resolved directory.
     #[must_use]
     pub fn from_root(root: impl Into<PathBuf>) -> Self {
-        Self { root: root.into() }
+        Self::from_root_with_config(root, TransferConfig::default())
+    }
+
+    /// Like [`from_root`](Self::from_root), but carries a [`TransferConfig`] for
+    /// concurrency / bandwidth control. [`from_root`](Self::from_root) and
+    /// [`new`](Self::new) delegate here with [`TransferConfig::default`].
+    #[must_use]
+    pub fn from_root_with_config(root: impl Into<PathBuf>, config: TransferConfig) -> Self {
+        Self {
+            root: root.into(),
+            config,
+        }
     }
 
     /// Returns the store's root directory.
     #[must_use]
     pub fn root(&self) -> &Path {
         &self.root
+    }
+
+    /// The [`TransferConfig`] (concurrency / bandwidth) this store was built
+    /// with. Consumed by the transfer loops in later gates.
+    #[must_use]
+    pub fn transfer_config(&self) -> &TransferConfig {
+        &self.config
     }
 
     /// Absolute on-disk path of an object given its checksum.

--- a/crates/snapdir-stores/src/file_store.rs
+++ b/crates/snapdir-stores/src/file_store.rs
@@ -114,6 +114,37 @@ impl FileStore {
     fn manifest_disk_path(&self, id: &str) -> PathBuf {
         self.root.join(manifest_path(id))
     }
+
+    /// Copies a batch of `(source, target, expected_checksum)` jobs through
+    /// [`persist`] across a thread pool bounded by `self.config.concurrency`.
+    ///
+    /// Local copies have no network bandwidth concern, so the async
+    /// rate-limited transfer driver does not apply here — only the concurrency
+    /// cap. The first [`StoreError`] is propagated and stops scheduling further
+    /// work (`try_for_each`). A `concurrency` of 1 yields a single-threaded
+    /// sequential copy. Each task uses a fresh, cheap, stateless
+    /// [`Blake3Hasher`] to sidestep any `Sync` concern.
+    fn parallel_copy(&self, jobs: &[(PathBuf, PathBuf, String)]) -> Result<(), StoreError> {
+        use rayon::prelude::*;
+
+        if jobs.is_empty() {
+            return Ok(());
+        }
+
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(self.config.concurrency.get())
+            .build()
+            .map_err(|err| StoreError::Backend {
+                message: "failed to build copy thread pool".to_owned(),
+                source: Some(Box::new(err)),
+            })?;
+
+        pool.install(|| {
+            jobs.par_iter().try_for_each(|(source, target, expected)| {
+                persist(source, target, expected, &Blake3Hasher::new())
+            })
+        })
+    }
 }
 
 impl Store for FileStore {
@@ -152,6 +183,17 @@ impl Store for FileStore {
 
     fn fetch_files(&self, manifest: &Manifest, dest: &Path) -> Result<(), StoreError> {
         let hasher = Blake3Hasher::new();
+
+        // First, SEQUENTIAL pass: materialize every directory and pre-create
+        // each file's parent (so the parallel copies below never race on
+        // `create_dir_all` of the same ancestor), short-circuit files that are
+        // already present-and-verified (skip-if-present-and-verified — no object
+        // read at all, so a populated dest succeeds even if the store object is
+        // gone), and confirm the source object exists for the rest (preserving
+        // the `ObjectNotFound` error when a needed source is missing). The file
+        // entries that actually need copying are collected as `(source, target,
+        // checksum)` jobs for the parallel phase.
+        let mut jobs: Vec<(PathBuf, PathBuf, String)> = Vec::new();
         for entry in manifest.entries() {
             let rel = strip_leading_dot_slash(&entry.path);
             let target = dest.join(rel);
@@ -160,12 +202,10 @@ impl Store for FileStore {
                     fs::create_dir_all(&target)?;
                 }
                 PathType::File => {
-                    // Skip-if-present-and-verified: a destination file that
-                    // already exists and whose content hashes to the manifest's
-                    // checksum needs no copy — and critically no object read at
-                    // all (so a populated dest succeeds even if the store object
-                    // is gone). A mismatching/corrupt local file falls through
-                    // and is repaired by the persist below.
+                    // A destination file that already exists and whose content
+                    // hashes to the manifest's checksum needs no copy. A
+                    // mismatching/corrupt local file falls through and is
+                    // repaired by the persist below.
                     if file_present_and_verified(&target, &entry.checksum, &hasher) {
                         continue;
                     }
@@ -178,11 +218,15 @@ impl Store for FileStore {
                             checksum: entry.checksum.clone(),
                         });
                     }
-                    persist(&source, &target, &entry.checksum, &hasher)?;
+                    jobs.push((source, target, entry.checksum.clone()));
                 }
             }
         }
-        Ok(())
+
+        // Parallel copy phase, bounded by `config.concurrency`. `try_for_each`
+        // propagates the first `StoreError` and stops scheduling new work. Each
+        // task uses a fresh, cheap, stateless `Blake3Hasher`.
+        self.parallel_copy(&jobs)
     }
 
     fn push(&self, manifest: &Manifest, source: &Path) -> Result<(), StoreError> {
@@ -199,21 +243,28 @@ impl Store for FileStore {
             return Ok(());
         }
 
-        // Push every referenced object that is absent, BEFORE the manifest.
+        // Collect every referenced object that is absent (skip-if-present per
+        // object: an object already filed under its content address is trusted,
+        // it is content-addressable). These are copied BEFORE the manifest.
+        let mut jobs: Vec<(PathBuf, PathBuf, String)> = Vec::new();
         for entry in manifest.entries() {
             if entry.path_type != PathType::File {
                 continue;
             }
             let object_target = self.object_disk_path(&entry.checksum);
             if object_target.exists() {
-                // Skip-if-present per object: trust an object already filed
-                // under its content address (it is content-addressable).
                 continue;
             }
             let rel = strip_leading_dot_slash(&entry.path);
             let object_source = source.join(rel);
-            persist(&object_source, &object_target, &entry.checksum, &hasher)?;
+            jobs.push((object_source, object_target, entry.checksum.clone()));
         }
+
+        // Parallel copy phase, bounded by `config.concurrency`. ALL-OR-NOTHING:
+        // any error returns immediately and NO manifest is written; the
+        // manifest is written only after every object copy succeeds, preserving
+        // the invariant that a present manifest implies present objects.
+        self.parallel_copy(&jobs)?;
 
         // Write the manifest last, via the same verify/retry/atomic-rename
         // path, so a present manifest always implies present objects.
@@ -784,6 +835,224 @@ mod tests {
                 assert_eq!(checksum, foo_entry.checksum);
             }
             other => panic!("expected ObjectNotFound (cannot repair), got {other:?}"),
+        }
+    }
+
+    /// Builds a small nested tree under `source` (several files across nested
+    /// directories) and returns its manifest + snapshot id, with real BLAKE3
+    /// checksums so store verification passes. Layout:
+    ///
+    /// ```text
+    /// ./a.txt            "a contents\n"
+    /// ./b.txt            "b contents\n"
+    /// ./sub/             (dir)
+    /// ./sub/c.txt        "c contents\n"
+    /// ./sub/deep/        (dir)
+    /// ./sub/deep/d.txt   "d contents\n"
+    /// ```
+    fn make_nested_source(source: &Path) -> (Manifest, String) {
+        let hasher = Blake3Hasher::new();
+        let files: &[(&str, &[u8])] = &[
+            ("a.txt", b"a contents\n"),
+            ("b.txt", b"b contents\n"),
+            ("sub/c.txt", b"c contents\n"),
+            ("sub/deep/d.txt", b"d contents\n"),
+        ];
+
+        fs::create_dir_all(source.join("sub/deep")).unwrap();
+        for (rel, bytes) in files {
+            fs::write(source.join(rel), bytes).unwrap();
+        }
+
+        let mut manifest = Manifest::new();
+        // Directory entries first; their checksums/sizes are not verified on
+        // fetch (only files are content-addressed), so placeholder values are
+        // fine for re-materialization. The snapshot id derivation in core hashes
+        // the rendered text regardless, and we round-trip through it below.
+        manifest.push(ManifestEntry::new(PathType::Directory, "700", "x", 0, "./"));
+        manifest.push(ManifestEntry::new(
+            PathType::Directory,
+            "700",
+            "x",
+            0,
+            "./sub/",
+        ));
+        manifest.push(ManifestEntry::new(
+            PathType::Directory,
+            "700",
+            "x",
+            0,
+            "./sub/deep/",
+        ));
+        for (rel, bytes) in files {
+            let sum = hasher.hash_hex(bytes);
+            #[allow(clippy::cast_possible_truncation)]
+            manifest.push(ManifestEntry::new(
+                PathType::File,
+                "600",
+                sum,
+                bytes.len() as u64,
+                format!("./{rel}"),
+            ));
+        }
+
+        let manifest = Manifest::from_entries(manifest.entries().to_vec());
+        let id = snapdir_core::merkle::snapshot_id(&manifest, &hasher);
+        (manifest, id)
+    }
+
+    /// Asserts the four nested files re-materialized byte-identically at `dest`.
+    fn assert_nested_dest(dest: &Path) {
+        assert_eq!(fs::read(dest.join("a.txt")).unwrap(), b"a contents\n");
+        assert_eq!(fs::read(dest.join("b.txt")).unwrap(), b"b contents\n");
+        assert_eq!(fs::read(dest.join("sub/c.txt")).unwrap(), b"c contents\n");
+        assert_eq!(
+            fs::read(dest.join("sub/deep/d.txt")).unwrap(),
+            b"d contents\n"
+        );
+    }
+
+    #[test]
+    fn filestore_parallel_roundtrip_byte_identical() {
+        // A multi-threaded (concurrency=4) push+fetch round-trip of a nested
+        // tree must re-materialize byte-identically, and a sequential
+        // (concurrency=1) run must produce the identical store + dest.
+        let src_dir = TempDir::new("src");
+        let (manifest, id) = make_nested_source(src_dir.path());
+
+        // Parallel run.
+        let par_store_dir = TempDir::new("store-par");
+        let par_dest_dir = TempDir::new("dest-par");
+        let par_store =
+            FileStore::from_root_with_config(par_store_dir.path(), TransferConfig::new(4, None));
+        par_store.push(&manifest, src_dir.path()).expect("par push");
+        let par_manifest = par_store.get_manifest(&id).expect("par get manifest");
+        assert_eq!(par_manifest, manifest, "round-tripped manifest matches");
+        par_store
+            .fetch_files(&par_manifest, par_dest_dir.path())
+            .expect("par fetch");
+        assert_nested_dest(par_dest_dir.path());
+
+        // Sequential run into a fresh store/dest.
+        let seq_store_dir = TempDir::new("store-seq");
+        let seq_dest_dir = TempDir::new("dest-seq");
+        let seq_store =
+            FileStore::from_root_with_config(seq_store_dir.path(), TransferConfig::new(1, None));
+        seq_store.push(&manifest, src_dir.path()).expect("seq push");
+        let seq_id = snapdir_core::merkle::snapshot_id(&manifest, &Blake3Hasher::new());
+        assert_eq!(seq_id, id, "snapshot id is concurrency-independent");
+        seq_store
+            .fetch_files(&manifest, seq_dest_dir.path())
+            .expect("seq fetch");
+        assert_nested_dest(seq_dest_dir.path());
+
+        // Both stores landed every object at the identical sharded key with
+        // identical bytes.
+        for entry in manifest.entries() {
+            if entry.path_type != PathType::File {
+                continue;
+            }
+            let key = object_path(&entry.checksum);
+            let par_obj = par_store_dir.path().join(&key);
+            let seq_obj = seq_store_dir.path().join(&key);
+            assert!(par_obj.exists(), "par object {key} present");
+            assert!(seq_obj.exists(), "seq object {key} present");
+            assert_eq!(
+                fs::read(&par_obj).unwrap(),
+                fs::read(&seq_obj).unwrap(),
+                "par and seq object bytes identical"
+            );
+        }
+    }
+
+    #[test]
+    fn filestore_parallel_concurrency_one_sequential() {
+        // The concurrency=1 (single-thread pool) path is a correct sequential
+        // copy: round-trips byte-identically.
+        let store_dir = TempDir::new("store");
+        let src_dir = TempDir::new("src");
+        let dest_dir = TempDir::new("dest");
+        let (manifest, id) = make_nested_source(src_dir.path());
+
+        let store =
+            FileStore::from_root_with_config(store_dir.path(), TransferConfig::new(1, None));
+        store.push(&manifest, src_dir.path()).expect("push");
+        let fetched = store.get_manifest(&id).expect("get manifest");
+        store.fetch_files(&fetched, dest_dir.path()).expect("fetch");
+        assert_nested_dest(dest_dir.path());
+    }
+
+    #[test]
+    fn filestore_parallel_all_or_nothing_bad_object() {
+        // A source file whose bytes do not match its manifest checksum must make
+        // push fail with `Integrity` AND write NO manifest (all-or-nothing:
+        // manifest is written only after every parallel object copy succeeds).
+        let store_dir = TempDir::new("store");
+        let src_dir = TempDir::new("src");
+        let (manifest, id) = make_nested_source(src_dir.path());
+
+        // Corrupt one source file so its bytes no longer hash to the manifest
+        // checksum; persist's source-verify trips and push returns Integrity.
+        fs::write(src_dir.path().join("sub/c.txt"), b"TAMPERED\n").unwrap();
+
+        let store =
+            FileStore::from_root_with_config(store_dir.path(), TransferConfig::new(4, None));
+        match store.push(&manifest, src_dir.path()) {
+            Err(StoreError::Integrity { .. }) => {}
+            other => panic!("expected Integrity from bad source object, got {other:?}"),
+        }
+
+        // ALL-OR-NOTHING: the manifest must NOT have been written.
+        let man_path = store.manifest_disk_path(&id);
+        assert!(
+            !man_path.exists(),
+            "manifest must not be written when an object copy fails"
+        );
+    }
+
+    #[test]
+    fn filestore_parallel_large_n_round_trips() {
+        // Exercise the concurrency bound with N >> concurrency files.
+        let store_dir = TempDir::new("store");
+        let src_dir = TempDir::new("src");
+        let dest_dir = TempDir::new("dest");
+        let hasher = Blake3Hasher::new();
+
+        let mut manifest = Manifest::new();
+        manifest.push(ManifestEntry::new(PathType::Directory, "700", "x", 0, "./"));
+        let n = 50usize;
+        for i in 0..n {
+            let name = format!("file-{i:03}.txt");
+            let contents = format!("contents of file {i}\n");
+            fs::write(src_dir.path().join(&name), contents.as_bytes()).unwrap();
+            let sum = hasher.hash_hex(contents.as_bytes());
+            #[allow(clippy::cast_possible_truncation)]
+            manifest.push(ManifestEntry::new(
+                PathType::File,
+                "600",
+                sum,
+                contents.len() as u64,
+                format!("./{name}"),
+            ));
+        }
+        let manifest = Manifest::from_entries(manifest.entries().to_vec());
+        let id = snapdir_core::merkle::snapshot_id(&manifest, &hasher);
+
+        let store =
+            FileStore::from_root_with_config(store_dir.path(), TransferConfig::new(4, None));
+        store.push(&manifest, src_dir.path()).expect("push N files");
+        let fetched = store.get_manifest(&id).expect("get manifest");
+        store
+            .fetch_files(&fetched, dest_dir.path())
+            .expect("fetch N files");
+
+        for i in 0..n {
+            let name = format!("file-{i:03}.txt");
+            let expected = format!("contents of file {i}\n");
+            assert_eq!(
+                fs::read(dest_dir.path().join(&name)).unwrap(),
+                expected.as_bytes()
+            );
         }
     }
 

--- a/crates/snapdir-stores/src/gcs_store.rs
+++ b/crates/snapdir-stores/src/gcs_store.rs
@@ -56,6 +56,8 @@ use google_cloud_storage::client::{Storage, StorageControl};
 use snapdir_core::manifest::{Manifest, PathType};
 use snapdir_core::merkle::{Blake3Hasher, Hasher};
 use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
+
+use crate::util::file_present_and_verified;
 use tokio::runtime::Runtime;
 
 /// Number of times a fetch is retried when the downloaded bytes fail their
@@ -345,6 +347,7 @@ impl Store for GcsStore {
     }
 
     fn fetch_files(&self, manifest: &Manifest, dest: &Path) -> Result<(), StoreError> {
+        let hasher = Blake3Hasher::new();
         self.runtime.block_on(async {
             for entry in manifest.entries() {
                 let rel = strip_leading_dot_slash(&entry.path);
@@ -354,6 +357,13 @@ impl Store for GcsStore {
                         std::fs::create_dir_all(&target)?;
                     }
                     PathType::File => {
+                        // Skip-if-present-and-verified: avoid the network GET
+                        // entirely when the destination file already exists and
+                        // hashes to the manifest's checksum. A corrupt/mismatched
+                        // local file falls through and is repaired below.
+                        if file_present_and_verified(&target, &entry.checksum, &hasher) {
+                            continue;
+                        }
                         if let Some(parent) = target.parent() {
                             std::fs::create_dir_all(parent)?;
                         }

--- a/crates/snapdir-stores/src/gcs_store.rs
+++ b/crates/snapdir-stores/src/gcs_store.rs
@@ -57,6 +57,7 @@ use snapdir_core::manifest::{Manifest, PathType};
 use snapdir_core::merkle::{Blake3Hasher, Hasher};
 use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
 
+use crate::transfer::TransferConfig;
 use crate::util::file_present_and_verified;
 use tokio::runtime::Runtime;
 
@@ -151,6 +152,7 @@ pub struct GcsStore {
     control: StorageControl,
     location: GcsLocation,
     runtime: Arc<Runtime>,
+    config: TransferConfig,
 }
 
 impl GcsStore {
@@ -166,6 +168,18 @@ impl GcsStore {
     /// [`StoreError::Backend`] if the tokio runtime cannot be created or the SDK
     /// clients cannot be built (e.g. credentials cannot be resolved).
     pub fn connect(store_url: &str) -> Result<Self, StoreError> {
+        Self::connect_with(store_url, TransferConfig::default())
+    }
+
+    /// Like [`connect`](Self::connect), but carries a [`TransferConfig`] for
+    /// concurrency / bandwidth control. The existing [`connect`](Self::connect)
+    /// delegates here with [`TransferConfig::default`].
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Backend`] if the tokio runtime cannot be created or the SDK
+    /// clients cannot be built (e.g. credentials cannot be resolved).
+    pub fn connect_with(store_url: &str, config: TransferConfig) -> Result<Self, StoreError> {
         let location = GcsLocation::parse(store_url);
         let runtime = build_runtime()?;
         install_ring_provider();
@@ -187,6 +201,7 @@ impl GcsStore {
             control,
             location,
             runtime: Arc::new(runtime),
+            config,
         })
     }
 
@@ -206,6 +221,7 @@ impl GcsStore {
             control,
             location,
             runtime: Arc::new(build_runtime()?),
+            config: TransferConfig::default(),
         })
     }
 
@@ -213,6 +229,13 @@ impl GcsStore {
     #[must_use]
     pub fn location(&self) -> &GcsLocation {
         &self.location
+    }
+
+    /// The [`TransferConfig`] (concurrency / bandwidth) this store was built
+    /// with. Consumed by the transfer loops in later gates.
+    #[must_use]
+    pub fn transfer_config(&self) -> &TransferConfig {
+        &self.config
     }
 
     /// Metadata HEAD on an object key; `Ok(true)` if it exists, `Ok(false)` if

--- a/crates/snapdir-stores/src/gcs_store.rs
+++ b/crates/snapdir-stores/src/gcs_store.rs
@@ -53,11 +53,12 @@ use std::sync::Arc;
 use google_cloud_gax::error::rpc::Code;
 use google_cloud_gax::error::Error as GcsError;
 use google_cloud_storage::client::{Storage, StorageControl};
-use snapdir_core::manifest::{Manifest, PathType};
+use snapdir_core::manifest::Manifest;
 use snapdir_core::merkle::{Blake3Hasher, Hasher};
 use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
 
 use crate::fetch::fetch_files_concurrent;
+use crate::push::{push_objects_concurrent, upload_object};
 use crate::transfer::{RateLimiter, TransferConfig};
 use tokio::runtime::Runtime;
 
@@ -389,54 +390,51 @@ impl Store for GcsStore {
         let hasher = Blake3Hasher::new();
         let id = snapdir_core::merkle::snapshot_id(manifest, &hasher);
 
+        // Concurrent upload via the shared orchestrator: it owns the bounded
+        // per-object pass and the manifest-last / all-or-nothing ordering. GCS
+        // injects the per-object skip-present + upload (via `upload_object`,
+        // which also owns the shared read+verify) and the manifest-write
+        // closure. A failed push writes NO manifest.
+        let limiter = RateLimiter::new(self.config.max_bytes_per_sec);
         self.runtime.block_on(async {
-            // Skip-if-present: a present manifest implies all its objects are
-            // present (we always write the manifest last).
+            // Skip-if-manifest-present pre-check: a present manifest implies all
+            // its objects are present (we always write the manifest last).
             let manifest_key = self.location.manifest_key(&id);
             if self.key_exists(&manifest_key).await? {
                 return Ok(());
             }
 
-            // Push every referenced object that is absent, BEFORE the manifest.
-            for entry in manifest.entries() {
-                if entry.path_type != PathType::File {
-                    continue;
-                }
-                let object_key = self.location.object_key(&entry.checksum);
-                if self.key_exists(&object_key).await? {
-                    // Skip-if-present per object (content-addressable).
-                    continue;
-                }
-                let rel = strip_leading_dot_slash(&entry.path);
-                let object_source = source.join(rel);
-                let bytes = std::fs::read(&object_source)?;
-                // Verify the source still matches its manifest checksum before
-                // upload (the oracle's invalid-source guard).
-                let actual = hasher.hash_hex(&bytes);
-                if actual != entry.checksum {
-                    return Err(StoreError::Integrity {
-                        address: object_source.display().to_string(),
-                        expected: entry.checksum.clone(),
-                        actual,
-                    });
-                }
-                self.put_bytes(&object_key, bytes).await?;
-            }
-
-            // Write the manifest last (verified to hash back to its id),
-            // exactly as the oracle stores the manifest text.
-            let mut text = manifest.to_string();
-            text.push('\n');
-            let manifest_actual = hasher.hash_hex(text.as_bytes());
-            if manifest_actual != id {
-                return Err(StoreError::Integrity {
-                    address: manifest_key.clone(),
-                    expected: id.clone(),
-                    actual: manifest_actual,
-                });
-            }
-            self.put_bytes(&manifest_key, text.into_bytes()).await?;
-            Ok(())
+            push_objects_concurrent(
+                manifest,
+                &self.config,
+                |entry| {
+                    let object_key = self.location.object_key(&entry.checksum);
+                    upload_object(
+                        entry,
+                        object_key,
+                        source,
+                        &limiter,
+                        |key| async move { self.key_exists(&key).await },
+                        |key, bytes| async move { self.put_bytes(&key, bytes).await },
+                    )
+                },
+                || async {
+                    // Write the manifest last (verified to hash back to its id),
+                    // exactly as the oracle stores the manifest text.
+                    let mut text = manifest.to_string();
+                    text.push('\n');
+                    let manifest_actual = hasher.hash_hex(text.as_bytes());
+                    if manifest_actual != id {
+                        return Err(StoreError::Integrity {
+                            address: manifest_key.clone(),
+                            expected: id.clone(),
+                            actual: manifest_actual,
+                        });
+                    }
+                    self.put_bytes(&manifest_key, text.into_bytes()).await
+                },
+            )
+            .await
         })
     }
 }
@@ -495,16 +493,18 @@ fn is_not_found(err: &GcsError) -> bool {
             .is_some_and(|status| status.code == Code::NotFound)
 }
 
-/// Strips a leading `./` and a trailing `/` from a manifest path so the
-/// remainder can be joined onto a destination root (shared with `FileStore`).
-fn strip_leading_dot_slash(path: &str) -> &str {
-    let trimmed = path.strip_prefix("./").unwrap_or(path);
-    trimmed.strip_suffix('/').unwrap_or(trimmed)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use snapdir_core::manifest::PathType;
+
+    /// Strips a leading `./` and a trailing `/` from a manifest path. Kept as a
+    /// test-only assertion of the path normalization the orchestrator
+    /// (`crate::push`) performs.
+    fn strip_leading_dot_slash(path: &str) -> &str {
+        let trimmed = path.strip_prefix("./").unwrap_or(path);
+        trimmed.strip_suffix('/').unwrap_or(trimmed)
+    }
 
     // The canonical content-addressable fixtures (shared across the s3/gcs
     // store test suites).

--- a/crates/snapdir-stores/src/gcs_store.rs
+++ b/crates/snapdir-stores/src/gcs_store.rs
@@ -57,8 +57,8 @@ use snapdir_core::manifest::{Manifest, PathType};
 use snapdir_core::merkle::{Blake3Hasher, Hasher};
 use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
 
-use crate::transfer::TransferConfig;
-use crate::util::file_present_and_verified;
+use crate::fetch::fetch_files_concurrent;
+use crate::transfer::{RateLimiter, TransferConfig};
 use tokio::runtime::Runtime;
 
 /// Number of times a fetch is retried when the downloaded bytes fail their
@@ -370,36 +370,18 @@ impl Store for GcsStore {
     }
 
     fn fetch_files(&self, manifest: &Manifest, dest: &Path) -> Result<(), StoreError> {
-        let hasher = Blake3Hasher::new();
+        // Concurrent download via the shared orchestrator: it owns the
+        // skip-if-present-and-verified short-circuit, directory creation, the
+        // bounded-concurrency pass, the per-object rate limit, and the atomic
+        // write. GCS only injects the per-object download, preserving the
+        // BLAKE3-verify + retry discipline of `fetch_verified`.
+        let limiter = RateLimiter::new(self.config.max_bytes_per_sec);
         self.runtime.block_on(async {
-            for entry in manifest.entries() {
-                let rel = strip_leading_dot_slash(&entry.path);
-                let target = dest.join(rel);
-                match entry.path_type {
-                    PathType::Directory => {
-                        std::fs::create_dir_all(&target)?;
-                    }
-                    PathType::File => {
-                        // Skip-if-present-and-verified: avoid the network GET
-                        // entirely when the destination file already exists and
-                        // hashes to the manifest's checksum. A corrupt/mismatched
-                        // local file falls through and is repaired below.
-                        if file_present_and_verified(&target, &entry.checksum, &hasher) {
-                            continue;
-                        }
-                        if let Some(parent) = target.parent() {
-                            std::fs::create_dir_all(parent)?;
-                        }
-                        let key = self.location.object_key(&entry.checksum);
-                        let bytes = self.fetch_verified(&key, &entry.checksum).await?;
-                        // The download already gave us verified bytes; write to a
-                        // temp sibling then atomically rename into place (atomic
-                        // on one filesystem), matching the oracle's tmp+mv.
-                        write_atomic(&target, &bytes)?;
-                    }
-                }
-            }
-            Ok(())
+            fetch_files_concurrent(manifest, dest, &self.config, &limiter, |entry| async {
+                let key = self.location.object_key(&entry.checksum);
+                self.fetch_verified(&key, &entry.checksum).await
+            })
+            .await
         })
     }
 
@@ -511,28 +493,6 @@ fn is_not_found(err: &GcsError) -> bool {
         || err
             .status()
             .is_some_and(|status| status.code == Code::NotFound)
-}
-
-/// Writes `bytes` to `target` via a temp sibling + atomic rename (same fs).
-fn write_atomic(target: &Path, bytes: &[u8]) -> Result<(), StoreError> {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    if let Some(parent) = target.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let pid = std::process::id();
-    let file_name = target
-        .file_name()
-        .map(|s| s.to_string_lossy().into_owned())
-        .unwrap_or_default();
-    let tmp = match target.parent() {
-        Some(parent) => parent.join(format!("{file_name}.{pid}.{n}.tmp")),
-        None => std::path::PathBuf::from(format!("{file_name}.{pid}.{n}.tmp")),
-    };
-    std::fs::write(&tmp, bytes)?;
-    std::fs::rename(&tmp, target)?;
-    Ok(())
 }
 
 /// Strips a leading `./` and a trailing `/` from a manifest path so the

--- a/crates/snapdir-stores/src/lib.rs
+++ b/crates/snapdir-stores/src/lib.rs
@@ -23,6 +23,7 @@ pub mod b2_store;
 pub(crate) mod fetch;
 pub mod file_store;
 pub mod gcs_store;
+pub(crate) mod push;
 pub mod router;
 pub mod s3_store;
 pub mod shim;

--- a/crates/snapdir-stores/src/lib.rs
+++ b/crates/snapdir-stores/src/lib.rs
@@ -20,6 +20,7 @@
 //!   [`TransferConfig`] for the (later) concurrent transfer loops.
 
 pub mod b2_store;
+pub(crate) mod fetch;
 pub mod file_store;
 pub mod gcs_store;
 pub mod router;

--- a/crates/snapdir-stores/src/lib.rs
+++ b/crates/snapdir-stores/src/lib.rs
@@ -15,6 +15,9 @@
 //!   third-party `snapdir-<name>-store` binaries via the documented
 //!   `get-manifest-command` / `get-fetch-files-command` / `get-push-command`
 //!   contract.
+//! - [`transfer`] ([`TransferConfig`], [`RateLimiter`], [`run_concurrent`]) —
+//!   the concurrency + bandwidth-limiting foundation each store carries via a
+//!   [`TransferConfig`] for the (later) concurrent transfer loops.
 
 pub mod b2_store;
 pub mod file_store;
@@ -22,6 +25,7 @@ pub mod gcs_store;
 pub mod router;
 pub mod s3_store;
 pub mod shim;
+pub mod transfer;
 pub(crate) mod util;
 
 pub use b2_store::B2Store;
@@ -30,3 +34,4 @@ pub use gcs_store::{GcsLocation, GcsStore};
 pub use router::{resolve_adapter, Adapter, RouteError};
 pub use s3_store::{S3Location, S3Store};
 pub use shim::ExternalStore;
+pub use transfer::{run_concurrent, RateLimiter, TransferConfig};

--- a/crates/snapdir-stores/src/lib.rs
+++ b/crates/snapdir-stores/src/lib.rs
@@ -22,6 +22,7 @@ pub mod gcs_store;
 pub mod router;
 pub mod s3_store;
 pub mod shim;
+pub(crate) mod util;
 
 pub use b2_store::B2Store;
 pub use file_store::FileStore;

--- a/crates/snapdir-stores/src/push.rs
+++ b/crates/snapdir-stores/src/push.rs
@@ -1,0 +1,474 @@
+//! Shared concurrent push orchestrator for object-store backends.
+//!
+//! `S3Store::push` and `GcsStore::push` (and, via S3, `B2Store`) are
+//! byte-identical except for the per-object existence check, the per-object
+//! upload, and the final manifest write. [`push_objects_concurrent`] factors
+//! out that loop so both backends upload objects concurrently (bounded by the
+//! store's [`TransferConfig`] concurrency, throttled by a shared
+//! [`RateLimiter`]) while each backend injects only those store-specific calls.
+//!
+//! The orchestrator preserves every Bash/oracle invariant of the original
+//! sequential push loops:
+//!
+//! - **Per-object content-addressed skip:** the injected `key_exists` closure
+//!   is consulted for every `File` entry; a present object is skipped with no
+//!   read and no upload (content-addressed, so a present object is already the
+//!   right bytes).
+//! - **Invalid-source guard (verify-before-upload):** for an absent object the
+//!   source file at `source.join(rel)` is read and its BLAKE3 is verified
+//!   against the manifest checksum *before* the upload; a mismatch is a
+//!   [`StoreError::Integrity`] and no manifest is written. The read + verify is
+//!   shared here so S3 and GCS never duplicate it.
+//! - **Manifest-last / all-or-nothing:** the injected `write_manifest` closure
+//!   is called **exactly once and only after every object upload has returned
+//!   `Ok`**. If any object upload errors, [`run_concurrent`] returns that error
+//!   and the orchestrator returns it *without* writing the manifest — a failed
+//!   push leaves no manifest, so a present manifest always implies all of its
+//!   objects are present.
+//! - **First error wins:** [`run_concurrent`] propagates the first upload error
+//!   and cancels the rest.
+//!
+//! The skip-if-manifest-present early return stays in each store's `push`
+//! (a cheap pre-check) *before* this orchestrator is called.
+
+use std::path::Path;
+
+use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
+use snapdir_core::merkle::{Blake3Hasher, Hasher};
+use snapdir_core::store::StoreError;
+
+use crate::transfer::{run_concurrent, RateLimiter, TransferConfig};
+
+/// Strips a leading `./` and a trailing `/` from a manifest path so the
+/// remainder can be joined onto a source root (shared with the backends).
+fn strip_leading_dot_slash(path: &str) -> &str {
+    let trimmed = path.strip_prefix("./").unwrap_or(path);
+    trimmed.strip_suffix('/').unwrap_or(trimmed)
+}
+
+/// Reads the source file for `entry` under `source`, verifying its BLAKE3
+/// against the manifest checksum (the oracle's invalid-source guard) and
+/// acquiring rate-limit budget for its byte length before returning the bytes
+/// ready to upload.
+///
+/// Factored out so S3/GCS upload closures inject only `key_exists` +
+/// `put_bytes` and never duplicate the read/verify/throttle logic.
+///
+/// # Errors
+///
+/// - I/O errors reading `source.join(rel)`.
+/// - [`StoreError::Integrity`] when the source bytes no longer hash to the
+///   entry's checksum.
+async fn read_verified(
+    entry: &ManifestEntry,
+    source: &Path,
+    rate_limiter: &RateLimiter,
+) -> Result<Vec<u8>, StoreError> {
+    let rel = strip_leading_dot_slash(&entry.path);
+    let object_source = source.join(rel);
+    let bytes = std::fs::read(&object_source)?;
+    let actual = Blake3Hasher::new().hash_hex(&bytes);
+    if actual != entry.checksum {
+        return Err(StoreError::Integrity {
+            address: object_source.display().to_string(),
+            expected: entry.checksum.clone(),
+            actual,
+        });
+    }
+    // Throttle by the (verified) object size before the upload.
+    rate_limiter.acquire(bytes.len() as u64).await;
+    Ok(bytes)
+}
+
+/// Uploads every absent object referenced by `manifest` concurrently, then —
+/// only if every upload succeeded — writes the manifest via `write_manifest`.
+///
+/// `upload_one` is the per-object closure each backend injects: given a `File`
+/// [`ManifestEntry`], it performs the store-specific existence check + upload.
+/// It is handed [`read_verified`] (as the `read`-and-verify step) so each
+/// backend only injects `key_exists` + `put_bytes`. `write_manifest` is the
+/// backend's manifest-write closure (its own verify + `put_bytes`).
+///
+/// The orchestrator owns bounded concurrency and the manifest-last /
+/// all-or-nothing ordering.
+///
+/// # Errors
+///
+/// Propagates the first [`StoreError`] from any object upload (remaining
+/// in-flight uploads are cancelled and **no** manifest is written), or the
+/// error from `write_manifest`.
+pub(crate) async fn push_objects_concurrent<'a, U, UFut, W, WFut>(
+    manifest: &'a Manifest,
+    config: &TransferConfig,
+    upload_one: U,
+    write_manifest: W,
+) -> Result<(), StoreError>
+where
+    U: Fn(&'a ManifestEntry) -> UFut,
+    UFut: std::future::Future<Output = Result<(), StoreError>>,
+    W: FnOnce() -> WFut,
+    WFut: std::future::Future<Output = Result<(), StoreError>>,
+{
+    // Only `File` entries carry object bytes; directories live only in the
+    // manifest text. Order is irrelevant (content-addressed).
+    let files: Vec<&ManifestEntry> = manifest
+        .entries()
+        .iter()
+        .filter(|e| e.path_type == PathType::File)
+        .collect();
+
+    // Concurrent object pass: each task runs the injected per-object work
+    // (existence check, then read+verify+upload for absent objects). The first
+    // error is propagated and the rest cancelled.
+    run_concurrent(files, config.concurrency, upload_one).await?;
+
+    // Manifest-last / all-or-nothing: only after every object upload returned
+    // Ok do we write the manifest. A failed push (an error above) returns
+    // early and leaves no manifest.
+    write_manifest().await
+}
+
+/// The shared per-object upload step S3/GCS inject into
+/// [`push_objects_concurrent`]: skip if the object key already exists,
+/// otherwise read+verify the source (via [`read_verified`]) and upload it.
+///
+/// Backends supply `key_exists` and `put_bytes` closures over their own
+/// `&self`; `object_key` is the backend's content-addressed key for the entry.
+///
+/// # Errors
+///
+/// Propagates errors from `key_exists`, the source read/verify, or `put_bytes`.
+pub(crate) async fn upload_object<KFut, PFut>(
+    entry: &ManifestEntry,
+    object_key: String,
+    source: &Path,
+    rate_limiter: &RateLimiter,
+    key_exists: impl FnOnce(String) -> KFut,
+    put_bytes: impl FnOnce(String, Vec<u8>) -> PFut,
+) -> Result<(), StoreError>
+where
+    KFut: std::future::Future<Output = Result<bool, StoreError>>,
+    PFut: std::future::Future<Output = Result<(), StoreError>>,
+{
+    // Per-object content-addressed skip: a present object is already the right
+    // bytes, so no read and no upload.
+    if key_exists(object_key.clone()).await? {
+        return Ok(());
+    }
+    let bytes = read_verified(entry, source, rate_limiter).await?;
+    put_bytes(object_key, bytes).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snapdir_core::merkle::Hasher;
+    use std::collections::HashSet;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+
+    /// Multi-thread runtime with time enabled so concurrent uploads genuinely
+    /// overlap and the in-flight high-water mark is meaningful.
+    fn runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(4)
+            .enable_time()
+            .build()
+            .expect("build tokio runtime")
+    }
+
+    /// A temp-dir helper (avoids a dev-dependency) that removes itself on drop.
+    struct TempDir {
+        path: std::path::PathBuf,
+    }
+
+    impl TempDir {
+        fn new() -> Self {
+            static COUNTER: AtomicUsize = AtomicUsize::new(0);
+            let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path =
+                std::env::temp_dir().join(format!("snapdir-push-test-{}-{n}", std::process::id()));
+            std::fs::create_dir_all(&path).expect("create temp dir");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    fn checksum_of(bytes: &[u8]) -> String {
+        Blake3Hasher::new().hash_hex(bytes)
+    }
+
+    /// Builds a manifest (a root dir entry + one `File` per `(rel, contents)`)
+    /// and writes each file's contents under `src` so read+verify is real.
+    fn manifest_and_source(files: &[(&str, &[u8])], src: &Path) -> Manifest {
+        let mut m = Manifest::new();
+        m.push(ManifestEntry::new(
+            PathType::Directory,
+            "700",
+            "0".repeat(64),
+            0,
+            "./",
+        ));
+        for (path, contents) in files {
+            if let Some(parent) = Path::new(path).parent() {
+                std::fs::create_dir_all(src.join(parent)).unwrap();
+            }
+            std::fs::write(src.join(path), contents).unwrap();
+            m.push(ManifestEntry::new(
+                PathType::File,
+                "600",
+                checksum_of(contents),
+                contents.len() as u64,
+                format!("./{path}"),
+            ));
+        }
+        Manifest::from_entries(m.entries().to_vec())
+    }
+
+    /// A fake S3/GCS-like backend: tracks which keys "exist", records uploaded
+    /// checksums, the in-flight high-water mark, and whether the manifest was
+    /// written (and that it was written after the uploads).
+    struct FakeStore {
+        /// Object keys that already exist (skip-present source of truth).
+        present: HashSet<String>,
+        /// Checksums actually uploaded (in completion order).
+        uploaded: Mutex<Vec<String>>,
+        /// Currently in-flight uploads.
+        in_flight: AtomicUsize,
+        /// Peak simultaneous in-flight uploads.
+        high_water: AtomicUsize,
+        /// Set once the manifest write closure runs.
+        manifest_written: AtomicBool,
+        /// How many uploads had completed when the manifest was written.
+        uploads_done_at_manifest: AtomicUsize,
+        /// Checksum whose upload must fail (all-or-nothing test); empty = none.
+        fail_checksum: String,
+    }
+
+    impl FakeStore {
+        fn new(present: &[&str], fail_checksum: &str) -> Arc<Self> {
+            Arc::new(Self {
+                present: present.iter().map(|s| (*s).to_owned()).collect(),
+                uploaded: Mutex::new(Vec::new()),
+                in_flight: AtomicUsize::new(0),
+                high_water: AtomicUsize::new(0),
+                manifest_written: AtomicBool::new(false),
+                uploads_done_at_manifest: AtomicUsize::new(0),
+                fail_checksum: fail_checksum.to_owned(),
+            })
+        }
+
+        // `async` (despite no await) to model the real backends' async
+        // existence check the orchestrator awaits.
+        #[allow(clippy::unused_async)]
+        async fn key_exists(&self, key: String) -> Result<bool, StoreError> {
+            Ok(self.present.contains(&key))
+        }
+
+        async fn put_bytes(&self, _key: String, bytes: Vec<u8>) -> Result<(), StoreError> {
+            let cur = self.in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+            self.high_water.fetch_max(cur, Ordering::SeqCst);
+            // Hold the slot so concurrent uploads actually overlap.
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            let sum = checksum_of(&bytes);
+            self.in_flight.fetch_sub(1, Ordering::SeqCst);
+            if !self.fail_checksum.is_empty() && sum == self.fail_checksum {
+                return Err(StoreError::Backend {
+                    message: "upload blew up".to_owned(),
+                    source: None,
+                });
+            }
+            self.uploaded.lock().unwrap().push(sum);
+            Ok(())
+        }
+
+        #[allow(clippy::unused_async)]
+        async fn write_manifest(&self) -> Result<(), StoreError> {
+            self.uploads_done_at_manifest
+                .store(self.uploaded.lock().unwrap().len(), Ordering::SeqCst);
+            self.manifest_written.store(true, Ordering::SeqCst);
+            Ok(())
+        }
+    }
+
+    /// Runs the orchestrator over `manifest`/`src` with `fake` injected.
+    fn run_push(
+        fake: &Arc<FakeStore>,
+        manifest: &Manifest,
+        src: &Path,
+        concurrency: usize,
+    ) -> Result<(), StoreError> {
+        let cfg = TransferConfig::new(concurrency, None);
+        let limiter = RateLimiter::new(None);
+        let rt = runtime();
+        rt.block_on(async {
+            push_objects_concurrent(
+                manifest,
+                &cfg,
+                |entry| {
+                    let fake = Arc::clone(fake);
+                    let limiter = &limiter;
+                    async move {
+                        // Use the entry's checksum as the object key so the
+                        // fake's `present` set keys on checksums directly.
+                        upload_object(
+                            entry,
+                            entry.checksum.clone(),
+                            src,
+                            limiter,
+                            |key| {
+                                let fake = Arc::clone(&fake);
+                                async move { fake.key_exists(key).await }
+                            },
+                            |key, bytes| {
+                                let fake = Arc::clone(&fake);
+                                async move { fake.put_bytes(key, bytes).await }
+                            },
+                        )
+                        .await
+                    }
+                },
+                || {
+                    let fake = Arc::clone(fake);
+                    async move { fake.write_manifest().await }
+                },
+            )
+            .await
+        })
+    }
+
+    #[test]
+    fn concurrent_upload_all_objects_then_manifest() {
+        let files: &[(&str, &[u8])] = &[
+            ("a.txt", b"alpha" as &[u8]),
+            ("nested/b.txt", b"bravo"),
+            ("nested/deep/c.txt", b"charlie"),
+            ("d.txt", b"delta"),
+        ];
+
+        for concurrency in [1usize, 4] {
+            let src = TempDir::new();
+            let manifest = manifest_and_source(files, src.path());
+            let fake = FakeStore::new(&[], "");
+
+            run_push(&fake, &manifest, src.path(), concurrency).expect("push must succeed");
+
+            // Every absent object was uploaded exactly once.
+            let mut uploaded = fake.uploaded.lock().unwrap().clone();
+            uploaded.sort();
+            let mut expected: Vec<String> = files.iter().map(|(_, c)| checksum_of(c)).collect();
+            expected.sort();
+            assert_eq!(uploaded, expected, "all absent objects must be uploaded");
+
+            // Concurrency bound: peak in-flight == min(concurrency, n), == 1 at
+            // concurrency 1 (strictly sequential).
+            let hw = fake.high_water.load(Ordering::SeqCst);
+            let want = concurrency.min(files.len());
+            assert_eq!(
+                hw, want,
+                "concurrency={concurrency}: peak in-flight {hw} != expected {want}"
+            );
+
+            // Manifest written EXACTLY once, and only AFTER all uploads.
+            assert!(
+                fake.manifest_written.load(Ordering::SeqCst),
+                "manifest must be written"
+            );
+            assert_eq!(
+                fake.uploads_done_at_manifest.load(Ordering::SeqCst),
+                files.len(),
+                "manifest must be written only after every object upload completed"
+            );
+        }
+    }
+
+    #[test]
+    fn concurrent_upload_skips_present_objects() {
+        let files: &[(&str, &[u8])] = &[
+            ("present.txt", b"already-here" as &[u8]),
+            ("missing.txt", b"needs-upload"),
+        ];
+        let src = TempDir::new();
+        let manifest = manifest_and_source(files, src.path());
+
+        // Mark `present.txt`'s object key (its checksum) as already present.
+        let present_sum = checksum_of(b"already-here");
+        let fake = FakeStore::new(&[present_sum.as_str()], "");
+
+        run_push(&fake, &manifest, src.path(), 4).expect("push must succeed");
+
+        let uploaded = fake.uploaded.lock().unwrap().clone();
+        let missing_sum = checksum_of(b"needs-upload");
+        assert!(
+            !uploaded.contains(&present_sum),
+            "present object must never be uploaded"
+        );
+        assert_eq!(
+            uploaded,
+            vec![missing_sum],
+            "only the absent object should be uploaded"
+        );
+        assert!(fake.manifest_written.load(Ordering::SeqCst));
+    }
+
+    #[test]
+    fn concurrent_upload_all_or_nothing_on_failure() {
+        let files: &[(&str, &[u8])] = &[
+            ("ok1.txt", b"one" as &[u8]),
+            ("boom.txt", b"two"),
+            ("ok2.txt", b"three"),
+        ];
+        let src = TempDir::new();
+        let manifest = manifest_and_source(files, src.path());
+
+        // The upload of `boom.txt`'s object fails.
+        let boom_sum = checksum_of(b"two");
+        let fake = FakeStore::new(&[], boom_sum.as_str());
+
+        let result = run_push(&fake, &manifest, src.path(), 4);
+
+        let err = result.expect_err("a failing object upload must surface");
+        assert!(
+            matches!(err, StoreError::Backend { ref message, .. } if message == "upload blew up"),
+            "unexpected error: {err:?}"
+        );
+        // THE invariant: a failed push writes NO manifest.
+        assert!(
+            !fake.manifest_written.load(Ordering::SeqCst),
+            "write_manifest must NEVER be called when an object upload fails"
+        );
+    }
+
+    #[test]
+    fn concurrent_upload_rejects_corrupt_source() {
+        let files: &[(&str, &[u8])] = &[("good.txt", b"good" as &[u8]), ("bad.txt", b"bad")];
+        let src = TempDir::new();
+        let manifest = manifest_and_source(files, src.path());
+
+        // Corrupt `bad.txt` on disk so its bytes no longer match the manifest
+        // checksum: the verify-before-upload guard must fire.
+        std::fs::write(src.path().join("bad.txt"), b"tampered").unwrap();
+        let fake = FakeStore::new(&[], "");
+
+        let result = run_push(&fake, &manifest, src.path(), 4);
+
+        let err = result.expect_err("a corrupt source must surface an Integrity error");
+        assert!(
+            matches!(err, StoreError::Integrity { .. }),
+            "unexpected error: {err:?}"
+        );
+        assert!(
+            !fake.manifest_written.load(Ordering::SeqCst),
+            "a corrupt source must leave no manifest"
+        );
+    }
+}

--- a/crates/snapdir-stores/src/s3_store.rs
+++ b/crates/snapdir-stores/src/s3_store.rs
@@ -49,6 +49,8 @@ use aws_smithy_http_client::Builder as HttpClientBuilder;
 use snapdir_core::manifest::{Manifest, PathType};
 use snapdir_core::merkle::{Blake3Hasher, Hasher};
 use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
+
+use crate::util::file_present_and_verified;
 use tokio::runtime::Runtime;
 
 /// Number of times a fetch is retried when the downloaded bytes fail their
@@ -331,6 +333,7 @@ impl Store for S3Store {
     }
 
     fn fetch_files(&self, manifest: &Manifest, dest: &Path) -> Result<(), StoreError> {
+        let hasher = Blake3Hasher::new();
         self.runtime.block_on(async {
             for entry in manifest.entries() {
                 let rel = strip_leading_dot_slash(&entry.path);
@@ -340,6 +343,13 @@ impl Store for S3Store {
                         std::fs::create_dir_all(&target)?;
                     }
                     PathType::File => {
+                        // Skip-if-present-and-verified: avoid the network GET
+                        // entirely when the destination file already exists and
+                        // hashes to the manifest's checksum. A corrupt/mismatched
+                        // local file falls through and is repaired below.
+                        if file_present_and_verified(&target, &entry.checksum, &hasher) {
+                            continue;
+                        }
                         if let Some(parent) = target.parent() {
                             std::fs::create_dir_all(parent)?;
                         }

--- a/crates/snapdir-stores/src/s3_store.rs
+++ b/crates/snapdir-stores/src/s3_store.rs
@@ -50,6 +50,8 @@ use snapdir_core::manifest::{Manifest, PathType};
 use snapdir_core::merkle::{Blake3Hasher, Hasher};
 use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
 
+use crate::transfer::TransferConfig;
+
 use crate::util::file_present_and_verified;
 use tokio::runtime::Runtime;
 
@@ -135,6 +137,7 @@ pub struct S3Store {
     client: Client,
     location: S3Location,
     runtime: Arc<Runtime>,
+    config: TransferConfig,
 }
 
 impl S3Store {
@@ -151,6 +154,22 @@ impl S3Store {
     /// [`StoreError::Backend`] if the tokio runtime cannot be created or the
     /// AWS configuration cannot be loaded.
     pub fn connect(store_url: &str, endpoint_url: Option<&str>) -> Result<Self, StoreError> {
+        Self::connect_with(store_url, endpoint_url, TransferConfig::default())
+    }
+
+    /// Like [`connect`](Self::connect), but carries a [`TransferConfig`] for
+    /// concurrency / bandwidth control. The existing [`connect`](Self::connect)
+    /// delegates here with [`TransferConfig::default`].
+    ///
+    /// # Errors
+    ///
+    /// [`StoreError::Backend`] if the tokio runtime cannot be created or the
+    /// AWS configuration cannot be loaded.
+    pub fn connect_with(
+        store_url: &str,
+        endpoint_url: Option<&str>,
+        config: TransferConfig,
+    ) -> Result<Self, StoreError> {
         let location = S3Location::parse(store_url);
         let runtime = build_runtime()?;
 
@@ -180,6 +199,7 @@ impl S3Store {
             client,
             location,
             runtime: Arc::new(runtime),
+            config,
         })
     }
 
@@ -195,6 +215,7 @@ impl S3Store {
             client,
             location,
             runtime: Arc::new(build_runtime()?),
+            config: TransferConfig::default(),
         })
     }
 
@@ -202,6 +223,13 @@ impl S3Store {
     #[must_use]
     pub fn location(&self) -> &S3Location {
         &self.location
+    }
+
+    /// The [`TransferConfig`] (concurrency / bandwidth) this store was built
+    /// with. Consumed by the transfer loops in later gates.
+    #[must_use]
+    pub fn transfer_config(&self) -> &TransferConfig {
+        &self.config
     }
 
     /// HEAD an object key; `Ok(true)` if it exists, `Ok(false)` if absent.

--- a/crates/snapdir-stores/src/s3_store.rs
+++ b/crates/snapdir-stores/src/s3_store.rs
@@ -50,9 +50,9 @@ use snapdir_core::manifest::{Manifest, PathType};
 use snapdir_core::merkle::{Blake3Hasher, Hasher};
 use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
 
-use crate::transfer::TransferConfig;
+use crate::fetch::fetch_files_concurrent;
+use crate::transfer::{RateLimiter, TransferConfig};
 
-use crate::util::file_present_and_verified;
 use tokio::runtime::Runtime;
 
 /// Number of times a fetch is retried when the downloaded bytes fail their
@@ -361,36 +361,18 @@ impl Store for S3Store {
     }
 
     fn fetch_files(&self, manifest: &Manifest, dest: &Path) -> Result<(), StoreError> {
-        let hasher = Blake3Hasher::new();
+        // Concurrent download via the shared orchestrator: it owns the
+        // skip-if-present-and-verified short-circuit, directory creation, the
+        // bounded-concurrency pass, the per-object rate limit, and the atomic
+        // write. S3 only injects the per-object download, preserving the
+        // BLAKE3-verify + retry discipline of `fetch_verified`.
+        let limiter = RateLimiter::new(self.config.max_bytes_per_sec);
         self.runtime.block_on(async {
-            for entry in manifest.entries() {
-                let rel = strip_leading_dot_slash(&entry.path);
-                let target = dest.join(rel);
-                match entry.path_type {
-                    PathType::Directory => {
-                        std::fs::create_dir_all(&target)?;
-                    }
-                    PathType::File => {
-                        // Skip-if-present-and-verified: avoid the network GET
-                        // entirely when the destination file already exists and
-                        // hashes to the manifest's checksum. A corrupt/mismatched
-                        // local file falls through and is repaired below.
-                        if file_present_and_verified(&target, &entry.checksum, &hasher) {
-                            continue;
-                        }
-                        if let Some(parent) = target.parent() {
-                            std::fs::create_dir_all(parent)?;
-                        }
-                        let key = self.location.object_key(&entry.checksum);
-                        let bytes = self.fetch_verified(&key, &entry.checksum).await?;
-                        // S3 GET already gave us verified bytes; write to a temp
-                        // sibling then atomically rename into place (atomic on
-                        // one filesystem), matching the oracle's tmp+mv.
-                        write_atomic(&target, &bytes)?;
-                    }
-                }
-            }
-            Ok(())
+            fetch_files_concurrent(manifest, dest, &self.config, &limiter, |entry| async {
+                let key = self.location.object_key(&entry.checksum);
+                self.fetch_verified(&key, &entry.checksum).await
+            })
+            .await
         })
     }
 
@@ -478,28 +460,6 @@ where
         message: message.to_owned(),
         source: Some(Box::new(source)),
     }
-}
-
-/// Writes `bytes` to `target` via a temp sibling + atomic rename (same fs).
-fn write_atomic(target: &Path, bytes: &[u8]) -> Result<(), StoreError> {
-    use std::sync::atomic::{AtomicU64, Ordering};
-    static COUNTER: AtomicU64 = AtomicU64::new(0);
-    if let Some(parent) = target.parent() {
-        std::fs::create_dir_all(parent)?;
-    }
-    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
-    let pid = std::process::id();
-    let file_name = target
-        .file_name()
-        .map(|s| s.to_string_lossy().into_owned())
-        .unwrap_or_default();
-    let tmp = match target.parent() {
-        Some(parent) => parent.join(format!("{file_name}.{pid}.{n}.tmp")),
-        None => std::path::PathBuf::from(format!("{file_name}.{pid}.{n}.tmp")),
-    };
-    std::fs::write(&tmp, bytes)?;
-    std::fs::rename(&tmp, target)?;
-    Ok(())
 }
 
 /// Strips a leading `./` and a trailing `/` from a manifest path so the

--- a/crates/snapdir-stores/src/s3_store.rs
+++ b/crates/snapdir-stores/src/s3_store.rs
@@ -46,11 +46,12 @@ use aws_sdk_s3::Client;
 use aws_smithy_http_client::tls::rustls_provider::CryptoMode;
 use aws_smithy_http_client::tls::Provider as TlsProvider;
 use aws_smithy_http_client::Builder as HttpClientBuilder;
-use snapdir_core::manifest::{Manifest, PathType};
+use snapdir_core::manifest::Manifest;
 use snapdir_core::merkle::{Blake3Hasher, Hasher};
 use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
 
 use crate::fetch::fetch_files_concurrent;
+use crate::push::{push_objects_concurrent, upload_object};
 use crate::transfer::{RateLimiter, TransferConfig};
 
 use tokio::runtime::Runtime;
@@ -380,54 +381,51 @@ impl Store for S3Store {
         let hasher = Blake3Hasher::new();
         let id = snapdir_core::merkle::snapshot_id(manifest, &hasher);
 
+        // Concurrent upload via the shared orchestrator: it owns the bounded
+        // per-object pass and the manifest-last / all-or-nothing ordering. S3
+        // injects the per-object skip-present + upload (via `upload_object`,
+        // which also owns the shared read+verify) and the manifest-write
+        // closure. A failed push writes NO manifest.
+        let limiter = RateLimiter::new(self.config.max_bytes_per_sec);
         self.runtime.block_on(async {
-            // Skip-if-present: a present manifest implies all its objects are
-            // present (we always write the manifest last).
+            // Skip-if-manifest-present pre-check: a present manifest implies all
+            // its objects are present (we always write the manifest last).
             let manifest_key = self.location.manifest_key(&id);
             if self.key_exists(&manifest_key).await? {
                 return Ok(());
             }
 
-            // Push every referenced object that is absent, BEFORE the manifest.
-            for entry in manifest.entries() {
-                if entry.path_type != PathType::File {
-                    continue;
-                }
-                let object_key = self.location.object_key(&entry.checksum);
-                if self.key_exists(&object_key).await? {
-                    // Skip-if-present per object (content-addressable).
-                    continue;
-                }
-                let rel = strip_leading_dot_slash(&entry.path);
-                let object_source = source.join(rel);
-                let bytes = std::fs::read(&object_source)?;
-                // Verify the source still matches its manifest checksum before
-                // upload (the oracle's invalid-source guard).
-                let actual = hasher.hash_hex(&bytes);
-                if actual != entry.checksum {
-                    return Err(StoreError::Integrity {
-                        address: object_source.display().to_string(),
-                        expected: entry.checksum.clone(),
-                        actual,
-                    });
-                }
-                self.put_bytes(&object_key, bytes).await?;
-            }
-
-            // Write the manifest last (verified to hash back to its id),
-            // exactly as the oracle stores `echo "${manifest}"` text.
-            let mut text = manifest.to_string();
-            text.push('\n');
-            let manifest_actual = hasher.hash_hex(text.as_bytes());
-            if manifest_actual != id {
-                return Err(StoreError::Integrity {
-                    address: manifest_key.clone(),
-                    expected: id.clone(),
-                    actual: manifest_actual,
-                });
-            }
-            self.put_bytes(&manifest_key, text.into_bytes()).await?;
-            Ok(())
+            push_objects_concurrent(
+                manifest,
+                &self.config,
+                |entry| {
+                    let object_key = self.location.object_key(&entry.checksum);
+                    upload_object(
+                        entry,
+                        object_key,
+                        source,
+                        &limiter,
+                        |key| async move { self.key_exists(&key).await },
+                        |key, bytes| async move { self.put_bytes(&key, bytes).await },
+                    )
+                },
+                || async {
+                    // Write the manifest last (verified to hash back to its id),
+                    // exactly as the oracle stores `echo "${manifest}"` text.
+                    let mut text = manifest.to_string();
+                    text.push('\n');
+                    let manifest_actual = hasher.hash_hex(text.as_bytes());
+                    if manifest_actual != id {
+                        return Err(StoreError::Integrity {
+                            address: manifest_key.clone(),
+                            expected: id.clone(),
+                            actual: manifest_actual,
+                        });
+                    }
+                    self.put_bytes(&manifest_key, text.into_bytes()).await
+                },
+            )
+            .await
         })
     }
 }
@@ -462,16 +460,18 @@ where
     }
 }
 
-/// Strips a leading `./` and a trailing `/` from a manifest path so the
-/// remainder can be joined onto a destination root (shared with `FileStore`).
-fn strip_leading_dot_slash(path: &str) -> &str {
-    let trimmed = path.strip_prefix("./").unwrap_or(path);
-    trimmed.strip_suffix('/').unwrap_or(trimmed)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
+    use snapdir_core::manifest::PathType;
+
+    /// Strips a leading `./` and a trailing `/` from a manifest path. Kept as a
+    /// test-only assertion of the path normalization the orchestrator
+    /// (`crate::push`) performs.
+    fn strip_leading_dot_slash(path: &str) -> &str {
+        let trimmed = path.strip_prefix("./").unwrap_or(path);
+        trimmed.strip_suffix('/').unwrap_or(trimmed)
+    }
 
     // The canonical content-addressable fixtures from the s3 store test suite.
     const FOO_CHECKSUM: &str = "49dc870df1de7fd60794cebce449f5ccdae575affaa67a24b62acb03e039db92";

--- a/crates/snapdir-stores/src/transfer.rs
+++ b/crates/snapdir-stores/src/transfer.rs
@@ -1,0 +1,321 @@
+//! Transfer configuration, rate limiting, and bounded-concurrency driver.
+//!
+//! This module is the foundation for concurrent object transfers and bandwidth
+//! limiting. It provides:
+//!
+//! - [`TransferConfig`] — how many objects to transfer in parallel and an
+//!   optional aggregate byte-rate cap.
+//! - [`RateLimiter`] — a zero-dependency async token bucket built on
+//!   [`tokio::time`], shareable across tasks via [`Arc`].
+//! - [`run_concurrent`] — a generic bounded-concurrency driver that runs up to
+//!   `concurrency` async operations in flight and returns the first error.
+//!
+//! Nothing here changes the existing (sequential) push / fetch loops yet; the
+//! stores merely carry a [`TransferConfig`] so later gates can wire these
+//! primitives into their transfer loops.
+
+use std::num::NonZeroUsize;
+use std::sync::Arc;
+use std::time::Duration;
+
+use futures::stream::{self, StreamExt, TryStreamExt};
+use snapdir_core::store::StoreError;
+use tokio::sync::Mutex;
+
+/// Upper bound on the auto-detected default concurrency.
+const DEFAULT_CONCURRENCY_CAP: usize = 16;
+
+/// Configuration for object transfers: how many to run in parallel and an
+/// optional aggregate byte-rate cap.
+///
+/// `Default` auto-detects the available parallelism (capped at
+/// [`DEFAULT_CONCURRENCY_CAP`]) and leaves bandwidth unlimited.
+#[derive(Debug, Clone)]
+pub struct TransferConfig {
+    /// Maximum number of object transfers to run concurrently.
+    pub concurrency: NonZeroUsize,
+    /// Optional aggregate bandwidth cap, in bytes per second. `None` means
+    /// unlimited.
+    pub max_bytes_per_sec: Option<u64>,
+}
+
+impl TransferConfig {
+    /// Builds a config, clamping `concurrency` to at least 1.
+    #[must_use]
+    pub fn new(concurrency: usize, max_bytes_per_sec: Option<u64>) -> Self {
+        Self {
+            concurrency: NonZeroUsize::new(concurrency.max(1)).unwrap_or(NonZeroUsize::MIN),
+            max_bytes_per_sec,
+        }
+    }
+}
+
+impl Default for TransferConfig {
+    fn default() -> Self {
+        let detected = std::thread::available_parallelism()
+            .map_or(1, NonZeroUsize::get)
+            .clamp(1, DEFAULT_CONCURRENCY_CAP);
+        Self {
+            // `detected` is >= 1, so the NonZeroUsize is always Some.
+            concurrency: NonZeroUsize::new(detected).unwrap_or(NonZeroUsize::MIN),
+            max_bytes_per_sec: None,
+        }
+    }
+}
+
+/// Shared token-bucket state, guarded by an async mutex.
+#[derive(Debug)]
+struct Bucket {
+    /// Currently available tokens (bytes).
+    tokens: f64,
+    /// Last time the bucket was refilled.
+    last_refill: tokio::time::Instant,
+}
+
+/// Inner state of a [`RateLimiter`].
+#[derive(Debug)]
+struct Inner {
+    /// Refill rate in bytes per second. `0` is impossible here (unlimited is
+    /// modelled by `bucket = None`).
+    rate: f64,
+    /// Maximum burst capacity, in bytes (~1 second's worth of budget).
+    capacity: f64,
+    /// `None` when unlimited; otherwise the live bucket state.
+    bucket: Option<Mutex<Bucket>>,
+}
+
+/// An async token-bucket rate limiter that throttles aggregate transfer
+/// throughput.
+///
+/// Construct with [`RateLimiter::new`]. When `max_bytes_per_sec` is `None` (or
+/// `Some(0)`), the limiter is unlimited and [`acquire`](RateLimiter::acquire)
+/// returns immediately. Otherwise tokens refill at `max_bytes_per_sec` per
+/// second, allowing a burst of up to ~1 second's worth of budget.
+///
+/// The limiter is [`Arc`]-shareable and [`Clone`] (cloning shares the same
+/// underlying bucket).
+#[derive(Debug, Clone)]
+pub struct RateLimiter {
+    inner: Arc<Inner>,
+}
+
+impl RateLimiter {
+    /// Builds a limiter. `None` (or `Some(0)`) yields an unlimited, no-op
+    /// limiter whose [`acquire`](RateLimiter::acquire) never waits.
+    #[must_use]
+    pub fn new(max_bytes_per_sec: Option<u64>) -> Self {
+        let inner = match max_bytes_per_sec {
+            Some(rate) if rate > 0 => {
+                #[allow(clippy::cast_precision_loss)]
+                let rate = rate as f64;
+                Inner {
+                    rate,
+                    capacity: rate,
+                    bucket: Some(Mutex::new(Bucket {
+                        tokens: rate,
+                        last_refill: tokio::time::Instant::now(),
+                    })),
+                }
+            }
+            _ => Inner {
+                rate: 0.0,
+                capacity: 0.0,
+                bucket: None,
+            },
+        };
+        Self {
+            inner: Arc::new(inner),
+        }
+    }
+
+    /// Blocks until `n` bytes of budget are available, refilling the bucket at
+    /// the configured rate. Unlimited limiters return immediately.
+    ///
+    /// A single request larger than the bucket capacity is still satisfied: the
+    /// bucket is allowed to go negative and the caller waits out the deficit,
+    /// so throttling is correct even for objects bigger than one second's
+    /// worth of budget.
+    pub async fn acquire(&self, n: u64) {
+        let Some(bucket) = self.inner.bucket.as_ref() else {
+            return; // unlimited fast path
+        };
+        if n == 0 {
+            return;
+        }
+        #[allow(clippy::cast_precision_loss)]
+        let need = n as f64;
+
+        loop {
+            let wait = {
+                let mut state = bucket.lock().await;
+                let now = tokio::time::Instant::now();
+                let elapsed = now.duration_since(state.last_refill).as_secs_f64();
+                state.tokens = (state.tokens + elapsed * self.inner.rate).min(self.inner.capacity);
+                state.last_refill = now;
+
+                if state.tokens >= need {
+                    state.tokens -= need;
+                    return;
+                }
+                // Not enough budget: compute how long until the deficit is
+                // covered, then sleep (releasing the lock first).
+                let deficit = need - state.tokens;
+                deficit / self.inner.rate
+            };
+            tokio::time::sleep(Duration::from_secs_f64(wait)).await;
+        }
+    }
+}
+
+/// Runs `op` over `items` with at most `concurrency` operations in flight,
+/// collecting their results in completion-independent order and returning the
+/// first error encountered (remaining in-flight work is cancelled).
+///
+/// This is the engine later gates use to drive concurrent uploads/downloads.
+///
+/// # Errors
+///
+/// Returns the first [`StoreError`] produced by any operation.
+pub async fn run_concurrent<I, T, F, Fut>(
+    items: I,
+    concurrency: NonZeroUsize,
+    op: F,
+) -> Result<Vec<T>, StoreError>
+where
+    I: IntoIterator,
+    F: Fn(I::Item) -> Fut,
+    Fut: std::future::Future<Output = Result<T, StoreError>>,
+{
+    stream::iter(items)
+        .map(op)
+        .buffer_unordered(concurrency.get())
+        .try_collect()
+        .await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    /// Builds a current-thread tokio runtime with time enabled, avoiding a
+    /// dependency on the `#[tokio::test]` macro (keeps tokio's feature set
+    /// minimal).
+    fn runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .expect("build tokio runtime")
+    }
+
+    #[test]
+    fn transfer_config_default_caps_concurrency() {
+        let cfg = TransferConfig::default();
+        assert!(cfg.concurrency.get() >= 1, "concurrency must be >= 1");
+        assert!(
+            cfg.concurrency.get() <= DEFAULT_CONCURRENCY_CAP,
+            "default concurrency must be capped at {DEFAULT_CONCURRENCY_CAP}, got {}",
+            cfg.concurrency.get()
+        );
+        assert_eq!(cfg.max_bytes_per_sec, None);
+
+        // The clamping ctor never yields 0.
+        assert_eq!(TransferConfig::new(0, None).concurrency.get(), 1);
+        assert_eq!(TransferConfig::new(7, Some(99)).concurrency.get(), 7);
+        assert_eq!(TransferConfig::new(7, Some(99)).max_bytes_per_sec, Some(99));
+    }
+
+    /// Drives `run_concurrent` over N > concurrency items, recording the peak
+    /// number of simultaneously-running ops, and asserts the bound is exactly
+    /// `min(concurrency, N)` — and strictly 1 (sequential) when concurrency=1.
+    fn max_in_flight_for(concurrency: usize, items: usize) -> usize {
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let high_water = Arc::new(AtomicUsize::new(0));
+
+        let rt = runtime();
+        let result = rt.block_on(async {
+            let in_flight = Arc::clone(&in_flight);
+            let high_water = Arc::clone(&high_water);
+            run_concurrent(
+                0..items,
+                NonZeroUsize::new(concurrency).unwrap(),
+                move |_item| {
+                    let in_flight = Arc::clone(&in_flight);
+                    let high_water = Arc::clone(&high_water);
+                    async move {
+                        let cur = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                        high_water.fetch_max(cur, Ordering::SeqCst);
+                        tokio::time::sleep(Duration::from_millis(20)).await;
+                        in_flight.fetch_sub(1, Ordering::SeqCst);
+                        Ok::<_, StoreError>(())
+                    }
+                },
+            )
+            .await
+        });
+        assert!(result.is_ok());
+        high_water.load(Ordering::SeqCst)
+    }
+
+    #[test]
+    fn transfer_config_run_concurrent_max_in_flight() {
+        // concurrency=4 over 12 items: peak in-flight is exactly 4.
+        assert_eq!(max_in_flight_for(4, 12), 4);
+        // concurrency=1 over 5 items: strictly sequential, peak in-flight is 1.
+        assert_eq!(max_in_flight_for(1, 5), 1);
+        // concurrency greater than item count is bounded by the item count.
+        assert_eq!(max_in_flight_for(8, 3), 3);
+    }
+
+    #[test]
+    fn transfer_config_run_concurrent_propagates_error() {
+        let rt = runtime();
+        let result: Result<Vec<()>, StoreError> = rt.block_on(async {
+            run_concurrent(0..10, NonZeroUsize::new(3).unwrap(), |item| async move {
+                if item == 5 {
+                    Err(StoreError::Backend {
+                        message: "boom".to_owned(),
+                        source: None,
+                    })
+                } else {
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                    Ok(())
+                }
+            })
+            .await
+        });
+        let err = result.expect_err("must surface the failing op's error");
+        assert!(
+            matches!(err, StoreError::Backend { ref message, .. } if message == "boom"),
+            "unexpected error: {err:?}"
+        );
+    }
+
+    #[test]
+    fn transfer_config_rate_limiter() {
+        let rt = runtime();
+        rt.block_on(async {
+            // Unlimited: acquiring a large amount returns essentially instantly.
+            let unlimited = RateLimiter::new(None);
+            let start = tokio::time::Instant::now();
+            unlimited.acquire(1_000_000).await;
+            assert!(
+                start.elapsed() < Duration::from_millis(200),
+                "unlimited acquire should not block"
+            );
+
+            // Limited to 1000 bytes/sec. The bucket starts full (1000), so the
+            // first 1000 bytes are free; acquiring another ~2000 bytes total
+            // must wait for the deficit to refill — at least ~1s.
+            let limiter = RateLimiter::new(Some(1000));
+            let start = tokio::time::Instant::now();
+            limiter.acquire(1000).await; // drains the initial burst
+            limiter.acquire(1000).await; // must wait ~1s to refill
+            let elapsed = start.elapsed();
+            assert!(
+                elapsed >= Duration::from_millis(900),
+                "throttled acquire should take ~1s, took {elapsed:?}"
+            );
+        });
+    }
+}

--- a/crates/snapdir-stores/src/util.rs
+++ b/crates/snapdir-stores/src/util.rs
@@ -1,0 +1,45 @@
+//! Small shared helpers used across the in-lane store backends.
+//!
+//! Kept crate-private so the three [`Store`](snapdir_core::store::Store)
+//! implementations (`file://`, `s3://`, `gs://`) share one definition of the
+//! fetch-side "already present and verified?" decision rather than each
+//! reimplementing it.
+
+use std::path::Path;
+
+use snapdir_core::merkle::Hasher;
+use snapdir_core::store::StoreError;
+
+/// Hashes a file's full byte content with `hasher`, returning its hex digest.
+///
+/// Reused by every backend's `fetch_files` to recompute a destination file's
+/// content address (BLAKE3) for the skip-if-present-and-verified check.
+pub(crate) fn hash_file(path: &Path, hasher: &impl Hasher) -> Result<String, StoreError> {
+    let bytes = std::fs::read(path)?;
+    Ok(hasher.hash_hex(&bytes))
+}
+
+/// Returns `true` when `target` already exists as a regular file whose
+/// locally-recomputed content hash equals `expected`.
+///
+/// This is the fetch-side skip gate: a present, checksum-matching destination
+/// file never needs to be re-copied or re-downloaded (and a mismatching one is
+/// left for the caller to repair by overwriting). The check is content-gated,
+/// not mere existence — a corrupt local file returns `false` so it gets
+/// re-fetched, and any non-file (directory, symlink target, …) also returns
+/// `false`.
+///
+/// A read error while hashing an existing file is treated as "not a clean
+/// match" (`false`) rather than propagated, so a transiently unreadable
+/// destination falls through to a normal fetch instead of aborting the run.
+pub(crate) fn file_present_and_verified(
+    target: &Path,
+    expected: &str,
+    hasher: &impl Hasher,
+) -> bool {
+    match std::fs::symlink_metadata(target) {
+        Ok(meta) if meta.is_file() => {}
+        _ => return false,
+    }
+    matches!(hash_file(target, hasher), Ok(actual) if actual == expected)
+}

--- a/docs/rust-port/CHANGELOG.md
+++ b/docs/rust-port/CHANGELOG.md
@@ -7,6 +7,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.1.0]
+
+### Added
+
+- **Concurrent object transfers.** `push` and `pull`/`fetch` now transfer objects
+  concurrently instead of one at a time — across S3, GCS, and B2 (network) and the
+  local `file://` store. Concurrency defaults to the number of available CPUs (capped
+  at 16) and is tunable with `--jobs/-j N` (`SNAPDIR_JOBS`); `--jobs 1` restores fully
+  sequential transfers.
+- **Aggregate bandwidth limiting.** `--limit-rate RATE` (`SNAPDIR_LIMIT_RATE`) caps the
+  *total* network throughput across all in-flight transfers via a single token bucket,
+  using wget-style suffixes (e.g. `512K`, `10M`, `1G`). It applies to the network stores;
+  local `file://` copies are not rate-limited.
+- **`--verbose` transfer reporting.** Under `--verbose`, the transfer commands print the
+  effective settings to stderr, e.g. `transfers: 8 concurrent, limit 10M`.
+
+### Fixed
+
+- **`--dryrun` is now honored.** The global `--dryrun` flag was declared but never
+  checked, so `push --dryrun` (and other mutating commands) still wrote to the store.
+  `push` (incl. staged `--id`), `stage`, `fetch`, `checkout`, `pull`, and `flush-cache`
+  now perform zero writes under `--dryrun`, and `verify-cache --purge` does not purge.
+- **`pull` no longer re-downloads data that is already local.** `fetch_files` skips any
+  destination file already present whose checksum matches the manifest (no copy, and no
+  network GET), and `fetch`/`pull` skip the store entirely when the snapshot is already
+  cached — so a repeated pull of the same snapshot performs no redundant transfers.
+  Corrupted local files are detected and repaired.
+
+### Changed
+
+- **`--exclude` and `--paths` accept multiple patterns** — repeated (`--exclude a
+  --exclude b`) and/or comma-delimited (`--exclude a,b`) — combined as a logical OR
+  (a path matches if it matches any pattern). The `%system%` / `%common%` macros are
+  expanded per pattern. A single value behaves exactly as before.
+
+The manifest byte-format and content-addressed object/manifest layout are unchanged, so
+snapshots remain fully interoperable with 1.0.x.
+
 ## [1.0.1]
 
 ### Fixed


### PR DESCRIPTION
Post-1.0.1 work in two groups (12 commits). All tests green: `cargo test --workspace --locked` → 284 passed / 0 failed; clippy `-D warnings` clean. The frozen manifest format and content-addressed sharding are unchanged throughout, so snapshots remain interoperable.

## Correctness fixes (post-1.0)

- **`feat(cli)`** `--exclude`/`--paths` accept repeated **and** comma-delimited values, OR-combined (a path matches if it matches any pattern), with per-pattern `%system%`/`%common%` macro expansion. A single value behaves exactly as before.
- **`fix(cli)`** honor `--dryrun` across every mutating command. It was a dead flag — declared but never read — so `push --dryrun` actually uploaded objects. Now push (incl. staged `--id`), stage, fetch, checkout, pull, and flush-cache perform zero writes under `--dryrun`, and `verify-cache --purge` is forced non-purging (report + non-zero exit preserved).
- **`fix(stores)`** `fetch_files` skips destination files that already exist and whose locally recomputed checksum matches the manifest — no copy for FileStore, and no network GET for S3/GCS. Corrupt/mismatched local files fall through and are repaired.
- **`perf(cli)`** `pull`/`fetch` skip the store entirely when the snapshot manifest is already cached, so a second pull of the same id does **zero** store reads. Fixes slow repeat pulls that re-downloaded every object.
- **`test(cli)`** end-to-end push/pull correctness suite: idempotent re-pull, dry-run leaves the store/dest untouched, offline corrupt-file repair, and multi/comma `--exclude` behavior.

## Concurrent transfers + bandwidth control

- **`feat(stores)`** `TransferConfig` + a zero-dependency async token-bucket rate limiter + a bounded-concurrency engine (`run_concurrent`).
- **`feat(cli)`** `--jobs/-j N` (concurrency cap; default auto = available parallelism, capped at 16; `--jobs 1` = sequential) and `--limit-rate RATE` (aggregate total bandwidth, wget-style suffixes), with `SNAPDIR_JOBS` / `SNAPDIR_LIMIT_RATE` env.
- **`perf(stores)`** uploads and downloads run concurrently on S3/GCS (B2 inherits via S3) through shared injectable orchestrators. Push preserves manifest-last / all-or-nothing (no manifest is written unless every object upload succeeds); fetch preserves skip-if-present-and-verified and per-object verification.
- **`perf(stores)`** local FileStore copies are parallelized (rayon), bounded by `--jobs`.
- **`feat(cli)`** `--verbose` reports the effective concurrency, e.g. `transfers: 8 concurrent, limit 10M`, so the setting is verifiable in the field.
- **`test(cli)`** end-to-end `--jobs` / `--limit-rate` verification.

### Notes

- Object transfers are whole-object buffered in memory (peak ≈ concurrency × object size); streaming/multipart for very large objects is a deliberate non-goal here.
- `--limit-rate` is an aggregate cap across all in-flight network transfers (one shared token bucket); it does not apply to local FileStore copies.
