### PR TITLE
release: 1.3.0 — opt-in adaptive transfer tuner + clearer progress line

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3492,6 +3492,7 @@ name = "snapdir-core"
 version = "1.2.0"
 dependencies = [
  "blake3",
+ "libc",
  "md-5",
  "proptest",
  "regex",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-benches"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "criterion",
  "iai-callgrind",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-catalog"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "redb",
  "serde",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-cli"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3489,7 +3489,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-core"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "blake3",
  "libc",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-stores"
-version = "1.2.0"
+version = "1.3.0"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.2.0"
+version = "1.3.0"
 edition = "2021"
 rust-version = "1.91.1"
 authors = ["Bermi Ferrer <bermi@bermilabs.com>"]
@@ -22,9 +22,9 @@ categories = ["command-line-utilities", "filesystem"]
 
 [workspace.dependencies]
 # Internal crates
-snapdir-core = { path = "crates/snapdir-core", version = "1.2.0" }
-snapdir-catalog = { path = "crates/snapdir-catalog", version = "1.2.0" }
-snapdir-stores = { path = "crates/snapdir-stores", version = "1.2.0" }
+snapdir-core = { path = "crates/snapdir-core", version = "1.3.0" }
+snapdir-catalog = { path = "crates/snapdir-catalog", version = "1.3.0" }
+snapdir-stores = { path = "crates/snapdir-stores", version = "1.3.0" }
 
 # Errors: thiserror in libs, anyhow (+ context) in the bin.
 thiserror = "2"

--- a/_typos.toml
+++ b/_typos.toml
@@ -31,6 +31,9 @@ persit = "persit"
 # `anc` / `anc_lines` / `oracle_anc` are local variable identifiers (short for
 # "ancestor(s)") used across the catalog tests.
 anc = "anc"
+# AIMD = Additive Increase Multiplicative Decrease (TCP-style congestion control);
+# the Phase-18 adaptive tuner's algorithm — intentional, not "aimed".
+aimd = "aimd"
 
 [default.extend-identifiers]
 # crate / API identifiers that look like typos but are intentional.

--- a/benches/tests/determinism.rs
+++ b/benches/tests/determinism.rs
@@ -44,7 +44,9 @@ use snapdir_benches::{gate_scenarios, Scenario};
 use snapdir_core::merkle::snapshot_id;
 use snapdir_core::store::Store;
 use snapdir_core::{walk, Blake3Hasher, ExcludeMatcher, Manifest, PathType, WalkOptions};
-use snapdir_stores::{sync_snapshot, FileStore, StreamStore, TransferConfig};
+use snapdir_stores::{
+    sync_snapshot, FileStore, StreamStore, TransferAdaptivePolicy, TransferConfig,
+};
 use tempfile::TempDir;
 
 /// One recorded golden row for a GATE-tier scenario. The values are produced by
@@ -373,6 +375,81 @@ fn determinism_full_local_round_trip_preserves_snapshot_id() {
         assert_eq!(
             round_trip_id, id,
             "round-trip id must equal the source id == the golden for {:?}",
+            scenario.name
+        );
+    }
+}
+
+/// Phase-18 "speed-only / byte-identical" invariant guard. The adaptive tuner
+/// (concurrency / rate controller) is allowed to change ONLY the SPEED of a
+/// transfer — never the BYTES. This re-runs the exact same full local round-trip
+/// as [`determinism_full_local_round_trip_preserves_snapshot_id`], but with the
+/// adaptive policy turned ON and a LOW ceiling (2) on every leg — A's push, the
+/// A -> B sync, and B's fetch all carry the adaptive [`TransferConfig`] (stores
+/// are built via [`FileStore::from_root_with_config`] so push/fetch are adaptive
+/// too; the same config is threaded into `sync_snapshot`). Ceiling 2 forces the
+/// gate/controller to actually clamp/gate on the multi-object scenarios. The
+/// assertion is identical to the non-adaptive test: the re-walked fetched tree
+/// must re-id to the SAME snapshot id == the recorded golden. If the adaptive
+/// path ever perturbed a single byte, this snapshot id would diverge and the
+/// test would fail — proving adaptivity is speed-only.
+#[test]
+fn determinism_adaptive_round_trip_preserves_snapshot_id() {
+    if regen_mode() {
+        // No goldens to assert against during regeneration.
+        return;
+    }
+    // Adaptive ON with a low ceiling so the controller/gate is genuinely
+    // exercised (ceiling 2 clamps real concurrency on multi-object scenarios).
+    let config = TransferConfig::new(4, None).with_adaptive(TransferAdaptivePolicy::On {
+        fraction: 0.8,
+        ceiling: 2,
+    });
+
+    for scenario in gate_scenarios() {
+        let (computed, src_dir, manifest) = materialize_and_compute(&scenario);
+        let id = computed.snapshot_id.clone();
+        assert_eq!(
+            id,
+            golden_for(scenario.name).snapshot_id,
+            "precondition: source id must equal the golden for {:?}",
+            scenario.name
+        );
+
+        let from_store_dir = TempDir::new().expect("create source store dir");
+        let to_store_dir = TempDir::new().expect("create destination store dir");
+        let dest_dir = TempDir::new().expect("create fetch dest dir");
+
+        // Build BOTH stores with the adaptive config so the push (into A) and the
+        // fetch (out of B) legs run under the adaptive policy, not just the sync.
+        let a = FileStore::from_root_with_config(from_store_dir.path(), config.clone());
+        let b = FileStore::from_root_with_config(to_store_dir.path(), config.clone());
+
+        a.push(&manifest, src_dir.path()).expect("push into A");
+        let report = sync_snapshot(
+            &a as &(dyn StreamStore + Sync),
+            &b as &(dyn StreamStore + Sync),
+            &id,
+            &config,
+            false,
+            None,
+        )
+        .expect("adaptive sync A -> B");
+        assert!(!report.dry_run, "round-trip sync must be a real copy");
+
+        let m2 = b.get_manifest(&id).expect("B has the synced manifest");
+        b.fetch_files(&m2, dest_dir.path())
+            .expect("fetch files out of B");
+
+        // Re-walk the fetched tree WITHOUT an exclude: excluded paths were never
+        // in the manifest, so the fetched tree already omits that subtree.
+        let round_tripped = walk_with(dest_dir.path(), &WalkOptions::default());
+        let round_trip_id = snapshot_id(&round_tripped, &Blake3Hasher::new());
+
+        assert_eq!(
+            round_trip_id, id,
+            "adaptive round-trip id must be byte-identical to the non-adaptive id \
+             == the golden for {:?} (adaptivity must be speed-only)",
             scenario.name
         );
     }

--- a/crates/snapdir-cli/src/cli.rs
+++ b/crates/snapdir-cli/src/cli.rs
@@ -33,8 +33,13 @@ use snapdir_core::{
 };
 use snapdir_stores::{
     resolve_adapter, Adapter, B2Store, ExternalStore, FileStore, GcsStore, S3Store, StreamStore,
-    TransferConfig,
+    TransferAdaptivePolicy, TransferConfig,
 };
+
+/// Upper bound for the adaptive concurrency ceiling (`--max-jobs` / `--jobs`
+/// under `--adaptive`). Keeps an over-eager explicit value from oversubscribing
+/// the controller's in-flight window.
+const ADAPTIVE_CEILING_CAP: usize = 64;
 
 /// Content-addressable directory snapshots.
 #[derive(Debug, Parser)]
@@ -167,6 +172,29 @@ pub struct GlobalArgs {
     /// Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers).
     #[arg(long, global = true, value_name = "RATE", env = "SNAPDIR_LIMIT_RATE")]
     pub limit_rate: Option<String>,
+
+    /// Adaptively tune transfer concurrency/bandwidth toward a fraction
+    /// (default 0.8) of measured CPU/network capacity; backs off under
+    /// contention. Opt-in; default is full speed.
+    ///
+    /// Presence (with or without a value) opts in; the optional value is the
+    /// politeness fraction in `(0.0, 1.0]`.
+    #[arg(
+        long,
+        global = true,
+        value_name = "FRACTION",
+        num_args = 0..=1,
+        require_equals = true,
+        default_missing_value = "0.8",
+        env = "SNAPDIR_ADAPTIVE",
+        value_parser = parse_adaptive_fraction
+    )]
+    pub adaptive: Option<f64>,
+
+    /// Adaptive concurrency ceiling (only meaningful with `--adaptive`). When
+    /// unset, defaults to the auto concurrency; clamped to a sane upper bound.
+    #[arg(long, global = true, value_name = "N", env = "SNAPDIR_MAX_JOBS")]
+    pub max_jobs: Option<usize>,
 }
 
 /// The `snapdir` subcommands, matching the Bash orchestrator one-for-one.
@@ -1014,8 +1042,18 @@ impl Cli {
     }
 
     /// Builds the [`TransferConfig`] from the global `--jobs` / `--limit-rate`
-    /// flags. `--jobs` unset or `0` falls back to the stores' auto-detected
-    /// default concurrency; `--limit-rate` unset means unlimited bandwidth.
+    /// / `--adaptive` / `--max-jobs` flags. `--jobs` unset or `0` falls back to
+    /// the stores' auto-detected default concurrency; `--limit-rate` unset means
+    /// unlimited bandwidth.
+    ///
+    /// Without `--adaptive`, the result is byte-for-byte the historical
+    /// non-adaptive config: `TransferConfig::new(concurrency, max_bytes_per_sec)`
+    /// ([`TransferAdaptivePolicy::Off`]). With `--adaptive=f` the same base
+    /// config gains an [`TransferAdaptivePolicy::On`] policy whose `fraction` is
+    /// `f` and whose `ceiling` is `--max-jobs` if set, else an explicit
+    /// `--jobs N`, else the auto concurrency (the ceiling is clamped to
+    /// [`ADAPTIVE_CEILING_CAP`]). `--limit-rate` is carried unchanged as the
+    /// rate cap in both paths.
     ///
     /// # Errors
     ///
@@ -1025,12 +1063,29 @@ impl Cli {
             Some(rate) => Some(parse_rate(rate)?),
             None => None,
         };
+        let auto = TransferConfig::default().concurrency.get();
         let concurrency = match self.globals.jobs {
             Some(n) if n > 0 => n,
             // Unset or 0 => auto (the stores' default).
-            _ => TransferConfig::default().concurrency.get(),
+            _ => auto,
         };
-        Ok(TransferConfig::new(concurrency, max_bytes_per_sec))
+        let base = TransferConfig::new(concurrency, max_bytes_per_sec);
+        match self.globals.adaptive {
+            // No `--adaptive`: byte-for-byte the historical non-adaptive config.
+            None => Ok(base),
+            // `--adaptive[=f]`: opt into adaptive tuning. The ceiling is
+            // `--max-jobs` if set, else an explicit `--jobs N`, else `auto`,
+            // clamped to a sane upper bound.
+            Some(fraction) => {
+                let ceiling = self
+                    .globals
+                    .max_jobs
+                    .or(self.globals.jobs.filter(|&n| n > 0))
+                    .unwrap_or(auto)
+                    .clamp(1, ADAPTIVE_CEILING_CAP);
+                Ok(base.with_adaptive(TransferAdaptivePolicy::On { fraction, ceiling }))
+            }
+        }
     }
 
     /// Field observability for the transfer commands: under `--verbose`, print
@@ -1051,10 +1106,28 @@ impl Cli {
         let Ok(config) = self.transfer_config() else {
             return;
         };
-        let concurrency = config.concurrency.get();
-        match self.globals.limit_rate.as_deref() {
-            Some(rate) => eprintln!("transfers: {concurrency} concurrent, limit {rate}"),
-            None => eprintln!("transfers: {concurrency} concurrent"),
+        match config.adaptive {
+            TransferAdaptivePolicy::On { fraction, ceiling } => {
+                #[allow(
+                    clippy::cast_possible_truncation,
+                    clippy::cast_sign_loss,
+                    clippy::cast_precision_loss
+                )]
+                let pct = (fraction * 100.0).round() as u64;
+                match self.globals.limit_rate.as_deref() {
+                    Some(rate) => eprintln!(
+                        "adaptive: target {pct}% of capacity, ceiling {ceiling}, limit {rate}"
+                    ),
+                    None => eprintln!("adaptive: target {pct}% of capacity, ceiling {ceiling}"),
+                }
+            }
+            TransferAdaptivePolicy::Off => {
+                let concurrency = config.concurrency.get();
+                match self.globals.limit_rate.as_deref() {
+                    Some(rate) => eprintln!("transfers: {concurrency} concurrent, limit {rate}"),
+                    None => eprintln!("transfers: {concurrency} concurrent"),
+                }
+            }
         }
     }
 
@@ -1422,6 +1495,22 @@ fn parse_rate(s: &str) -> Result<u64> {
     Ok((value * multiplier) as u64)
 }
 
+/// clap `value_parser` for `--adaptive[=FRACTION]`: a finite `f64` in the
+/// half-open range `(0.0, 1.0]` (the politeness fraction). Rejects `<= 0` and
+/// `> 1` so a nonsensical target can't slip through.
+fn parse_adaptive_fraction(s: &str) -> Result<f64, String> {
+    let value: f64 = s
+        .trim()
+        .parse()
+        .map_err(|_| format!("invalid --adaptive '{s}': expected a number in (0.0, 1.0]"))?;
+    if !value.is_finite() || value <= 0.0 || value > 1.0 {
+        return Err(format!(
+            "invalid --adaptive '{s}': fraction must be in (0.0, 1.0]"
+        ));
+    }
+    Ok(value)
+}
+
 /// Reformats a `SNAPDIR*` environment variable into the oracle's `defaults`
 /// option line, faithfully reproducing the `sed -E 's|^_?SNAPDIR_|--|; s|_|-|g;'
 /// | tr '[:upper:]' '[:lower:]'` pipeline applied to the `KEY=VALUE` text:
@@ -1700,6 +1789,8 @@ mod tests {
         unsafe {
             std::env::remove_var("SNAPDIR_JOBS");
             std::env::remove_var("SNAPDIR_LIMIT_RATE");
+            std::env::remove_var("SNAPDIR_ADAPTIVE");
+            std::env::remove_var("SNAPDIR_MAX_JOBS");
         }
         let mut full = vec!["snapdir"];
         full.extend_from_slice(args);
@@ -1776,5 +1867,122 @@ mod tests {
         assert!(cli_with(&["--limit-rate", "nope"])
             .transfer_config()
             .is_err());
+    }
+
+    #[test]
+    fn adaptive_flag_without_value_defaults_to_point_eight() {
+        let cfg = cli_with(&["--adaptive"]).transfer_config().unwrap();
+        match cfg.adaptive {
+            TransferAdaptivePolicy::On { fraction, ceiling } => {
+                assert!(
+                    (fraction - 0.8).abs() < 1e-9,
+                    "expected fraction ~0.8, got {fraction}"
+                );
+                // Ceiling defaults to the auto concurrency when unset.
+                assert_eq!(ceiling, TransferConfig::default().concurrency.get());
+            }
+            TransferAdaptivePolicy::Off => panic!("expected adaptive On"),
+        }
+    }
+
+    #[test]
+    fn adaptive_flag_with_explicit_fraction() {
+        let cfg = cli_with(&["--adaptive=0.5"]).transfer_config().unwrap();
+        match cfg.adaptive {
+            TransferAdaptivePolicy::On { fraction, .. } => {
+                assert!(
+                    (fraction - 0.5).abs() < 1e-9,
+                    "expected fraction ~0.5, got {fraction}"
+                );
+            }
+            TransferAdaptivePolicy::Off => panic!("expected adaptive On"),
+        }
+    }
+
+    #[test]
+    fn adaptive_flag_out_of_range_is_rejected() {
+        // clap value_parser rejects <= 0 and > 1 at parse time.
+        for bad in ["0", "0.0", "1.5", "-0.2", "nope"] {
+            unsafe {
+                std::env::remove_var("SNAPDIR_ADAPTIVE");
+                std::env::remove_var("SNAPDIR_MAX_JOBS");
+            }
+            let arg = format!("--adaptive={bad}");
+            assert!(
+                Cli::try_parse_from(["snapdir", &arg, "defaults"]).is_err(),
+                "expected --adaptive={bad} to be rejected"
+            );
+        }
+        // 1.0 is the inclusive upper bound and must be accepted.
+        let cfg = cli_with(&["--adaptive=1.0"]).transfer_config().unwrap();
+        assert!(matches!(cfg.adaptive, TransferAdaptivePolicy::On { .. }));
+    }
+
+    #[test]
+    fn adaptive_unset_equals_pre_phase18_value() {
+        // The default (no --adaptive) MUST be byte-for-byte the historical
+        // non-adaptive config: Off, same concurrency + max_bytes_per_sec.
+        let cfg = cli_with(&["--jobs", "4", "--limit-rate", "1M"])
+            .transfer_config()
+            .unwrap();
+        let expected = TransferConfig::new(4, Some(1_048_576));
+        assert_eq!(cfg.adaptive, TransferAdaptivePolicy::Off);
+        assert_eq!(cfg.adaptive, expected.adaptive);
+        assert_eq!(cfg.concurrency, expected.concurrency);
+        assert_eq!(cfg.max_bytes_per_sec, expected.max_bytes_per_sec);
+
+        // Same for the all-defaults case.
+        let cfg = cli_with(&[]).transfer_config().unwrap();
+        let expected = TransferConfig::new(TransferConfig::default().concurrency.get(), None);
+        assert_eq!(cfg.adaptive, TransferAdaptivePolicy::Off);
+        assert_eq!(cfg.concurrency, expected.concurrency);
+        assert_eq!(cfg.max_bytes_per_sec, expected.max_bytes_per_sec);
+    }
+
+    #[test]
+    fn adaptive_max_jobs_sets_ceiling() {
+        let cfg = cli_with(&["--adaptive", "--max-jobs", "8"])
+            .transfer_config()
+            .unwrap();
+        match cfg.adaptive {
+            TransferAdaptivePolicy::On { ceiling, .. } => assert_eq!(ceiling, 8),
+            TransferAdaptivePolicy::Off => panic!("expected adaptive On"),
+        }
+
+        // An explicit --jobs acts as the ceiling under --adaptive when
+        // --max-jobs is unset; --limit-rate still threads through.
+        let cfg = cli_with(&["--adaptive=0.6", "--jobs", "3", "--limit-rate", "512K"])
+            .transfer_config()
+            .unwrap();
+        match cfg.adaptive {
+            TransferAdaptivePolicy::On { fraction, ceiling } => {
+                assert!((fraction - 0.6).abs() < 1e-9);
+                assert_eq!(ceiling, 3);
+            }
+            TransferAdaptivePolicy::Off => panic!("expected adaptive On"),
+        }
+        assert_eq!(cfg.max_bytes_per_sec, Some(524_288));
+
+        // --max-jobs wins over --jobs for the ceiling.
+        let cfg = cli_with(&["--adaptive", "--jobs", "2", "--max-jobs", "12"])
+            .transfer_config()
+            .unwrap();
+        match cfg.adaptive {
+            TransferAdaptivePolicy::On { ceiling, .. } => assert_eq!(ceiling, 12),
+            TransferAdaptivePolicy::Off => panic!("expected adaptive On"),
+        }
+    }
+
+    #[test]
+    fn adaptive_ceiling_is_clamped_to_cap() {
+        let cfg = cli_with(&["--adaptive", "--max-jobs", "9999"])
+            .transfer_config()
+            .unwrap();
+        match cfg.adaptive {
+            TransferAdaptivePolicy::On { ceiling, .. } => {
+                assert_eq!(ceiling, ADAPTIVE_CEILING_CAP);
+            }
+            TransferAdaptivePolicy::Off => panic!("expected adaptive On"),
+        }
     }
 }

--- a/crates/snapdir-cli/src/cli.rs
+++ b/crates/snapdir-cli/src/cli.rs
@@ -1162,11 +1162,20 @@ impl Cli {
             );
             // Modern (unicode) glyphs unless the terminal is explicitly dumb.
             let ascii = matches!(std::env::var("TERM").as_deref(), Ok("dumb"));
-            let reporter = ProgressReporter::start(Arc::clone(&meter), jobs, true, color, ascii);
+            // Thread the true adaptive politeness fraction (`--adaptive[=F]`)
+            // into the renderer's adaptive readout; `None` when not adaptive.
+            let reporter = ProgressReporter::start(
+                Arc::clone(&meter),
+                jobs,
+                true,
+                color,
+                ascii,
+                self.globals.adaptive,
+            );
             (Some(meter), reporter)
         } else {
             let reporter =
-                ProgressReporter::start(Arc::new(Meter::new()), jobs, false, false, false);
+                ProgressReporter::start(Arc::new(Meter::new()), jobs, false, false, false, None);
             (None, reporter)
         }
     }

--- a/crates/snapdir-cli/src/progress.rs
+++ b/crates/snapdir-cli/src/progress.rs
@@ -840,6 +840,9 @@ mod tests {
             objects_skipped: skipped,
             in_flight,
             phase,
+            // Not-adaptive: the live-tuning fields are advisory and unset here.
+            current_limit: 0,
+            target_rate: 0,
         }
     }
 

--- a/crates/snapdir-cli/src/progress.rs
+++ b/crates/snapdir-cli/src/progress.rs
@@ -160,6 +160,36 @@ pub(crate) fn human_bytes(n: u64) -> String {
     }
 }
 
+/// Picks the [`BYTE_UNITS`] index appropriate for `n` (the magnitude whose
+/// value lands in `[1, 1024)`). Used to choose a size unit *once* from the
+/// known/estimated total and HOLD it for the whole transfer, so the size field
+/// never flips MB↔GB mid-stream (which would reflow the layout).
+fn unit_index_for(n: u64) -> usize {
+    if n < 1024 {
+        return 0;
+    }
+    let mut value = n as f64;
+    let mut unit = 0usize;
+    while value >= KIB && unit < BYTE_UNITS.len() - 1 {
+        value /= KIB;
+        unit += 1;
+    }
+    unit
+}
+
+/// Formats `n` bytes in the *fixed* unit `unit` (an index into [`BYTE_UNITS`])
+/// to one decimal place, e.g. `unit=3` (GB) renders `1.2` for ~1.2 GB and
+/// `0.4` for ~400 MB. Holding the unit + decimals fixed keeps the field's
+/// visible width stable as the value grows. The unit *label* is rendered
+/// separately by the caller (so `<xfer>/<total> GB` shares one suffix).
+fn bytes_in_unit(n: u64, unit: usize) -> String {
+    // `unit` is a [`BYTE_UNITS`] index (0..=5), so the cast never wraps.
+    let exp = i32::try_from(unit).unwrap_or(0);
+    let divisor = KIB.powi(exp);
+    let value = n as f64 / divisor;
+    format!("{value:.1}")
+}
+
 /// Formats a transfer rate, e.g. `148 MB/s`, `1.5 KB/s`, `0 B/s`.
 pub(crate) fn human_rate(bytes_per_sec: f64) -> String {
     if !bytes_per_sec.is_finite() || bytes_per_sec <= 0.0 {
@@ -168,6 +198,19 @@ pub(crate) fn human_rate(bytes_per_sec: f64) -> String {
     // Round to whole bytes and reuse the byte humanizer for consistent units.
     let bytes = bytes_per_sec.round() as u64;
     format!("{}/s", human_bytes(bytes))
+}
+
+/// Number of decimal digits in `n` (at least 1, so `0` is width 1). Used to
+/// left-pad the `done` count to the `total`'s width so the `done/total` field
+/// keeps a constant visible width as `done` climbs.
+fn decimal_digits(n: u64) -> usize {
+    let mut n = n;
+    let mut digits = 1usize;
+    while n >= 10 {
+        n /= 10;
+        digits += 1;
+    }
+    digits
 }
 
 /// Formats a coarse ETA duration, e.g. `1m05s`, `12s`, `2h03m`.
@@ -186,6 +229,30 @@ fn human_eta(d: Duration) -> String {
     }
 }
 
+/// The fixed visible width of the eta *value* slot (without the `eta ` label).
+/// Sized to hold the widest common form (`12m34s`, `2h03m`, and the `--`
+/// placeholder), so the field — and everything after it — never reflows as the
+/// eta ticks across magnitudes.
+const ETA_SLOT: usize = 6;
+
+/// Renders the eta value padded/clamped to [`ETA_SLOT`] columns. `None` (no
+/// stable signal yet) renders a right-padded `--` so the slot still occupies a
+/// constant width.
+fn eta_slot(eta: Option<Duration>) -> String {
+    let raw = match eta {
+        Some(d) => human_eta(d),
+        None => "--".to_owned(),
+    };
+    // Left-pad to a fixed width so the value is right-aligned in its slot;
+    // clamp overly-wide values (huge etas) so the column never grows.
+    let w = visible_width(&raw);
+    if w >= ETA_SLOT {
+        raw.chars().take(ETA_SLOT).collect()
+    } else {
+        format!("{}{}", " ".repeat(ETA_SLOT - w), raw)
+    }
+}
+
 // ---------------------------------------------------------------------------
 // 3. The pure line formatter.
 // ---------------------------------------------------------------------------
@@ -201,7 +268,8 @@ pub(crate) struct RenderMetrics {
     pub(crate) rate_out: f64,
     /// Smoothed objects/sec.
     pub(crate) obj_per_sec: f64,
-    /// Estimated time remaining, when computable.
+    /// The *displayed* ETA: throttled (refreshed at most every ~2s) and damped
+    /// so it counts down smoothly. `None` until a stable signal exists.
     pub(crate) eta: Option<Duration>,
     /// Resident set size in bytes, when sampleable.
     pub(crate) rss: Option<u64>,
@@ -211,6 +279,21 @@ pub(crate) struct RenderMetrics {
     pub(crate) jobs: usize,
     /// Monotonic spinner frame counter (mod the frame-set length).
     pub(crate) spinner_frame: usize,
+    /// Held size unit (index into [`BYTE_UNITS`]) for the byte field, chosen
+    /// once from the estimated total and held for the whole transfer so the
+    /// size column never flips units mid-stream. `None` falls back to a unit
+    /// derived from the live bytes-out.
+    pub(crate) size_unit: Option<usize>,
+    /// Estimated total bytes for the transfer (derived from the observed
+    /// average object size), when computable; `0`/`None` hides the estimate.
+    pub(crate) byte_total_est: Option<u64>,
+    /// The adaptive *politeness fraction* (`--adaptive[=FRACTION]`, in
+    /// `(0.0, 1.0]`), threaded from the CLI. This is the TRUE fraction the
+    /// operator asked for — it is NOT derivable from the [`MeterSnapshot`]
+    /// (whose `current_limit` is a concurrency count and `target_rate` is a
+    /// byte rate). Rendered as `(auto <fraction>)` when adaptive is active
+    /// (`current_limit > 0`). `None` when not adaptive.
+    pub(crate) adaptive_fraction: Option<f64>,
 }
 
 // Modern (unicode) glyph set — every glyph is display-width 1.
@@ -376,18 +459,35 @@ impl LineFields {
             0.0
         };
 
+        // Counts are labeled as *files* and the `done` value is left-padded to
+        // the digit-width of `total`, so e.g. `8/61` and `38/61` occupy the
+        // same width (no reflow as the count climbs).
         let counts = if determinate {
             let pct = (fraction * 100.0).clamp(0.0, 100.0);
-            format!("{pct:>3.0}% {done}/{total}")
+            let total_digits = decimal_digits(total);
+            format!("{pct:>3.0}% {done:>total_digits$}/{total} files")
         } else {
-            format!("{done} objs")
+            // Indeterminate: a digit-stable, explicitly-labeled file count.
+            format!("{done} files")
         };
 
-        let bytes = format!(
-            "{}/{}",
-            human_bytes(snap.bytes_out),
-            human_bytes(snap.bytes_in)
-        );
+        // Size field: always carries a unit, and the unit is the *held* one
+        // (chosen once from the estimated total) so it never flips mid-stream.
+        // When an estimated total is known we show `<xfer>/<est> <UNIT>`,
+        // otherwise just `<xfer> <UNIT>`. The transferred figure is bytes-out
+        // (the work the operator cares about for an upload/sync).
+        let unit = m
+            .size_unit
+            .unwrap_or_else(|| unit_index_for(snap.bytes_out));
+        let unit_label = BYTE_UNITS[unit];
+        let bytes = match m.byte_total_est {
+            Some(total_bytes) if total_bytes >= snap.bytes_out => format!(
+                "{}/{} {unit_label}",
+                bytes_in_unit(snap.bytes_out, unit),
+                bytes_in_unit(total_bytes, unit),
+            ),
+            _ => format!("{} {unit_label}", bytes_in_unit(snap.bytes_out, unit)),
+        };
         let (down_sym, up_sym) = if ascii {
             ("down".to_owned(), "up".to_owned())
         } else {
@@ -399,17 +499,38 @@ impl LineFields {
             human_rate(m.rate_out)
         );
 
+        // Concurrency / adaptive readout. When the meter reports adaptive is
+        // active (`current_limit > 0`) we surface it as `jobs <in>/<ceiling>
+        // (auto <fraction>)`, where `<ceiling>` is the adaptive ceiling the
+        // renderer already holds (`m.jobs`), `<in>` is the live in-flight
+        // gauge, and `<fraction>` is the TRUE politeness fraction threaded
+        // from the CLI (`--adaptive[=FRACTION]`). The fraction is NOT derivable
+        // from the meter (its `current_limit` is a concurrency count and
+        // `target_rate` is a byte rate), so when it wasn't threaded we fall
+        // back to a bare `(auto)` with no misleading number. When not adaptive,
+        // we keep the plain `<in>/<jobs>` style.
+        let conc = if snap.current_limit > 0 {
+            match m.adaptive_fraction {
+                Some(f) => format!("jobs {}/{} (auto {f:.1})", snap.in_flight, m.jobs),
+                None => format!("jobs {}/{} (auto)", snap.in_flight, m.jobs),
+            }
+        } else {
+            format!("{}/{}", snap.in_flight, m.jobs)
+        };
+
         Self {
             spinner: spinner_glyph(m.spinner_frame, ascii).to_string(),
             label,
             counts,
             bytes,
             rates,
-            conc: format!("{}/{}", snap.in_flight, m.jobs),
+            conc,
             obj: Some(format!("{:.0} obj/s", m.obj_per_sec)),
             mem: m.rss.map(|r| format!("mem {}", human_bytes(r))),
             cpu: m.cpu_pct.map(|c| format!("cpu {c:.0}%")),
-            eta: m.eta.map(|d| format!("eta {}", human_eta(d))),
+            // eta always occupies a fixed-width slot (value `--` when no stable
+            // signal yet) so fields after it never reflow as the eta ticks.
+            eta: Some(format!("eta {}", eta_slot(m.eta))),
             determinate,
             fraction,
         }
@@ -675,11 +796,44 @@ struct RenderState {
     obj_per_sec: f64,
     spinner_frame: usize,
     cpu: CpuSampler,
+    /// Heavily-smoothed bytes/sec written out, used as the steady denominator
+    /// for the byte-based ETA (steadier than the display rate `rate_out`).
+    smooth_bps: f64,
+    /// The currently-DISPLAYED eta (held between throttled refreshes and damped
+    /// toward new estimates). `None` until a stable signal is established.
+    displayed_eta: Option<Duration>,
+    /// When `displayed_eta` was last refreshed, for the ~2s throttle.
+    last_eta_update: Option<Instant>,
+    /// Held size unit (index into [`BYTE_UNITS`]) for the byte field, latched
+    /// once from the first credible total estimate and never changed after, so
+    /// the size column never flips units mid-stream.
+    size_unit: Option<usize>,
+    /// The adaptive politeness fraction threaded from the CLI
+    /// (`--adaptive[=FRACTION]`), or `None` when not adaptive. Constant for the
+    /// life of the reporter; surfaced verbatim in the adaptive readout.
+    adaptive_fraction: Option<f64>,
 }
 
+/// Smoothing factor for the steady byte-rate used by the ETA (much heavier
+/// than [`EWMA_ALPHA`] so the ETA denominator barely flickers).
+const ETA_RATE_ALPHA: f64 = 0.1;
+
+/// Minimum interval between DISPLAYED-eta refreshes. The spinner/bar/bps/iops
+/// keep their 100ms cadence; only the eta value is held between these.
+const ETA_REFRESH: Duration = Duration::from_secs(2);
+
+/// Maximum fraction the displayed eta may move toward a new estimate per
+/// refresh, so it settles and counts down smoothly instead of jumping.
+const ETA_DAMP: f64 = 0.3;
+
+/// Require at least this many completed objects before showing any eta, so we
+/// never flash a wild value before a rate is established.
+const ETA_MIN_OBJECTS: u64 = 4;
+
 impl RenderState {
-    /// Initializes from the meter and primes the CPU baseline.
-    fn init(meter: &Meter) -> Self {
+    /// Initializes from the meter and primes the CPU baseline. `adaptive_fraction`
+    /// is the CLI's `--adaptive[=FRACTION]` value (or `None` when not adaptive).
+    fn init(meter: &Meter, adaptive_fraction: Option<f64>) -> Self {
         let mut state = Self {
             last: Instant::now(),
             last_snap: meter.snapshot(),
@@ -688,6 +842,11 @@ impl RenderState {
             obj_per_sec: 0.0,
             spinner_frame: 0,
             cpu: CpuSampler::new(),
+            smooth_bps: 0.0,
+            displayed_eta: None,
+            last_eta_update: None,
+            size_unit: None,
+            adaptive_fraction,
         };
         let _ = state.cpu.poll();
         state
@@ -707,22 +866,111 @@ impl RenderState {
             self.rate_in = ewma(self.rate_in, d_in / dt);
             self.rate_out = ewma(self.rate_out, d_out / dt);
             self.obj_per_sec = ewma(self.obj_per_sec, d_obj / dt);
+            self.smooth_bps =
+                ETA_RATE_ALPHA * (d_out / dt) + (1.0 - ETA_RATE_ALPHA) * self.smooth_bps;
         }
         self.last = now;
         self.last_snap = snap;
         self.spinner_frame = self.spinner_frame.wrapping_add(1);
 
+        let byte_total_est = estimate_total_bytes(&snap);
+        // Latch the size unit once, from the first credible total estimate
+        // (or, failing that, the live bytes-out), and hold it thereafter.
+        if self.size_unit.is_none() {
+            if let Some(total) = byte_total_est {
+                self.size_unit = Some(unit_index_for(total.max(snap.bytes_out)));
+            } else if snap.bytes_out >= 1024 {
+                self.size_unit = Some(unit_index_for(snap.bytes_out));
+            }
+        }
+
+        let eta = self.update_eta(&snap, byte_total_est, now);
+
         RenderMetrics {
             rate_in: self.rate_in,
             rate_out: self.rate_out,
             obj_per_sec: self.obj_per_sec,
-            eta: compute_eta(&snap, self.obj_per_sec),
+            eta,
             rss: sample_rss(),
             cpu_pct: self.cpu.poll(),
             jobs,
             spinner_frame: self.spinner_frame,
+            size_unit: self.size_unit,
+            byte_total_est,
+            adaptive_fraction: self.adaptive_fraction,
         }
     }
+
+    /// Computes the THROTTLED + DAMPED displayed eta. The freshly-estimated eta
+    /// (byte-based, from [`compute_eta_bytes`]) is recomputed every tick, but
+    /// the *displayed* value is only refreshed every [`ETA_REFRESH`]; between
+    /// refreshes the previous value is held verbatim. On a refresh the new
+    /// estimate is damped (moved at most [`ETA_DAMP`] toward it) so it settles
+    /// smoothly instead of jumping.
+    fn update_eta(
+        &mut self,
+        snap: &MeterSnapshot,
+        byte_total_est: Option<u64>,
+        now: Instant,
+    ) -> Option<Duration> {
+        // Require a minimum number of completed objects before trusting any
+        // estimate, so we never flash a wild value before a rate is set.
+        let done = snap.objects_done + snap.objects_skipped;
+        let fresh = if done >= ETA_MIN_OBJECTS {
+            compute_eta_bytes(snap, byte_total_est, self.smooth_bps)
+        } else {
+            None
+        };
+
+        let Some(fresh) = fresh else {
+            // No credible fresh estimate this tick: HOLD whatever we last
+            // displayed (which is `None` until the first credible refresh).
+            return self.displayed_eta;
+        };
+
+        let due = match self.last_eta_update {
+            None => true, // first credible refresh: adopt directly
+            Some(last) => now.duration_since(last) >= ETA_REFRESH,
+        };
+        if due {
+            let next = match self.displayed_eta {
+                Some(prev) => damp_duration(prev, fresh, ETA_DAMP),
+                None => fresh,
+            };
+            self.displayed_eta = Some(next);
+            self.last_eta_update = Some(now);
+        }
+        self.displayed_eta
+    }
+}
+
+/// Moves `from` at most `frac` of the way toward `to` (a damped step on a
+/// duration, in seconds), so the displayed eta counts down smoothly.
+fn damp_duration(from: Duration, to: Duration, frac: f64) -> Duration {
+    let a = from.as_secs_f64();
+    let b = to.as_secs_f64();
+    let next = a + (b - a) * frac.clamp(0.0, 1.0);
+    Duration::from_secs_f64(next.max(0.0))
+}
+
+/// Estimates the transfer's total bytes from the observed average object size:
+/// `avg = bytes_out / completed`, `total ≈ avg * objects_total`. Returns `None`
+/// when the total object count is unknown or nothing has completed yet (no
+/// average to extrapolate from).
+fn estimate_total_bytes(snap: &MeterSnapshot) -> Option<u64> {
+    if snap.objects_total == 0 {
+        return None;
+    }
+    let completed = snap.objects_done + snap.objects_skipped;
+    if completed == 0 || snap.bytes_out == 0 {
+        return None;
+    }
+    let avg = snap.bytes_out as f64 / completed as f64;
+    let total = avg * snap.objects_total as f64;
+    if !total.is_finite() || total < 0.0 {
+        return None;
+    }
+    Some(total as u64)
 }
 
 impl ProgressReporter {
@@ -734,6 +982,7 @@ impl ProgressReporter {
         active: bool,
         color: bool,
         ascii: bool,
+        adaptive_fraction: Option<f64>,
     ) -> ProgressReporter {
         let stop = Arc::new(AtomicBool::new(false));
         if !active {
@@ -750,7 +999,7 @@ impl ProgressReporter {
         let stderr_lock: Arc<Mutex<()>> = Arc::new(Mutex::new(()));
 
         let handle = std::thread::spawn(move || {
-            let mut state = RenderState::init(&meter);
+            let mut state = RenderState::init(&meter, adaptive_fraction);
             while !stop_thread.load(Ordering::Relaxed) {
                 std::thread::sleep(TICK);
                 if stop_thread.load(Ordering::Relaxed) {
@@ -797,22 +1046,39 @@ fn ewma(prev: f64, sample: f64) -> f64 {
     EWMA_ALPHA * sample + (1.0 - EWMA_ALPHA) * prev
 }
 
-/// Estimates remaining time from the objects gauge and the smoothed obj/s rate.
-/// `None` when the total is unknown or the rate is non-positive.
-fn compute_eta(snap: &MeterSnapshot, obj_per_sec: f64) -> Option<Duration> {
-    if snap.objects_total == 0 || obj_per_sec <= 0.0 {
+/// Estimates remaining time in BYTES (steadier than object count for mixed
+/// sizes): `remaining_bytes = total_est - bytes_out`, divided by the heavily
+/// smoothed byte rate `smooth_bps`. Falls back to an object-rate estimate when
+/// no byte total can be estimated (e.g. all-equal-size or unknown sizes), using
+/// `smooth_bps`-derived progress is not possible.
+///
+/// `None` when the total objects are unknown or no usable rate exists. The
+/// caller is responsible for throttling/damping the returned value.
+fn compute_eta_bytes(
+    snap: &MeterSnapshot,
+    byte_total_est: Option<u64>,
+    smooth_bps: f64,
+) -> Option<Duration> {
+    if snap.objects_total == 0 {
         return None;
     }
     let done = snap.objects_done + snap.objects_skipped;
-    let remaining = snap.objects_total.saturating_sub(done);
-    if remaining == 0 {
+    if snap.objects_total.saturating_sub(done) == 0 {
         return Some(Duration::ZERO);
     }
-    let secs = remaining as f64 / obj_per_sec;
-    if !secs.is_finite() || secs < 0.0 {
-        return None;
+
+    // Preferred: byte-based estimate with the heavily-smoothed byte rate.
+    if let Some(total) = byte_total_est {
+        if smooth_bps > 0.0 && total >= snap.bytes_out {
+            let remaining = (total - snap.bytes_out) as f64;
+            let secs = remaining / smooth_bps;
+            if secs.is_finite() && secs >= 0.0 {
+                return Some(Duration::from_secs_f64(secs));
+            }
+        }
     }
-    Some(Duration::from_secs_f64(secs))
+
+    None
 }
 
 // ---------------------------------------------------------------------------
@@ -917,20 +1183,24 @@ mod tests {
             cpu_pct: Some(85.0),
             jobs: 16,
             spinner_frame: 0,
+            ..Default::default()
         };
         let style = Style { color: false };
         let line = format_line(&s, &m, 200, &style, false);
 
         // (30 done + 10 skipped) / 100 = 40%.
         assert!(line.contains("40%"), "percent missing: {line}");
-        assert!(line.contains("40/100"), "counts missing: {line}");
+        // Counts are explicitly labeled as files.
+        assert!(line.contains("40/100 files"), "files count missing: {line}");
         assert!(line.contains('↓'), "down arrow missing: {line}");
         assert!(line.contains('↑'), "up arrow missing: {line}");
         assert!(line.contains("148 MB/s"), "rate_in missing: {line}");
         assert!(line.contains("4/16"), "concurrency missing: {line}");
         assert!(line.contains("mem 64 MB"), "mem missing: {line}");
         assert!(line.contains("cpu 85%"), "cpu missing: {line}");
-        assert!(line.contains("eta 42s"), "eta missing: {line}");
+        // eta value lives in a fixed-width slot (right-aligned, padded).
+        assert!(line.contains("42s"), "eta value missing: {line}");
+        assert!(line.contains("eta "), "eta label missing: {line}");
         assert!(line.contains("transfer"), "phase missing: {line}");
         assert!(
             line.contains('█') || line.contains('░'),
@@ -938,7 +1208,8 @@ mod tests {
         );
         assert!(line.contains("12 obj/s"), "obj/s missing: {line}");
 
-        // None metrics are omitted.
+        // None mem/cpu are omitted; eta with no signal renders the `--`
+        // placeholder in its fixed-width slot (not removed).
         let m2 = RenderMetrics {
             eta: None,
             rss: None,
@@ -948,7 +1219,10 @@ mod tests {
         let line2 = format_line(&s, &m2, 200, &style, false);
         assert!(!line2.contains("mem "), "mem should be omitted: {line2}");
         assert!(!line2.contains("cpu "), "cpu should be omitted: {line2}");
-        assert!(!line2.contains("eta "), "eta should be omitted: {line2}");
+        // eta with no signal renders the `--` placeholder (right-aligned in its
+        // fixed slot), not removed.
+        assert!(line2.contains("eta "), "eta label missing: {line2}");
+        assert!(line2.contains("--"), "eta placeholder missing: {line2}");
     }
 
     #[test]
@@ -971,13 +1245,14 @@ mod tests {
             cpu_pct: None,
             jobs: 16,
             spinner_frame: 1,
+            ..Default::default()
         };
         let style = Style { color: false };
         let line = format_line(&s, &m, 200, &style, true); // ascii = true
 
         assert!(line.contains("down"), "ascii down missing: {line}");
         assert!(line.contains("up"), "ascii up missing: {line}");
-        assert!(line.contains("8/16"), "concurrency missing: {line}");
+        assert!(line.contains("8/16 files"), "files count missing: {line}");
         assert!(line.contains("50%"), "percent missing: {line}");
         assert!(
             line.contains('[') && line.contains(']'),
@@ -1001,7 +1276,7 @@ mod tests {
         let style = Style { color: false };
         let line = format_line(&s, &m, 200, &style, false);
         assert!(
-            line.contains("5 objs"),
+            line.contains("5 files"),
             "indeterminate count missing: {line}"
         );
         assert!(!line.contains('%'), "no percent when indeterminate: {line}");
@@ -1029,6 +1304,7 @@ mod tests {
             cpu_pct: Some(85.0),
             jobs: 16,
             spinner_frame: 0,
+            ..Default::default()
         };
         let style = Style { color: false };
 
@@ -1083,7 +1359,245 @@ mod tests {
     fn progress_render_reporter_inactive_is_inert() {
         // An inactive reporter spawns no thread and finish() is a no-op.
         let meter = Arc::new(Meter::new());
-        let reporter = ProgressReporter::start(meter, 4, false, false, false);
+        let reporter = ProgressReporter::start(meter, 4, false, false, false, None);
         reporter.finish();
+    }
+
+    /// Strips ANSI escapes (`\x1b[...m`) so column offsets can be measured on
+    /// the visible text only. Tests use `color: false` so this is a no-op, but
+    /// keeping it makes the offset assertions robust to styling.
+    fn strip_ansi(s: &str) -> String {
+        let mut out = String::with_capacity(s.len());
+        let mut chars = s.chars().peekable();
+        while let Some(c) = chars.next() {
+            if c == '\x1b' {
+                // Skip until the terminating 'm' of a CSI sequence.
+                for n in chars.by_ref() {
+                    if n == 'm' {
+                        break;
+                    }
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    }
+
+    /// Visible-column offset of the first occurrence of `needle` in `hay`.
+    fn col_of(hay: &str, needle: &str) -> usize {
+        let plain = strip_ansi(hay);
+        let byte_idx = plain.find(needle).unwrap_or_else(|| {
+            panic!("needle {needle:?} not found in line {plain:?}");
+        });
+        plain[..byte_idx].chars().count()
+    }
+
+    #[test]
+    fn progress_render_width_stable_columns() {
+        // As `done` and bytes change width over a transfer, the labeled fields
+        // after them must NOT shift: their visible-column offsets stay fixed.
+        let style = Style { color: false };
+        let total = 61u64;
+        // Held unit (GB) chosen once; estimate ~2 GB total.
+        let unit = Some(unit_index_for(2 * 1024 * 1024 * 1024));
+        let est = Some(2 * 1024 * 1024 * 1024u64);
+
+        let mut files_cols = Vec::new();
+        let mut rate_cols = Vec::new();
+        let mut eta_cols = Vec::new();
+        for (done, bytes_out) in [
+            (8u64, 120 * 1024 * 1024u64),
+            (38, 1100 * 1024 * 1024),
+            (60, 1900 * 1024 * 1024),
+        ] {
+            let s = snap(0, bytes_out, done, total, 0, 4, Phase::Transfer);
+            let m = RenderMetrics {
+                rate_in: 0.0,
+                rate_out: 18_000_000.0,
+                obj_per_sec: 5.0,
+                eta: Some(Duration::from_secs(80)),
+                rss: None,
+                cpu_pct: None,
+                jobs: 16,
+                spinner_frame: 0,
+                size_unit: unit,
+                byte_total_est: est,
+                adaptive_fraction: None,
+            };
+            // Wide enough that no optional is dropped.
+            let line = format_line(&s, &m, 200, &style, false);
+            files_cols.push(col_of(&line, "files"));
+            rate_cols.push(col_of(&line, "/s"));
+            eta_cols.push(col_of(&line, "eta "));
+        }
+        assert!(
+            files_cols.windows(2).all(|w| w[0] == w[1]),
+            "`files` column reflowed: {files_cols:?}"
+        );
+        assert!(
+            rate_cols.windows(2).all(|w| w[0] == w[1]),
+            "rate column reflowed: {rate_cols:?}"
+        );
+        assert!(
+            eta_cols.windows(2).all(|w| w[0] == w[1]),
+            "eta column reflowed: {eta_cols:?}"
+        );
+    }
+
+    #[test]
+    fn progress_render_files_vs_size_labels() {
+        let s = snap(0, 1_400_000_000, 38, 61, 0, 6, Phase::Transfer);
+        let m = RenderMetrics {
+            rate_out: 18_000_000.0,
+            jobs: 16,
+            size_unit: Some(unit_index_for(2_000_000_000)),
+            byte_total_est: Some(2_000_000_000),
+            ..Default::default()
+        };
+        let style = Style { color: false };
+        let line = strip_ansi(&format_line(&s, &m, 200, &style, false));
+        // Count is labeled as files.
+        assert!(line.contains("38/61 files"), "files label missing: {line}");
+        // Size carries a unit (no bare ambiguous number for the transferred
+        // size): the byte field reads `<xfer>/<est> GB`.
+        assert!(
+            line.contains(" GB") && line.contains('/'),
+            "unit-suffixed size missing: {line}"
+        );
+    }
+
+    #[test]
+    fn progress_render_eta_held_then_smooth() {
+        // Drive RenderState with snapshots ~100ms apart and assert the DISPLAYED
+        // eta is HELD within a <2s window, and that a settled stream produces a
+        // smoothly-decreasing eta (no large jumps).
+        let meter = Meter::new();
+        meter.set_phase(Phase::Transfer);
+        let mut state = RenderState::init(&meter, None);
+
+        // Build a steady stream: equal-size objects, constant byte rate.
+        let total = 100u64;
+        let obj_bytes = 10_000_000u64; // 10 MB/object
+        let mut t = 0u64;
+        let mut displayed: Vec<Option<Duration>> = Vec::new();
+        // 30 ticks * 100ms = ~3s of stream.
+        for i in 0..30u64 {
+            let done = (i + 1).min(total);
+            let s = snap(0, done * obj_bytes, done, total, 0, 4, Phase::Transfer);
+            // Sleep 100ms of *wall* time so the throttle window is real.
+            std::thread::sleep(Duration::from_millis(100));
+            let m = state.tick(s, 16);
+            displayed.push(m.eta);
+            t += 1;
+        }
+        let _ = t;
+
+        // Find the first tick that established an eta.
+        let first_some = displayed.iter().position(Option::is_some);
+        assert!(first_some.is_some(), "eta never established: {displayed:?}");
+        let start = first_some.unwrap();
+
+        // HOLD: within ~1.5s (15 ticks) after the first refresh there must be a
+        // run where the value does not change (it's throttled to >=2s). Assert
+        // at least two consecutive identical displayed values exist.
+        let vals: Vec<Duration> = displayed[start..].iter().filter_map(|x| *x).collect();
+        let has_held = vals.windows(2).any(|w| w[0] == w[1]);
+        assert!(has_held, "eta never held between refreshes: {vals:?}");
+
+        // SMOOTH: consecutive displayed values never jump by more than the
+        // whole remaining estimate (damping keeps steps small); concretely, no
+        // step grows the eta wildly and the trend is downward overall.
+        for w in vals.windows(2) {
+            let a = w[0].as_secs_f64();
+            let b = w[1].as_secs_f64();
+            assert!(
+                (b - a) <= a.max(1.0),
+                "eta jumped upward sharply: {a} -> {b}"
+            );
+        }
+        assert!(
+            vals.last().unwrap() <= vals.first().unwrap(),
+            "eta did not trend downward: {vals:?}"
+        );
+    }
+
+    #[test]
+    fn progress_render_no_eta_before_signal() {
+        // With too few completed objects, no eta is shown (no wild early value).
+        let meter = Meter::new();
+        let mut state = RenderState::init(&meter, None);
+        let s = snap(0, 5_000_000, 1, 100, 0, 4, Phase::Transfer);
+        std::thread::sleep(Duration::from_millis(100));
+        let m = state.tick(s, 16);
+        assert!(m.eta.is_none(), "eta should be None before signal");
+        // And the rendered line shows the placeholder, not a number.
+        let style = Style { color: false };
+        let line = format_line(&s, &m, 200, &style, false);
+        assert!(line.contains("eta "), "eta label missing: {line}");
+        assert!(line.contains("--"), "eta placeholder missing: {line}");
+    }
+
+    #[test]
+    fn progress_render_adaptive_readout() {
+        let style = Style { color: false };
+        // Adaptive active (current_limit > 0) WITH the threaded politeness
+        // fraction → shows the TRUE fraction: `jobs <in>/<ceiling> (auto 0.8)`.
+        let mut s = snap(0, 1_000_000, 10, 100, 0, 6, Phase::Transfer);
+        s.current_limit = 4_000_000;
+        s.target_rate = 5_000_000;
+        let m = RenderMetrics {
+            jobs: 16,
+            size_unit: Some(2),
+            adaptive_fraction: Some(0.8),
+            ..Default::default()
+        };
+        let line = strip_ansi(&format_line(&s, &m, 200, &style, false));
+        assert!(line.contains("jobs 6/16"), "adaptive jobs missing: {line}");
+        assert!(line.contains("(auto 0.8)"), "true fraction missing: {line}");
+
+        // Adaptive active but the fraction wasn't threaded → bare `(auto)` with
+        // NO misleading number.
+        let m_nofrac = RenderMetrics {
+            adaptive_fraction: None,
+            ..m
+        };
+        let line_nofrac = strip_ansi(&format_line(&s, &m_nofrac, 200, &style, false));
+        assert!(
+            line_nofrac.contains("jobs 6/16 (auto)"),
+            "bare auto fallback missing: {line_nofrac}"
+        );
+        // No digit leaks into the bare-auto form (e.g. no `(auto 0`).
+        assert!(
+            !line_nofrac.contains("(auto 0"),
+            "unexpected number in bare auto: {line_nofrac}"
+        );
+
+        // Not adaptive: current_limit == 0 → plain in_flight/jobs, no `auto`.
+        let s2 = snap(0, 1_000_000, 10, 100, 0, 6, Phase::Transfer);
+        let line2 = strip_ansi(&format_line(&s2, &m, 200, &style, false));
+        assert!(line2.contains("6/16"), "plain conc missing: {line2}");
+        assert!(
+            !line2.contains("auto"),
+            "unexpected auto indicator: {line2}"
+        );
+    }
+
+    #[test]
+    fn progress_render_adaptive_fraction_threaded_through_tick() {
+        // The fraction supplied to RenderState::init propagates into the
+        // RenderMetrics emitted by tick(), independent of meter contents.
+        let meter = Meter::new();
+        let mut state = RenderState::init(&meter, Some(0.5));
+        let mut s = snap(0, 1_000_000, 10, 100, 0, 6, Phase::Transfer);
+        s.current_limit = 4_000_000;
+        let m = state.tick(s, 16);
+        assert_eq!(m.adaptive_fraction, Some(0.5));
+        let style = Style { color: false };
+        let line = strip_ansi(&format_line(&s, &m, 200, &style, false));
+        assert!(
+            line.contains("(auto 0.5)"),
+            "threaded fraction not rendered: {line}"
+        );
     }
 }

--- a/crates/snapdir-cli/tests/cmd/help-ancestors.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-ancestors.trycmd
@@ -5,26 +5,91 @@ List ancestor snapshot IDs and their locations
 Usage: snapdir ancestors [OPTIONS]
 
 Options:
-      --cache-dir <DIR>       Directory where the object cache is stored [env: SNAPDIR_CACHE_DIR=]
-      --catalog <NAME>        Catalog adapter to use [env: SNAPDIR_CATALOG=]
-      --store <URI>           Store URI: `protocol://location/path`
-      --id <ID>               Snapshot ID to operate on
-      --exclude <PATTERN>     Exclude paths matching PATTERN
-      --paths <PATTERN>       Only include paths matching PATTERN
-      --linked                Use symlinks instead of copies
-      --force                 Force an action to run
-      --purge                 Purge objects with invalid checksums
-      --keep                  Keep the staging directory
-      --dryrun                Run without making any changes
-      --verbose               Enable verbose output
-      --debug                 Enable debug output
-      --no-progress           Disable the live progress line (transfers still run) [env: SNAPDIR_NO_PROGRESS=]
-  -q, --quiet                 Suppress stderr banners and the live progress line
-      --color <WHEN>          When to colorize progress output: auto, always, or never [default: auto]
-      --location <DIR|STORE>  Context (directory or store) for catalog queries
-  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
-      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
-  -h, --help                  Print help
-  -V, --version               Print version
+      --cache-dir <DIR>
+          Directory where the object cache is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
+      --catalog <NAME>
+          Catalog adapter to use
+          
+          [env: SNAPDIR_CATALOG=]
+
+      --store <URI>
+          Store URI: `protocol://location/path`
+
+      --id <ID>
+          Snapshot ID to operate on
+
+      --exclude <PATTERN>
+          Exclude paths matching PATTERN
+
+      --paths <PATTERN>
+          Only include paths matching PATTERN
+
+      --linked
+          Use symlinks instead of copies
+
+      --force
+          Force an action to run
+
+      --purge
+          Purge objects with invalid checksums
+
+      --keep
+          Keep the staging directory
+
+      --dryrun
+          Run without making any changes
+
+      --verbose
+          Enable verbose output
+
+      --debug
+          Enable debug output
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+          
+          [default: auto]
+
+      --location <DIR|STORE>
+          Context (directory or store) for catalog queries
+
+  -j, --jobs <N>
+          Max concurrent object transfers (0/auto = number of CPUs, capped)
+          
+          [env: SNAPDIR_JOBS=]
+
+      --limit-rate <RATE>
+          Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)
+          
+          [env: SNAPDIR_LIMIT_RATE=]
+
+      --adaptive[=<FRACTION>]
+          Adaptively tune transfer concurrency/bandwidth toward a fraction (default 0.8) of measured CPU/network capacity; backs off under contention. Opt-in; default is full speed.
+          
+          Presence (with or without a value) opts in; the optional value is the politeness fraction in `(0.0, 1.0]`.
+          
+          [env: SNAPDIR_ADAPTIVE=]
+
+      --max-jobs <N>
+          Adaptive concurrency ceiling (only meaningful with `--adaptive`). When unset, defaults to the auto concurrency; clamped to a sane upper bound
+          
+          [env: SNAPDIR_MAX_JOBS=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```

--- a/crates/snapdir-cli/tests/cmd/help-checkout.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-checkout.trycmd
@@ -5,29 +5,95 @@ Check out a snapshot to a directory
 Usage: snapdir checkout [OPTIONS] [DIR]
 
 Arguments:
-  [DIR]  Destination directory
+  [DIR]
+          Destination directory
 
 Options:
-      --cache-dir <DIR>       Directory where the object cache is stored [env: SNAPDIR_CACHE_DIR=]
-      --catalog <NAME>        Catalog adapter to use [env: SNAPDIR_CATALOG=]
-      --store <URI>           Store URI: `protocol://location/path`
-      --id <ID>               Snapshot ID to operate on
-      --exclude <PATTERN>     Exclude paths matching PATTERN
-      --paths <PATTERN>       Only include paths matching PATTERN
-      --linked                Use symlinks instead of copies
-      --force                 Force an action to run
-      --purge                 Purge objects with invalid checksums
-      --keep                  Keep the staging directory
-      --dryrun                Run without making any changes
-      --verbose               Enable verbose output
-      --debug                 Enable debug output
-      --no-progress           Disable the live progress line (transfers still run) [env: SNAPDIR_NO_PROGRESS=]
-  -q, --quiet                 Suppress stderr banners and the live progress line
-      --color <WHEN>          When to colorize progress output: auto, always, or never [default: auto]
-      --location <DIR|STORE>  Context (directory or store) for catalog queries
-  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
-      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
-  -h, --help                  Print help
-  -V, --version               Print version
+      --cache-dir <DIR>
+          Directory where the object cache is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
+      --catalog <NAME>
+          Catalog adapter to use
+          
+          [env: SNAPDIR_CATALOG=]
+
+      --store <URI>
+          Store URI: `protocol://location/path`
+
+      --id <ID>
+          Snapshot ID to operate on
+
+      --exclude <PATTERN>
+          Exclude paths matching PATTERN
+
+      --paths <PATTERN>
+          Only include paths matching PATTERN
+
+      --linked
+          Use symlinks instead of copies
+
+      --force
+          Force an action to run
+
+      --purge
+          Purge objects with invalid checksums
+
+      --keep
+          Keep the staging directory
+
+      --dryrun
+          Run without making any changes
+
+      --verbose
+          Enable verbose output
+
+      --debug
+          Enable debug output
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+          
+          [default: auto]
+
+      --location <DIR|STORE>
+          Context (directory or store) for catalog queries
+
+  -j, --jobs <N>
+          Max concurrent object transfers (0/auto = number of CPUs, capped)
+          
+          [env: SNAPDIR_JOBS=]
+
+      --limit-rate <RATE>
+          Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)
+          
+          [env: SNAPDIR_LIMIT_RATE=]
+
+      --adaptive[=<FRACTION>]
+          Adaptively tune transfer concurrency/bandwidth toward a fraction (default 0.8) of measured CPU/network capacity; backs off under contention. Opt-in; default is full speed.
+          
+          Presence (with or without a value) opts in; the optional value is the politeness fraction in `(0.0, 1.0]`.
+          
+          [env: SNAPDIR_ADAPTIVE=]
+
+      --max-jobs <N>
+          Adaptive concurrency ceiling (only meaningful with `--adaptive`). When unset, defaults to the auto concurrency; clamped to a sane upper bound
+          
+          [env: SNAPDIR_MAX_JOBS=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```

--- a/crates/snapdir-cli/tests/cmd/help-defaults.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-defaults.trycmd
@@ -5,26 +5,91 @@ Print default settings and arguments
 Usage: snapdir defaults [OPTIONS]
 
 Options:
-      --cache-dir <DIR>       Directory where the object cache is stored [env: SNAPDIR_CACHE_DIR=]
-      --catalog <NAME>        Catalog adapter to use [env: SNAPDIR_CATALOG=]
-      --store <URI>           Store URI: `protocol://location/path`
-      --id <ID>               Snapshot ID to operate on
-      --exclude <PATTERN>     Exclude paths matching PATTERN
-      --paths <PATTERN>       Only include paths matching PATTERN
-      --linked                Use symlinks instead of copies
-      --force                 Force an action to run
-      --purge                 Purge objects with invalid checksums
-      --keep                  Keep the staging directory
-      --dryrun                Run without making any changes
-      --verbose               Enable verbose output
-      --debug                 Enable debug output
-      --no-progress           Disable the live progress line (transfers still run) [env: SNAPDIR_NO_PROGRESS=]
-  -q, --quiet                 Suppress stderr banners and the live progress line
-      --color <WHEN>          When to colorize progress output: auto, always, or never [default: auto]
-      --location <DIR|STORE>  Context (directory or store) for catalog queries
-  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
-      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
-  -h, --help                  Print help
-  -V, --version               Print version
+      --cache-dir <DIR>
+          Directory where the object cache is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
+      --catalog <NAME>
+          Catalog adapter to use
+          
+          [env: SNAPDIR_CATALOG=]
+
+      --store <URI>
+          Store URI: `protocol://location/path`
+
+      --id <ID>
+          Snapshot ID to operate on
+
+      --exclude <PATTERN>
+          Exclude paths matching PATTERN
+
+      --paths <PATTERN>
+          Only include paths matching PATTERN
+
+      --linked
+          Use symlinks instead of copies
+
+      --force
+          Force an action to run
+
+      --purge
+          Purge objects with invalid checksums
+
+      --keep
+          Keep the staging directory
+
+      --dryrun
+          Run without making any changes
+
+      --verbose
+          Enable verbose output
+
+      --debug
+          Enable debug output
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+          
+          [default: auto]
+
+      --location <DIR|STORE>
+          Context (directory or store) for catalog queries
+
+  -j, --jobs <N>
+          Max concurrent object transfers (0/auto = number of CPUs, capped)
+          
+          [env: SNAPDIR_JOBS=]
+
+      --limit-rate <RATE>
+          Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)
+          
+          [env: SNAPDIR_LIMIT_RATE=]
+
+      --adaptive[=<FRACTION>]
+          Adaptively tune transfer concurrency/bandwidth toward a fraction (default 0.8) of measured CPU/network capacity; backs off under contention. Opt-in; default is full speed.
+          
+          Presence (with or without a value) opts in; the optional value is the politeness fraction in `(0.0, 1.0]`.
+          
+          [env: SNAPDIR_ADAPTIVE=]
+
+      --max-jobs <N>
+          Adaptive concurrency ceiling (only meaningful with `--adaptive`). When unset, defaults to the auto concurrency; clamped to a sane upper bound
+          
+          [env: SNAPDIR_MAX_JOBS=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```

--- a/crates/snapdir-cli/tests/cmd/help-fetch.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-fetch.trycmd
@@ -5,26 +5,91 @@ Fetch a snapshot from a store into the local cache
 Usage: snapdir fetch [OPTIONS]
 
 Options:
-      --cache-dir <DIR>       Directory where the object cache is stored [env: SNAPDIR_CACHE_DIR=]
-      --catalog <NAME>        Catalog adapter to use [env: SNAPDIR_CATALOG=]
-      --store <URI>           Store URI: `protocol://location/path`
-      --id <ID>               Snapshot ID to operate on
-      --exclude <PATTERN>     Exclude paths matching PATTERN
-      --paths <PATTERN>       Only include paths matching PATTERN
-      --linked                Use symlinks instead of copies
-      --force                 Force an action to run
-      --purge                 Purge objects with invalid checksums
-      --keep                  Keep the staging directory
-      --dryrun                Run without making any changes
-      --verbose               Enable verbose output
-      --debug                 Enable debug output
-      --no-progress           Disable the live progress line (transfers still run) [env: SNAPDIR_NO_PROGRESS=]
-  -q, --quiet                 Suppress stderr banners and the live progress line
-      --color <WHEN>          When to colorize progress output: auto, always, or never [default: auto]
-      --location <DIR|STORE>  Context (directory or store) for catalog queries
-  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
-      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
-  -h, --help                  Print help
-  -V, --version               Print version
+      --cache-dir <DIR>
+          Directory where the object cache is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
+      --catalog <NAME>
+          Catalog adapter to use
+          
+          [env: SNAPDIR_CATALOG=]
+
+      --store <URI>
+          Store URI: `protocol://location/path`
+
+      --id <ID>
+          Snapshot ID to operate on
+
+      --exclude <PATTERN>
+          Exclude paths matching PATTERN
+
+      --paths <PATTERN>
+          Only include paths matching PATTERN
+
+      --linked
+          Use symlinks instead of copies
+
+      --force
+          Force an action to run
+
+      --purge
+          Purge objects with invalid checksums
+
+      --keep
+          Keep the staging directory
+
+      --dryrun
+          Run without making any changes
+
+      --verbose
+          Enable verbose output
+
+      --debug
+          Enable debug output
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+          
+          [default: auto]
+
+      --location <DIR|STORE>
+          Context (directory or store) for catalog queries
+
+  -j, --jobs <N>
+          Max concurrent object transfers (0/auto = number of CPUs, capped)
+          
+          [env: SNAPDIR_JOBS=]
+
+      --limit-rate <RATE>
+          Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)
+          
+          [env: SNAPDIR_LIMIT_RATE=]
+
+      --adaptive[=<FRACTION>]
+          Adaptively tune transfer concurrency/bandwidth toward a fraction (default 0.8) of measured CPU/network capacity; backs off under contention. Opt-in; default is full speed.
+          
+          Presence (with or without a value) opts in; the optional value is the politeness fraction in `(0.0, 1.0]`.
+          
+          [env: SNAPDIR_ADAPTIVE=]
+
+      --max-jobs <N>
+          Adaptive concurrency ceiling (only meaningful with `--adaptive`). When unset, defaults to the auto concurrency; clamped to a sane upper bound
+          
+          [env: SNAPDIR_MAX_JOBS=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```

--- a/crates/snapdir-cli/tests/cmd/help-flush-cache.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-flush-cache.trycmd
@@ -5,26 +5,91 @@ Flush the local cache
 Usage: snapdir flush-cache [OPTIONS]
 
 Options:
-      --cache-dir <DIR>       Directory where the object cache is stored [env: SNAPDIR_CACHE_DIR=]
-      --catalog <NAME>        Catalog adapter to use [env: SNAPDIR_CATALOG=]
-      --store <URI>           Store URI: `protocol://location/path`
-      --id <ID>               Snapshot ID to operate on
-      --exclude <PATTERN>     Exclude paths matching PATTERN
-      --paths <PATTERN>       Only include paths matching PATTERN
-      --linked                Use symlinks instead of copies
-      --force                 Force an action to run
-      --purge                 Purge objects with invalid checksums
-      --keep                  Keep the staging directory
-      --dryrun                Run without making any changes
-      --verbose               Enable verbose output
-      --debug                 Enable debug output
-      --no-progress           Disable the live progress line (transfers still run) [env: SNAPDIR_NO_PROGRESS=]
-  -q, --quiet                 Suppress stderr banners and the live progress line
-      --color <WHEN>          When to colorize progress output: auto, always, or never [default: auto]
-      --location <DIR|STORE>  Context (directory or store) for catalog queries
-  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
-      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
-  -h, --help                  Print help
-  -V, --version               Print version
+      --cache-dir <DIR>
+          Directory where the object cache is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
+      --catalog <NAME>
+          Catalog adapter to use
+          
+          [env: SNAPDIR_CATALOG=]
+
+      --store <URI>
+          Store URI: `protocol://location/path`
+
+      --id <ID>
+          Snapshot ID to operate on
+
+      --exclude <PATTERN>
+          Exclude paths matching PATTERN
+
+      --paths <PATTERN>
+          Only include paths matching PATTERN
+
+      --linked
+          Use symlinks instead of copies
+
+      --force
+          Force an action to run
+
+      --purge
+          Purge objects with invalid checksums
+
+      --keep
+          Keep the staging directory
+
+      --dryrun
+          Run without making any changes
+
+      --verbose
+          Enable verbose output
+
+      --debug
+          Enable debug output
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+          
+          [default: auto]
+
+      --location <DIR|STORE>
+          Context (directory or store) for catalog queries
+
+  -j, --jobs <N>
+          Max concurrent object transfers (0/auto = number of CPUs, capped)
+          
+          [env: SNAPDIR_JOBS=]
+
+      --limit-rate <RATE>
+          Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)
+          
+          [env: SNAPDIR_LIMIT_RATE=]
+
+      --adaptive[=<FRACTION>]
+          Adaptively tune transfer concurrency/bandwidth toward a fraction (default 0.8) of measured CPU/network capacity; backs off under contention. Opt-in; default is full speed.
+          
+          Presence (with or without a value) opts in; the optional value is the politeness fraction in `(0.0, 1.0]`.
+          
+          [env: SNAPDIR_ADAPTIVE=]
+
+      --max-jobs <N>
+          Adaptive concurrency ceiling (only meaningful with `--adaptive`). When unset, defaults to the auto concurrency; clamped to a sane upper bound
+          
+          [env: SNAPDIR_MAX_JOBS=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```

--- a/crates/snapdir-cli/tests/cmd/help-id.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-id.trycmd
@@ -5,29 +5,95 @@ Print the manifest ID of a directory or a manifest piped via stdin
 Usage: snapdir id [OPTIONS] [PATH]
 
 Arguments:
-  [PATH]  Directory to describe (omit to read a manifest from stdin)
+  [PATH]
+          Directory to describe (omit to read a manifest from stdin)
 
 Options:
-      --cache-dir <DIR>       Directory where the object cache is stored [env: SNAPDIR_CACHE_DIR=]
-      --catalog <NAME>        Catalog adapter to use [env: SNAPDIR_CATALOG=]
-      --store <URI>           Store URI: `protocol://location/path`
-      --id <ID>               Snapshot ID to operate on
-      --exclude <PATTERN>     Exclude paths matching PATTERN
-      --paths <PATTERN>       Only include paths matching PATTERN
-      --linked                Use symlinks instead of copies
-      --force                 Force an action to run
-      --purge                 Purge objects with invalid checksums
-      --keep                  Keep the staging directory
-      --dryrun                Run without making any changes
-      --verbose               Enable verbose output
-      --debug                 Enable debug output
-      --no-progress           Disable the live progress line (transfers still run) [env: SNAPDIR_NO_PROGRESS=]
-  -q, --quiet                 Suppress stderr banners and the live progress line
-      --color <WHEN>          When to colorize progress output: auto, always, or never [default: auto]
-      --location <DIR|STORE>  Context (directory or store) for catalog queries
-  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
-      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
-  -h, --help                  Print help
-  -V, --version               Print version
+      --cache-dir <DIR>
+          Directory where the object cache is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
+      --catalog <NAME>
+          Catalog adapter to use
+          
+          [env: SNAPDIR_CATALOG=]
+
+      --store <URI>
+          Store URI: `protocol://location/path`
+
+      --id <ID>
+          Snapshot ID to operate on
+
+      --exclude <PATTERN>
+          Exclude paths matching PATTERN
+
+      --paths <PATTERN>
+          Only include paths matching PATTERN
+
+      --linked
+          Use symlinks instead of copies
+
+      --force
+          Force an action to run
+
+      --purge
+          Purge objects with invalid checksums
+
+      --keep
+          Keep the staging directory
+
+      --dryrun
+          Run without making any changes
+
+      --verbose
+          Enable verbose output
+
+      --debug
+          Enable debug output
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+          
+          [default: auto]
+
+      --location <DIR|STORE>
+          Context (directory or store) for catalog queries
+
+  -j, --jobs <N>
+          Max concurrent object transfers (0/auto = number of CPUs, capped)
+          
+          [env: SNAPDIR_JOBS=]
+
+      --limit-rate <RATE>
+          Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)
+          
+          [env: SNAPDIR_LIMIT_RATE=]
+
+      --adaptive[=<FRACTION>]
+          Adaptively tune transfer concurrency/bandwidth toward a fraction (default 0.8) of measured CPU/network capacity; backs off under contention. Opt-in; default is full speed.
+          
+          Presence (with or without a value) opts in; the optional value is the politeness fraction in `(0.0, 1.0]`.
+          
+          [env: SNAPDIR_ADAPTIVE=]
+
+      --max-jobs <N>
+          Adaptive concurrency ceiling (only meaningful with `--adaptive`). When unset, defaults to the auto concurrency; clamped to a sane upper bound
+          
+          [env: SNAPDIR_MAX_JOBS=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```

--- a/crates/snapdir-cli/tests/cmd/help-locations.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-locations.trycmd
@@ -5,26 +5,91 @@ List directories and stores where snapshots have been recorded
 Usage: snapdir locations [OPTIONS]
 
 Options:
-      --cache-dir <DIR>       Directory where the object cache is stored [env: SNAPDIR_CACHE_DIR=]
-      --catalog <NAME>        Catalog adapter to use [env: SNAPDIR_CATALOG=]
-      --store <URI>           Store URI: `protocol://location/path`
-      --id <ID>               Snapshot ID to operate on
-      --exclude <PATTERN>     Exclude paths matching PATTERN
-      --paths <PATTERN>       Only include paths matching PATTERN
-      --linked                Use symlinks instead of copies
-      --force                 Force an action to run
-      --purge                 Purge objects with invalid checksums
-      --keep                  Keep the staging directory
-      --dryrun                Run without making any changes
-      --verbose               Enable verbose output
-      --debug                 Enable debug output
-      --no-progress           Disable the live progress line (transfers still run) [env: SNAPDIR_NO_PROGRESS=]
-  -q, --quiet                 Suppress stderr banners and the live progress line
-      --color <WHEN>          When to colorize progress output: auto, always, or never [default: auto]
-      --location <DIR|STORE>  Context (directory or store) for catalog queries
-  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
-      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
-  -h, --help                  Print help
-  -V, --version               Print version
+      --cache-dir <DIR>
+          Directory where the object cache is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
+      --catalog <NAME>
+          Catalog adapter to use
+          
+          [env: SNAPDIR_CATALOG=]
+
+      --store <URI>
+          Store URI: `protocol://location/path`
+
+      --id <ID>
+          Snapshot ID to operate on
+
+      --exclude <PATTERN>
+          Exclude paths matching PATTERN
+
+      --paths <PATTERN>
+          Only include paths matching PATTERN
+
+      --linked
+          Use symlinks instead of copies
+
+      --force
+          Force an action to run
+
+      --purge
+          Purge objects with invalid checksums
+
+      --keep
+          Keep the staging directory
+
+      --dryrun
+          Run without making any changes
+
+      --verbose
+          Enable verbose output
+
+      --debug
+          Enable debug output
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+          
+          [default: auto]
+
+      --location <DIR|STORE>
+          Context (directory or store) for catalog queries
+
+  -j, --jobs <N>
+          Max concurrent object transfers (0/auto = number of CPUs, capped)
+          
+          [env: SNAPDIR_JOBS=]
+
+      --limit-rate <RATE>
+          Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)
+          
+          [env: SNAPDIR_LIMIT_RATE=]
+
+      --adaptive[=<FRACTION>]
+          Adaptively tune transfer concurrency/bandwidth toward a fraction (default 0.8) of measured CPU/network capacity; backs off under contention. Opt-in; default is full speed.
+          
+          Presence (with or without a value) opts in; the optional value is the politeness fraction in `(0.0, 1.0]`.
+          
+          [env: SNAPDIR_ADAPTIVE=]
+
+      --max-jobs <N>
+          Adaptive concurrency ceiling (only meaningful with `--adaptive`). When unset, defaults to the auto concurrency; clamped to a sane upper bound
+          
+          [env: SNAPDIR_MAX_JOBS=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```

--- a/crates/snapdir-cli/tests/cmd/help-manifest.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-manifest.trycmd
@@ -5,32 +5,104 @@ Print the manifest of a directory
 Usage: snapdir manifest [OPTIONS] [PATH]
 
 Arguments:
-  [PATH]  Directory to describe
+  [PATH]
+          Directory to describe
 
 Options:
-      --absolute              Emit absolute paths instead of `./`-relative paths
-      --cache-dir <DIR>       Directory where the object cache is stored [env: SNAPDIR_CACHE_DIR=]
-      --catalog <NAME>        Catalog adapter to use [env: SNAPDIR_CATALOG=]
-      --no-follow             Do not follow symbolic links (plain `find` instead of `find -L`)
-      --checksum-bin <NAME>   Checksum binary to mirror: `b3sum` (default), `md5sum`, `sha256sum`
-      --store <URI>           Store URI: `protocol://location/path`
-      --exclude <PATTERN>     Exclude paths matching the extended-regex PATTERN (supports the `%system%` / `%common%` macros)
-      --id <ID>               Snapshot ID to operate on
-      --paths <PATTERN>       Only include paths matching PATTERN
-      --linked                Use symlinks instead of copies
-      --force                 Force an action to run
-      --purge                 Purge objects with invalid checksums
-      --keep                  Keep the staging directory
-      --dryrun                Run without making any changes
-      --verbose               Enable verbose output
-      --debug                 Enable debug output
-      --no-progress           Disable the live progress line (transfers still run) [env: SNAPDIR_NO_PROGRESS=]
-  -q, --quiet                 Suppress stderr banners and the live progress line
-      --color <WHEN>          When to colorize progress output: auto, always, or never [default: auto]
-      --location <DIR|STORE>  Context (directory or store) for catalog queries
-  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
-      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
-  -h, --help                  Print help
-  -V, --version               Print version
+      --absolute
+          Emit absolute paths instead of `./`-relative paths
+
+      --cache-dir <DIR>
+          Directory where the object cache is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
+      --catalog <NAME>
+          Catalog adapter to use
+          
+          [env: SNAPDIR_CATALOG=]
+
+      --no-follow
+          Do not follow symbolic links (plain `find` instead of `find -L`)
+
+      --checksum-bin <NAME>
+          Checksum binary to mirror: `b3sum` (default), `md5sum`, `sha256sum`
+
+      --store <URI>
+          Store URI: `protocol://location/path`
+
+      --exclude <PATTERN>
+          Exclude paths matching the extended-regex PATTERN (supports the `%system%` / `%common%` macros)
+
+      --id <ID>
+          Snapshot ID to operate on
+
+      --paths <PATTERN>
+          Only include paths matching PATTERN
+
+      --linked
+          Use symlinks instead of copies
+
+      --force
+          Force an action to run
+
+      --purge
+          Purge objects with invalid checksums
+
+      --keep
+          Keep the staging directory
+
+      --dryrun
+          Run without making any changes
+
+      --verbose
+          Enable verbose output
+
+      --debug
+          Enable debug output
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+          
+          [default: auto]
+
+      --location <DIR|STORE>
+          Context (directory or store) for catalog queries
+
+  -j, --jobs <N>
+          Max concurrent object transfers (0/auto = number of CPUs, capped)
+          
+          [env: SNAPDIR_JOBS=]
+
+      --limit-rate <RATE>
+          Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)
+          
+          [env: SNAPDIR_LIMIT_RATE=]
+
+      --adaptive[=<FRACTION>]
+          Adaptively tune transfer concurrency/bandwidth toward a fraction (default 0.8) of measured CPU/network capacity; backs off under contention. Opt-in; default is full speed.
+          
+          Presence (with or without a value) opts in; the optional value is the politeness fraction in `(0.0, 1.0]`.
+          
+          [env: SNAPDIR_ADAPTIVE=]
+
+      --max-jobs <N>
+          Adaptive concurrency ceiling (only meaningful with `--adaptive`). When unset, defaults to the auto concurrency; clamped to a sane upper bound
+          
+          [env: SNAPDIR_MAX_JOBS=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```

--- a/crates/snapdir-cli/tests/cmd/help-pull.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-pull.trycmd
@@ -5,29 +5,95 @@ Fetch a snapshot from a store and check it out to the given path
 Usage: snapdir pull [OPTIONS] [PATH]
 
 Arguments:
-  [PATH]  Destination directory
+  [PATH]
+          Destination directory
 
 Options:
-      --cache-dir <DIR>       Directory where the object cache is stored [env: SNAPDIR_CACHE_DIR=]
-      --catalog <NAME>        Catalog adapter to use [env: SNAPDIR_CATALOG=]
-      --store <URI>           Store URI: `protocol://location/path`
-      --id <ID>               Snapshot ID to operate on
-      --exclude <PATTERN>     Exclude paths matching PATTERN
-      --paths <PATTERN>       Only include paths matching PATTERN
-      --linked                Use symlinks instead of copies
-      --force                 Force an action to run
-      --purge                 Purge objects with invalid checksums
-      --keep                  Keep the staging directory
-      --dryrun                Run without making any changes
-      --verbose               Enable verbose output
-      --debug                 Enable debug output
-      --no-progress           Disable the live progress line (transfers still run) [env: SNAPDIR_NO_PROGRESS=]
-  -q, --quiet                 Suppress stderr banners and the live progress line
-      --color <WHEN>          When to colorize progress output: auto, always, or never [default: auto]
-      --location <DIR|STORE>  Context (directory or store) for catalog queries
-  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
-      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
-  -h, --help                  Print help
-  -V, --version               Print version
+      --cache-dir <DIR>
+          Directory where the object cache is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
+      --catalog <NAME>
+          Catalog adapter to use
+          
+          [env: SNAPDIR_CATALOG=]
+
+      --store <URI>
+          Store URI: `protocol://location/path`
+
+      --id <ID>
+          Snapshot ID to operate on
+
+      --exclude <PATTERN>
+          Exclude paths matching PATTERN
+
+      --paths <PATTERN>
+          Only include paths matching PATTERN
+
+      --linked
+          Use symlinks instead of copies
+
+      --force
+          Force an action to run
+
+      --purge
+          Purge objects with invalid checksums
+
+      --keep
+          Keep the staging directory
+
+      --dryrun
+          Run without making any changes
+
+      --verbose
+          Enable verbose output
+
+      --debug
+          Enable debug output
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+          
+          [default: auto]
+
+      --location <DIR|STORE>
+          Context (directory or store) for catalog queries
+
+  -j, --jobs <N>
+          Max concurrent object transfers (0/auto = number of CPUs, capped)
+          
+          [env: SNAPDIR_JOBS=]
+
+      --limit-rate <RATE>
+          Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)
+          
+          [env: SNAPDIR_LIMIT_RATE=]
+
+      --adaptive[=<FRACTION>]
+          Adaptively tune transfer concurrency/bandwidth toward a fraction (default 0.8) of measured CPU/network capacity; backs off under contention. Opt-in; default is full speed.
+          
+          Presence (with or without a value) opts in; the optional value is the politeness fraction in `(0.0, 1.0]`.
+          
+          [env: SNAPDIR_ADAPTIVE=]
+
+      --max-jobs <N>
+          Adaptive concurrency ceiling (only meaningful with `--adaptive`). When unset, defaults to the auto concurrency; clamped to a sane upper bound
+          
+          [env: SNAPDIR_MAX_JOBS=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```

--- a/crates/snapdir-cli/tests/cmd/help-push.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-push.trycmd
@@ -5,29 +5,95 @@ Push a snapshot to a store given its path or a staged manifest ID
 Usage: snapdir push [OPTIONS] [PATH]
 
 Arguments:
-  [PATH]  Directory to push (omit when using `--id`)
+  [PATH]
+          Directory to push (omit when using `--id`)
 
 Options:
-      --cache-dir <DIR>       Directory where the object cache is stored [env: SNAPDIR_CACHE_DIR=]
-      --catalog <NAME>        Catalog adapter to use [env: SNAPDIR_CATALOG=]
-      --store <URI>           Store URI: `protocol://location/path`
-      --id <ID>               Snapshot ID to operate on
-      --exclude <PATTERN>     Exclude paths matching PATTERN
-      --paths <PATTERN>       Only include paths matching PATTERN
-      --linked                Use symlinks instead of copies
-      --force                 Force an action to run
-      --purge                 Purge objects with invalid checksums
-      --keep                  Keep the staging directory
-      --dryrun                Run without making any changes
-      --verbose               Enable verbose output
-      --debug                 Enable debug output
-      --no-progress           Disable the live progress line (transfers still run) [env: SNAPDIR_NO_PROGRESS=]
-  -q, --quiet                 Suppress stderr banners and the live progress line
-      --color <WHEN>          When to colorize progress output: auto, always, or never [default: auto]
-      --location <DIR|STORE>  Context (directory or store) for catalog queries
-  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
-      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
-  -h, --help                  Print help
-  -V, --version               Print version
+      --cache-dir <DIR>
+          Directory where the object cache is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
+      --catalog <NAME>
+          Catalog adapter to use
+          
+          [env: SNAPDIR_CATALOG=]
+
+      --store <URI>
+          Store URI: `protocol://location/path`
+
+      --id <ID>
+          Snapshot ID to operate on
+
+      --exclude <PATTERN>
+          Exclude paths matching PATTERN
+
+      --paths <PATTERN>
+          Only include paths matching PATTERN
+
+      --linked
+          Use symlinks instead of copies
+
+      --force
+          Force an action to run
+
+      --purge
+          Purge objects with invalid checksums
+
+      --keep
+          Keep the staging directory
+
+      --dryrun
+          Run without making any changes
+
+      --verbose
+          Enable verbose output
+
+      --debug
+          Enable debug output
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+          
+          [default: auto]
+
+      --location <DIR|STORE>
+          Context (directory or store) for catalog queries
+
+  -j, --jobs <N>
+          Max concurrent object transfers (0/auto = number of CPUs, capped)
+          
+          [env: SNAPDIR_JOBS=]
+
+      --limit-rate <RATE>
+          Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)
+          
+          [env: SNAPDIR_LIMIT_RATE=]
+
+      --adaptive[=<FRACTION>]
+          Adaptively tune transfer concurrency/bandwidth toward a fraction (default 0.8) of measured CPU/network capacity; backs off under contention. Opt-in; default is full speed.
+          
+          Presence (with or without a value) opts in; the optional value is the politeness fraction in `(0.0, 1.0]`.
+          
+          [env: SNAPDIR_ADAPTIVE=]
+
+      --max-jobs <N>
+          Adaptive concurrency ceiling (only meaningful with `--adaptive`). When unset, defaults to the auto concurrency; clamped to a sane upper bound
+          
+          [env: SNAPDIR_MAX_JOBS=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```

--- a/crates/snapdir-cli/tests/cmd/help-revisions.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-revisions.trycmd
@@ -5,26 +5,91 @@ List snapshot IDs created on a location (store or absolute path)
 Usage: snapdir revisions [OPTIONS]
 
 Options:
-      --cache-dir <DIR>       Directory where the object cache is stored [env: SNAPDIR_CACHE_DIR=]
-      --catalog <NAME>        Catalog adapter to use [env: SNAPDIR_CATALOG=]
-      --store <URI>           Store URI: `protocol://location/path`
-      --id <ID>               Snapshot ID to operate on
-      --exclude <PATTERN>     Exclude paths matching PATTERN
-      --paths <PATTERN>       Only include paths matching PATTERN
-      --linked                Use symlinks instead of copies
-      --force                 Force an action to run
-      --purge                 Purge objects with invalid checksums
-      --keep                  Keep the staging directory
-      --dryrun                Run without making any changes
-      --verbose               Enable verbose output
-      --debug                 Enable debug output
-      --no-progress           Disable the live progress line (transfers still run) [env: SNAPDIR_NO_PROGRESS=]
-  -q, --quiet                 Suppress stderr banners and the live progress line
-      --color <WHEN>          When to colorize progress output: auto, always, or never [default: auto]
-      --location <DIR|STORE>  Context (directory or store) for catalog queries
-  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
-      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
-  -h, --help                  Print help
-  -V, --version               Print version
+      --cache-dir <DIR>
+          Directory where the object cache is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
+      --catalog <NAME>
+          Catalog adapter to use
+          
+          [env: SNAPDIR_CATALOG=]
+
+      --store <URI>
+          Store URI: `protocol://location/path`
+
+      --id <ID>
+          Snapshot ID to operate on
+
+      --exclude <PATTERN>
+          Exclude paths matching PATTERN
+
+      --paths <PATTERN>
+          Only include paths matching PATTERN
+
+      --linked
+          Use symlinks instead of copies
+
+      --force
+          Force an action to run
+
+      --purge
+          Purge objects with invalid checksums
+
+      --keep
+          Keep the staging directory
+
+      --dryrun
+          Run without making any changes
+
+      --verbose
+          Enable verbose output
+
+      --debug
+          Enable debug output
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+          
+          [default: auto]
+
+      --location <DIR|STORE>
+          Context (directory or store) for catalog queries
+
+  -j, --jobs <N>
+          Max concurrent object transfers (0/auto = number of CPUs, capped)
+          
+          [env: SNAPDIR_JOBS=]
+
+      --limit-rate <RATE>
+          Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)
+          
+          [env: SNAPDIR_LIMIT_RATE=]
+
+      --adaptive[=<FRACTION>]
+          Adaptively tune transfer concurrency/bandwidth toward a fraction (default 0.8) of measured CPU/network capacity; backs off under contention. Opt-in; default is full speed.
+          
+          Presence (with or without a value) opts in; the optional value is the politeness fraction in `(0.0, 1.0]`.
+          
+          [env: SNAPDIR_ADAPTIVE=]
+
+      --max-jobs <N>
+          Adaptive concurrency ceiling (only meaningful with `--adaptive`). When unset, defaults to the auto concurrency; clamped to a sane upper bound
+          
+          [env: SNAPDIR_MAX_JOBS=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```

--- a/crates/snapdir-cli/tests/cmd/help-stage.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-stage.trycmd
@@ -5,29 +5,95 @@ Save a snapshot of a directory into the local cache
 Usage: snapdir stage [OPTIONS] [DIR]
 
 Arguments:
-  [DIR]  Directory to stage
+  [DIR]
+          Directory to stage
 
 Options:
-      --cache-dir <DIR>       Directory where the object cache is stored [env: SNAPDIR_CACHE_DIR=]
-      --catalog <NAME>        Catalog adapter to use [env: SNAPDIR_CATALOG=]
-      --store <URI>           Store URI: `protocol://location/path`
-      --id <ID>               Snapshot ID to operate on
-      --exclude <PATTERN>     Exclude paths matching PATTERN
-      --paths <PATTERN>       Only include paths matching PATTERN
-      --linked                Use symlinks instead of copies
-      --force                 Force an action to run
-      --purge                 Purge objects with invalid checksums
-      --keep                  Keep the staging directory
-      --dryrun                Run without making any changes
-      --verbose               Enable verbose output
-      --debug                 Enable debug output
-      --no-progress           Disable the live progress line (transfers still run) [env: SNAPDIR_NO_PROGRESS=]
-  -q, --quiet                 Suppress stderr banners and the live progress line
-      --color <WHEN>          When to colorize progress output: auto, always, or never [default: auto]
-      --location <DIR|STORE>  Context (directory or store) for catalog queries
-  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
-      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
-  -h, --help                  Print help
-  -V, --version               Print version
+      --cache-dir <DIR>
+          Directory where the object cache is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
+      --catalog <NAME>
+          Catalog adapter to use
+          
+          [env: SNAPDIR_CATALOG=]
+
+      --store <URI>
+          Store URI: `protocol://location/path`
+
+      --id <ID>
+          Snapshot ID to operate on
+
+      --exclude <PATTERN>
+          Exclude paths matching PATTERN
+
+      --paths <PATTERN>
+          Only include paths matching PATTERN
+
+      --linked
+          Use symlinks instead of copies
+
+      --force
+          Force an action to run
+
+      --purge
+          Purge objects with invalid checksums
+
+      --keep
+          Keep the staging directory
+
+      --dryrun
+          Run without making any changes
+
+      --verbose
+          Enable verbose output
+
+      --debug
+          Enable debug output
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+          
+          [default: auto]
+
+      --location <DIR|STORE>
+          Context (directory or store) for catalog queries
+
+  -j, --jobs <N>
+          Max concurrent object transfers (0/auto = number of CPUs, capped)
+          
+          [env: SNAPDIR_JOBS=]
+
+      --limit-rate <RATE>
+          Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)
+          
+          [env: SNAPDIR_LIMIT_RATE=]
+
+      --adaptive[=<FRACTION>]
+          Adaptively tune transfer concurrency/bandwidth toward a fraction (default 0.8) of measured CPU/network capacity; backs off under contention. Opt-in; default is full speed.
+          
+          Presence (with or without a value) opts in; the optional value is the politeness fraction in `(0.0, 1.0]`.
+          
+          [env: SNAPDIR_ADAPTIVE=]
+
+      --max-jobs <N>
+          Adaptive concurrency ceiling (only meaningful with `--adaptive`). When unset, defaults to the auto concurrency; clamped to a sane upper bound
+          
+          [env: SNAPDIR_MAX_JOBS=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```

--- a/crates/snapdir-cli/tests/cmd/help-sync.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-sync.trycmd
@@ -5,28 +5,97 @@ Copy a snapshot (its manifest + objects) directly between two stores, streaming 
 Usage: snapdir sync [OPTIONS] --from <STORE> --to <STORE>
 
 Options:
-      --cache-dir <DIR>       Directory where the object cache is stored [env: SNAPDIR_CACHE_DIR=]
-      --from <STORE>          Source store URI: `protocol://location/path`
-      --catalog <NAME>        Catalog adapter to use [env: SNAPDIR_CATALOG=]
-      --to <STORE>            Destination store URI: `protocol://location/path`
-      --store <URI>           Store URI: `protocol://location/path`
-      --id <ID>               Snapshot ID to operate on
-      --exclude <PATTERN>     Exclude paths matching PATTERN
-      --paths <PATTERN>       Only include paths matching PATTERN
-      --linked                Use symlinks instead of copies
-      --force                 Force an action to run
-      --purge                 Purge objects with invalid checksums
-      --keep                  Keep the staging directory
-      --dryrun                Run without making any changes
-      --verbose               Enable verbose output
-      --debug                 Enable debug output
-      --no-progress           Disable the live progress line (transfers still run) [env: SNAPDIR_NO_PROGRESS=]
-  -q, --quiet                 Suppress stderr banners and the live progress line
-      --color <WHEN>          When to colorize progress output: auto, always, or never [default: auto]
-      --location <DIR|STORE>  Context (directory or store) for catalog queries
-  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
-      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
-  -h, --help                  Print help
-  -V, --version               Print version
+      --cache-dir <DIR>
+          Directory where the object cache is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
+      --from <STORE>
+          Source store URI: `protocol://location/path`
+
+      --catalog <NAME>
+          Catalog adapter to use
+          
+          [env: SNAPDIR_CATALOG=]
+
+      --to <STORE>
+          Destination store URI: `protocol://location/path`
+
+      --store <URI>
+          Store URI: `protocol://location/path`
+
+      --id <ID>
+          Snapshot ID to operate on
+
+      --exclude <PATTERN>
+          Exclude paths matching PATTERN
+
+      --paths <PATTERN>
+          Only include paths matching PATTERN
+
+      --linked
+          Use symlinks instead of copies
+
+      --force
+          Force an action to run
+
+      --purge
+          Purge objects with invalid checksums
+
+      --keep
+          Keep the staging directory
+
+      --dryrun
+          Run without making any changes
+
+      --verbose
+          Enable verbose output
+
+      --debug
+          Enable debug output
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+          
+          [default: auto]
+
+      --location <DIR|STORE>
+          Context (directory or store) for catalog queries
+
+  -j, --jobs <N>
+          Max concurrent object transfers (0/auto = number of CPUs, capped)
+          
+          [env: SNAPDIR_JOBS=]
+
+      --limit-rate <RATE>
+          Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)
+          
+          [env: SNAPDIR_LIMIT_RATE=]
+
+      --adaptive[=<FRACTION>]
+          Adaptively tune transfer concurrency/bandwidth toward a fraction (default 0.8) of measured CPU/network capacity; backs off under contention. Opt-in; default is full speed.
+          
+          Presence (with or without a value) opts in; the optional value is the politeness fraction in `(0.0, 1.0]`.
+          
+          [env: SNAPDIR_ADAPTIVE=]
+
+      --max-jobs <N>
+          Adaptive concurrency ceiling (only meaningful with `--adaptive`). When unset, defaults to the auto concurrency; clamped to a sane upper bound
+          
+          [env: SNAPDIR_MAX_JOBS=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```

--- a/crates/snapdir-cli/tests/cmd/help-verify-cache.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-verify-cache.trycmd
@@ -5,26 +5,91 @@ Verify the integrity of the local cache
 Usage: snapdir verify-cache [OPTIONS]
 
 Options:
-      --cache-dir <DIR>       Directory where the object cache is stored [env: SNAPDIR_CACHE_DIR=]
-      --catalog <NAME>        Catalog adapter to use [env: SNAPDIR_CATALOG=]
-      --store <URI>           Store URI: `protocol://location/path`
-      --id <ID>               Snapshot ID to operate on
-      --exclude <PATTERN>     Exclude paths matching PATTERN
-      --paths <PATTERN>       Only include paths matching PATTERN
-      --linked                Use symlinks instead of copies
-      --force                 Force an action to run
-      --purge                 Purge objects with invalid checksums
-      --keep                  Keep the staging directory
-      --dryrun                Run without making any changes
-      --verbose               Enable verbose output
-      --debug                 Enable debug output
-      --no-progress           Disable the live progress line (transfers still run) [env: SNAPDIR_NO_PROGRESS=]
-  -q, --quiet                 Suppress stderr banners and the live progress line
-      --color <WHEN>          When to colorize progress output: auto, always, or never [default: auto]
-      --location <DIR|STORE>  Context (directory or store) for catalog queries
-  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
-      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
-  -h, --help                  Print help
-  -V, --version               Print version
+      --cache-dir <DIR>
+          Directory where the object cache is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
+      --catalog <NAME>
+          Catalog adapter to use
+          
+          [env: SNAPDIR_CATALOG=]
+
+      --store <URI>
+          Store URI: `protocol://location/path`
+
+      --id <ID>
+          Snapshot ID to operate on
+
+      --exclude <PATTERN>
+          Exclude paths matching PATTERN
+
+      --paths <PATTERN>
+          Only include paths matching PATTERN
+
+      --linked
+          Use symlinks instead of copies
+
+      --force
+          Force an action to run
+
+      --purge
+          Purge objects with invalid checksums
+
+      --keep
+          Keep the staging directory
+
+      --dryrun
+          Run without making any changes
+
+      --verbose
+          Enable verbose output
+
+      --debug
+          Enable debug output
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+          
+          [default: auto]
+
+      --location <DIR|STORE>
+          Context (directory or store) for catalog queries
+
+  -j, --jobs <N>
+          Max concurrent object transfers (0/auto = number of CPUs, capped)
+          
+          [env: SNAPDIR_JOBS=]
+
+      --limit-rate <RATE>
+          Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)
+          
+          [env: SNAPDIR_LIMIT_RATE=]
+
+      --adaptive[=<FRACTION>]
+          Adaptively tune transfer concurrency/bandwidth toward a fraction (default 0.8) of measured CPU/network capacity; backs off under contention. Opt-in; default is full speed.
+          
+          Presence (with or without a value) opts in; the optional value is the politeness fraction in `(0.0, 1.0]`.
+          
+          [env: SNAPDIR_ADAPTIVE=]
+
+      --max-jobs <N>
+          Adaptive concurrency ceiling (only meaningful with `--adaptive`). When unset, defaults to the auto concurrency; clamped to a sane upper bound
+          
+          [env: SNAPDIR_MAX_JOBS=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```

--- a/crates/snapdir-cli/tests/cmd/help-verify.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-verify.trycmd
@@ -5,26 +5,91 @@ Verify the integrity of a staged snapshot
 Usage: snapdir verify [OPTIONS]
 
 Options:
-      --cache-dir <DIR>       Directory where the object cache is stored [env: SNAPDIR_CACHE_DIR=]
-      --catalog <NAME>        Catalog adapter to use [env: SNAPDIR_CATALOG=]
-      --store <URI>           Store URI: `protocol://location/path`
-      --id <ID>               Snapshot ID to operate on
-      --exclude <PATTERN>     Exclude paths matching PATTERN
-      --paths <PATTERN>       Only include paths matching PATTERN
-      --linked                Use symlinks instead of copies
-      --force                 Force an action to run
-      --purge                 Purge objects with invalid checksums
-      --keep                  Keep the staging directory
-      --dryrun                Run without making any changes
-      --verbose               Enable verbose output
-      --debug                 Enable debug output
-      --no-progress           Disable the live progress line (transfers still run) [env: SNAPDIR_NO_PROGRESS=]
-  -q, --quiet                 Suppress stderr banners and the live progress line
-      --color <WHEN>          When to colorize progress output: auto, always, or never [default: auto]
-      --location <DIR|STORE>  Context (directory or store) for catalog queries
-  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
-      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
-  -h, --help                  Print help
-  -V, --version               Print version
+      --cache-dir <DIR>
+          Directory where the object cache is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
+      --catalog <NAME>
+          Catalog adapter to use
+          
+          [env: SNAPDIR_CATALOG=]
+
+      --store <URI>
+          Store URI: `protocol://location/path`
+
+      --id <ID>
+          Snapshot ID to operate on
+
+      --exclude <PATTERN>
+          Exclude paths matching PATTERN
+
+      --paths <PATTERN>
+          Only include paths matching PATTERN
+
+      --linked
+          Use symlinks instead of copies
+
+      --force
+          Force an action to run
+
+      --purge
+          Purge objects with invalid checksums
+
+      --keep
+          Keep the staging directory
+
+      --dryrun
+          Run without making any changes
+
+      --verbose
+          Enable verbose output
+
+      --debug
+          Enable debug output
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+          
+          [default: auto]
+
+      --location <DIR|STORE>
+          Context (directory or store) for catalog queries
+
+  -j, --jobs <N>
+          Max concurrent object transfers (0/auto = number of CPUs, capped)
+          
+          [env: SNAPDIR_JOBS=]
+
+      --limit-rate <RATE>
+          Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)
+          
+          [env: SNAPDIR_LIMIT_RATE=]
+
+      --adaptive[=<FRACTION>]
+          Adaptively tune transfer concurrency/bandwidth toward a fraction (default 0.8) of measured CPU/network capacity; backs off under contention. Opt-in; default is full speed.
+          
+          Presence (with or without a value) opts in; the optional value is the politeness fraction in `(0.0, 1.0]`.
+          
+          [env: SNAPDIR_ADAPTIVE=]
+
+      --max-jobs <N>
+          Adaptive concurrency ceiling (only meaningful with `--adaptive`). When unset, defaults to the auto concurrency; clamped to a sane upper bound
+          
+          [env: SNAPDIR_MAX_JOBS=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```

--- a/crates/snapdir-cli/tests/cmd/help.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help.trycmd
@@ -24,26 +24,91 @@ Commands:
   help          Print this message or the help of the given subcommand(s)
 
 Options:
-      --cache-dir <DIR>       Directory where the object cache is stored [env: SNAPDIR_CACHE_DIR=]
-      --catalog <NAME>        Catalog adapter to use [env: SNAPDIR_CATALOG=]
-      --store <URI>           Store URI: `protocol://location/path`
-      --id <ID>               Snapshot ID to operate on
-      --exclude <PATTERN>     Exclude paths matching PATTERN
-      --paths <PATTERN>       Only include paths matching PATTERN
-      --linked                Use symlinks instead of copies
-      --force                 Force an action to run
-      --purge                 Purge objects with invalid checksums
-      --keep                  Keep the staging directory
-      --dryrun                Run without making any changes
-      --verbose               Enable verbose output
-      --debug                 Enable debug output
-      --no-progress           Disable the live progress line (transfers still run) [env: SNAPDIR_NO_PROGRESS=]
-  -q, --quiet                 Suppress stderr banners and the live progress line
-      --color <WHEN>          When to colorize progress output: auto, always, or never [default: auto]
-      --location <DIR|STORE>  Context (directory or store) for catalog queries
-  -j, --jobs <N>              Max concurrent object transfers (0/auto = number of CPUs, capped) [env: SNAPDIR_JOBS=]
-      --limit-rate <RATE>     Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers) [env: SNAPDIR_LIMIT_RATE=]
-  -h, --help                  Print help
-  -V, --version               Print version
+      --cache-dir <DIR>
+          Directory where the object cache is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
+      --catalog <NAME>
+          Catalog adapter to use
+          
+          [env: SNAPDIR_CATALOG=]
+
+      --store <URI>
+          Store URI: `protocol://location/path`
+
+      --id <ID>
+          Snapshot ID to operate on
+
+      --exclude <PATTERN>
+          Exclude paths matching PATTERN
+
+      --paths <PATTERN>
+          Only include paths matching PATTERN
+
+      --linked
+          Use symlinks instead of copies
+
+      --force
+          Force an action to run
+
+      --purge
+          Purge objects with invalid checksums
+
+      --keep
+          Keep the staging directory
+
+      --dryrun
+          Run without making any changes
+
+      --verbose
+          Enable verbose output
+
+      --debug
+          Enable debug output
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+          
+          [default: auto]
+
+      --location <DIR|STORE>
+          Context (directory or store) for catalog queries
+
+  -j, --jobs <N>
+          Max concurrent object transfers (0/auto = number of CPUs, capped)
+          
+          [env: SNAPDIR_JOBS=]
+
+      --limit-rate <RATE>
+          Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)
+          
+          [env: SNAPDIR_LIMIT_RATE=]
+
+      --adaptive[=<FRACTION>]
+          Adaptively tune transfer concurrency/bandwidth toward a fraction (default 0.8) of measured CPU/network capacity; backs off under contention. Opt-in; default is full speed.
+          
+          Presence (with or without a value) opts in; the optional value is the politeness fraction in `(0.0, 1.0]`.
+          
+          [env: SNAPDIR_ADAPTIVE=]
+
+      --max-jobs <N>
+          Adaptive concurrency ceiling (only meaningful with `--adaptive`). When unset, defaults to the auto concurrency; clamped to a sane upper bound
+          
+          [env: SNAPDIR_MAX_JOBS=]
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
 
 ```

--- a/crates/snapdir-core/Cargo.toml
+++ b/crates/snapdir-core/Cargo.toml
@@ -11,6 +11,7 @@ description = "snapdir core: manifest format, BLAKE3 merkle hashing, store trait
 
 [dependencies]
 blake3 = "1.8.5"
+libc = "0.2"
 md-5 = "0.11"
 regex = "1"
 sha2 = "0.11"

--- a/crates/snapdir-core/src/lib.rs
+++ b/crates/snapdir-core/src/lib.rs
@@ -22,6 +22,7 @@ pub mod excludes;
 pub mod manifest;
 pub mod merkle;
 pub mod progress;
+pub mod resources;
 pub mod store;
 pub mod walk;
 
@@ -39,5 +40,6 @@ pub use merkle::{
     Sha256Hasher,
 };
 pub use progress::{Meter, MeterSnapshot, Phase};
+pub use resources::{resident_set_bytes, total_ram_bytes, CpuSampler};
 pub use store::{manifest_path, object_path, Store, StoreError, MANIFESTS_DIR, OBJECTS_DIR};
 pub use walk::{walk, walk_with_meter, PathMode, WalkError, WalkOptions};

--- a/crates/snapdir-core/src/progress.rs
+++ b/crates/snapdir-core/src/progress.rs
@@ -73,6 +73,12 @@ pub struct MeterSnapshot {
     pub in_flight: u64,
     /// The current coarse [`Phase`].
     pub phase: Phase,
+    /// Advisory: the current adaptive throughput limit in bytes/sec, or `0`
+    /// when not adaptive / unset. Display-only; never throttles the walk.
+    pub current_limit: u64,
+    /// Advisory: the adaptive controller's target throughput in bytes/sec, or
+    /// `0` when not adaptive / unset. Display-only; never throttles the walk.
+    pub target_rate: u64,
 }
 
 /// A lock-free progress meter shared across threads behind an
@@ -91,6 +97,13 @@ pub struct Meter {
     objects_skipped: AtomicU64,
     in_flight: AtomicU64,
     phase: AtomicU8,
+    /// Advisory adaptive throughput limit in bytes/sec (`0` = unset). Display
+    /// only — set by the adaptive controller for the renderer to show; reading
+    /// or writing it never affects the walk's output.
+    current_limit: AtomicU64,
+    /// Advisory adaptive target throughput in bytes/sec (`0` = unset). Display
+    /// only, with the same advisory semantics as `current_limit`.
+    target_rate: AtomicU64,
 }
 
 impl Meter {
@@ -145,6 +158,22 @@ impl Meter {
         self.objects_skipped.fetch_add(n, Ordering::Relaxed);
     }
 
+    /// Sets the advisory adaptive throughput limit (bytes/sec; `0` = unset).
+    ///
+    /// Display-only: the renderer reads this to show the live adaptive value.
+    /// It does not throttle or otherwise change the walk's behavior or output.
+    pub fn set_current_limit(&self, n: u64) {
+        self.current_limit.store(n, Ordering::Relaxed);
+    }
+
+    /// Sets the advisory adaptive target throughput (bytes/sec; `0` = unset).
+    ///
+    /// Display-only, with the same advisory semantics as
+    /// [`set_current_limit`](Meter::set_current_limit).
+    pub fn set_target_rate(&self, n: u64) {
+        self.target_rate.store(n, Ordering::Relaxed);
+    }
+
     /// Sets the current coarse [`Phase`].
     pub fn set_phase(&self, p: Phase) {
         self.phase.store(p.as_u8(), Ordering::Relaxed);
@@ -171,6 +200,8 @@ impl Meter {
             objects_skipped: self.objects_skipped.load(Ordering::Relaxed),
             in_flight: self.in_flight.load(Ordering::Relaxed),
             phase: self.phase(),
+            current_limit: self.current_limit.load(Ordering::Relaxed),
+            target_rate: self.target_rate.load(Ordering::Relaxed),
         }
     }
 }
@@ -242,5 +273,26 @@ mod tests {
         let snap = meter.snapshot();
         assert_eq!(snap.in_flight, 0, "gauge saturates at 0, no underflow");
         assert_eq!(snap.objects_done, 4);
+    }
+
+    #[test]
+    fn resources_meter_adaptive_fields_round_trip() {
+        let meter = Meter::new();
+        // Default advisory atoms are 0 (not adaptive / unset).
+        let initial = meter.snapshot();
+        assert_eq!(initial.current_limit, 0);
+        assert_eq!(initial.target_rate, 0);
+
+        meter.set_current_limit(5_000_000);
+        meter.set_target_rate(8_000_000);
+        let snap = meter.snapshot();
+        assert_eq!(snap.current_limit, 5_000_000);
+        assert_eq!(snap.target_rate, 8_000_000);
+
+        // Setters overwrite (store, not add) and 0 clears back to unset.
+        meter.set_current_limit(0);
+        let snap = meter.snapshot();
+        assert_eq!(snap.current_limit, 0);
+        assert_eq!(snap.target_rate, 8_000_000, "target unchanged");
     }
 }

--- a/crates/snapdir-core/src/resources.rs
+++ b/crates/snapdir-core/src/resources.rs
@@ -1,0 +1,276 @@
+//! Best-effort system-resource samplers (CPU, RSS, total RAM).
+//!
+//! Per the library-purity principle this module does **no** terminal I/O and
+//! reads **no** `$HOME`/config/environment for *behavior*: it queries live
+//! **system** state via a few `libc` syscalls (CPU time, resident set size,
+//! physical RAM) so a higher-level controller can make adaptive decisions
+//! (e.g. a concurrency/throughput guardrail in the stores lane). It is purely
+//! advisory runtime telemetry and is **never** consulted by the walk, the
+//! manifest builder, or any snapshot computation — a walk samples identically
+//! whether or not anything reads these numbers.
+//!
+//! Everything here is strictly best-effort: every platform read that fails
+//! yields `None` rather than panicking. Each `unsafe` block performs exactly
+//! one syscall into a plain-old-data struct and checks the return code before
+//! trusting the result; no `unwrap`/`expect` is used on any syscall path.
+//!
+//! The [`CpuSampler`] mirrors the renderer's sampler in
+//! `snapdir-cli`'s `progress` module, and [`resident_set_bytes`] mirrors its
+//! `sample_rss`; [`total_ram_bytes`] is new (the controller needs a
+//! memory-budget denominator that the CLI renderer never sampled).
+
+// This module converts kernel time/size counters between integer syscall
+// outputs and `f64` to derive a CPU percentage. The lossy/sign casts are
+// inherent to an *advisory* utilization number (never a correctness path), so
+// the pedantic cast lints are allowed module-wide rather than peppered onto
+// every arithmetic line, matching the CLI progress engine's convention.
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::cast_lossless
+)]
+
+use std::time::Instant;
+
+/// Reads cumulative process CPU time (user + system) in seconds via
+/// `getrusage(RUSAGE_SELF)`. Returns `None` on failure; never panics.
+fn rusage_cpu_secs() -> Option<f64> {
+    // SAFETY: rusage is plain POD; we pass a valid &mut to a single syscall and
+    // only read the struct after confirming the return code is 0.
+    unsafe {
+        let mut ru: libc::rusage = std::mem::zeroed();
+        if libc::getrusage(libc::RUSAGE_SELF, std::ptr::addr_of_mut!(ru)) != 0 {
+            return None;
+        }
+        let secs = |tv: libc::timeval| tv.tv_sec as f64 + tv.tv_usec as f64 / 1_000_000.0;
+        Some(secs(ru.ru_utime) + secs(ru.ru_stime))
+    }
+}
+
+/// Samples process CPU utilization as a percentage of total machine capacity,
+/// normalized by the number of available cores so `100%` means "one core fully
+/// busy". Values can exceed 100% (up to ~`100 × cores`) when multiple cores are
+/// saturated, and are clamped to that range.
+///
+/// Stateful: each [`poll`](CpuSampler::poll) measures the CPU consumed since the
+/// previous poll over the elapsed wall-clock window. The first poll only
+/// establishes a baseline and returns `None`.
+pub struct CpuSampler {
+    /// `(instant, cumulative_cpu_seconds)` captured at the previous poll.
+    prev: Option<(Instant, f64)>,
+    /// Available parallelism (logical cores), used to normalize the percentage.
+    cores: f64,
+}
+
+impl CpuSampler {
+    /// Creates a sampler. `cores` comes from
+    /// [`std::thread::available_parallelism`], falling back to `1` if the count
+    /// is unavailable.
+    #[must_use]
+    pub fn new() -> Self {
+        let cores = std::thread::available_parallelism().map_or(1.0, |n| n.get() as f64);
+        Self { prev: None, cores }
+    }
+
+    /// Polls CPU usage. The first call establishes a baseline and returns
+    /// `None`; subsequent calls return `Some(pct)` over the elapsed window —
+    /// `(cpu_delta / wall_delta) / cores * 100`, clamped to `[0, 100 × cores]` —
+    /// or `None` if `getrusage` is unavailable or no wall time has elapsed.
+    pub fn poll(&mut self) -> Option<f64> {
+        let now = Instant::now();
+        let cpu = rusage_cpu_secs()?;
+        match self.prev {
+            None => {
+                self.prev = Some((now, cpu));
+                None
+            }
+            Some((prev_t, prev_cpu)) => {
+                let wall = now.duration_since(prev_t).as_secs_f64();
+                self.prev = Some((now, cpu));
+                if wall <= 0.0 {
+                    return None;
+                }
+                let cpu_delta = (cpu - prev_cpu).max(0.0);
+                let pct = (cpu_delta / wall) / self.cores * 100.0;
+                Some(pct.clamp(0.0, 100.0 * self.cores))
+            }
+        }
+    }
+}
+
+impl Default for CpuSampler {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Returns the current process resident set size (RSS) in bytes, best-effort.
+///
+/// - Linux: 2nd field (resident pages) of `/proc/self/statm` × page size.
+/// - macOS: mach `task_info(MACH_TASK_BASIC_INFO)` `.resident_size`.
+/// - Other targets: `None`.
+///
+/// Returns `None` on any error; never panics.
+#[must_use]
+pub fn resident_set_bytes() -> Option<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        let statm = std::fs::read_to_string("/proc/self/statm").ok()?;
+        let resident_pages: u64 = statm.split_whitespace().nth(1)?.parse().ok()?;
+        // SAFETY: sysconf is a pure query with no pointer args; we check its
+        // return for the documented `-1` failure sentinel before using it.
+        let page_size = unsafe { libc::sysconf(libc::_SC_PAGESIZE) };
+        if page_size <= 0 {
+            return None;
+        }
+        Some(resident_pages.saturating_mul(page_size as u64))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        // SAFETY: task_info writes into a correctly-sized info struct; we pass
+        // the matching flavor + count and only read `resident_size` after the
+        // kern_return_t is KERN_SUCCESS. `mach_task_self_` is the static that
+        // the deprecated `mach_task_self()` helper merely reads; use it
+        // directly to avoid pulling the `mach2` crate for one port handle.
+        #[allow(deprecated)]
+        unsafe {
+            let mut info: libc::mach_task_basic_info = std::mem::zeroed();
+            let mut count: libc::mach_msg_type_number_t =
+                (std::mem::size_of::<libc::mach_task_basic_info>()
+                    / std::mem::size_of::<libc::integer_t>())
+                    as libc::mach_msg_type_number_t;
+            let kr = libc::task_info(
+                libc::mach_task_self_,
+                libc::MACH_TASK_BASIC_INFO,
+                std::ptr::addr_of_mut!(info).cast(),
+                std::ptr::addr_of_mut!(count),
+            );
+            if kr == libc::KERN_SUCCESS {
+                Some(info.resident_size)
+            } else {
+                None
+            }
+        }
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        None
+    }
+}
+
+/// Returns the total physical RAM of the machine in bytes, best-effort.
+///
+/// - Linux: `sysconf(_SC_PHYS_PAGES) × sysconf(_SC_PAGE_SIZE)`.
+/// - macOS: `sysctlbyname("hw.memsize", …)`.
+/// - Other targets: `None`.
+///
+/// Returns `None` on any error; never panics. The adaptive controller uses this
+/// as the denominator of its memory-budget guardrail.
+#[must_use]
+pub fn total_ram_bytes() -> Option<u64> {
+    #[cfg(target_os = "linux")]
+    {
+        // SAFETY: both are pure sysconf queries with no pointer args; we check
+        // each for the documented `-1`/`0` failure sentinels before using them.
+        let pages = unsafe { libc::sysconf(libc::_SC_PHYS_PAGES) };
+        let page_size = unsafe { libc::sysconf(libc::_SC_PAGE_SIZE) };
+        if pages <= 0 || page_size <= 0 {
+            return None;
+        }
+        Some((pages as u64).saturating_mul(page_size as u64))
+    }
+    #[cfg(target_os = "macos")]
+    {
+        let mut memsize: u64 = 0;
+        let mut len: libc::size_t = std::mem::size_of::<u64>();
+        // The sysctl name is a NUL-terminated C string.
+        let name = c"hw.memsize";
+        // SAFETY: we pass a valid NUL-terminated name, a correctly-sized output
+        // buffer (`&mut u64`) with its matching length, and no new-value
+        // buffer; the result is only trusted when the call returns 0 and the
+        // kernel reported the full 8-byte width.
+        let rc = unsafe {
+            libc::sysctlbyname(
+                name.as_ptr(),
+                std::ptr::addr_of_mut!(memsize).cast(),
+                std::ptr::addr_of_mut!(len),
+                std::ptr::null_mut(),
+                0,
+            )
+        };
+        if rc == 0 && len == std::mem::size_of::<u64>() && memsize > 0 {
+            Some(memsize)
+        } else {
+            None
+        }
+    }
+    #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+    {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resources_samplers_are_bounded_and_safe() {
+        // resident_set_bytes: either Some(plausible) or None; never panics.
+        if let Some(rss) = resident_set_bytes() {
+            assert!(rss > 0, "rss should be positive when sampled: {rss}");
+            assert!(
+                rss < 1024u64 * 1024 * 1024 * 1024,
+                "rss implausibly large: {rss}"
+            );
+        }
+
+        // CpuSampler: first poll is a baseline (None); a later poll is either
+        // None or Some(non-negative, finite) and never exceeds 100 × cores.
+        let cores = std::thread::available_parallelism().map_or(1.0, |n| n.get() as f64);
+        let mut sampler = CpuSampler::new();
+        assert!(
+            sampler.poll().is_none(),
+            "first poll must be a baseline (None)"
+        );
+        // Do a little work so the second window has a chance of being > 0.
+        let mut acc = 0u64;
+        for i in 0..1_000_000u64 {
+            acc = acc.wrapping_add(i);
+        }
+        std::hint::black_box(acc);
+        if let Some(pct) = sampler.poll() {
+            assert!(pct >= 0.0, "cpu pct negative: {pct}");
+            assert!(pct.is_finite(), "cpu pct not finite: {pct}");
+            assert!(
+                pct <= 100.0 * cores + 1e-6,
+                "cpu pct exceeds capacity: {pct} (cores {cores})"
+            );
+        }
+    }
+
+    #[test]
+    fn resources_total_ram_is_positive() {
+        let ram = total_ram_bytes();
+        #[cfg(any(target_os = "linux", target_os = "macos"))]
+        {
+            // This is the dev/CI platform — total RAM must be sampleable and
+            // sane (> 0, and not absurdly large).
+            let n = ram.expect("total_ram_bytes must be Some on linux/macos");
+            assert!(n > 0, "total ram should be positive: {n}");
+            assert!(
+                n < 1024u64 * 1024 * 1024 * 1024 * 1024,
+                "total ram implausibly large: {n}"
+            );
+        }
+        #[cfg(not(any(target_os = "linux", target_os = "macos")))]
+        {
+            // On a truly unknown OS we only require that it does not panic;
+            // None is acceptable, but a Some must still be > 0.
+            if let Some(n) = ram {
+                assert!(n > 0, "total ram should be positive when sampled: {n}");
+            }
+        }
+    }
+}

--- a/crates/snapdir-stores/src/adaptive.rs
+++ b/crates/snapdir-stores/src/adaptive.rs
@@ -1,0 +1,1214 @@
+//! Adaptive concurrency + throughput control (pure control logic).
+//!
+//! This module is the **brain and the gate** of snapdir's adaptive transfer
+//! tuning, but it deliberately performs **no** network or real I/O and reads
+//! **no** real clock or system samplers itself — every external signal (CPU,
+//! RSS, elapsed time, per-op outcomes) is *injected*. That keeps the controller
+//! fully deterministic and unit-testable; wiring it into the live transfer
+//! loops (and feeding it [`snapdir_core::resources`] samples + a real monotonic
+//! clock) is a later gate.
+//!
+//! Three pieces:
+//!
+//! - [`AdaptiveGate`] — a **resizable** concurrency permit pool shared by both
+//!   transfer backends. It exposes an async [`acquire`](AdaptiveGate::acquire)
+//!   (tokio semaphore) for the futures path and a zero-dependency blocking
+//!   [`acquire_blocking`](AdaptiveGate::acquire_blocking) (mutex + condvar) for
+//!   the rayon path; [`set_limit`](AdaptiveGate::set_limit) retunes both live.
+//! - [`AdaptiveController`] — the control law (slow-start → AIMD, latency
+//!   gradient, congestion backoff with cooldown, CPU/memory guardrails,
+//!   periodic re-probing) that turns injected op samples + metrics into a
+//!   [`Decision`] (next concurrency limit + target byte-rate).
+//! - Supporting value types: [`AdaptivePolicy`], [`OpSample`], [`OpResult`],
+//!   [`Decision`].
+
+// The controller works in `f64` throughput/latency space and converts to/from
+// integer concurrency limits and byte-rates. Those casts are inherent to an
+// *advisory* control signal (never a correctness path), so the pedantic cast
+// lints are allowed module-wide, matching the resources sampler's convention.
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss
+)]
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Condvar, Mutex, PoisonError};
+use std::time::Duration;
+
+use tokio::sync::{OwnedSemaphorePermit, Semaphore};
+
+// ---------------------------------------------------------------------------
+// AdaptiveGate — resizable concurrency permit pool (async + blocking).
+// ---------------------------------------------------------------------------
+
+/// State for the hand-rolled, zero-dependency blocking counting semaphore that
+/// backs the rayon path.
+#[derive(Debug)]
+struct BlockingState {
+    /// Permits currently available to hand out.
+    available: usize,
+    /// The effective concurrency limit (number of permits that *should* exist,
+    /// counting both available and in-flight). `set_limit` adjusts this.
+    limit: usize,
+    /// Permits currently checked out (held by live guards).
+    in_flight: usize,
+}
+
+/// Shared inner state of an [`AdaptiveGate`].
+#[derive(Debug)]
+struct GateInner {
+    /// Absolute upper bound on the limit (construction param). `limit` is always
+    /// clamped to `[1, ceiling]`.
+    ceiling: usize,
+    /// The current logical limit, mirrored across both backends. Stored as an
+    /// atomic for cheap reads (e.g. [`AdaptiveGate::limit`]).
+    limit: AtomicUsize,
+    /// The async permit pool (futures/tokio path). Resized via `add_permits` /
+    /// acquire-and-`forget`.
+    sem: Arc<Semaphore>,
+    /// Outstanding "shrink debt" for the async pool: permits a `set_limit`
+    /// shrink wanted to remove but couldn't (they were in flight). The next
+    /// permit Drops pay this down by forgetting instead of returning, so the
+    /// semaphore's effective capacity converges to the new limit without ever
+    /// revoking a held permit. `tokio::sync::Semaphore` has no "max" knob, so
+    /// this debt is how a shrink-below-in-flight is made exact.
+    async_debt: AtomicUsize,
+    /// The blocking permit pool (rayon path): a counting semaphore built from a
+    /// mutex + condvar.
+    blocking: Mutex<BlockingState>,
+    /// Wakes blocking waiters when permits become available (limit raised or a
+    /// guard dropped).
+    blocking_cv: Condvar,
+}
+
+/// A resizable concurrency permit pool shared by both transfer backends.
+///
+/// The pool starts at `start` permits and can be retuned live with
+/// [`set_limit`](AdaptiveGate::set_limit) anywhere in `[1, ceiling]`. It serves
+/// two access paths over **one shared logical limit**:
+///
+/// - **async** ([`acquire`](AdaptiveGate::acquire)) for the futures/tokio
+///   transfer loop, backed by [`tokio::sync::Semaphore`];
+/// - **blocking** ([`acquire_blocking`](AdaptiveGate::acquire_blocking)) for the
+///   rayon store-to-store sync path, backed by a zero-dependency
+///   mutex+condvar counting semaphore (mirrors the token-bucket style in
+///   [`crate::transfer`]).
+///
+/// Both return an RAII guard that releases its permit on drop. `set_limit`
+/// grows the async pool with `add_permits` and shrinks it by acquiring and
+/// [`forget`](tokio::sync::SemaphorePermit::forget)ting permits (the standard
+/// resizable-semaphore technique); for the blocking pool it adjusts the
+/// available count and notifies waiters. Shrinking **never** revokes a permit
+/// already held — it only reduces how many *new* permits can be handed out, so
+/// in-flight work drains naturally and shrinking can never deadlock held
+/// permits.
+///
+/// The gate is [`Clone`] (cloning shares the same underlying pools via [`Arc`]).
+#[derive(Clone, Debug)]
+pub struct AdaptiveGate {
+    inner: Arc<GateInner>,
+}
+
+/// RAII guard for an async permit acquired from an [`AdaptiveGate`]. Releases
+/// the permit on drop — unless the gate carries outstanding shrink debt, in
+/// which case this permit is *forgotten* to pay that debt down (so a shrink
+/// that happened while this permit was in flight takes effect exactly).
+#[derive(Debug)]
+pub struct GatePermit {
+    inner: Arc<GateInner>,
+    // `Option` so Drop can move the permit out to either return it (drop) or
+    // forget it (pay shrink debt).
+    permit: Option<OwnedSemaphorePermit>,
+}
+
+impl Drop for GatePermit {
+    fn drop(&mut self) {
+        let Some(permit) = self.permit.take() else {
+            return;
+        };
+        // If a shrink is still owed permits, consume this one toward that debt
+        // (forget => the semaphore's capacity drops by one) instead of
+        // returning it to the pool.
+        let mut debt = self.inner.async_debt.load(Ordering::SeqCst);
+        loop {
+            if debt == 0 {
+                return; // no debt: let the permit drop normally (returns it)
+            }
+            match self.inner.async_debt.compare_exchange_weak(
+                debt,
+                debt - 1,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => {
+                    permit.forget();
+                    return;
+                }
+                Err(actual) => debt = actual,
+            }
+        }
+    }
+}
+
+/// RAII guard for a blocking permit acquired from an [`AdaptiveGate`]. Releases
+/// the permit (and notifies one waiter) on drop.
+#[derive(Debug)]
+pub struct BlockingGatePermit {
+    inner: Arc<GateInner>,
+}
+
+impl Drop for BlockingGatePermit {
+    fn drop(&mut self) {
+        let mut state = self
+            .inner
+            .blocking
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        state.in_flight = state.in_flight.saturating_sub(1);
+        // Only return the permit to the available pool if we are still within
+        // the (possibly shrunk) limit; otherwise the permit is absorbed by the
+        // shrink (in_flight already dropped, which is what matters).
+        if state.available + state.in_flight < state.limit {
+            state.available += 1;
+            drop(state);
+            self.inner.blocking_cv.notify_one();
+        }
+    }
+}
+
+impl AdaptiveGate {
+    /// Builds a gate whose limit starts at `start` and can be retuned anywhere in
+    /// `[1, ceiling]`. Both `start` and `ceiling` are clamped to at least 1, and
+    /// `start` is clamped to `ceiling`.
+    #[must_use]
+    pub fn new(start: usize, ceiling: usize) -> Self {
+        let ceiling = ceiling.max(1);
+        let start = start.clamp(1, ceiling);
+        Self {
+            inner: Arc::new(GateInner {
+                ceiling,
+                limit: AtomicUsize::new(start),
+                sem: Arc::new(Semaphore::new(start)),
+                async_debt: AtomicUsize::new(0),
+                blocking: Mutex::new(BlockingState {
+                    available: start,
+                    limit: start,
+                    in_flight: 0,
+                }),
+                blocking_cv: Condvar::new(),
+            }),
+        }
+    }
+
+    /// The construction-time ceiling (the maximum the limit can ever reach).
+    #[must_use]
+    pub fn ceiling(&self) -> usize {
+        self.inner.ceiling
+    }
+
+    /// The current logical concurrency limit (shared by both backends).
+    #[must_use]
+    pub fn limit(&self) -> usize {
+        self.inner.limit.load(Ordering::SeqCst)
+    }
+
+    /// Retunes the effective concurrency limit live, clamped to `[1, ceiling]`.
+    ///
+    /// Grows the async pool with `add_permits`; shrinks it by reserving (and
+    /// forgetting) the surplus permits so the semaphore's effective capacity
+    /// drops without revoking permits already in flight. Adjusts the blocking
+    /// pool's available count symmetrically and wakes waiters when growing.
+    /// Returns the new (clamped) limit.
+    pub fn set_limit(&self, n: usize) -> usize {
+        let new = n.clamp(1, self.inner.ceiling);
+        let old = self.inner.limit.swap(new, Ordering::SeqCst);
+        if new == old {
+            return new;
+        }
+
+        // --- async pool -----------------------------------------------------
+        if new > old {
+            // First, pay down any outstanding shrink debt with the growth (we
+            // owed removals that hadn't landed yet); only add the remainder.
+            let grow = new - old;
+            let paid = self.take_debt(grow);
+            let remainder = grow - paid;
+            if remainder > 0 {
+                self.inner.sem.add_permits(remainder);
+            }
+        } else {
+            // Shrink: remove (old - new) permits. Forget what's available now;
+            // record the rest as debt to be paid by in-flight permits' Drop.
+            let mut to_remove = old - new;
+            while to_remove > 0 {
+                if let Ok(permit) = self.inner.sem.clone().try_acquire_owned() {
+                    permit.forget();
+                    to_remove -= 1;
+                } else {
+                    break; // remainder is in flight; record it as debt
+                }
+            }
+            if to_remove > 0 {
+                self.inner.async_debt.fetch_add(to_remove, Ordering::SeqCst);
+            }
+        }
+
+        // --- blocking pool --------------------------------------------------
+        {
+            let mut state = self
+                .inner
+                .blocking
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            state.limit = new;
+            // Recompute available as (limit - in_flight), floored at 0. Growing
+            // raises available; shrinking lowers it (never touching in-flight
+            // guards, which release against the new limit on drop).
+            state.available = new.saturating_sub(state.in_flight);
+            drop(state);
+            if new > old {
+                self.inner.blocking_cv.notify_all();
+            }
+        }
+
+        new
+    }
+
+    /// Reduces the outstanding async shrink debt by up to `n`, returning how
+    /// much was actually paid (so the caller can apply only the remainder when
+    /// growing the pool).
+    fn take_debt(&self, n: usize) -> usize {
+        let mut debt = self.inner.async_debt.load(Ordering::SeqCst);
+        loop {
+            let pay = debt.min(n);
+            if pay == 0 {
+                return 0;
+            }
+            match self.inner.async_debt.compare_exchange_weak(
+                debt,
+                debt - pay,
+                Ordering::SeqCst,
+                Ordering::SeqCst,
+            ) {
+                Ok(_) => return pay,
+                Err(actual) => debt = actual,
+            }
+        }
+    }
+
+    /// Acquires one async permit, awaiting if the pool is at its current limit.
+    /// The returned [`GatePermit`] releases the permit on drop.
+    ///
+    /// # Panics
+    ///
+    /// Never under normal use; the semaphore is only closed when the gate is
+    /// dropped, which cannot happen while a caller holds an `&self`.
+    pub async fn acquire(&self) -> GatePermit {
+        let permit = Arc::clone(&self.inner.sem)
+            .acquire_owned()
+            .await
+            .expect("AdaptiveGate semaphore is never closed while the gate is alive");
+        GatePermit {
+            inner: Arc::clone(&self.inner),
+            permit: Some(permit),
+        }
+    }
+
+    /// Blocking sibling of [`acquire`](AdaptiveGate::acquire): parks the calling
+    /// OS thread until a permit is free, then returns a guard that releases it
+    /// on drop. Used by the rayon store-to-store sync path.
+    #[must_use]
+    pub fn acquire_blocking(&self) -> BlockingGatePermit {
+        let mut state = self
+            .inner
+            .blocking
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
+        while state.available == 0 {
+            state = self
+                .inner
+                .blocking_cv
+                .wait(state)
+                .unwrap_or_else(PoisonError::into_inner);
+        }
+        state.available -= 1;
+        state.in_flight += 1;
+        BlockingGatePermit {
+            inner: Arc::clone(&self.inner),
+        }
+    }
+
+    /// Best-effort count of async permits currently available (for tests/metrics).
+    #[must_use]
+    pub fn available_permits(&self) -> usize {
+        self.inner.sem.available_permits()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Controller value types.
+// ---------------------------------------------------------------------------
+
+/// Outcome class of a single transfer operation, fed to
+/// [`AdaptiveController::record_op`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum OpResult {
+    /// Completed successfully.
+    Ok,
+    /// The backend explicitly throttled us (e.g. HTTP 429 / `SlowDown`).
+    Throttle,
+    /// A hard error, treated as congestion when timeout-class (e.g. request
+    /// timeout, connection reset).
+    HardErr,
+}
+
+/// One sampled transfer operation: bytes moved, observed latency, and outcome.
+#[derive(Clone, Copy, Debug)]
+pub struct OpSample {
+    /// Bytes transferred by this operation.
+    pub bytes: u64,
+    /// End-to-end latency of the operation.
+    pub latency: Duration,
+    /// Outcome class.
+    pub result: OpResult,
+}
+
+/// The controller's tuning policy (its *view* of config; the `TransferConfig`
+/// integration is a later gate).
+#[derive(Clone, Copy, Debug)]
+pub struct AdaptivePolicy {
+    /// Target operating fraction of the discovered knee (default `0.8`): the
+    /// controller aims for `fraction × knee` for both concurrency and rate,
+    /// leaving headroom.
+    pub fraction: f64,
+    /// Absolute concurrency ceiling; the limit never exceeds this.
+    pub ceiling: usize,
+    /// Total machine RAM in bytes, the denominator of the memory-budget
+    /// guardrail (`limit × p95_obj_size ≤ fraction × total_ram`). `0` disables
+    /// the memory cap.
+    pub total_ram: u64,
+    /// Optional hard cap on the target byte-rate (e.g. a user `--max-rate`).
+    /// `None` means rate is bounded only by the measured goodput knee.
+    pub max_rate: Option<u64>,
+}
+
+impl AdaptivePolicy {
+    /// Builds a policy. `fraction` is clamped to `(0, 1]` (default `0.8` if
+    /// non-finite or out of range); `ceiling` is clamped to at least 1.
+    #[must_use]
+    pub fn new(fraction: f64, ceiling: usize, total_ram: u64, max_rate: Option<u64>) -> Self {
+        let fraction = if fraction.is_finite() && fraction > 0.0 && fraction <= 1.0 {
+            fraction
+        } else {
+            0.8
+        };
+        Self {
+            fraction,
+            ceiling: ceiling.max(1),
+            total_ram,
+            max_rate,
+        }
+    }
+}
+
+impl Default for AdaptivePolicy {
+    fn default() -> Self {
+        Self {
+            fraction: 0.8,
+            ceiling: 16,
+            total_ram: 0,
+            max_rate: None,
+        }
+    }
+}
+
+/// The controller's output for one [`tick`](AdaptiveController::tick): the next
+/// concurrency limit and an optional target byte-rate.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Decision {
+    /// The new concurrency limit to apply (clamped to `[1, ceiling]` and the
+    /// memory budget).
+    pub limit: usize,
+    /// The new aggregate target byte-rate, or `None` for unlimited. Computed as
+    /// `fraction × measured-goodput-knee`, clamped to `policy.max_rate`.
+    pub target_rate: Option<u64>,
+}
+
+// ---------------------------------------------------------------------------
+// AdaptiveController — the pure control law.
+// ---------------------------------------------------------------------------
+
+/// Which phase of the control law we are in.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+enum Phase {
+    /// Multiplicatively ramping up (`×1.5`/tick) until the first congestion/knee.
+    SlowStart,
+    /// Additive-increase / multiplicative-decrease steady state.
+    Aimd,
+}
+
+/// EWMA smoothing factor for goodput / rtt (higher = more responsive).
+const EWMA_ALPHA: f64 = 0.3;
+/// Slow-start growth multiplier per tick.
+const SLOW_START_MULT: f64 = 1.5;
+/// Multiplicative decrease factor on congestion (AIMD's `×0.5`).
+const BACKOFF_MULT: f64 = 0.5;
+/// Latency-gradient threshold: `rtt_min/rtt` below this ⇒ queueing detected.
+const GRADIENT_THRESHOLD: f64 = 0.7;
+/// CPU percentage above which we never increase the limit.
+const CPU_NO_INCREASE_PCT: f64 = 85.0;
+/// CPU percentage above which we actively decrease the limit.
+const CPU_DECREASE_PCT: f64 = 95.0;
+/// Cooldown after a congestion event during which we never increase.
+const COOLDOWN: Duration = Duration::from_secs(15);
+/// Re-probe interval when stable.
+const REPROBE_INTERVAL: Duration = Duration::from_secs(15);
+/// Relative goodput improvement required for slow-start to keep growing /
+/// for a re-probe to be kept (hysteresis).
+const IMPROVE_EPS: f64 = 0.02;
+
+/// Injected monotonic timestamp. The controller never reads a real clock; the
+/// caller passes a monotonically non-decreasing value (real code:
+/// `Instant::now()`; tests: a fake counter). Stored as nanoseconds since an
+/// arbitrary epoch so the type is trivially `Copy` and deterministic.
+pub type MonoTime = Duration;
+
+/// The adaptive control brain.
+///
+/// PURE and deterministic: it never calls [`std::time::Instant::now`] or the
+/// [`snapdir_core::resources`] samplers. All time and metrics are injected via
+/// [`tick`](AdaptiveController::tick); per-op feedback via
+/// [`record_op`](AdaptiveController::record_op). Given the same inputs it always
+/// produces the same [`Decision`]s.
+#[derive(Debug)]
+pub struct AdaptiveController {
+    policy: AdaptivePolicy,
+
+    /// Current concurrency limit (the controller's authoritative value).
+    limit: f64,
+    /// Control phase (slow-start vs AIMD).
+    phase: Phase,
+
+    /// EWMA of goodput in bytes/sec (across recorded ops since the last tick).
+    goodput_ewma: f64,
+    /// Best goodput seen so far (the "knee" estimate).
+    goodput_knee: f64,
+    /// Goodput EWMA captured at the previous tick (for slow-start improvement).
+    goodput_prev_tick: f64,
+
+    /// EWMA of per-op latency, in seconds.
+    rtt_ewma: f64,
+    /// Minimum latency observed (the unloaded baseline), in seconds.
+    rtt_min: f64,
+
+    /// Accumulators for ops recorded since the last `tick`.
+    acc_bytes: u64,
+    acc_latency_secs: f64,
+    acc_count: u64,
+    /// Set when any op since the last tick was a Throttle / timeout-class error.
+    congestion_seen: bool,
+
+    /// `Some(deadline)` while in a post-congestion cooldown (no increases).
+    cooldown_until: Option<MonoTime>,
+    /// Time of the last re-probe (or controller start).
+    last_reprobe: MonoTime,
+    /// `Some((limit_before, goodput_before))` while a re-probe is outstanding,
+    /// so the next tick can keep-or-revert it.
+    probe_pending: Option<(f64, f64)>,
+
+    /// Whether `tick` has run at least once (to seed `last_reprobe`).
+    started: bool,
+}
+
+impl AdaptiveController {
+    /// Builds a controller from a policy. The limit starts at `2` (slow-start
+    /// seed), clamped to the policy ceiling.
+    #[must_use]
+    pub fn new(policy: AdaptivePolicy) -> Self {
+        let start = 2.0_f64.min(policy.ceiling as f64).max(1.0);
+        Self {
+            policy,
+            limit: start,
+            phase: Phase::SlowStart,
+            goodput_ewma: 0.0,
+            goodput_knee: 0.0,
+            goodput_prev_tick: 0.0,
+            rtt_ewma: 0.0,
+            rtt_min: f64::INFINITY,
+            acc_bytes: 0,
+            acc_latency_secs: 0.0,
+            acc_count: 0,
+            congestion_seen: false,
+            cooldown_until: None,
+            last_reprobe: Duration::ZERO,
+            probe_pending: None,
+            started: false,
+        }
+    }
+
+    /// The current concurrency limit (clamped to `[1, ceiling]`).
+    #[must_use]
+    pub fn current_limit(&self) -> usize {
+        (self.limit.round() as usize).clamp(1, self.policy.ceiling)
+    }
+
+    /// Records one completed (or failed) operation, updating the running EWMAs
+    /// and the congestion marker. Call between ticks; the accumulated samples
+    /// are folded into the goodput/rtt estimates at the next
+    /// [`tick`](AdaptiveController::tick).
+    pub fn record_op(&mut self, sample: OpSample) {
+        let secs = sample.latency.as_secs_f64().max(0.0);
+
+        // Per-op latency EWMA + min (baseline) tracking. Skip zero-latency
+        // degenerate samples for the min so a bogus 0 never pins rtt_min.
+        if secs > 0.0 {
+            if self.rtt_ewma <= 0.0 {
+                self.rtt_ewma = secs;
+            } else {
+                self.rtt_ewma = EWMA_ALPHA.mul_add(secs - self.rtt_ewma, self.rtt_ewma);
+            }
+            if secs < self.rtt_min {
+                self.rtt_min = secs;
+            }
+        }
+
+        self.acc_bytes = self.acc_bytes.saturating_add(sample.bytes);
+        self.acc_latency_secs += secs;
+        self.acc_count += 1;
+
+        match sample.result {
+            OpResult::Throttle | OpResult::HardErr => self.congestion_seen = true,
+            OpResult::Ok => {}
+        }
+    }
+
+    /// Applies the control law for one interval and returns the next
+    /// [`Decision`]. `now` is the injected monotonic time, `cpu_pct`/`rss` are
+    /// best-effort system samples (`None` ⇒ unknown ⇒ that guardrail is
+    /// skipped), and `p95_obj_size` is the recent 95th-percentile object size
+    /// used by the memory-budget guardrail.
+    ///
+    /// The controller never reads a real clock or sampler; all of these are
+    /// supplied by the (later) wiring gate.
+    pub fn tick(
+        &mut self,
+        now: MonoTime,
+        cpu_pct: Option<f64>,
+        _rss: Option<u64>,
+        p95_obj_size: u64,
+    ) -> Decision {
+        if !self.started {
+            self.started = true;
+            self.last_reprobe = now;
+        }
+
+        // ---- fold accumulated op samples into the goodput EWMA -------------
+        let interval_goodput = self.window_goodput();
+        if interval_goodput > 0.0 {
+            if self.goodput_ewma <= 0.0 {
+                self.goodput_ewma = interval_goodput;
+            } else {
+                self.goodput_ewma =
+                    EWMA_ALPHA.mul_add(interval_goodput - self.goodput_ewma, self.goodput_ewma);
+            }
+            if self.goodput_ewma > self.goodput_knee {
+                self.goodput_knee = self.goodput_ewma;
+            }
+        }
+        let congestion = self.congestion_seen;
+        let gradient = self.latency_gradient();
+
+        // ---- guardrail flags ----------------------------------------------
+        let cpu_blocks_increase = cpu_pct.is_some_and(|c| c > CPU_NO_INCREASE_PCT);
+        let cpu_forces_decrease = cpu_pct.is_some_and(|c| c > CPU_DECREASE_PCT);
+        let in_cooldown = self.cooldown_until.is_some_and(|d| now < d);
+        // Latency gradient below threshold ⇒ queue building ⇒ hold/decrease.
+        let queueing = gradient.is_some_and(|g| g < GRADIENT_THRESHOLD);
+
+        // A pending re-probe is resolved first (keep if it helped, else revert).
+        if let Some((prev_limit, prev_goodput)) = self.probe_pending.take() {
+            let improved = self.goodput_ewma > prev_goodput * (1.0 + IMPROVE_EPS);
+            if !improved || congestion || queueing {
+                self.limit = prev_limit; // revert the speculative probe
+            }
+            // else: keep the higher limit.
+        }
+
+        // ---- congestion backoff (highest priority) ------------------------
+        if congestion {
+            self.limit = (self.limit * BACKOFF_MULT).max(1.0);
+            self.phase = Phase::Aimd; // first knee ends slow-start
+            self.cooldown_until = Some(now + COOLDOWN);
+            self.goodput_prev_tick = self.goodput_ewma;
+            return self.finish(now, p95_obj_size);
+        }
+
+        // ---- CPU hard decrease --------------------------------------------
+        if cpu_forces_decrease {
+            self.limit = (self.limit * BACKOFF_MULT).max(1.0);
+            self.goodput_prev_tick = self.goodput_ewma;
+            return self.finish(now, p95_obj_size);
+        }
+
+        // ---- latency-gradient hold/decrease -------------------------------
+        if queueing {
+            // Queue building without an explicit error: gently decrease and
+            // leave slow-start. Hysteresis: only step down by one.
+            if self.phase == Phase::SlowStart {
+                self.phase = Phase::Aimd;
+            }
+            self.limit = (self.limit - 1.0).max(1.0);
+            self.goodput_prev_tick = self.goodput_ewma;
+            return self.finish(now, p95_obj_size);
+        }
+
+        // ---- no-increase guards (cooldown / CPU≈busy) ---------------------
+        if in_cooldown || cpu_blocks_increase {
+            self.goodput_prev_tick = self.goodput_ewma;
+            return self.finish(now, p95_obj_size);
+        }
+
+        // ---- healthy: grow per phase --------------------------------------
+        match self.phase {
+            Phase::SlowStart => {
+                // Keep multiplying while goodput is still rising; once it
+                // plateaus, treat as the knee and switch to AIMD.
+                let rising = self.goodput_ewma > self.goodput_prev_tick * (1.0 + IMPROVE_EPS)
+                    || self.goodput_prev_tick <= 0.0;
+                if rising {
+                    self.limit *= SLOW_START_MULT;
+                } else {
+                    self.phase = Phase::Aimd;
+                    self.limit += 1.0; // gentle additive after the knee
+                }
+            }
+            Phase::Aimd => {
+                // Additive increase, but periodically do an explicit re-probe
+                // (mark it pending so the next tick keeps-or-reverts).
+                if now >= self.last_reprobe + REPROBE_INTERVAL {
+                    self.last_reprobe = now;
+                    self.probe_pending = Some((self.limit, self.goodput_ewma));
+                    self.limit += 1.0;
+                } else {
+                    self.limit += 1.0;
+                }
+            }
+        }
+
+        self.goodput_prev_tick = self.goodput_ewma;
+        self.finish(now, p95_obj_size)
+    }
+
+    /// Goodput over the just-closed window (bytes / summed-latency), or 0 when
+    /// no ops were recorded.
+    fn window_goodput(&self) -> f64 {
+        if self.acc_count == 0 || self.acc_latency_secs <= 0.0 {
+            return 0.0;
+        }
+        // Aggregate goodput ≈ bytes moved divided by the *average* per-op
+        // latency times concurrency is implicit in the op stream; here we use
+        // the simple bytes / total-latency * current-limit estimate, which
+        // rises with both faster ops and more parallelism.
+        let per_op = self.acc_bytes as f64 / self.acc_latency_secs;
+        per_op * self.limit
+    }
+
+    /// `rtt_min / rtt_ewma` (∈ (0,1]); `None` until both are known. Near 1.0
+    /// means no queueing; small means latency has inflated (congestion).
+    fn latency_gradient(&self) -> Option<f64> {
+        if self.rtt_ewma > 0.0 && self.rtt_min.is_finite() && self.rtt_min > 0.0 {
+            Some((self.rtt_min / self.rtt_ewma).clamp(0.0, 1.0))
+        } else {
+            None
+        }
+    }
+
+    /// Applies the hard caps (ceiling + memory budget), resets the per-window
+    /// accumulators, and packages the [`Decision`].
+    fn finish(&mut self, _now: MonoTime, p95_obj_size: u64) -> Decision {
+        // Memory-budget hard cap: limit × p95_obj_size ≤ fraction × total_ram.
+        let mem_cap = self.memory_cap(p95_obj_size);
+        let ceiling = self.policy.ceiling;
+        let capped = (self.limit.round() as usize).clamp(1, ceiling).min(mem_cap);
+        // Persist the capped value so the cap is sticky (the controller never
+        // "remembers" a limit it is not allowed to use).
+        self.limit = capped as f64;
+
+        // Reset per-window accumulators.
+        self.acc_bytes = 0;
+        self.acc_latency_secs = 0.0;
+        self.acc_count = 0;
+        self.congestion_seen = false;
+
+        Decision {
+            limit: capped,
+            target_rate: self.target_rate(),
+        }
+    }
+
+    /// The largest concurrency the memory budget permits:
+    /// `floor(fraction × total_ram / p95_obj_size)`, at least 1. When either
+    /// `total_ram` or `p95_obj_size` is 0 the budget is unbounded (returns the
+    /// ceiling).
+    fn memory_cap(&self, p95_obj_size: u64) -> usize {
+        if self.policy.total_ram == 0 || p95_obj_size == 0 {
+            return self.policy.ceiling;
+        }
+        let budget = self.policy.fraction * self.policy.total_ram as f64;
+        let cap = (budget / p95_obj_size as f64).floor();
+        if cap < 1.0 {
+            1
+        } else {
+            (cap as usize).min(self.policy.ceiling)
+        }
+    }
+
+    /// `fraction × measured-goodput-knee`, clamped to `policy.max_rate`. `None`
+    /// until a knee has been observed and no rate cap forces a value.
+    fn target_rate(&self) -> Option<u64> {
+        let knee_rate = if self.goodput_knee > 0.0 {
+            Some((self.policy.fraction * self.goodput_knee).max(1.0) as u64)
+        } else {
+            None
+        };
+        match (knee_rate, self.policy.max_rate) {
+            (Some(k), Some(m)) => Some(k.min(m)),
+            (Some(k), None) => Some(k),
+            (None, Some(m)) => Some(m),
+            (None, None) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::thread;
+
+    // ----- AdaptiveGate: async ----------------------------------------------
+
+    fn runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .expect("build tokio runtime")
+    }
+
+    #[test]
+    fn adaptive_gate_async_acquire_blocks_beyond_limit() {
+        let rt = runtime();
+        rt.block_on(async {
+            let gate = AdaptiveGate::new(2, 8);
+            let p1 = gate.acquire().await;
+            let p2 = gate.acquire().await;
+            assert_eq!(gate.available_permits(), 0, "both permits taken");
+
+            // A third acquire must not be immediately ready.
+            let fut = gate.acquire();
+            tokio::pin!(fut);
+            let pending = futures::poll!(&mut fut);
+            assert!(pending.is_pending(), "third acquire blocks at limit 2");
+
+            // Raising the limit unblocks it.
+            gate.set_limit(3);
+            let p3 = futures::poll!(&mut fut);
+            assert!(p3.is_ready(), "set_limit(3) frees a permit for the waiter");
+            drop((p1, p2));
+        });
+    }
+
+    /// Mirror transfer.rs's `max_in_flight_for` idiom: drive many acquires and
+    /// record the peak concurrent holders under a fixed gate limit.
+    fn peak_under_limit(limit: usize, items: usize) -> usize {
+        let rt = runtime();
+        rt.block_on(async {
+            let gate = AdaptiveGate::new(limit, 32);
+            let in_flight = Arc::new(AtomicUsize::new(0));
+            let high = Arc::new(AtomicUsize::new(0));
+            let mut handles = Vec::new();
+            for _ in 0..items {
+                let gate = gate.clone();
+                let in_flight = Arc::clone(&in_flight);
+                let high = Arc::clone(&high);
+                handles.push(tokio::spawn(async move {
+                    let _p = gate.acquire().await;
+                    let cur = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    high.fetch_max(cur, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    in_flight.fetch_sub(1, Ordering::SeqCst);
+                }));
+            }
+            for h in handles {
+                h.await.unwrap();
+            }
+            high.load(Ordering::SeqCst)
+        })
+    }
+
+    #[test]
+    fn adaptive_gate_async_set_limit_changes_max_in_flight() {
+        assert_eq!(peak_under_limit(3, 12), 3, "limit 3 caps in-flight at 3");
+        assert_eq!(peak_under_limit(1, 5), 1, "limit 1 is strictly sequential");
+    }
+
+    #[test]
+    fn adaptive_gate_async_shrink_does_not_deadlock_held_permits() {
+        let rt = runtime();
+        rt.block_on(async {
+            let gate = AdaptiveGate::new(4, 8);
+            let p1 = gate.acquire().await;
+            let p2 = gate.acquire().await;
+            // Shrink below the number of held permits.
+            let new = gate.set_limit(1);
+            assert_eq!(new, 1);
+            // Dropping held permits must not panic/deadlock; afterwards the
+            // effective limit settles to 1.
+            drop(p1);
+            drop(p2);
+            // Acquire one (should succeed) and confirm a second blocks.
+            let _q = gate.acquire().await;
+            let fut = gate.acquire();
+            tokio::pin!(fut);
+            assert!(
+                futures::poll!(&mut fut).is_pending(),
+                "after shrink to 1, only one permit is available"
+            );
+        });
+    }
+
+    // ----- AdaptiveGate: blocking -------------------------------------------
+
+    #[test]
+    fn adaptive_gate_blocking_acquire_and_set_limit() {
+        let gate = AdaptiveGate::new(1, 8);
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let high = Arc::new(AtomicUsize::new(0));
+
+        // With limit 1, two threads must serialize (peak in-flight 1).
+        let mut handles = Vec::new();
+        for _ in 0..4 {
+            let gate = gate.clone();
+            let in_flight = Arc::clone(&in_flight);
+            let high = Arc::clone(&high);
+            handles.push(thread::spawn(move || {
+                let _p = gate.acquire_blocking();
+                let cur = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                high.fetch_max(cur, Ordering::SeqCst);
+                thread::sleep(Duration::from_millis(30));
+                in_flight.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(
+            high.load(Ordering::SeqCst),
+            1,
+            "blocking limit 1 serializes"
+        );
+
+        // Now raise the limit and confirm parallelism rises.
+        let gate2 = AdaptiveGate::new(1, 8);
+        gate2.set_limit(3);
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let high = Arc::new(AtomicUsize::new(0));
+        let mut handles = Vec::new();
+        for _ in 0..6 {
+            let gate = gate2.clone();
+            let in_flight = Arc::clone(&in_flight);
+            let high = Arc::clone(&high);
+            handles.push(thread::spawn(move || {
+                let _p = gate.acquire_blocking();
+                let cur = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                high.fetch_max(cur, Ordering::SeqCst);
+                thread::sleep(Duration::from_millis(30));
+                in_flight.fetch_sub(1, Ordering::SeqCst);
+            }));
+        }
+        for h in handles {
+            h.join().unwrap();
+        }
+        let peak = high.load(Ordering::SeqCst);
+        assert!(
+            (1..=3).contains(&peak) && peak >= 2,
+            "after set_limit(3) peak in-flight should reach ~3, got {peak}"
+        );
+    }
+
+    #[test]
+    fn adaptive_gate_blocking_shrink_does_not_deadlock() {
+        let gate = AdaptiveGate::new(4, 8);
+        let p1 = gate.acquire_blocking();
+        let p2 = gate.acquire_blocking();
+        gate.set_limit(1); // shrink below held count
+        drop(p1);
+        drop(p2);
+        // A subsequent acquire must still succeed (no deadlock / no lost permit).
+        let got = Arc::new(AtomicUsize::new(0));
+        let g = gate.clone();
+        let got2 = Arc::clone(&got);
+        let h = thread::spawn(move || {
+            let _p = g.acquire_blocking();
+            got2.fetch_add(1, Ordering::SeqCst);
+        });
+        h.join().unwrap();
+        assert_eq!(got.load(Ordering::SeqCst), 1, "acquire after shrink works");
+    }
+
+    // ----- AdaptiveController -----------------------------------------------
+
+    /// Convenience: a healthy Ok op of `bytes` at `latency_ms`.
+    fn ok_op(bytes: u64, latency_ms: u64) -> OpSample {
+        OpSample {
+            bytes,
+            latency: Duration::from_millis(latency_ms),
+            result: OpResult::Ok,
+        }
+    }
+
+    fn big_policy() -> AdaptivePolicy {
+        // Big RAM so the memory guardrail never bites unless a test wants it.
+        AdaptivePolicy::new(0.8, 64, u64::MAX, None)
+    }
+
+    #[test]
+    fn adaptive_controller_healthy_stream_ramps_up_then_caps() {
+        let mut c = AdaptiveController::new(big_policy());
+        let mut t = Duration::ZERO;
+        let mut last = c.current_limit();
+        let mut max_seen = last;
+        // Rising goodput: each tick the ops get "faster" (more bytes/sec).
+        for i in 0..20u64 {
+            for _ in 0..4 {
+                c.record_op(ok_op(1_000_000 + i * 200_000, 50));
+            }
+            let d = c.tick(t, Some(30.0), Some(0), 4096);
+            assert!(d.limit <= 64, "never exceed ceiling");
+            max_seen = max_seen.max(d.limit);
+            last = d.limit;
+            t += Duration::from_secs(1);
+        }
+        assert!(
+            max_seen > 2,
+            "healthy stream should ramp the limit up from the start of 2, got max {max_seen}"
+        );
+        assert!(last <= 64, "stays within ceiling, got {last}");
+    }
+
+    #[test]
+    fn adaptive_controller_throttle_backs_off_and_cooldown_holds() {
+        let mut c = AdaptiveController::new(big_policy());
+        let mut t = Duration::ZERO;
+        // Ramp up first.
+        for _ in 0..6 {
+            for _ in 0..4 {
+                c.record_op(ok_op(2_000_000, 40));
+            }
+            c.tick(t, Some(20.0), Some(0), 4096);
+            t += Duration::from_secs(1);
+        }
+        let before = c.current_limit();
+        assert!(before > 2, "should have grown before the throttle");
+
+        // Inject a Throttle.
+        c.record_op(OpSample {
+            bytes: 1000,
+            latency: Duration::from_millis(40),
+            result: OpResult::Throttle,
+        });
+        let d = c.tick(t, Some(20.0), Some(0), 4096);
+        assert!(
+            d.limit <= before / 2 + 1,
+            "throttle should at least halve the limit: before {before}, after {}",
+            d.limit
+        );
+        let after_backoff = d.limit;
+        t += Duration::from_secs(1);
+
+        // For the 15s cooldown, even healthy ticks must not increase the limit.
+        for _ in 0..10 {
+            for _ in 0..4 {
+                c.record_op(ok_op(5_000_000, 20)); // very healthy
+            }
+            let d = c.tick(t, Some(10.0), Some(0), 4096);
+            assert!(
+                d.limit <= after_backoff,
+                "no increase during cooldown: {} > {after_backoff}",
+                d.limit
+            );
+            t += Duration::from_secs(1);
+        }
+
+        // After the cooldown (>15s), increases resume.
+        t += Duration::from_secs(6);
+        for _ in 0..3 {
+            for _ in 0..4 {
+                c.record_op(ok_op(6_000_000, 20));
+            }
+            c.tick(t, Some(10.0), Some(0), 4096);
+            t += Duration::from_secs(1);
+        }
+        assert!(
+            c.current_limit() > after_backoff,
+            "limit should recover after the cooldown expires"
+        );
+    }
+
+    #[test]
+    fn adaptive_controller_rising_latency_holds_without_error() {
+        let mut c = AdaptiveController::new(big_policy());
+        let mut t = Duration::ZERO;
+        // Establish a low rtt_min with fast ops, ramp up.
+        for _ in 0..5 {
+            for _ in 0..4 {
+                c.record_op(ok_op(2_000_000, 10)); // 10ms baseline
+            }
+            c.tick(t, Some(20.0), Some(0), 4096);
+            t += Duration::from_secs(1);
+        }
+        let peak = c.current_limit();
+
+        // Now latency inflates massively (queueing) but NO errors: gradient
+        // rtt_min/rtt drops well below threshold ⇒ controller must not grow.
+        for _ in 0..6 {
+            for _ in 0..4 {
+                c.record_op(ok_op(2_000_000, 200)); // 200ms now, 20x baseline
+            }
+            let d = c.tick(t, Some(20.0), Some(0), 4096);
+            assert!(
+                d.limit <= peak,
+                "high latency gradient must hold/decrease (no growth): {} > {peak}",
+                d.limit
+            );
+            t += Duration::from_secs(1);
+        }
+        assert!(
+            c.current_limit() <= peak,
+            "latency-gradient guard held the limit at/below the peak"
+        );
+    }
+
+    #[test]
+    fn adaptive_controller_memory_budget_caps_limit() {
+        // Tiny RAM, large object size ⇒ memory budget forces a small limit.
+        // budget = 0.8 * 10MiB = 8MiB; p95 = 2MiB ⇒ cap = floor(8/2) = 4.
+        let total_ram = 10 * 1024 * 1024;
+        let p95 = 2 * 1024 * 1024;
+        let policy = AdaptivePolicy::new(0.8, 64, total_ram, None);
+        let mut c = AdaptiveController::new(policy);
+        let mut t = Duration::ZERO;
+        for _ in 0..30 {
+            for _ in 0..4 {
+                c.record_op(ok_op(10_000_000, 10)); // very healthy, wants to grow
+            }
+            let d = c.tick(t, Some(10.0), Some(0), p95);
+            // Invariant: limit * p95 <= fraction * total_ram (never violated).
+            assert!(
+                (d.limit as u64) * p95 <= ((0.8 * total_ram as f64) as u64),
+                "memory budget violated: limit {} * p95 {} > budget",
+                d.limit,
+                p95
+            );
+            assert!(
+                d.limit <= 4,
+                "memory cap should pin limit at 4, got {}",
+                d.limit
+            );
+            t += Duration::from_secs(1);
+        }
+    }
+
+    #[test]
+    fn adaptive_controller_high_cpu_prevents_increase() {
+        let mut c = AdaptiveController::new(big_policy());
+        let mut t = Duration::ZERO;
+        // Warm up a little at low CPU.
+        for _ in 0..3 {
+            for _ in 0..4 {
+                c.record_op(ok_op(2_000_000, 20));
+            }
+            c.tick(t, Some(20.0), Some(0), 4096);
+            t += Duration::from_secs(1);
+        }
+        let before = c.current_limit();
+        // Now CPU is pinned > 85%: no increase, even with healthy ops.
+        for _ in 0..8 {
+            for _ in 0..4 {
+                c.record_op(ok_op(5_000_000, 10));
+            }
+            let d = c.tick(t, Some(90.0), Some(0), 4096);
+            assert!(
+                d.limit <= before,
+                "cpu>85 must block increases: {} > {before}",
+                d.limit
+            );
+            t += Duration::from_secs(1);
+        }
+    }
+
+    #[test]
+    fn adaptive_controller_converges_on_steady_stream() {
+        let mut c = AdaptiveController::new(big_policy());
+        let mut t = Duration::ZERO;
+        // Run long enough to ramp and settle on a perfectly steady stream.
+        let mut limits = Vec::new();
+        for _ in 0..60 {
+            for _ in 0..4 {
+                c.record_op(ok_op(3_000_000, 25)); // identical every op
+            }
+            let d = c.tick(t, Some(40.0), Some(0), 4096);
+            limits.push(d.limit);
+            t += Duration::from_secs(1);
+        }
+        // Look at the tail: it should not oscillate wildly. Measure the spread
+        // of the last 15 ticks.
+        let tail = &limits[limits.len() - 15..];
+        let min = *tail.iter().min().unwrap();
+        let max = *tail.iter().max().unwrap();
+        assert!(
+            max - min <= 3,
+            "steady stream should converge (small tail spread), got min {min} max {max} tail {tail:?}"
+        );
+    }
+
+    #[test]
+    fn adaptive_controller_target_rate_respects_fraction() {
+        let mut c = AdaptiveController::new(big_policy());
+        let mut t = Duration::ZERO;
+        let mut last_rate = None;
+        for _ in 0..15 {
+            for _ in 0..4 {
+                c.record_op(ok_op(1_000_000, 100)); // steady goodput
+            }
+            let d = c.tick(t, Some(30.0), Some(0), 4096);
+            last_rate = d.target_rate;
+            t += Duration::from_secs(1);
+        }
+        let rate = last_rate.expect("a knee should have produced a target_rate");
+        // target_rate must be ~fraction (0.8) of the measured goodput knee.
+        // We don't know the exact knee, but it must be positive and the
+        // controller computed it as 0.8 * knee, so re-deriving: rate/0.8 = knee.
+        assert!(
+            rate > 0,
+            "target_rate should be positive once a knee is known"
+        );
+
+        // With a max_rate cap below the knee fraction, the target is clamped.
+        let policy = AdaptivePolicy::new(0.8, 64, u64::MAX, Some(1234));
+        let mut c2 = AdaptiveController::new(policy);
+        let mut t2 = Duration::ZERO;
+        for _ in 0..10 {
+            for _ in 0..4 {
+                c2.record_op(ok_op(10_000_000, 10));
+            }
+            let d = c2.tick(t2, Some(30.0), Some(0), 4096);
+            assert!(
+                d.target_rate.unwrap_or(0) <= 1234,
+                "target_rate must respect max_rate cap"
+            );
+            t2 += Duration::from_secs(1);
+        }
+    }
+}

--- a/crates/snapdir-stores/src/adaptive.rs
+++ b/crates/snapdir-stores/src/adaptive.rs
@@ -34,8 +34,10 @@
 
 use std::sync::atomic::{AtomicUsize, Ordering};
 use std::sync::{Arc, Condvar, Mutex, PoisonError};
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
+use snapdir_core::resources::{resident_set_bytes, CpuSampler};
+use snapdir_core::Meter;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
 // ---------------------------------------------------------------------------
@@ -781,6 +783,149 @@ impl AdaptiveController {
     }
 }
 
+// ---------------------------------------------------------------------------
+// ControllerDriver — bridges the pure controller to the live transfer loops.
+// ---------------------------------------------------------------------------
+
+/// Computes the 95th-percentile of a set of object sizes (the memory-budget
+/// denominator the controller's `tick` expects). An empty set yields `0`
+/// (memory guardrail disabled). The slice is cloned + sorted locally so the
+/// caller's data is untouched.
+#[must_use]
+pub fn p95_object_size(sizes: &[u64]) -> u64 {
+    if sizes.is_empty() {
+        return 0;
+    }
+    let mut sorted = sizes.to_vec();
+    sorted.sort_unstable();
+    // Nearest-rank p95: index = ceil(0.95 * n) - 1, clamped into range.
+    let n = sorted.len();
+    let rank = ((0.95 * n as f64).ceil() as usize).max(1);
+    sorted[rank.min(n) - 1]
+}
+
+/// Shared, live bridge between a pure [`AdaptiveController`] and the running
+/// transfer backends.
+///
+/// The controller is `&mut` and deterministic; this wrapper owns it behind a
+/// [`Mutex`] (tick is infrequent, so contention is negligible) and adds the
+/// *impure* parts the controller deliberately omits: a real monotonic clock, a
+/// live [`CpuSampler`] + RSS sampler, the manifest's p95 object size, and the
+/// application of each [`Decision`] to the shared [`AdaptiveGate`] (concurrency)
+/// and — for the network backends — a rate-limiter setter + display [`Meter`].
+///
+/// Both transfer paths use it identically:
+///
+/// - every completed/failed op calls [`record_op`](ControllerDriver::record_op)
+///   with its measured `OpSample`;
+/// - a lightweight driver (a tokio `interval` task for the async path, a
+///   `std::thread` for the rayon path) periodically calls
+///   [`tick`](ControllerDriver::tick), which samples CPU/RSS, advances the
+///   controller, resizes the gate, and reports the new limit/rate.
+///
+/// The driver is [`Clone`] (the controller, gate, sampler and the
+/// rate/limit appliers are all shared via [`Arc`]).
+#[derive(Clone)]
+pub struct ControllerDriver {
+    controller: Arc<Mutex<AdaptiveController>>,
+    gate: AdaptiveGate,
+    cpu: Arc<Mutex<CpuSampler>>,
+    p95_obj_size: u64,
+    /// Wall-clock origin: `tick` injects `now = epoch.elapsed()` so the
+    /// controller sees a monotonic [`MonoTime`].
+    epoch: Instant,
+    /// Applies a target byte-rate to the backend's live rate limiter (async or
+    /// blocking). Local `FileStore` has no rate limit, so this is `None`.
+    rate_applier: Option<Arc<dyn Fn(Option<u64>) + Send + Sync>>,
+    /// Optional display meter: the new limit / target rate are mirrored into it
+    /// for the progress bar (advisory only).
+    meter: Option<Arc<Meter>>,
+}
+
+// The closure / mutex-wrapped controller fields are intentionally omitted from
+// the human-facing debug view (a `dyn Fn` is not `Debug`, and the controller's
+// internals are large + uninteresting here); the load-bearing live state
+// (limits, p95, wiring presence) is shown instead.
+#[allow(clippy::missing_fields_in_debug)]
+impl std::fmt::Debug for ControllerDriver {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ControllerDriver")
+            .field("gate_limit", &self.gate.limit())
+            .field("ceiling", &self.gate.ceiling())
+            .field("p95_obj_size", &self.p95_obj_size)
+            .field("has_rate_applier", &self.rate_applier.is_some())
+            .field("has_meter", &self.meter.is_some())
+            .finish()
+    }
+}
+
+impl ControllerDriver {
+    /// Builds a driver around a fresh controller for `policy`, the shared
+    /// `gate`, the manifest's `p95_obj_size`, an optional `rate_applier` (the
+    /// backend's live rate-limit setter; `None` for the rate-less local store),
+    /// and an optional display `meter`.
+    #[must_use]
+    pub fn new(
+        policy: AdaptivePolicy,
+        gate: AdaptiveGate,
+        p95_obj_size: u64,
+        rate_applier: Option<Arc<dyn Fn(Option<u64>) + Send + Sync>>,
+        meter: Option<Arc<Meter>>,
+    ) -> Self {
+        Self {
+            controller: Arc::new(Mutex::new(AdaptiveController::new(policy))),
+            gate,
+            cpu: Arc::new(Mutex::new(CpuSampler::new())),
+            p95_obj_size,
+            epoch: Instant::now(),
+            rate_applier,
+            meter,
+        }
+    }
+
+    /// Records one completed/failed op into the shared controller.
+    pub fn record_op(&self, sample: OpSample) {
+        self.controller
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .record_op(sample);
+    }
+
+    /// Advances the controller one interval: samples CPU/RSS, ticks with the
+    /// injected monotonic clock + p95 object size, then applies the resulting
+    /// [`Decision`] to the gate (concurrency), the rate applier (byte-rate), and
+    /// the display meter. Returns the decision for tests/inspection.
+    pub fn tick(&self) -> Decision {
+        let cpu_pct = self
+            .cpu
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner)
+            .poll();
+        let rss = resident_set_bytes();
+        let now = self.epoch.elapsed();
+
+        let decision = {
+            let mut controller = self
+                .controller
+                .lock()
+                .unwrap_or_else(PoisonError::into_inner);
+            controller.tick(now, cpu_pct, rss, self.p95_obj_size)
+        };
+
+        // Apply: resize the shared gate, retune the rate limiter, mirror both
+        // into the display meter (all advisory; never change what is transferred).
+        self.gate.set_limit(decision.limit);
+        if let Some(apply) = &self.rate_applier {
+            apply(decision.target_rate);
+        }
+        if let Some(meter) = &self.meter {
+            meter.set_current_limit(decision.limit as u64);
+            meter.set_target_rate(decision.target_rate.unwrap_or(0));
+        }
+        decision
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1170,6 +1315,74 @@ mod tests {
         assert!(
             max - min <= 3,
             "steady stream should converge (small tail spread), got min {min} max {max} tail {tail:?}"
+        );
+    }
+
+    // ----- ControllerDriver -------------------------------------------------
+
+    #[test]
+    fn p95_object_size_nearest_rank() {
+        assert_eq!(p95_object_size(&[]), 0, "empty -> 0 (memory cap disabled)");
+        assert_eq!(p95_object_size(&[42]), 42, "single element");
+        // 1..=100: nearest-rank p95 = the 95th value = 95.
+        let sizes: Vec<u64> = (1..=100).collect();
+        assert_eq!(p95_object_size(&sizes), 95);
+        // p95 is robust to one huge outlier in a small set (returns the max here).
+        assert_eq!(p95_object_size(&[1, 1, 1, 1_000_000]), 1_000_000);
+    }
+
+    #[test]
+    fn controller_driver_throttle_drives_gate_decrease() {
+        // A driver wired to a gate: record several healthy ops + tick to grow the
+        // gate, then inject a Throttle + tick and assert the gate's live limit
+        // dropped (the controller's backoff was applied to the real gate).
+        let gate = AdaptiveGate::new(2, 32);
+        let applied_rate = Arc::new(Mutex::new(None::<Option<u64>>));
+        let rate_sink = Arc::clone(&applied_rate);
+        let rate_applier: Arc<dyn Fn(Option<u64>) + Send + Sync> = Arc::new(move |r| {
+            *rate_sink.lock().unwrap() = Some(r);
+        });
+        let policy = AdaptivePolicy::new(0.8, 32, u64::MAX, None);
+        let driver = ControllerDriver::new(policy, gate.clone(), 4096, Some(rate_applier), None);
+
+        // Grow: healthy ops over several ticks should raise the gate above 2.
+        for _ in 0..8 {
+            for _ in 0..4 {
+                driver.record_op(OpSample {
+                    bytes: 2_000_000,
+                    latency: Duration::from_millis(40),
+                    result: OpResult::Ok,
+                });
+            }
+            driver.tick();
+        }
+        let grown = gate.limit();
+        assert!(
+            grown > 2,
+            "healthy stream should grow the gate, got {grown}"
+        );
+
+        // Inject a Throttle, then tick: the gate's limit must drop (backoff).
+        driver.record_op(OpSample {
+            bytes: 1000,
+            latency: Duration::from_millis(40),
+            result: OpResult::Throttle,
+        });
+        let decision = driver.tick();
+        assert!(
+            gate.limit() < grown,
+            "throttle must shrink the gate: {} >= {grown}",
+            gate.limit()
+        );
+        assert_eq!(
+            gate.limit(),
+            decision.limit,
+            "the gate reflects the decision's limit"
+        );
+        // A rate was applied to the limiter at least once (target_rate flows out).
+        assert!(
+            applied_rate.lock().unwrap().is_some(),
+            "the rate applier must have been invoked"
         );
     }
 

--- a/crates/snapdir-stores/src/fetch.rs
+++ b/crates/snapdir-stores/src/fetch.rs
@@ -26,13 +26,21 @@
 //!   write error and cancels the rest.
 
 use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
 
 use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
 use snapdir_core::merkle::Blake3Hasher;
 use snapdir_core::store::StoreError;
 use snapdir_core::Meter;
 
-use crate::transfer::{run_concurrent, RateLimiter, TransferConfig};
+use crate::adaptive::{
+    p95_object_size, AdaptiveGate, AdaptivePolicy as ControllerPolicy, ControllerDriver, OpResult,
+    OpSample,
+};
+use crate::transfer::{
+    classify_error, run_adaptive, run_concurrent, AdaptivePolicy, RateLimiter, TransferConfig,
+};
 use crate::util::file_present_and_verified;
 
 /// Strips a leading `./` and a trailing `/` from a manifest path so the
@@ -89,6 +97,7 @@ pub(crate) async fn fetch_files_concurrent<'a, F, Fut>(
     config: &TransferConfig,
     rate_limiter: &RateLimiter,
     meter: Option<&Meter>,
+    meter_arc: Option<Arc<Meter>>,
     download: F,
 ) -> Result<(), StoreError>
 where
@@ -132,9 +141,9 @@ where
         m.set_total(total);
     }
 
-    // Concurrent pass: download + atomically write each missing object, bounded
-    // by `config.concurrency` and throttled by the shared rate limiter.
-    run_concurrent(to_download, config.concurrency, |(entry, target)| {
+    // The per-object download+write step, shared by the fixed and adaptive
+    // passes (so they transfer byte-identically; only scheduling/rate differ).
+    let download_one = |entry: &'a ManifestEntry, target: std::path::PathBuf| {
         let download = &download;
         let rate_limiter = &rate_limiter;
         async move {
@@ -154,12 +163,103 @@ where
                 m.add_out(bytes.len() as u64);
                 m.object_finished();
             }
-            Ok(())
+            Ok::<(), StoreError>(())
         }
-    })
-    .await?;
+    };
+
+    match config.adaptive {
+        AdaptivePolicy::Off => {
+            // Concurrent pass: download + atomically write each missing object,
+            // bounded by `config.concurrency`, throttled by the rate limiter.
+            run_concurrent(to_download, config.concurrency, |(entry, target)| {
+                download_one(entry, target)
+            })
+            .await?;
+        }
+        AdaptivePolicy::On { fraction, ceiling } => {
+            run_adaptive_downloads(
+                to_download,
+                config,
+                rate_limiter,
+                meter_arc,
+                fraction,
+                ceiling,
+                download_one,
+            )
+            .await?;
+        }
+    }
 
     Ok(())
+}
+
+/// Adaptive sibling of the fixed-concurrency download pass: window = ceiling,
+/// effective concurrency gated to the controller's live limit, every op timed +
+/// classified + recorded, with a background tick driver resizing the gate and
+/// retuning the rate limiter. Byte-identical to the `Off` path otherwise.
+#[allow(clippy::too_many_arguments)]
+async fn run_adaptive_downloads<'a, D, DFut>(
+    to_download: Vec<(&'a ManifestEntry, std::path::PathBuf)>,
+    config: &TransferConfig,
+    rate_limiter: &RateLimiter,
+    meter_arc: Option<Arc<Meter>>,
+    fraction: f64,
+    ceiling: usize,
+    download_one: D,
+) -> Result<(), StoreError>
+where
+    D: Fn(&'a ManifestEntry, std::path::PathBuf) -> DFut,
+    DFut: std::future::Future<Output = Result<(), StoreError>>,
+{
+    let sizes: Vec<u64> = to_download.iter().map(|(e, _)| e.size).collect();
+    let p95 = p95_object_size(&sizes);
+    let total_ram = snapdir_core::resources::total_ram_bytes().unwrap_or(0);
+    let policy = ControllerPolicy::new(fraction, ceiling, total_ram, config.max_bytes_per_sec);
+
+    let gate = AdaptiveGate::new(config.concurrency.get(), ceiling);
+
+    let limiter = rate_limiter.clone();
+    let rate_applier: Arc<dyn Fn(Option<u64>) + Send + Sync> = Arc::new(move |rate| {
+        let limiter = limiter.clone();
+        tokio::spawn(async move {
+            limiter.set_rate(rate).await;
+        });
+    });
+    let driver = ControllerDriver::new(policy, gate.clone(), p95, Some(rate_applier), meter_arc);
+
+    let tick_driver = driver.clone();
+    let mut ticker = tokio::time::interval(std::time::Duration::from_millis(250));
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let tick_handle = tokio::spawn(async move {
+        loop {
+            ticker.tick().await;
+            tick_driver.tick();
+        }
+    });
+
+    let result = run_adaptive(to_download, &gate, |(entry, target)| {
+        let download_one = &download_one;
+        let driver = &driver;
+        async move {
+            let started = Instant::now();
+            let outcome = download_one(entry, target).await;
+            let latency = started.elapsed();
+            let (bytes, op_result) = match &outcome {
+                Ok(()) => (entry.size, OpResult::Ok),
+                Err(err) => (0, classify_error(err)),
+            };
+            driver.record_op(OpSample {
+                bytes,
+                latency,
+                result: op_result,
+            });
+            outcome
+        }
+    })
+    .await;
+
+    tick_handle.abort();
+    result.map(|_| ())
 }
 
 #[cfg(test)]
@@ -300,10 +400,18 @@ mod tests {
             let rt = runtime();
             let fake_ref = Arc::clone(&fake);
             rt.block_on(async {
-                fetch_files_concurrent(&manifest, dest.path(), &cfg, &limiter, None, |entry| {
-                    let fake = Arc::clone(&fake_ref);
-                    async move { fake.download(entry).await }
-                })
+                fetch_files_concurrent(
+                    &manifest,
+                    dest.path(),
+                    &cfg,
+                    &limiter,
+                    None,
+                    None,
+                    |entry| {
+                        let fake = Arc::clone(&fake_ref);
+                        async move { fake.download(entry).await }
+                    },
+                )
                 .await
             })
             .expect("orchestrator must succeed");
@@ -346,10 +454,18 @@ mod tests {
         let rt = runtime();
         let fake_ref = Arc::clone(&fake);
         rt.block_on(async {
-            fetch_files_concurrent(&manifest, dest.path(), &cfg, &limiter, None, |entry| {
-                let fake = Arc::clone(&fake_ref);
-                async move { fake.download(entry).await }
-            })
+            fetch_files_concurrent(
+                &manifest,
+                dest.path(),
+                &cfg,
+                &limiter,
+                None,
+                None,
+                |entry| {
+                    let fake = Arc::clone(&fake_ref);
+                    async move { fake.download(entry).await }
+                },
+            )
             .await
         })
         .expect("orchestrator must succeed");
@@ -377,6 +493,65 @@ mod tests {
     }
 
     #[test]
+    fn adaptive_download_materializes_all_within_ceiling() {
+        // An adaptive fetch (policy On, ceiling 2) downloads every object,
+        // materializes the dest correctly, and never exceeds the ceiling for
+        // effective concurrency.
+        use crate::transfer::AdaptivePolicy;
+
+        let files: &[(&str, &[u8])] = &[
+            ("a.txt", b"alpha" as &[u8]),
+            ("nested/b.txt", b"bravo"),
+            ("nested/deep/c.txt", b"charlie"),
+            ("d.txt", b"delta"),
+            ("e.txt", b"echo"),
+        ];
+        let manifest = manifest_for(files);
+
+        let dest = TempDir::new();
+        let fake = FakeDownloader::new(files);
+        let cfg = TransferConfig::new(4, None).with_adaptive(AdaptivePolicy::On {
+            fraction: 0.8,
+            ceiling: 2,
+        });
+        let limiter = RateLimiter::new(None);
+
+        let rt = runtime();
+        let fake_ref = Arc::clone(&fake);
+        rt.block_on(async {
+            fetch_files_concurrent(
+                &manifest,
+                dest.path(),
+                &cfg,
+                &limiter,
+                None,
+                None,
+                |entry| {
+                    let fake = Arc::clone(&fake_ref);
+                    async move { fake.download(entry).await }
+                },
+            )
+            .await
+        })
+        .expect("adaptive orchestrator must succeed");
+
+        for (path, contents) in files {
+            let got = std::fs::read(dest.path().join(path))
+                .unwrap_or_else(|e| panic!("missing {path}: {e}"));
+            assert_eq!(&got, contents, "wrong bytes for {path}");
+        }
+        // The gate caps effective concurrency at the ceiling (2) regardless of
+        // the larger buffer window.
+        let hw = fake.high_water.load(Ordering::SeqCst);
+        assert!(
+            hw <= 2,
+            "effective concurrency must not exceed the ceiling 2, got {hw}"
+        );
+        // Every object was downloaded exactly once.
+        assert_eq!(fake.called.lock().unwrap().len(), files.len());
+    }
+
+    #[test]
     fn concurrent_download_propagates_error() {
         let files: &[(&str, &[u8])] = &[
             ("ok1.txt", b"one" as &[u8]),
@@ -393,18 +568,26 @@ mod tests {
         let rt = runtime();
         let boom = boom_sum.clone();
         let result = rt.block_on(async {
-            fetch_files_concurrent(&manifest, dest.path(), &cfg, &limiter, None, |entry| {
-                let boom = boom.clone();
-                async move {
-                    if entry.checksum == boom {
-                        return Err(StoreError::Backend {
-                            message: "download blew up".to_owned(),
-                            source: None,
-                        });
+            fetch_files_concurrent(
+                &manifest,
+                dest.path(),
+                &cfg,
+                &limiter,
+                None,
+                None,
+                |entry| {
+                    let boom = boom.clone();
+                    async move {
+                        if entry.checksum == boom {
+                            return Err(StoreError::Backend {
+                                message: "download blew up".to_owned(),
+                                source: None,
+                            });
+                        }
+                        Ok(b"unused".to_vec())
                     }
-                    Ok(b"unused".to_vec())
-                }
-            })
+                },
+            )
             .await
         });
 

--- a/crates/snapdir-stores/src/file_store.rs
+++ b/crates/snapdir-stores/src/file_store.rs
@@ -40,8 +40,12 @@ use snapdir_core::merkle::{Blake3Hasher, Hasher};
 use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
 use snapdir_core::Meter;
 
+use crate::adaptive::{
+    p95_object_size, AdaptiveGate, AdaptivePolicy as ControllerPolicy, ControllerDriver, OpResult,
+    OpSample,
+};
 use crate::stream::StreamStore;
-use crate::transfer::TransferConfig;
+use crate::transfer::{classify_error, AdaptivePolicy, TransferConfig};
 use crate::util::{file_present_and_verified, hash_file};
 
 /// Number of times the oracle retries a persist whose copied bytes fail their
@@ -145,11 +149,21 @@ impl FileStore {
     /// sequential copy. Each task uses a fresh, cheap, stateless
     /// [`Blake3Hasher`] to sidestep any `Sync` concern.
     fn parallel_copy(&self, jobs: &[(PathBuf, PathBuf, String)]) -> Result<(), StoreError> {
-        use rayon::prelude::*;
-
         if jobs.is_empty() {
             return Ok(());
         }
+        match self.config.adaptive {
+            AdaptivePolicy::Off => self.parallel_copy_fixed(jobs),
+            AdaptivePolicy::On { fraction, ceiling } => {
+                self.parallel_copy_adaptive(jobs, fraction, ceiling)
+            }
+        }
+    }
+
+    /// Fixed-concurrency rayon copy: pool sized to `config.concurrency`, no gate
+    /// or driver. The historical (byte-identical) local-copy path.
+    fn parallel_copy_fixed(&self, jobs: &[(PathBuf, PathBuf, String)]) -> Result<(), StoreError> {
+        use rayon::prelude::*;
 
         // `&Meter` is `Sync`, so it is shared across the rayon closures. `None`
         // means zero recording and byte-identical behavior.
@@ -181,6 +195,95 @@ impl FileStore {
                 Ok(())
             })
         })
+    }
+
+    /// Adaptive rayon copy: pool sized to the policy `ceiling`, each job gated to
+    /// the controller's live limit (effective concurrency ≤ ceiling), every copy
+    /// timed + classified + recorded, with a background `std::thread` ticking the
+    /// controller (~250ms) to resize the gate. Local FS has no network rate, so
+    /// the controller drives concurrency only (no rate applier).
+    ///
+    /// The exact objects copied and the first-error-wins (`try_for_each`)
+    /// semantics are identical to [`parallel_copy_fixed`]; only scheduling
+    /// differs.
+    fn parallel_copy_adaptive(
+        &self,
+        jobs: &[(PathBuf, PathBuf, String)],
+        fraction: f64,
+        ceiling: usize,
+    ) -> Result<(), StoreError> {
+        use rayon::prelude::*;
+
+        let meter = self.meter.as_deref();
+
+        let sizes: Vec<u64> = jobs
+            .iter()
+            .map(|(source, _, _)| std::fs::metadata(source).map_or(0, |md| md.len()))
+            .collect();
+        let p95 = p95_object_size(&sizes);
+        let total_ram = snapdir_core::resources::total_ram_bytes().unwrap_or(0);
+        let policy = ControllerPolicy::new(fraction, ceiling, total_ram, None);
+
+        let gate = AdaptiveGate::new(self.config.concurrency.get(), ceiling);
+        // No rate limiter for local copies (concurrency-only control).
+        let driver = ControllerDriver::new(policy, gate.clone(), p95, None, self.meter.clone());
+
+        // Background tick thread: stop it on the shared flag once the copy ends.
+        let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let tick_driver = driver.clone();
+        let tick_stop = Arc::clone(&stop);
+        let ticker = std::thread::spawn(move || {
+            while !tick_stop.load(std::sync::atomic::Ordering::Relaxed) {
+                std::thread::sleep(std::time::Duration::from_millis(250));
+                if tick_stop.load(std::sync::atomic::Ordering::Relaxed) {
+                    break;
+                }
+                tick_driver.tick();
+            }
+        });
+
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(ceiling.max(1))
+            .build()
+            .map_err(|err| StoreError::Backend {
+                message: "failed to build copy thread pool".to_owned(),
+                source: Some(Box::new(err)),
+            })?;
+
+        let result = pool.install(|| {
+            jobs.par_iter().try_for_each(|(source, target, expected)| {
+                // Gate to the controller's live limit (effective concurrency).
+                let _permit = gate.acquire_blocking();
+                if let Some(m) = meter {
+                    m.object_started();
+                }
+                let len = std::fs::metadata(source).map_or(0, |md| md.len());
+                let started = std::time::Instant::now();
+                let outcome = persist(source, target, expected, &Blake3Hasher::new());
+                let latency = started.elapsed();
+                let (bytes, op_result) = match &outcome {
+                    Ok(()) => (len, OpResult::Ok),
+                    Err(err) => (0, classify_error(err)),
+                };
+                driver.record_op(OpSample {
+                    bytes,
+                    latency,
+                    result: op_result,
+                });
+                outcome?;
+                if let Some(m) = meter {
+                    m.add_in(len);
+                    m.add_out(len);
+                    m.object_finished();
+                }
+                Ok(())
+            })
+        });
+
+        // Stop the tick thread and join it before returning.
+        stop.store(true, std::sync::atomic::Ordering::Relaxed);
+        let _ = ticker.join();
+        result
     }
 }
 
@@ -1093,6 +1196,66 @@ mod tests {
                 "par and seq object bytes identical"
             );
         }
+    }
+
+    #[test]
+    fn filestore_adaptive_push_fetch_same_snapshot_id_and_bytes() {
+        // INVARIANT: an adaptive (policy On, low ceiling) push+fetch produces a
+        // byte-identical store + dest and re-ids to the SAME snapshot id as the
+        // non-adaptive (Off) path over the same input. Adaptive only changes
+        // scheduling, never what is transferred.
+        use crate::transfer::AdaptivePolicy;
+
+        let src_dir = TempDir::new("src");
+        let (manifest, id) = make_nested_source(src_dir.path());
+
+        // Off path.
+        let off_store_dir = TempDir::new("store-off");
+        let off_dest_dir = TempDir::new("dest-off");
+        let off =
+            FileStore::from_root_with_config(off_store_dir.path(), TransferConfig::new(4, None));
+        off.push(&manifest, src_dir.path()).expect("off push");
+        let off_manifest = off.get_manifest(&id).expect("off manifest");
+        off.fetch_files(&off_manifest, off_dest_dir.path())
+            .expect("off fetch");
+
+        // Adaptive path (low ceiling = 2).
+        let on_store_dir = TempDir::new("store-on");
+        let on_dest_dir = TempDir::new("dest-on");
+        let on_cfg = TransferConfig::new(4, None).with_adaptive(AdaptivePolicy::On {
+            fraction: 0.8,
+            ceiling: 2,
+        });
+        let on = FileStore::from_root_with_config(on_store_dir.path(), on_cfg);
+        on.push(&manifest, src_dir.path()).expect("adaptive push");
+        let on_manifest = on.get_manifest(&id).expect("adaptive manifest");
+        on.fetch_files(&on_manifest, on_dest_dir.path())
+            .expect("adaptive fetch");
+
+        // Same snapshot id, re-derived from the round-tripped manifest.
+        let off_id = snapdir_core::merkle::snapshot_id(&off_manifest, &Blake3Hasher::new());
+        let on_id = snapdir_core::merkle::snapshot_id(&on_manifest, &Blake3Hasher::new());
+        assert_eq!(off_id, on_id, "adaptive must re-id to the same snapshot");
+        assert_eq!(on_id, id, "and it matches the original id");
+        assert_eq!(off_manifest, on_manifest, "round-tripped manifests equal");
+
+        // Byte-identical objects at identical sharded keys + identical dest trees.
+        for entry in manifest.entries() {
+            if entry.path_type != PathType::File {
+                continue;
+            }
+            let key = object_path(&entry.checksum);
+            let off_obj = off_store_dir.path().join(&key);
+            let on_obj = on_store_dir.path().join(&key);
+            assert!(on_obj.exists(), "adaptive object {key} present");
+            assert_eq!(
+                fs::read(&off_obj).unwrap(),
+                fs::read(&on_obj).unwrap(),
+                "Off vs On object bytes identical for {key}"
+            );
+        }
+        assert_nested_dest(off_dest_dir.path());
+        assert_nested_dest(on_dest_dir.path());
     }
 
     #[test]

--- a/crates/snapdir-stores/src/gcs_store.rs
+++ b/crates/snapdir-stores/src/gcs_store.rs
@@ -397,6 +397,7 @@ impl Store for GcsStore {
         // BLAKE3-verify + retry discipline of `fetch_verified`.
         let limiter = RateLimiter::new(self.config.max_bytes_per_sec);
         let meter = self.meter.as_deref();
+        let meter_arc = self.meter.clone();
         self.runtime.block_on(async {
             fetch_files_concurrent(
                 manifest,
@@ -404,6 +405,7 @@ impl Store for GcsStore {
                 &self.config,
                 &limiter,
                 meter,
+                meter_arc,
                 |entry| async {
                     let key = self.location.object_key(&entry.checksum);
                     self.fetch_verified(&key, &entry.checksum).await
@@ -424,6 +426,7 @@ impl Store for GcsStore {
         // closure. A failed push writes NO manifest.
         let limiter = RateLimiter::new(self.config.max_bytes_per_sec);
         let meter = self.meter.as_deref();
+        let meter_arc = self.meter.clone();
         self.runtime.block_on(async {
             // Skip-if-manifest-present pre-check: a present manifest implies all
             // its objects are present (we always write the manifest last).
@@ -435,7 +438,9 @@ impl Store for GcsStore {
             push_objects_concurrent(
                 manifest,
                 &self.config,
+                &limiter,
                 meter,
+                meter_arc,
                 |entry| {
                     let object_key = self.location.object_key(&entry.checksum);
                     upload_object(

--- a/crates/snapdir-stores/src/lib.rs
+++ b/crates/snapdir-stores/src/lib.rs
@@ -18,6 +18,11 @@
 //! - [`transfer`] ([`TransferConfig`], [`RateLimiter`], [`run_concurrent`]) —
 //!   the concurrency + bandwidth-limiting foundation each store carries via a
 //!   [`TransferConfig`] for the (later) concurrent transfer loops.
+//! - [`adaptive`] ([`AdaptiveGate`], [`AdaptiveController`]) — pure, injectable
+//!   adaptive control: a resizable concurrency permit pool (async + blocking)
+//!   plus a deterministic slow-start/AIMD controller that turns injected op
+//!   samples + system metrics into a concurrency limit and target byte-rate
+//!   (wiring into the live transfer loops is a later gate).
 //! - [`stream`] ([`StreamStore`]) — object/manifest-level, content-addressed,
 //!   verified read/write primitives (the foundation for store-to-store sync),
 //!   implemented for [`FileStore`], [`S3Store`], [`GcsStore`], and [`B2Store`].
@@ -28,6 +33,7 @@
 //!   [`BlockingRateLimiter`](transfer::BlockingRateLimiter); writes the manifest
 //!   last (all-or-nothing).
 
+pub mod adaptive;
 pub mod b2_store;
 pub(crate) mod fetch;
 pub mod file_store;
@@ -41,6 +47,9 @@ pub mod sync;
 pub mod transfer;
 pub(crate) mod util;
 
+pub use adaptive::{
+    AdaptiveController, AdaptiveGate, AdaptivePolicy, Decision, OpResult, OpSample,
+};
 pub use b2_store::B2Store;
 pub use file_store::FileStore;
 pub use gcs_store::{GcsLocation, GcsStore};

--- a/crates/snapdir-stores/src/lib.rs
+++ b/crates/snapdir-stores/src/lib.rs
@@ -48,7 +48,8 @@ pub mod transfer;
 pub(crate) mod util;
 
 pub use adaptive::{
-    AdaptiveController, AdaptiveGate, AdaptivePolicy, Decision, OpResult, OpSample,
+    p95_object_size, AdaptiveController, AdaptiveGate, AdaptivePolicy, ControllerDriver, Decision,
+    OpResult, OpSample,
 };
 pub use b2_store::B2Store;
 pub use file_store::FileStore;
@@ -58,4 +59,7 @@ pub use s3_store::{S3Location, S3Store};
 pub use shim::ExternalStore;
 pub use stream::StreamStore;
 pub use sync::{sync_snapshot, SyncReport};
-pub use transfer::{run_concurrent, BlockingRateLimiter, RateLimiter, TransferConfig};
+pub use transfer::{
+    classify_error, run_adaptive, run_concurrent, AdaptivePolicy as TransferAdaptivePolicy,
+    BlockingRateLimiter, RateLimiter, TransferConfig,
+};

--- a/crates/snapdir-stores/src/push.rs
+++ b/crates/snapdir-stores/src/push.rs
@@ -32,13 +32,21 @@
 //! (a cheap pre-check) *before* this orchestrator is called.
 
 use std::path::Path;
+use std::sync::Arc;
+use std::time::Instant;
 
 use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
 use snapdir_core::merkle::{Blake3Hasher, Hasher};
 use snapdir_core::store::StoreError;
 use snapdir_core::Meter;
 
-use crate::transfer::{run_concurrent, RateLimiter, TransferConfig};
+use crate::adaptive::{
+    p95_object_size, AdaptiveGate, AdaptivePolicy as ControllerPolicy, ControllerDriver, OpResult,
+    OpSample,
+};
+use crate::transfer::{
+    classify_error, run_adaptive, run_concurrent, AdaptivePolicy, RateLimiter, TransferConfig,
+};
 
 /// Strips a leading `./` and a trailing `/` from a manifest path so the
 /// remainder can be joined onto a source root (shared with the backends).
@@ -106,7 +114,9 @@ async fn read_verified(
 pub(crate) async fn push_objects_concurrent<'a, U, UFut, W, WFut>(
     manifest: &'a Manifest,
     config: &TransferConfig,
+    rate_limiter: &RateLimiter,
     meter: Option<&Meter>,
+    meter_arc: Option<Arc<Meter>>,
     upload_one: U,
     write_manifest: W,
 ) -> Result<(), StoreError>
@@ -131,15 +141,131 @@ where
         m.set_total(total);
     }
 
-    // Concurrent object pass: each task runs the injected per-object work
-    // (existence check, then read+verify+upload for absent objects). The first
-    // error is propagated and the rest cancelled.
-    run_concurrent(files, config.concurrency, upload_one).await?;
+    match config.adaptive {
+        AdaptivePolicy::Off => {
+            // Concurrent object pass: each task runs the injected per-object work
+            // (existence check, then read+verify+upload for absent objects). The
+            // first error is propagated and the rest cancelled.
+            run_concurrent(files, config.concurrency, upload_one).await?;
+        }
+        AdaptivePolicy::On { fraction, ceiling } => {
+            run_adaptive_objects(
+                &files,
+                config,
+                rate_limiter,
+                meter_arc,
+                fraction,
+                ceiling,
+                upload_one,
+            )
+            .await?;
+        }
+    }
 
     // Manifest-last / all-or-nothing: only after every object upload returned
     // Ok do we write the manifest. A failed push (an error above) returns
     // early and leaves no manifest.
     write_manifest().await
+}
+
+/// The adaptive sibling of the fixed-concurrency object pass: sizes the in-flight
+/// window to the policy ceiling, gates each upload to the controller's live
+/// limit, times + classifies + records every op, and runs a background tick
+/// driver that resizes the gate and retunes the shared rate limiter. The exact
+/// objects uploaded and the first-error-wins semantics are identical to the
+/// `Off` path — only scheduling/rate differ.
+#[allow(clippy::too_many_arguments)]
+async fn run_adaptive_objects<'a, U, UFut>(
+    files: &[&'a ManifestEntry],
+    config: &TransferConfig,
+    rate_limiter: &RateLimiter,
+    meter_arc: Option<Arc<Meter>>,
+    fraction: f64,
+    ceiling: usize,
+    upload_one: U,
+) -> Result<(), StoreError>
+where
+    U: Fn(&'a ManifestEntry) -> UFut,
+    UFut: std::future::Future<Output = Result<(), StoreError>>,
+{
+    let gate = AdaptiveGate::new(config.concurrency.get(), ceiling);
+    let driver = build_push_driver(
+        files,
+        config,
+        rate_limiter,
+        meter_arc,
+        fraction,
+        ceiling,
+        &gate,
+    );
+
+    // Background tick driver: ~250ms cadence (well below the controller's 15s
+    // cooldown/re-probe constants) so the gate/limiter track the controller live.
+    let tick_driver = driver.clone();
+    let mut ticker = tokio::time::interval(std::time::Duration::from_millis(250));
+    ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+    let tick_handle = tokio::spawn(async move {
+        loop {
+            ticker.tick().await;
+            tick_driver.tick();
+        }
+    });
+
+    let result = run_adaptive(files.iter().copied(), &gate, |entry| {
+        let upload_one = &upload_one;
+        let driver = &driver;
+        async move {
+            let started = Instant::now();
+            let outcome = upload_one(entry).await;
+            let latency = started.elapsed();
+            let (bytes, op_result) = match &outcome {
+                Ok(()) => (entry.size, OpResult::Ok),
+                Err(err) => (0, classify_error(err)),
+            };
+            driver.record_op(OpSample {
+                bytes,
+                latency,
+                result: op_result,
+            });
+            outcome
+        }
+    })
+    .await;
+
+    tick_handle.abort();
+    result.map(|_| ())
+}
+
+/// Builds the [`ControllerDriver`] for the async push path: a controller policy
+/// derived from the config (ceiling + fraction, machine RAM for the memory
+/// budget, `max_bytes_per_sec` as the rate cap), wired to retune the async
+/// [`RateLimiter`] and mirror the limit/rate into the display meter.
+fn build_push_driver(
+    files: &[&ManifestEntry],
+    config: &TransferConfig,
+    rate_limiter: &RateLimiter,
+    meter_arc: Option<Arc<Meter>>,
+    fraction: f64,
+    ceiling: usize,
+    gate: &AdaptiveGate,
+) -> ControllerDriver {
+    let sizes: Vec<u64> = files.iter().map(|e| e.size).collect();
+    let p95 = p95_object_size(&sizes);
+    let total_ram = snapdir_core::resources::total_ram_bytes().unwrap_or(0);
+    let policy = ControllerPolicy::new(fraction, ceiling, total_ram, config.max_bytes_per_sec);
+
+    // The async limiter's `set_rate` is async; bridge it to the driver's sync
+    // applier by spawning the retune on the current runtime (best-effort,
+    // advisory). Cloning shares the same bucket.
+    let limiter = rate_limiter.clone();
+    let rate_applier: Arc<dyn Fn(Option<u64>) + Send + Sync> = Arc::new(move |rate| {
+        let limiter = limiter.clone();
+        tokio::spawn(async move {
+            limiter.set_rate(rate).await;
+        });
+    });
+
+    ControllerDriver::new(policy, gate.clone(), p95, Some(rate_applier), meter_arc)
 }
 
 /// The shared per-object upload step S3/GCS inject into
@@ -343,6 +469,8 @@ mod tests {
             push_objects_concurrent(
                 manifest,
                 &cfg,
+                &limiter,
+                None,
                 None,
                 |entry| {
                     let fake = Arc::clone(fake);
@@ -420,6 +548,93 @@ mod tests {
                 "manifest must be written only after every object upload completed"
             );
         }
+    }
+
+    #[test]
+    fn adaptive_upload_all_objects_then_manifest_within_ceiling() {
+        // An adaptive push (policy On, ceiling 2) uploads every absent object,
+        // writes the manifest last, and caps effective concurrency at the ceiling.
+        use crate::transfer::AdaptivePolicy;
+
+        let files: &[(&str, &[u8])] = &[
+            ("a.txt", b"alpha" as &[u8]),
+            ("nested/b.txt", b"bravo"),
+            ("nested/deep/c.txt", b"charlie"),
+            ("d.txt", b"delta"),
+            ("e.txt", b"echo"),
+        ];
+        let src = TempDir::new();
+        let manifest = manifest_and_source(files, src.path());
+        let src_path = src.path().to_path_buf();
+        let fake = FakeStore::new(&[], "");
+
+        let cfg = TransferConfig::new(4, None).with_adaptive(AdaptivePolicy::On {
+            fraction: 0.8,
+            ceiling: 2,
+        });
+        let limiter = RateLimiter::new(None);
+        let rt = runtime();
+        let fake_ref = Arc::clone(&fake);
+        rt.block_on(async {
+            push_objects_concurrent(
+                &manifest,
+                &cfg,
+                &limiter,
+                None,
+                None,
+                |entry| {
+                    let fake = Arc::clone(&fake_ref);
+                    let limiter = &limiter;
+                    let src_path = &src_path;
+                    async move {
+                        upload_object(
+                            entry,
+                            entry.checksum.clone(),
+                            src_path,
+                            limiter,
+                            None,
+                            |key| {
+                                let fake = Arc::clone(&fake);
+                                async move { fake.key_exists(key).await }
+                            },
+                            |key, bytes| {
+                                let fake = Arc::clone(&fake);
+                                async move { fake.put_bytes(key, bytes).await }
+                            },
+                        )
+                        .await
+                    }
+                },
+                || {
+                    let fake = Arc::clone(&fake_ref);
+                    async move { fake.write_manifest().await }
+                },
+            )
+            .await
+        })
+        .expect("adaptive push must succeed");
+
+        // All objects uploaded exactly once.
+        let mut uploaded = fake.uploaded.lock().unwrap().clone();
+        uploaded.sort();
+        let mut expected: Vec<String> = files.iter().map(|(_, c)| checksum_of(c)).collect();
+        expected.sort();
+        assert_eq!(uploaded, expected, "all objects uploaded under adaptive");
+
+        // Effective concurrency capped at the ceiling (2).
+        let hw = fake.high_water.load(Ordering::SeqCst);
+        assert!(
+            hw <= 2,
+            "effective concurrency must not exceed ceiling 2, got {hw}"
+        );
+
+        // Manifest written exactly once, after every upload.
+        assert!(fake.manifest_written.load(Ordering::SeqCst));
+        assert_eq!(
+            fake.uploads_done_at_manifest.load(Ordering::SeqCst),
+            files.len(),
+            "manifest written only after every object upload"
+        );
     }
 
     #[test]

--- a/crates/snapdir-stores/src/s3_store.rs
+++ b/crates/snapdir-stores/src/s3_store.rs
@@ -388,6 +388,7 @@ impl Store for S3Store {
         // BLAKE3-verify + retry discipline of `fetch_verified`.
         let limiter = RateLimiter::new(self.config.max_bytes_per_sec);
         let meter = self.meter.as_deref();
+        let meter_arc = self.meter.clone();
         self.runtime.block_on(async {
             fetch_files_concurrent(
                 manifest,
@@ -395,6 +396,7 @@ impl Store for S3Store {
                 &self.config,
                 &limiter,
                 meter,
+                meter_arc,
                 |entry| async {
                     let key = self.location.object_key(&entry.checksum);
                     self.fetch_verified(&key, &entry.checksum).await
@@ -415,6 +417,7 @@ impl Store for S3Store {
         // closure. A failed push writes NO manifest.
         let limiter = RateLimiter::new(self.config.max_bytes_per_sec);
         let meter = self.meter.as_deref();
+        let meter_arc = self.meter.clone();
         self.runtime.block_on(async {
             // Skip-if-manifest-present pre-check: a present manifest implies all
             // its objects are present (we always write the manifest last).
@@ -426,7 +429,9 @@ impl Store for S3Store {
             push_objects_concurrent(
                 manifest,
                 &self.config,
+                &limiter,
                 meter,
+                meter_arc,
                 |entry| {
                     let object_key = self.location.object_key(&entry.checksum);
                     upload_object(

--- a/crates/snapdir-stores/src/sync.rs
+++ b/crates/snapdir-stores/src/sync.rs
@@ -35,15 +35,19 @@
 //!   [`StreamStore`] on both read and write, and the source manifest is verified
 //!   to hash to `id` by [`get_manifest`](snapdir_core::store::Store::get_manifest).
 
-use std::sync::atomic::{AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};
 use std::sync::Arc;
 
 use snapdir_core::manifest::PathType;
 use snapdir_core::store::StoreError;
 use snapdir_core::{Meter, Phase};
 
+use crate::adaptive::{
+    p95_object_size, AdaptiveGate, AdaptivePolicy as ControllerPolicy, ControllerDriver, OpResult,
+    OpSample,
+};
 use crate::stream::StreamStore;
-use crate::transfer::{BlockingRateLimiter, TransferConfig};
+use crate::transfer::{classify_error, AdaptivePolicy, BlockingRateLimiter, TransferConfig};
 
 /// Outcome of a [`sync_snapshot`] call.
 ///
@@ -81,6 +85,7 @@ pub struct SyncReport {
 ///
 /// Returns the first [`StoreError`] from any manifest/object operation. On an
 /// object error NO destination manifest is written.
+#[allow(clippy::too_many_lines)]
 pub fn sync_snapshot(
     from: &(dyn StreamStore + Sync),
     to: &(dyn StreamStore + Sync),
@@ -111,6 +116,14 @@ pub fn sync_snapshot(
         .filter(|e| e.path_type == PathType::File)
         .map(|e| e.checksum.as_str())
         .collect();
+    // Manifest-declared object sizes (for the adaptive controller's memory
+    // guardrail p95). Advisory only; never gates what is copied.
+    let object_sizes: Vec<u64> = manifest
+        .entries()
+        .iter()
+        .filter(|e| e.path_type == PathType::File)
+        .map(|e| e.size)
+        .collect();
 
     // Advisory progress: we are entering the transfer phase, and the total is
     // the sum of the to-copy object sizes (the File entries' manifest sizes).
@@ -135,34 +148,30 @@ pub fn sync_snapshot(
     let limiter = Arc::new(BlockingRateLimiter::new(config.max_bytes_per_sec));
 
     if !files.is_empty() {
-        let pool = rayon::ThreadPoolBuilder::new()
-            .num_threads(config.concurrency.get())
-            .build()
-            .map_err(|err| StoreError::Backend {
-                message: "failed to build sync thread pool".to_owned(),
-                source: Some(Box::new(err)),
-            })?;
-
-        pool.install(|| {
-            use rayon::prelude::*;
-            files.par_iter().try_for_each(|checksum| {
-                if to.has_object(checksum)? {
-                    skipped.fetch_add(1, Ordering::Relaxed);
-                    if let Some(m) = meter {
-                        m.add_skipped(1);
-                    }
-                    return Ok(());
-                }
-                if dry_run {
-                    // Count as "would copy"; never read or write anything.
-                    copied.fetch_add(1, Ordering::Relaxed);
-                    return Ok(());
-                }
-                // Bytes live only in memory: read from source, throttle, write
-                // to dest. Never written to any path.
+        // The per-object copy step, shared by the fixed and adaptive passes so
+        // they copy byte-identically (only scheduling/rate differ). `report` is
+        // called with the measured `OpSample` after each copy (a no-op for the
+        // fixed path; feeds the controller in the adaptive path).
+        let copy_one = |checksum: &str, report: &dyn Fn(OpSample)| -> Result<(), StoreError> {
+            if to.has_object(checksum)? {
+                skipped.fetch_add(1, Ordering::Relaxed);
                 if let Some(m) = meter {
-                    m.object_started();
+                    m.add_skipped(1);
                 }
+                return Ok(());
+            }
+            if dry_run {
+                // Count as "would copy"; never read or write anything.
+                copied.fetch_add(1, Ordering::Relaxed);
+                return Ok(());
+            }
+            // Bytes live only in memory: read from source, throttle, write to
+            // dest. Never written to any path.
+            if let Some(m) = meter {
+                m.object_started();
+            }
+            let started = std::time::Instant::now();
+            let outcome = (|| {
                 let blob = from.get_object(checksum)?;
                 let len = blob.len() as u64;
                 // Read from source (bytes-in).
@@ -171,16 +180,62 @@ pub fn sync_snapshot(
                 }
                 limiter.acquire_blocking(len);
                 to.put_object(checksum, blob)?;
-                // Written to dest (bytes-out), object done.
-                if let Some(m) = meter {
-                    m.add_out(len);
-                    m.object_finished();
-                }
-                copied.fetch_add(1, Ordering::Relaxed);
-                bytes.fetch_add(len, Ordering::Relaxed);
-                Ok::<(), StoreError>(())
-            })
-        })?;
+                Ok::<u64, StoreError>(len)
+            })();
+            let latency = started.elapsed();
+            match &outcome {
+                Ok(len) => report(OpSample {
+                    bytes: *len,
+                    latency,
+                    result: OpResult::Ok,
+                }),
+                Err(err) => report(OpSample {
+                    bytes: 0,
+                    latency,
+                    result: classify_error(err),
+                }),
+            }
+            let len = outcome?;
+            // Written to dest (bytes-out), object done.
+            if let Some(m) = meter {
+                m.add_out(len);
+                m.object_finished();
+            }
+            copied.fetch_add(1, Ordering::Relaxed);
+            bytes.fetch_add(len, Ordering::Relaxed);
+            Ok(())
+        };
+
+        match config.adaptive {
+            AdaptivePolicy::Off => {
+                let pool = rayon::ThreadPoolBuilder::new()
+                    .num_threads(config.concurrency.get())
+                    .build()
+                    .map_err(|err| StoreError::Backend {
+                        message: "failed to build sync thread pool".to_owned(),
+                        source: Some(Box::new(err)),
+                    })?;
+                let noop = |_: OpSample| {};
+                pool.install(|| {
+                    use rayon::prelude::*;
+                    files
+                        .par_iter()
+                        .try_for_each(|checksum| copy_one(checksum, &noop))
+                })?;
+            }
+            AdaptivePolicy::On { fraction, ceiling } => {
+                sync_objects_adaptive(
+                    &files,
+                    &object_sizes,
+                    config,
+                    &limiter,
+                    meter,
+                    fraction,
+                    ceiling,
+                    &copy_one,
+                )?;
+            }
+        }
     }
 
     // Manifest-last / all-or-nothing: only after every object copy succeeded
@@ -196,6 +251,82 @@ pub fn sync_snapshot(
         bytes_copied: bytes.into_inner(),
         dry_run,
     })
+}
+
+/// Adaptive store-to-store copy pass: pool sized to the policy `ceiling`, each
+/// object gated to the controller's live limit (effective concurrency ≤
+/// ceiling), every copy timed + classified + recorded via `copy_one`'s report
+/// hook, with a background `std::thread` ticking the controller (~250ms) to
+/// resize the gate and retune the shared [`BlockingRateLimiter`]. The exact
+/// objects copied and first-error-wins semantics are identical to the fixed
+/// pass; only scheduling/rate differ.
+#[allow(clippy::too_many_arguments)]
+fn sync_objects_adaptive<C>(
+    files: &[&str],
+    object_sizes: &[u64],
+    config: &TransferConfig,
+    limiter: &Arc<BlockingRateLimiter>,
+    meter: Option<&Meter>,
+    fraction: f64,
+    ceiling: usize,
+    copy_one: &C,
+) -> Result<(), StoreError>
+where
+    C: Fn(&str, &dyn Fn(OpSample)) -> Result<(), StoreError> + Sync,
+{
+    use rayon::prelude::*;
+
+    let p95 = p95_object_size(object_sizes);
+    let total_ram = snapdir_core::resources::total_ram_bytes().unwrap_or(0);
+    let policy = ControllerPolicy::new(fraction, ceiling, total_ram, config.max_bytes_per_sec);
+
+    let gate = AdaptiveGate::new(config.concurrency.get(), ceiling);
+
+    // Retune the shared synchronous limiter live (its `set_rate` is sync).
+    let blocking_limiter = Arc::clone(limiter);
+    let rate_applier: Arc<dyn Fn(Option<u64>) + Send + Sync> =
+        Arc::new(move |rate| blocking_limiter.set_rate(rate));
+    // The orchestrator only has a borrowed `&Meter`; the driver's optional
+    // display-meter mirror needs an owned `Arc<Meter>`, so the live limit/rate
+    // display is left to the meter recording in `copy_one` (None here). The
+    // controller still drives concurrency + rate correctly.
+    let _ = meter;
+    let driver = ControllerDriver::new(policy, gate.clone(), p95, Some(rate_applier), None);
+
+    // Background tick thread, stopped on the shared flag once the copy ends.
+    let stop = Arc::new(AtomicBool::new(false));
+    let tick_driver = driver.clone();
+    let tick_stop = Arc::clone(&stop);
+    let ticker = std::thread::spawn(move || {
+        while !tick_stop.load(Ordering::Relaxed) {
+            std::thread::sleep(std::time::Duration::from_millis(250));
+            if tick_stop.load(Ordering::Relaxed) {
+                break;
+            }
+            tick_driver.tick();
+        }
+    });
+
+    let pool = rayon::ThreadPoolBuilder::new()
+        .num_threads(ceiling.max(1))
+        .build()
+        .map_err(|err| StoreError::Backend {
+            message: "failed to build sync thread pool".to_owned(),
+            source: Some(Box::new(err)),
+        })?;
+
+    let result = pool.install(|| {
+        files.par_iter().try_for_each(|checksum| {
+            // Gate to the controller's live limit (effective concurrency).
+            let _permit = gate.acquire_blocking();
+            let report = |sample: OpSample| driver.record_op(sample);
+            copy_one(checksum, &report)
+        })
+    });
+
+    stop.store(true, Ordering::Relaxed);
+    let _ = ticker.join();
+    result
 }
 
 #[cfg(test)]
@@ -524,6 +655,49 @@ mod tests {
             b.get_manifest(&id).is_err(),
             "dest must have no manifest after a failed sync"
         );
+    }
+
+    #[test]
+    fn sync_snapshot_adaptive_mirrors_same_snapshot() {
+        // INVARIANT: an adaptive (policy On, low ceiling) sync mirrors the SAME
+        // snapshot id + the same objects as the non-adaptive (Off) sync over the
+        // same source. Adaptive only changes scheduling/rate.
+        let a_dir = TempDir::new("a");
+        let off_dir = TempDir::new("off");
+        let on_dir = TempDir::new("on");
+        let src_dir = TempDir::new("src");
+        let (manifest, id) = make_source(src_dir.path());
+        let n = object_count(&manifest);
+
+        let a = FileStore::from_root(a_dir.path());
+        a.push(&manifest, src_dir.path()).expect("stage into A");
+
+        let off = FileStore::from_root(off_dir.path());
+        let off_report = sync_snapshot(&a, &off, &id, &cfg(), false, None).expect("off sync");
+
+        let on = FileStore::from_root(on_dir.path());
+        let on_cfg = TransferConfig::new(4, None).with_adaptive(AdaptivePolicy::On {
+            fraction: 0.8,
+            ceiling: 2,
+        });
+        let on_report = sync_snapshot(&a, &on, &id, &on_cfg, false, None).expect("adaptive sync");
+
+        assert_eq!(off_report.objects_copied, n);
+        assert_eq!(
+            on_report.objects_copied, n,
+            "adaptive copies the same count"
+        );
+        assert_eq!(on_report.objects_skipped, 0);
+
+        // Both dests have the manifest (same id) and every object, byte-identical.
+        on.get_manifest(&id).expect("On dest has the manifest");
+        for entry in manifest.entries() {
+            if entry.path_type == PathType::File {
+                let off_blob = off.get_object(&entry.checksum).expect("off object");
+                let on_blob = on.get_object(&entry.checksum).expect("on object");
+                assert_eq!(off_blob, on_blob, "Off vs On object bytes identical");
+            }
+        }
     }
 
     #[test]

--- a/crates/snapdir-stores/src/transfer.rs
+++ b/crates/snapdir-stores/src/transfer.rs
@@ -64,8 +64,17 @@ impl Default for TransferConfig {
 }
 
 /// Shared token-bucket state, guarded by an async mutex.
+///
+/// The refill `rate`/`capacity` live **inside** the bucket (behind the same
+/// mutex as the running `tokens`) so [`RateLimiter::set_rate`] can retune the
+/// limiter live by relocking and updating them. A `rate` of `0.0` means
+/// "unlimited" — [`acquire`](RateLimiter::acquire) returns immediately.
 #[derive(Debug)]
 struct Bucket {
+    /// Refill rate in bytes per second. `0.0` means unlimited (no throttling).
+    rate: f64,
+    /// Maximum burst capacity, in bytes (~1 second's worth of budget).
+    capacity: f64,
     /// Currently available tokens (bytes).
     tokens: f64,
     /// Last time the bucket was refilled.
@@ -75,13 +84,9 @@ struct Bucket {
 /// Inner state of a [`RateLimiter`].
 #[derive(Debug)]
 struct Inner {
-    /// Refill rate in bytes per second. `0` is impossible here (unlimited is
-    /// modelled by `bucket = None`).
-    rate: f64,
-    /// Maximum burst capacity, in bytes (~1 second's worth of budget).
-    capacity: f64,
-    /// `None` when unlimited; otherwise the live bucket state.
-    bucket: Option<Mutex<Bucket>>,
+    /// The live bucket state (rate/capacity/tokens). A `rate` of `0.0` models
+    /// the unlimited case.
+    bucket: Mutex<Bucket>,
 }
 
 /// An async token-bucket rate limiter that throttles aggregate transfer
@@ -104,27 +109,64 @@ impl RateLimiter {
     /// limiter whose [`acquire`](RateLimiter::acquire) never waits.
     #[must_use]
     pub fn new(max_bytes_per_sec: Option<u64>) -> Self {
-        let inner = match max_bytes_per_sec {
-            Some(rate) if rate > 0 => {
-                #[allow(clippy::cast_precision_loss)]
-                let rate = rate as f64;
-                Inner {
-                    rate,
-                    capacity: rate,
-                    bucket: Some(Mutex::new(Bucket {
-                        tokens: rate,
-                        last_refill: tokio::time::Instant::now(),
-                    })),
-                }
+        #[allow(clippy::cast_precision_loss)]
+        let (rate, capacity, tokens) = match max_bytes_per_sec {
+            Some(r) if r > 0 => {
+                let r = r as f64;
+                (r, r, r)
             }
-            _ => Inner {
-                rate: 0.0,
-                capacity: 0.0,
-                bucket: None,
-            },
+            _ => (0.0, 0.0, 0.0),
         };
         Self {
-            inner: Arc::new(inner),
+            inner: Arc::new(Inner {
+                bucket: Mutex::new(Bucket {
+                    rate,
+                    capacity,
+                    tokens,
+                    last_refill: tokio::time::Instant::now(),
+                }),
+            }),
+        }
+    }
+
+    /// Retunes the limiter's aggregate byte-rate cap **live**, so an adaptive
+    /// controller can raise or lower throttling between operations.
+    ///
+    /// - `None` (or `Some(0)`) switches the limiter to **unlimited**: the rate
+    ///   and capacity drop to `0` and the bucket is emptied, so the next
+    ///   [`acquire`](RateLimiter::acquire) is a no-op.
+    /// - `Some(r > 0)` installs (or replaces) a bucket refilling at `r`
+    ///   bytes/sec with ~1 second of burst capacity. Switching from unlimited
+    ///   to limited primes the bucket full (`tokens = capacity`) so a freshly
+    ///   throttled limiter still allows one immediate burst.
+    ///
+    /// Calling `set_rate` is the only way the rate changes after [`new`];
+    /// limiters that never call it behave exactly as before.
+    pub async fn set_rate(&self, bytes_per_sec: Option<u64>) {
+        let mut state = self.inner.bucket.lock().await;
+        let was_unlimited = state.rate <= 0.0;
+        #[allow(clippy::cast_precision_loss)]
+        match bytes_per_sec {
+            Some(r) if r > 0 => {
+                let r = r as f64;
+                state.rate = r;
+                state.capacity = r;
+                // Switching unlimited -> limited: prime a full burst. When
+                // already limited, keep the running token count but clamp it to
+                // the new capacity so a rate drop takes effect promptly.
+                if was_unlimited {
+                    state.tokens = r;
+                } else {
+                    state.tokens = state.tokens.min(r);
+                }
+                state.last_refill = tokio::time::Instant::now();
+            }
+            _ => {
+                // Unlimited: empty the bucket; `acquire` short-circuits on rate==0.
+                state.rate = 0.0;
+                state.capacity = 0.0;
+                state.tokens = 0.0;
+            }
         }
     }
 
@@ -136,9 +178,6 @@ impl RateLimiter {
     /// so throttling is correct even for objects bigger than one second's
     /// worth of budget.
     pub async fn acquire(&self, n: u64) {
-        let Some(bucket) = self.inner.bucket.as_ref() else {
-            return; // unlimited fast path
-        };
         if n == 0 {
             return;
         }
@@ -147,10 +186,13 @@ impl RateLimiter {
 
         loop {
             let wait = {
-                let mut state = bucket.lock().await;
+                let mut state = self.inner.bucket.lock().await;
+                if state.rate <= 0.0 {
+                    return; // unlimited fast path (also covers live set_rate(None))
+                }
                 let now = tokio::time::Instant::now();
                 let elapsed = now.duration_since(state.last_refill).as_secs_f64();
-                state.tokens = (state.tokens + elapsed * self.inner.rate).min(self.inner.capacity);
+                state.tokens = (state.tokens + elapsed * state.rate).min(state.capacity);
                 state.last_refill = now;
 
                 if state.tokens >= need {
@@ -160,7 +202,7 @@ impl RateLimiter {
                 // Not enough budget: compute how long until the deficit is
                 // covered, then sleep (releasing the lock first).
                 let deficit = need - state.tokens;
-                deficit / self.inner.rate
+                deficit / state.rate
             };
             tokio::time::sleep(Duration::from_secs_f64(wait)).await;
         }
@@ -169,8 +211,16 @@ impl RateLimiter {
 
 /// Shared token-bucket state for [`BlockingRateLimiter`], guarded by a
 /// **synchronous** [`std::sync::Mutex`] (not tokio's async mutex).
+///
+/// As with [`Bucket`], the refill `rate`/`capacity` live inside the bucket so
+/// [`BlockingRateLimiter::set_rate`] can retune live. `rate == 0.0` means
+/// unlimited.
 #[derive(Debug)]
 struct BlockingBucket {
+    /// Refill rate in bytes per second. `0.0` means unlimited (no throttling).
+    rate: f64,
+    /// Maximum burst capacity, in bytes (~1 second's worth of budget).
+    capacity: f64,
     /// Currently available tokens (bytes).
     tokens: f64,
     /// Last time the bucket was refilled.
@@ -180,12 +230,9 @@ struct BlockingBucket {
 /// Inner state of a [`BlockingRateLimiter`].
 #[derive(Debug)]
 struct BlockingInner {
-    /// Refill rate in bytes per second.
-    rate: f64,
-    /// Maximum burst capacity, in bytes (~1 second's worth of budget).
-    capacity: f64,
-    /// `None` when unlimited; otherwise the live bucket state.
-    bucket: Option<std::sync::Mutex<BlockingBucket>>,
+    /// The live bucket state (rate/capacity/tokens). A `rate` of `0.0` models
+    /// the unlimited case.
+    bucket: std::sync::Mutex<BlockingBucket>,
 }
 
 /// A **synchronous** token-bucket rate limiter for the store-to-store sync
@@ -220,27 +267,56 @@ impl BlockingRateLimiter {
     /// [`acquire_blocking`](BlockingRateLimiter::acquire_blocking) never waits.
     #[must_use]
     pub fn new(max_bytes_per_sec: Option<u64>) -> Self {
-        let inner = match max_bytes_per_sec {
-            Some(rate) if rate > 0 => {
-                #[allow(clippy::cast_precision_loss)]
-                let rate = rate as f64;
-                BlockingInner {
-                    rate,
-                    capacity: rate,
-                    bucket: Some(std::sync::Mutex::new(BlockingBucket {
-                        tokens: rate,
-                        last_refill: std::time::Instant::now(),
-                    })),
-                }
+        #[allow(clippy::cast_precision_loss)]
+        let (rate, capacity, tokens) = match max_bytes_per_sec {
+            Some(r) if r > 0 => {
+                let r = r as f64;
+                (r, r, r)
             }
-            _ => BlockingInner {
-                rate: 0.0,
-                capacity: 0.0,
-                bucket: None,
-            },
+            _ => (0.0, 0.0, 0.0),
         };
         Self {
-            inner: Arc::new(inner),
+            inner: Arc::new(BlockingInner {
+                bucket: std::sync::Mutex::new(BlockingBucket {
+                    rate,
+                    capacity,
+                    tokens,
+                    last_refill: std::time::Instant::now(),
+                }),
+            }),
+        }
+    }
+
+    /// Retunes the limiter's aggregate byte-rate cap **live** (the synchronous
+    /// sibling of [`RateLimiter::set_rate`]). Same semantics: `None`/`Some(0)`
+    /// switches to unlimited and empties the bucket; `Some(r > 0)` installs a
+    /// bucket refilling at `r` bytes/sec (priming a full burst when switching
+    /// from unlimited).
+    pub fn set_rate(&self, bytes_per_sec: Option<u64>) {
+        let mut state = self
+            .inner
+            .bucket
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let was_unlimited = state.rate <= 0.0;
+        #[allow(clippy::cast_precision_loss)]
+        match bytes_per_sec {
+            Some(r) if r > 0 => {
+                let r = r as f64;
+                state.rate = r;
+                state.capacity = r;
+                if was_unlimited {
+                    state.tokens = r;
+                } else {
+                    state.tokens = state.tokens.min(r);
+                }
+                state.last_refill = std::time::Instant::now();
+            }
+            _ => {
+                state.rate = 0.0;
+                state.capacity = 0.0;
+                state.tokens = 0.0;
+            }
         }
     }
 
@@ -254,9 +330,6 @@ impl BlockingRateLimiter {
     /// of budget. Mirrors [`RateLimiter::acquire`], but parks the thread with
     /// [`std::thread::sleep`] instead of awaiting.
     pub fn acquire_blocking(&self, n: u64) {
-        let Some(bucket) = self.inner.bucket.as_ref() else {
-            return; // unlimited fast path
-        };
         if n == 0 {
             return;
         }
@@ -267,12 +340,17 @@ impl BlockingRateLimiter {
             let wait = {
                 // A poisoned bucket only means a thread panicked mid-acquire;
                 // the token state is still usable, so recover the guard.
-                let mut state = bucket
+                let mut state = self
+                    .inner
+                    .bucket
                     .lock()
                     .unwrap_or_else(std::sync::PoisonError::into_inner);
+                if state.rate <= 0.0 {
+                    return; // unlimited fast path (also covers live set_rate(None))
+                }
                 let now = std::time::Instant::now();
                 let elapsed = now.duration_since(state.last_refill).as_secs_f64();
-                state.tokens = (state.tokens + elapsed * self.inner.rate).min(self.inner.capacity);
+                state.tokens = (state.tokens + elapsed * state.rate).min(state.capacity);
                 state.last_refill = now;
 
                 if state.tokens >= need {
@@ -282,7 +360,7 @@ impl BlockingRateLimiter {
                 // Not enough budget: compute how long until the deficit is
                 // covered, then sleep (releasing the lock first).
                 let deficit = need - state.tokens;
-                deficit / self.inner.rate
+                deficit / state.rate
             };
             std::thread::sleep(Duration::from_secs_f64(wait));
         }
@@ -446,6 +524,76 @@ mod tests {
         assert!(
             elapsed >= Duration::from_millis(900),
             "throttled acquire_blocking should take ~1s, took {elapsed:?}"
+        );
+    }
+
+    #[test]
+    fn transfer_config_rate_limiter_set_rate_live() {
+        let rt = runtime();
+        rt.block_on(async {
+            // Start unlimited: a huge acquire returns instantly.
+            let limiter = RateLimiter::new(None);
+            let start = tokio::time::Instant::now();
+            limiter.acquire(1_000_000).await;
+            assert!(
+                start.elapsed() < Duration::from_millis(200),
+                "unlimited acquire should not block before set_rate"
+            );
+
+            // Tighten to 1000 B/s live. The bucket is primed full (1000), so the
+            // first 1000 bytes are free; the next 1000 must wait ~1s to refill.
+            limiter.set_rate(Some(1000)).await;
+            let start = tokio::time::Instant::now();
+            limiter.acquire(1000).await; // drains the freshly-primed burst
+            limiter.acquire(1000).await; // must wait ~1s
+            let elapsed = start.elapsed();
+            assert!(
+                elapsed >= Duration::from_millis(900),
+                "after set_rate(Some(1000)) a 2x-budget acquire should take ~1s, took {elapsed:?}"
+            );
+
+            // Raise the cap back to unlimited live: acquires stop waiting again.
+            limiter.set_rate(None).await;
+            let start = tokio::time::Instant::now();
+            limiter.acquire(1_000_000).await;
+            assert!(
+                start.elapsed() < Duration::from_millis(200),
+                "after set_rate(None) acquire should no longer block"
+            );
+        });
+    }
+
+    #[test]
+    fn sync_snapshot_blocking_rate_limiter_set_rate_live() {
+        use std::time::Instant;
+
+        // Start unlimited.
+        let limiter = BlockingRateLimiter::new(None);
+        let start = Instant::now();
+        limiter.acquire_blocking(1_000_000);
+        assert!(
+            start.elapsed() < Duration::from_millis(200),
+            "unlimited acquire_blocking should not block before set_rate"
+        );
+
+        // Tighten live to 1000 B/s.
+        limiter.set_rate(Some(1000));
+        let start = Instant::now();
+        limiter.acquire_blocking(1000); // primed burst
+        limiter.acquire_blocking(1000); // waits ~1s
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= Duration::from_millis(900),
+            "after set_rate(Some(1000)) a 2x-budget acquire should take ~1s, took {elapsed:?}"
+        );
+
+        // Back to unlimited live.
+        limiter.set_rate(Some(0));
+        let start = Instant::now();
+        limiter.acquire_blocking(1_000_000);
+        assert!(
+            start.elapsed() < Duration::from_millis(200),
+            "after set_rate(Some(0)) acquire_blocking should no longer block"
         );
     }
 

--- a/crates/snapdir-stores/src/transfer.rs
+++ b/crates/snapdir-stores/src/transfer.rs
@@ -22,31 +22,80 @@ use futures::stream::{self, StreamExt, TryStreamExt};
 use snapdir_core::store::StoreError;
 use tokio::sync::Mutex;
 
+use crate::adaptive::{AdaptiveGate, OpResult};
+
 /// Upper bound on the auto-detected default concurrency.
 const DEFAULT_CONCURRENCY_CAP: usize = 16;
 
-/// Configuration for object transfers: how many to run in parallel and an
-/// optional aggregate byte-rate cap.
+/// Whether (and how) a transfer adaptively tunes its concurrency / byte-rate.
+///
+/// This is the **config-level** policy carried by [`TransferConfig`] (distinct
+/// from [`crate::adaptive::AdaptivePolicy`], which is the controller's
+/// always-on tuning view). `Off` — the default — selects the historical fixed
+/// `concurrency` + fixed `max_bytes_per_sec` path, byte-for-byte unchanged.
+/// `On` selects the adaptive path, which sizes the in-flight window to
+/// `ceiling` and lets a live controller drive the effective concurrency in
+/// `[1, ceiling]` and the byte-rate from in-band per-op feedback. Adaptive
+/// **only** changes scheduling/rate: the exact bytes/objects transferred and
+/// the resulting snapshot are identical to the `Off` path.
+#[derive(Debug, Clone, Copy, PartialEq, Default)]
+pub enum AdaptivePolicy {
+    /// Fixed concurrency + fixed rate (the default; historical behavior).
+    #[default]
+    Off,
+    /// Adaptive concurrency + rate, bounded by `ceiling`, aiming for
+    /// `fraction × discovered-knee`.
+    On {
+        /// Target operating fraction of the discovered knee (clamped to
+        /// `(0, 1]`; `0.8` is the usual default).
+        fraction: f64,
+        /// Absolute concurrency ceiling; the effective limit never exceeds it.
+        ceiling: usize,
+    },
+}
+
+/// Configuration for object transfers: how many to run in parallel, an optional
+/// aggregate byte-rate cap, and whether to tune those adaptively.
 ///
 /// `Default` auto-detects the available parallelism (capped at
-/// [`DEFAULT_CONCURRENCY_CAP`]) and leaves bandwidth unlimited.
+/// [`DEFAULT_CONCURRENCY_CAP`]), leaves bandwidth unlimited, and disables
+/// adaptive tuning ([`AdaptivePolicy::Off`]).
 #[derive(Debug, Clone)]
 pub struct TransferConfig {
-    /// Maximum number of object transfers to run concurrently.
+    /// Maximum number of object transfers to run concurrently. In the adaptive
+    /// (`On`) path this is the slow-start *seed*; the effective in-flight
+    /// window is sized to the policy ceiling and gated to the live limit.
     pub concurrency: NonZeroUsize,
     /// Optional aggregate bandwidth cap, in bytes per second. `None` means
-    /// unlimited.
+    /// unlimited. In the adaptive path this is the rate *cap* (`max_rate`); the
+    /// controller may target a lower live rate.
     pub max_bytes_per_sec: Option<u64>,
+    /// Whether to tune concurrency / rate adaptively. [`AdaptivePolicy::Off`]
+    /// (the default) keeps the historical fixed-concurrency path byte-for-byte.
+    pub adaptive: AdaptivePolicy,
 }
 
 impl TransferConfig {
-    /// Builds a config, clamping `concurrency` to at least 1.
+    /// Builds a non-adaptive config, clamping `concurrency` to at least 1.
+    ///
+    /// The adaptive policy defaults to [`AdaptivePolicy::Off`], so existing
+    /// callers behave exactly as before. Use
+    /// [`with_adaptive`](Self::with_adaptive) to opt in.
     #[must_use]
     pub fn new(concurrency: usize, max_bytes_per_sec: Option<u64>) -> Self {
         Self {
             concurrency: NonZeroUsize::new(concurrency.max(1)).unwrap_or(NonZeroUsize::MIN),
             max_bytes_per_sec,
+            adaptive: AdaptivePolicy::Off,
         }
+    }
+
+    /// Returns this config with its adaptive policy set to `policy` (builder
+    /// style). `Off` is byte-identical to a plain [`new`](Self::new) config.
+    #[must_use]
+    pub fn with_adaptive(mut self, policy: AdaptivePolicy) -> Self {
+        self.adaptive = policy;
+        self
     }
 }
 
@@ -59,8 +108,136 @@ impl Default for TransferConfig {
             // `detected` is >= 1, so the NonZeroUsize is always Some.
             concurrency: NonZeroUsize::new(detected).unwrap_or(NonZeroUsize::MIN),
             max_bytes_per_sec: None,
+            adaptive: AdaptivePolicy::Off,
         }
     }
+}
+
+/// Classifies a [`StoreError`] for the adaptive controller's congestion signal.
+///
+/// Returns [`OpResult::Throttle`] for clearly *transient / backpressure*
+/// failures the controller should back off on (HTTP 429 / `SlowDown` / 503 /
+/// `RESOURCE_EXHAUSTED`, request timeouts, connection reset/closed, and the
+/// local-FS backpressure errno class — `WouldBlock`, EMFILE "too many open
+/// files", and a full disk). Everything else — `NotFound`, `Integrity`,
+/// `Parse`, and ordinary I/O / backend errors — is [`OpResult::HardErr`].
+///
+/// This is **conservative**: anything not clearly transient defaults to
+/// `HardErr`, so a real failure never masquerades as throttling. It inspects
+/// `StoreError::Backend`'s message + wrapped source string (the SDKs surface
+/// their status that way) and `StoreError::Io`'s [`std::io::ErrorKind`].
+#[must_use]
+pub fn classify_error(err: &StoreError) -> OpResult {
+    match err {
+        StoreError::Io(io_err) => classify_io_kind(io_err),
+        StoreError::Backend { message, source } => {
+            let mut text = message.to_ascii_lowercase();
+            if let Some(src) = source {
+                text.push(' ');
+                text.push_str(&src.to_string().to_ascii_lowercase());
+            }
+            if text_is_transient(&text) {
+                OpResult::Throttle
+            } else {
+                OpResult::HardErr
+            }
+        }
+        // NotFound / Integrity / Parse are never transient backpressure, and
+        // `StoreError` is `#[non_exhaustive]` so any future variant is — by the
+        // conservative rule — a hard error until proven transient.
+        _ => OpResult::HardErr,
+    }
+}
+
+/// Classifies a local-filesystem [`std::io::Error`] as transient backpressure
+/// vs a hard error. Only the clear backpressure errno classes
+/// (`WouldBlock`, a full filesystem, and EMFILE "too many open files", which
+/// stable Rust still surfaces as `Uncategorized` with that message) are
+/// treated as [`OpResult::Throttle`].
+fn classify_io_kind(err: &std::io::Error) -> OpResult {
+    use std::io::ErrorKind;
+    match err.kind() {
+        ErrorKind::WouldBlock | ErrorKind::StorageFull => OpResult::Throttle,
+        // EMFILE / ENFILE land in the catch-all `Other`/`Uncategorized` kind on
+        // stable Rust; sniff the message for "too many open files".
+        _ => {
+            if err
+                .to_string()
+                .to_ascii_lowercase()
+                .contains("too many open files")
+            {
+                OpResult::Throttle
+            } else {
+                OpResult::HardErr
+            }
+        }
+    }
+}
+
+/// Substring test for transient/backpressure SDK error text (case-folded).
+fn text_is_transient(text: &str) -> bool {
+    const TRANSIENT: &[&str] = &[
+        "slowdown",
+        "slow down",
+        "429",
+        "too many requests",
+        "503",
+        "service unavailable",
+        "serviceunavailable",
+        "resource_exhausted",
+        "resource exhausted",
+        "throttl",
+        "request timeout",
+        "requesttimeout",
+        "timed out",
+        "timeout",
+        "connection reset",
+        "connection closed",
+        "connection refused",
+        "broken pipe",
+        "too many open files",
+    ];
+    TRANSIENT.iter().any(|needle| text.contains(needle))
+}
+
+/// Runs `op` over `items` with the in-flight window sized to `gate.ceiling()`
+/// but the *effective* concurrency gated to the gate's live limit: each item
+/// acquires a [`GatePermit`](crate::adaptive::GatePermit) before `op` runs and
+/// holds it until `op` completes. This is the adaptive sibling of
+/// [`run_concurrent`]: a background tick driver resizes the gate live, so the
+/// number of simultaneously-running ops tracks the controller's limit while the
+/// buffer window stays at the ceiling.
+///
+/// Semantics match [`run_concurrent`] otherwise: completion-independent order,
+/// first-error-wins (remaining in-flight work is cancelled).
+///
+/// # Errors
+///
+/// Returns the first [`StoreError`] produced by any operation.
+pub async fn run_adaptive<I, T, F, Fut>(
+    items: I,
+    gate: &AdaptiveGate,
+    op: F,
+) -> Result<Vec<T>, StoreError>
+where
+    I: IntoIterator,
+    F: Fn(I::Item) -> Fut,
+    Fut: std::future::Future<Output = Result<T, StoreError>>,
+{
+    let window = gate.ceiling().max(1);
+    stream::iter(items)
+        .map(|item| {
+            let op = &op;
+            async move {
+                // Effective concurrency = the gate's current limit (<= ceiling),
+                // even though up to `window` futures are buffered.
+                let _permit = gate.acquire().await;
+                op(item).await
+            }
+        })
+        .buffer_unordered(window)
+        .try_collect()
+        .await
 }
 
 /// Shared token-bucket state, guarded by an async mutex.
@@ -594,6 +771,94 @@ mod tests {
         assert!(
             start.elapsed() < Duration::from_millis(200),
             "after set_rate(Some(0)) acquire_blocking should no longer block"
+        );
+    }
+
+    #[test]
+    fn classify_error_throttle_vs_hard() {
+        use crate::adaptive::OpResult;
+
+        // Backend errors whose message/source look like backpressure -> Throttle.
+        let transient_msgs = [
+            "S3 PUT object failed: SlowDown",
+            "got HTTP 503 Service Unavailable",
+            "rate limited: 429 Too Many Requests",
+            "RESOURCE_EXHAUSTED quota",
+            "request timeout while uploading",
+            "connection reset by peer",
+            "os error: too many open files",
+        ];
+        for msg in transient_msgs {
+            let err = StoreError::Backend {
+                message: msg.to_owned(),
+                source: None,
+            };
+            assert_eq!(
+                classify_error(&err),
+                OpResult::Throttle,
+                "expected Throttle for {msg:?}"
+            );
+        }
+
+        // Hard errors: NotFound / Integrity / Parse / ordinary backend failures.
+        let not_found = StoreError::ObjectNotFound {
+            checksum: "abc".to_owned(),
+        };
+        assert_eq!(classify_error(&not_found), OpResult::HardErr);
+        let integrity = StoreError::Integrity {
+            address: "x".to_owned(),
+            expected: "a".to_owned(),
+            actual: "b".to_owned(),
+        };
+        assert_eq!(classify_error(&integrity), OpResult::HardErr);
+        let other = StoreError::Backend {
+            message: "permission denied".to_owned(),
+            source: None,
+        };
+        assert_eq!(classify_error(&other), OpResult::HardErr);
+
+        // Local-FS backpressure errnos -> Throttle; a plain NotFound IO -> Hard.
+        let emfile = StoreError::Io(std::io::Error::other("too many open files (os error 24)"));
+        assert_eq!(classify_error(&emfile), OpResult::Throttle);
+        let would_block = StoreError::Io(std::io::Error::from(std::io::ErrorKind::WouldBlock));
+        assert_eq!(classify_error(&would_block), OpResult::Throttle);
+        let io_notfound = StoreError::Io(std::io::Error::from(std::io::ErrorKind::NotFound));
+        assert_eq!(classify_error(&io_notfound), OpResult::HardErr);
+    }
+
+    #[test]
+    fn run_adaptive_respects_gate_limit() {
+        use crate::adaptive::AdaptiveGate;
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let rt = runtime();
+        let gate = AdaptiveGate::new(2, 8);
+        let in_flight = Arc::new(AtomicUsize::new(0));
+        let high = Arc::new(AtomicUsize::new(0));
+        let in_flight2 = Arc::clone(&in_flight);
+        let high2 = Arc::clone(&high);
+
+        let result: Result<Vec<()>, StoreError> = rt.block_on(async move {
+            run_adaptive(0..20, &gate, move |_item| {
+                let in_flight = Arc::clone(&in_flight2);
+                let high = Arc::clone(&high2);
+                async move {
+                    let cur = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    high.fetch_max(cur, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(15)).await;
+                    in_flight.fetch_sub(1, Ordering::SeqCst);
+                    Ok(())
+                }
+            })
+            .await
+        });
+        assert!(result.is_ok());
+        // Window is the ceiling (8) but the gate's live limit is 2, so peak
+        // effective concurrency never exceeds 2.
+        assert!(
+            high.load(Ordering::SeqCst) <= 2,
+            "effective concurrency must be gated to the limit, got {}",
+            high.load(Ordering::SeqCst)
         );
     }
 

--- a/docs/rust-port/CHANGELOG.md
+++ b/docs/rust-port/CHANGELOG.md
@@ -7,6 +7,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.0]
+
+### Added
+
+- **Opt-in adaptive transfer tuning (`--adaptive[=FRACTION]`).** When passed,
+  `push`/`fetch`/`pull`/`checkout`/`stage`/`sync` auto-tune transfer concurrency
+  (and, for the network stores, the aggregate byte-rate) toward a polite
+  **fraction of measured capacity (default 0.8)**: it probes in-band (TCP-style
+  slow-start → AIMD with a latency-gradient guardrail), backs off fast under
+  throttling/timeouts or when CPU/memory are tight so it doesn't overwhelm the
+  host or co-tenants, and re-probes every ~15s to use newly-free capacity. A
+  `--max-jobs` flag (and `SNAPDIR_ADAPTIVE`/`SNAPDIR_MAX_JOBS` env) bound it.
+  **Off by default — default behavior is unchanged (full speed)**; `--jobs`/
+  `--limit-rate` remain hard overrides. Works across the local `file://` store
+  and S3/GCS/B2. Transfers remain byte-identical regardless of the tuner (it
+  changes only scheduling/rate).
+- **Clearer, steadier transfer progress.** The single-line progress display now
+  unambiguously labels counts (`N/M files`) vs sizes (unit-suffixed bytes), uses
+  fixed-width columns so the layout no longer reflows as digits change, and shows
+  a smoothed, throttled ETA that settles instead of flickering. When adaptive is
+  on it surfaces the live `(auto <fraction>)` target.
+
+The manifest byte-format and content-addressed object/manifest layout are unchanged, so
+snapshots remain fully interoperable with 1.x.
+
 ## [1.2.0]
 
 ### Added
@@ -212,7 +237,8 @@ Bash-written caches and remote buckets stay mutually readable.
   `gcloud`) in the shipped binary. External tools are used only by the test
   suite.
 
-[Unreleased]: https://github.com/snapdir/snapdir/compare/v1.2.0...HEAD
+[Unreleased]: https://github.com/snapdir/snapdir/compare/v1.3.0...HEAD
+[1.3.0]: https://github.com/snapdir/snapdir/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/snapdir/snapdir/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/snapdir/snapdir/compare/v1.0.1...v1.1.0
 [1.0.1]: https://github.com/snapdir/snapdir/compare/v1.0.0...v1.0.1


### PR DESCRIPTION
Releases **1.3.0**, shipping the Phase-18 work: an opt-in adaptive transfer tuner and a clearer, steadier progress line. The default behavior is unchanged (full speed), and the manifest byte-format and content-addressed object/manifest layout are **unchanged**, so snapshots remain fully interoperable with 1.x.

`cargo test --workspace --locked` → green (377 passed, 0 failed); the determinism suite — including a new adaptive round-trip test — proves the tuner changes only scheduling and rate, never the bytes.

## Added

### Opt-in adaptive transfer tuning (`--adaptive[=FRACTION]`)
When passed, `push`/`fetch`/`pull`/`checkout`/`stage`/`sync` auto-tune transfer concurrency (and, for the network stores, the aggregate byte-rate) toward a polite **fraction of measured capacity (default 0.8)**. It probes **in-band** — the real object transfers are the probe — using TCP-style **slow-start → AIMD** with a **latency-gradient** guardrail, and backs off fast on throttling/timeouts or when CPU/memory are tight so it doesn't overwhelm the host or co-tenants; it re-probes every ~15s to use newly-freed capacity. `--max-jobs` (and `SNAPDIR_ADAPTIVE` / `SNAPDIR_MAX_JOBS`) bound it.

- **Off by default — default behavior is unchanged (full speed).** `--jobs` / `--limit-rate` remain hard overrides; under `--adaptive` they act as the ceiling / rate cap.
- Works across the local `file://` store and S3 / GCS / B2.
- One resizable concurrency gate drives both the async (S3/GCS/B2) and rayon (local + store-to-store sync) paths; a zero-dependency token bucket carries the rate.
- **Byte-identical regardless of the tuner** — manifest-last, skip-if-present, and per-object verification are preserved.

### Clearer, steadier transfer progress
The single-line progress display now unambiguously labels counts (`N/M files`) vs sizes (unit-suffixed bytes), uses fixed-width columns so the layout no longer reflows as digits change, and shows a smoothed, throttled ETA that settles instead of flickering. When adaptive is on it surfaces the live `(auto <fraction>)` target.

The manifest format, directory merkle rule, snapshot-id derivation, and sharded object/manifest layout are untouched and remain guarded by the golden-format tests and the format-lock tripwire.
