### PR TITLE
release: 1.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-benches"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "criterion",
  "iai-callgrind",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-catalog"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "redb",
  "serde",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-cli"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3489,7 +3489,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-core"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "blake3",
  "libc",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-stores"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.3.0"
+version = "1.4.0"
 edition = "2021"
 rust-version = "1.91.1"
 authors = ["Bermi Ferrer <bermi@bermilabs.com>"]
@@ -22,9 +22,9 @@ categories = ["command-line-utilities", "filesystem"]
 
 [workspace.dependencies]
 # Internal crates
-snapdir-core = { path = "crates/snapdir-core", version = "1.3.0" }
-snapdir-catalog = { path = "crates/snapdir-catalog", version = "1.3.0" }
-snapdir-stores = { path = "crates/snapdir-stores", version = "1.3.0" }
+snapdir-core = { path = "crates/snapdir-core", version = "1.4.0" }
+snapdir-catalog = { path = "crates/snapdir-catalog", version = "1.4.0" }
+snapdir-stores = { path = "crates/snapdir-stores", version = "1.4.0" }
 
 # Errors: thiserror in libs, anyhow (+ context) in the bin.
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -108,6 +108,46 @@ Pick a backend by `--store` URI scheme:
 
 Cloud backends use native SDKs and standard credential chains — no bespoke env vars, no CLI shell-outs. Any other scheme dispatches to a `snapdir-<scheme>-store` binary on `PATH`.
 
+## Rate limiting & retries
+
+For the network backends (`s3://`, `gs://`, `b2://`), snapdir paces its requests and retries transient failures so transfers stay polite to the provider and survive throttling. The local `file://` store does no network retrying. No extra dependencies are pulled in for any of this — it is all in-process.
+
+### Retries & backoff
+
+Transient network failures — HTTP `429` / `503`, S3 `SlowDown`, GCS `RESOURCE_EXHAUSTED`, request timeouts, and connection reset/closed — are retried with **full-jitter exponential backoff**. A non-transient error (for example a `404` not-found) fails immediately; it is never retried.
+
+Each backoff is `random(0, min(cap, base × 2^attempt))`. When the server returns a `Retry-After` header (or a GCS backoff hint), it is honored as a floor — snapdir never retries sooner than the server asked, but may wait longer. Each SDK's own built-in retries are turned off so snapdir's policy is the single authority.
+
+Defaults: **5 total attempts** (the first try plus up to four retries), **250 ms** base, doubling, capped at **30 s**.
+
+| Flag | Env | Default | Meaning |
+| --- | --- | --- | --- |
+| `--max-retries` | `SNAPDIR_MAX_RETRIES` | `5` | Total attempts per request, including the first |
+| `--retry-base-ms` | `SNAPDIR_RETRY_BASE_MS` | `250` | Base backoff delay (ms) |
+| `--retry-max-ms` | `SNAPDIR_RETRY_MAX_MS` | `30000` | Backoff cap (ms) |
+
+### Request & bandwidth rate limiting
+
+| Flag | Env | Meaning |
+| --- | --- | --- |
+| `--max-requests` | `SNAPDIR_MAX_REQUESTS` | Cap on network requests per second |
+| `--limit-rate` | `SNAPDIR_LIMIT_RATE` | Aggregate byte-throughput cap (e.g. `10M`, `512K`) |
+
+When you don't set these, snapdir applies a conservative **per-backend default**, taken as the lower of each provider's published read/write limits:
+
+| Backend | Requests/s | Bandwidth | Source |
+| --- | --- | --- | --- |
+| `s3://` | 3500 | uncapped | [AWS S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html) |
+| `gs://` (GCS) | 1000 | uncapped | [Google Cloud Storage](https://docs.cloud.google.com/storage/docs/request-rate) |
+| `b2://` | 20 | 25 MiB/s | [Backblaze B2](https://www.backblaze.com/docs/cloud-storage-rate-limits) |
+| `file://` / local | uncapped | uncapped | — |
+
+Precedence, highest to lowest: **`--flag` > `SNAPDIR_*` env > per-backend default > global default.**
+
+### Adaptive concurrency (opt-in)
+
+`--adaptive` / `SNAPDIR_ADAPTIVE` is a separate, opt-in tuner that auto-tunes transfer concurrency (and network byte-rate) toward a polite fraction of measured capacity. It is **off by default** — default behavior is full speed. See the changelog for details.
+
 ## Use cases
 
 - Reproducible build/dataset artifacts addressed by content hash.

--- a/crates/snapdir-catalog/Cargo.toml
+++ b/crates/snapdir-catalog/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "snapdir catalog: redb-backed locations/ancestors/revisions."
+readme = "README.md"
 
 [dependencies]
 thiserror.workspace = true

--- a/crates/snapdir-catalog/README.md
+++ b/crates/snapdir-catalog/README.md
@@ -1,0 +1,17 @@
+# snapdir-catalog
+
+Catalog library for [snapdir](https://github.com/snapdir/snapdir) — content-addressable
+directory snapshots.
+
+This crate implements snapdir's local catalog: a pure-Rust,
+[redb](https://crates.io/crates/redb)-backed embedded store that tracks
+**locations**, **ancestors**, and **revisions** of snapshots. It has no SQLite or
+TLS dependencies.
+
+It is part of the snapdir project. See the
+[canonical repository](https://github.com/snapdir/snapdir) for full documentation,
+the CLI, and the available storage backends.
+
+## License
+
+MIT

--- a/crates/snapdir-cli/Cargo.toml
+++ b/crates/snapdir-cli/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "snapdir CLI: the `snapdir` binary exposing all subcommands."
+readme = "README.md"
 
 [[bin]]
 name = "snapdir"

--- a/crates/snapdir-cli/README.md
+++ b/crates/snapdir-cli/README.md
@@ -1,0 +1,23 @@
+# snapdir-cli
+
+The `snapdir` command-line binary — content-addressable directory snapshots.
+
+`snapdir` takes content-addressable snapshots of directories using BLAKE3 merkle
+hashing, and pushes/pulls them to local or cloud object stores (S3, Backblaze B2,
+Google Cloud Storage). This crate ships the `snapdir` binary that exposes all
+subcommands.
+
+## Install
+
+```sh
+cargo install snapdir-cli
+```
+
+This installs the `snapdir` executable. Run `snapdir --help` to get started.
+
+It is part of the snapdir project. See the
+[canonical repository](https://github.com/snapdir/snapdir) for full documentation.
+
+## License
+
+MIT

--- a/crates/snapdir-cli/src/cli.rs
+++ b/crates/snapdir-cli/src/cli.rs
@@ -80,7 +80,7 @@ pub struct GlobalArgs {
     pub catalog: Option<String>,
 
     /// Store URI: `protocol://location/path`.
-    #[arg(long, global = true, value_name = "URI")]
+    #[arg(long, global = true, value_name = "URI", env = "SNAPDIR_STORE")]
     pub store: Option<String>,
 
     /// Snapshot ID to operate on.
@@ -288,7 +288,7 @@ pub enum Command {
     /// streaming through memory — no local staging.
     Sync {
         /// Source store URI: `protocol://location/path`.
-        #[arg(long, value_name = "STORE")]
+        #[arg(long, value_name = "STORE", env = "SNAPDIR_STORE")]
         from: String,
         /// Destination store URI: `protocol://location/path`.
         #[arg(long, value_name = "STORE")]

--- a/crates/snapdir-cli/src/cli.rs
+++ b/crates/snapdir-cli/src/cli.rs
@@ -1650,16 +1650,68 @@ impl Drop for ScratchDir {
 /// oracle's `readlink` (`cd "$(dirname)" && pwd`/`basename`): the parent is
 /// made absolute, the basename is appended verbatim. Defaults to the current
 /// directory when no path is given.
+///
+/// The resolved absolute path is then normalized **lexically** so that the four
+/// surface forms `foo`, `./foo`, `foo/`, and `./foo/` all collapse to the same
+/// clean root. The walk downstream derives each entry's relative path with a
+/// string `strip_prefix(root)`; a trailing `/` or an interior `/./` on the root
+/// breaks that rewrite (it yields `.bar.txt` instead of `./bar.txt`, or makes
+/// `strip_prefix` miss and leak an absolute path). Normalizing here — and only
+/// here, in the CLI — keeps the frozen walk contract untouched while making
+/// every input form produce the identical manifest + snapshot id.
+///
+/// This is purely lexical: it does **not** call `.canonicalize()`, so symlinks
+/// and `..` keep their existing semantics and the not-found error path is
+/// preserved (the path need not exist yet for some commands).
 fn resolve_root(path: Option<&Path>) -> Result<PathBuf> {
     let raw = match path {
         Some(p) => p.to_path_buf(),
         None => std::env::current_dir().context("getting current directory")?,
     };
-    if raw.is_absolute() {
-        return Ok(raw);
+    let abs = if raw.is_absolute() {
+        raw
+    } else {
+        let cwd = std::env::current_dir().context("getting current directory")?;
+        cwd.join(raw)
+    };
+    Ok(lexically_normalize_root(&abs))
+}
+
+/// Lexically cleans an absolute root path for the walk, WITHOUT touching the
+/// filesystem (no symlink resolution):
+///
+/// - drops `CurDir` (`.`) components — collapses a leading `./` and any interior
+///   `/./` segments,
+/// - drops a trailing `/` (except the filesystem root `/` itself),
+/// - preserves `ParentDir` (`..`) and ordinary names verbatim — `..` keeps the
+///   existing semantics and is NOT resolved.
+///
+/// A canonical absolute path with no `.` segment and no trailing slash is
+/// returned byte-for-byte unchanged.
+fn lexically_normalize_root(abs: &Path) -> PathBuf {
+    use std::path::Component;
+    let mut out = PathBuf::new();
+    let mut pushed_any = false;
+    for comp in abs.components() {
+        match comp {
+            // Skip `.` segments entirely (leading `./`, interior `/./`).
+            Component::CurDir => {}
+            // The root `/` (and any prefix on non-unix) anchors the path.
+            Component::RootDir | Component::Prefix(_) => out.push(comp.as_os_str()),
+            // Ordinary names and `..` are kept verbatim, in order.
+            Component::Normal(_) | Component::ParentDir => {
+                out.push(comp.as_os_str());
+                pushed_any = true;
+            }
+        }
     }
-    let cwd = std::env::current_dir().context("getting current directory")?;
-    Ok(cwd.join(raw))
+    // `components()` already strips a trailing slash, so dropping it is implicit.
+    // Guard the degenerate "everything was `.`" case (e.g. a literal `/.`):
+    // fall back to the bare root so we never return an empty path.
+    if !pushed_any && out.as_os_str().is_empty() {
+        out.push(Component::RootDir.as_os_str());
+    }
+    out
 }
 
 /// OR-combines a list of `--exclude` patterns into a single expanded

--- a/crates/snapdir-cli/src/cli.rs
+++ b/crates/snapdir-cli/src/cli.rs
@@ -32,8 +32,8 @@ use snapdir_core::{
     PathMode, PathType, Phase, Sha256Hasher, Store, WalkOptions,
 };
 use snapdir_stores::{
-    resolve_adapter, Adapter, B2Store, ExternalStore, FileStore, GcsStore, S3Store, StreamStore,
-    TransferAdaptivePolicy, TransferConfig,
+    limits, resolve_adapter, Adapter, B2Store, ExternalStore, FileStore, GcsStore, RetryPolicy,
+    S3Store, StreamStore, TransferAdaptivePolicy, TransferConfig,
 };
 
 /// Upper bound for the adaptive concurrency ceiling (`--max-jobs` / `--jobs`
@@ -195,6 +195,22 @@ pub struct GlobalArgs {
     /// unset, defaults to the auto concurrency; clamped to a sane upper bound.
     #[arg(long, global = true, value_name = "N", env = "SNAPDIR_MAX_JOBS")]
     pub max_jobs: Option<usize>,
+
+    /// Total retry attempts per network request, including the first (default 5).
+    #[arg(long, global = true, value_name = "N")]
+    pub max_retries: Option<u32>,
+
+    /// Base backoff delay in milliseconds for request retries (default 250).
+    #[arg(long, global = true, value_name = "MS")]
+    pub retry_base_ms: Option<u64>,
+
+    /// Maximum backoff delay in milliseconds for request retries (default 30000).
+    #[arg(long, global = true, value_name = "MS")]
+    pub retry_max_ms: Option<u64>,
+
+    /// Cap request rate (req/s); 0/unset uses the per-backend default.
+    #[arg(long, global = true, value_name = "N")]
+    pub max_requests: Option<u64>,
 }
 
 /// The `snapdir` subcommands, matching the Bash orchestrator one-for-one.
@@ -1037,7 +1053,7 @@ impl Cli {
             .as_deref()
             .context("missing --store option")?;
         let adapter = resolve_adapter(store_url).context("resolving --store protocol")?;
-        let config = self.transfer_config()?;
+        let config = self.transfer_config_for(Some(adapter.name()))?;
         store_for_adapter(&adapter, store_url, config, meter)
     }
 
@@ -1059,9 +1075,37 @@ impl Cli {
     ///
     /// Returns an error when `--limit-rate` cannot be parsed as a byte rate.
     fn transfer_config(&self) -> Result<TransferConfig> {
-        let max_bytes_per_sec = match self.globals.limit_rate.as_deref() {
+        self.transfer_config_for(None)
+    }
+
+    /// Builds the [`TransferConfig`], layering in the per-backend rate-limit
+    /// defaults and the operator-configured retry policy for `scheme`.
+    ///
+    /// `scheme` is the canonical adapter name (`"file"`, `"s3"`, `"b2"`,
+    /// `"gcs"`); `None` (and any scheme with no published
+    /// [`limits::for_scheme`] defaults, e.g. `file`) leaves the byte-rate /
+    /// request-rate caps exactly where [`Self::transfer_config`] historically
+    /// left them. The retry policy is always installed (it defaults to
+    /// [`RetryPolicy::default`], inert until the stores consume it), and the
+    /// request-rate cap defaults to `None` unless a backend default or an
+    /// operator override applies — so with no new flags/env and a `None` /
+    /// capless scheme the result is byte-for-byte the historical config.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `--limit-rate` cannot be parsed as a byte rate.
+    fn transfer_config_for(&self, scheme: Option<&str>) -> Result<TransferConfig> {
+        // The byte/request caps layer the operator override over the per-backend
+        // default; `--limit-rate` is parsed here so a bad value still errors.
+        let limit_rate = match self.globals.limit_rate.as_deref() {
             Some(rate) => Some(parse_rate(rate)?),
             None => None,
+        };
+        let (max_requests_per_sec, max_bytes_per_sec) = match scheme {
+            Some(scheme) => self.resolve_rate_limits(scheme, limit_rate),
+            // No scheme: never apply a backend default; preserve historical
+            // behavior (request cap None, byte cap = --limit-rate as-is).
+            None => (None, limit_rate),
         };
         let auto = TransferConfig::default().concurrency.get();
         let concurrency = match self.globals.jobs {
@@ -1069,7 +1113,12 @@ impl Cli {
             // Unset or 0 => auto (the stores' default).
             _ => auto,
         };
-        let base = TransferConfig::new(concurrency, max_bytes_per_sec);
+        let base = TransferConfig::new(concurrency, max_bytes_per_sec)
+            .with_retry(self.resolve_retry_policy());
+        let base = TransferConfig {
+            max_requests_per_sec,
+            ..base
+        };
         match self.globals.adaptive {
             // No `--adaptive`: byte-for-byte the historical non-adaptive config.
             None => Ok(base),
@@ -1086,6 +1135,64 @@ impl Cli {
                 Ok(base.with_adaptive(TransferAdaptivePolicy::On { fraction, ceiling }))
             }
         }
+    }
+
+    /// Resolves the network-retry schedule with `--max-retries` /
+    /// `--retry-base-ms` / `--retry-max-ms` flags taking precedence over the
+    /// matching `SNAPDIR_MAX_RETRIES` / `SNAPDIR_RETRY_BASE_MS` /
+    /// `SNAPDIR_RETRY_MAX_MS` env vars, falling back to
+    /// [`RetryPolicy::default`] (5 attempts / 250ms base / 30000ms cap).
+    fn resolve_retry_policy(&self) -> RetryPolicy {
+        let default = RetryPolicy::default();
+        let max_attempts = self
+            .globals
+            .max_retries
+            .or_else(|| env_u64("SNAPDIR_MAX_RETRIES").and_then(|n| u32::try_from(n).ok()))
+            .unwrap_or(default.max_attempts);
+        let base_ms = self
+            .globals
+            .retry_base_ms
+            .or_else(|| env_u64("SNAPDIR_RETRY_BASE_MS"))
+            .map_or(default.base, std::time::Duration::from_millis);
+        let cap_ms = self
+            .globals
+            .retry_max_ms
+            .or_else(|| env_u64("SNAPDIR_RETRY_MAX_MS"))
+            .map_or(default.cap, std::time::Duration::from_millis);
+        RetryPolicy {
+            max_attempts,
+            base: base_ms,
+            cap: cap_ms,
+        }
+    }
+
+    /// Resolves the `(req/s, bytes/s)` caps for `scheme`, layering an operator
+    /// override over the published [`limits::for_scheme`] default over global
+    /// `None`.
+    ///
+    /// - req/s: `--max-requests` / `SNAPDIR_MAX_REQUESTS` (when `> 0`), else the
+    ///   conservative `min(read_rps, write_rps)` backend default, else `None`.
+    /// - bytes/s: `limit_rate` (the already-parsed `--limit-rate` /
+    ///   `SNAPDIR_LIMIT_RATE`), else the conservative `min(read_bps, write_bps)`
+    ///   backend default, else `None`.
+    ///
+    /// `TransferConfig` carries a single req/s and a single bytes/s, so the
+    /// conservative minimum of the read/write caps is chosen per dimension.
+    fn resolve_rate_limits(
+        &self,
+        scheme: &str,
+        limit_rate: Option<u64>,
+    ) -> (Option<u64>, Option<u64>) {
+        let backend = limits::for_scheme(scheme);
+        let req_override = self
+            .globals
+            .max_requests
+            .or_else(|| env_u64("SNAPDIR_MAX_REQUESTS"))
+            .filter(|&n| n > 0);
+        let max_requests_per_sec =
+            req_override.or_else(|| min_opt(backend.read_rps, backend.write_rps));
+        let max_bytes_per_sec = limit_rate.or_else(|| min_opt(backend.read_bps, backend.write_bps));
+        (max_requests_per_sec, max_bytes_per_sec)
     }
 
     /// Field observability for the transfer commands: under `--verbose`, print
@@ -1198,11 +1305,16 @@ impl Cli {
             "sync --from and --to must differ (both are {from_url})"
         );
 
-        let config = self.transfer_config()?;
         let from_adapter = resolve_adapter(from_url).context("resolving --from store protocol")?;
         let to_adapter = resolve_adapter(to_url).context("resolving --to store protocol")?;
-        let from_store = stream_store_for_adapter(&from_adapter, from_url, config.clone(), None)?;
-        let to_store = stream_store_for_adapter(&to_adapter, to_url, config.clone(), None)?;
+        // Each endpoint gets its own per-backend rate-limit defaults; the shared
+        // sync pipe (concurrency, retry, byte budget accounting) is driven by the
+        // source-side config below.
+        let from_config = self.transfer_config_for(Some(from_adapter.name()))?;
+        let to_config = self.transfer_config_for(Some(to_adapter.name()))?;
+        let from_store = stream_store_for_adapter(&from_adapter, from_url, from_config, None)?;
+        let to_store = stream_store_for_adapter(&to_adapter, to_url, to_config, None)?;
+        let config = self.transfer_config_for(Some(from_adapter.name()))?;
 
         self.log_transfer_config();
 
@@ -1502,6 +1614,26 @@ fn parse_rate(s: &str) -> Result<u64> {
 
     #[allow(clippy::cast_possible_truncation, clippy::cast_sign_loss)]
     Ok((value * multiplier) as u64)
+}
+
+/// Reads an environment variable as a `u64`, returning `None` when the variable
+/// is unset, empty, or does not parse as a non-negative integer. Used by the
+/// rate-limit / retry resolvers for their `SNAPDIR_*` env fallbacks.
+fn env_u64(key: &str) -> Option<u64> {
+    std::env::var(key).ok().and_then(|v| v.trim().parse().ok())
+}
+
+/// The smaller of two optional caps, treating `None` as "no cap on that
+/// dimension": `min(Some, Some)` is the lesser, `min(Some, None)` / `min(None,
+/// Some)` is the present one, and `min(None, None)` is `None`. Used to collapse
+/// a backend's separate read/write caps into the single value `TransferConfig`
+/// carries (the conservative choice).
+fn min_opt(a: Option<u64>, b: Option<u64>) -> Option<u64> {
+    match (a, b) {
+        (Some(x), Some(y)) => Some(x.min(y)),
+        (Some(x), None) | (None, Some(x)) => Some(x),
+        (None, None) => None,
+    }
 }
 
 /// clap `value_parser` for `--adaptive[=FRACTION]`: a finite `f64` in the
@@ -2045,5 +2177,171 @@ mod tests {
             }
             TransferAdaptivePolicy::Off => panic!("expected adaptive On"),
         }
+    }
+
+    /// Serializes the env-mutating rate-limit/retry tests so their `set_var` /
+    /// `remove_var` on the shared `SNAPDIR_*` process env can't race.
+    static RATELIMIT_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Removes every rate-limit / retry env var so a resolver sees only its
+    /// explicit flags (and any var the test sets afterward).
+    fn ratelimit_clear_env() {
+        unsafe {
+            for key in [
+                "SNAPDIR_MAX_RETRIES",
+                "SNAPDIR_RETRY_BASE_MS",
+                "SNAPDIR_RETRY_MAX_MS",
+                "SNAPDIR_MAX_REQUESTS",
+                "SNAPDIR_LIMIT_RATE",
+            ] {
+                std::env::remove_var(key);
+            }
+        }
+    }
+
+    #[test]
+    fn ratelimit_retry_policy_flag_beats_env_beats_default() {
+        let _guard = RATELIMIT_ENV_LOCK.lock().unwrap();
+
+        // Default (no flags, no env) == RetryPolicy::default().
+        ratelimit_clear_env();
+        let p = cli_with(&[]).resolve_retry_policy();
+        assert_eq!(p, RetryPolicy::default());
+        assert_eq!(p.max_attempts, 5);
+        assert_eq!(p.base, std::time::Duration::from_millis(250));
+        assert_eq!(p.cap, std::time::Duration::from_secs(30));
+
+        // Env beats default.
+        ratelimit_clear_env();
+        unsafe {
+            std::env::set_var("SNAPDIR_MAX_RETRIES", "7");
+            std::env::set_var("SNAPDIR_RETRY_BASE_MS", "100");
+            std::env::set_var("SNAPDIR_RETRY_MAX_MS", "9000");
+        }
+        let p = cli_with(&[]).resolve_retry_policy();
+        assert_eq!(p.max_attempts, 7);
+        assert_eq!(p.base, std::time::Duration::from_millis(100));
+        assert_eq!(p.cap, std::time::Duration::from_secs(9));
+
+        // Flag beats env.
+        let p = cli_with(&[
+            "--max-retries",
+            "9",
+            "--retry-base-ms",
+            "500",
+            "--retry-max-ms",
+            "45000",
+        ])
+        .resolve_retry_policy();
+        assert_eq!(p.max_attempts, 9);
+        assert_eq!(p.base, std::time::Duration::from_millis(500));
+        assert_eq!(p.cap, std::time::Duration::from_secs(45));
+
+        ratelimit_clear_env();
+    }
+
+    #[test]
+    fn ratelimit_rate_limits_per_backend_defaults() {
+        let _guard = RATELIMIT_ENV_LOCK.lock().unwrap();
+        ratelimit_clear_env();
+        let cli = cli_with(&[]);
+
+        // b2: min(read_rps 20, write_rps 50) = 20 req/s; min(read_bps 25MiB,
+        // write_bps 100MiB) = 25 MiB/s.
+        assert_eq!(
+            cli.resolve_rate_limits("b2", None),
+            (Some(20), Some(25 * 1024 * 1024))
+        );
+        // s3: min(5500, 3500) = 3500 req/s; no byte cap.
+        assert_eq!(cli.resolve_rate_limits("s3", None), (Some(3500), None));
+        // gcs / gs: min(5000, 1000) = 1000 req/s; no byte cap.
+        assert_eq!(cli.resolve_rate_limits("gcs", None), (Some(1000), None));
+        assert_eq!(cli.resolve_rate_limits("gs", None), (Some(1000), None));
+        // file / unknown: no caps at all.
+        assert_eq!(cli.resolve_rate_limits("file", None), (None, None));
+        assert_eq!(cli.resolve_rate_limits("azure", None), (None, None));
+
+        ratelimit_clear_env();
+    }
+
+    #[test]
+    fn ratelimit_max_requests_flag_beats_env_beats_backend_default() {
+        let _guard = RATELIMIT_ENV_LOCK.lock().unwrap();
+
+        // Backend default applies when neither flag nor env is set (b2 => 20).
+        ratelimit_clear_env();
+        assert_eq!(cli_with(&[]).resolve_rate_limits("b2", None).0, Some(20));
+        // ...and is None for a capless scheme (global None).
+        assert_eq!(cli_with(&[]).resolve_rate_limits("file", None).0, None);
+
+        // Env beats the backend default.
+        ratelimit_clear_env();
+        unsafe {
+            std::env::set_var("SNAPDIR_MAX_REQUESTS", "2");
+        }
+        assert_eq!(cli_with(&[]).resolve_rate_limits("b2", None).0, Some(2));
+        // Env also supplies a cap for a scheme that has no backend default.
+        assert_eq!(cli_with(&[]).resolve_rate_limits("file", None).0, Some(2));
+
+        // Flag beats env (and the backend default).
+        let cli = cli_with(&["--max-requests", "3"]);
+        assert_eq!(cli.resolve_rate_limits("b2", None).0, Some(3));
+        assert_eq!(cli.resolve_rate_limits("file", None).0, Some(3));
+
+        // An explicit 0 means "unset" => fall through to the backend default.
+        ratelimit_clear_env();
+        let cli = cli_with(&["--max-requests", "0"]);
+        assert_eq!(cli.resolve_rate_limits("b2", None).0, Some(20));
+        assert_eq!(cli.resolve_rate_limits("file", None).0, None);
+
+        ratelimit_clear_env();
+    }
+
+    #[test]
+    fn ratelimit_limit_rate_overrides_backend_byte_default() {
+        let _guard = RATELIMIT_ENV_LOCK.lock().unwrap();
+        ratelimit_clear_env();
+        let cli = cli_with(&[]);
+
+        // No --limit-rate: b2 falls back to its 25 MiB/s byte default.
+        assert_eq!(
+            cli.resolve_rate_limits("b2", None).1,
+            Some(25 * 1024 * 1024)
+        );
+        // An explicit --limit-rate value overrides the backend byte default.
+        assert_eq!(
+            cli.resolve_rate_limits("b2", Some(1_048_576)).1,
+            Some(1_048_576)
+        );
+        // For a capless scheme the byte cap is exactly the --limit-rate value.
+        assert_eq!(
+            cli.resolve_rate_limits("file", Some(1_048_576)).1,
+            Some(1_048_576)
+        );
+        assert_eq!(cli.resolve_rate_limits("file", None).1, None);
+
+        ratelimit_clear_env();
+    }
+
+    #[test]
+    fn ratelimit_transfer_config_unchanged_when_knobs_unset() {
+        let _guard = RATELIMIT_ENV_LOCK.lock().unwrap();
+        ratelimit_clear_env();
+
+        // No new flags / env + a capless scheme (file) MUST be byte-for-byte the
+        // historical config: req-rate None, byte-rate None, retry = default.
+        let scheme_cfg = cli_with(&[]).transfer_config_for(Some("file")).unwrap();
+        let no_scheme_cfg = cli_with(&[]).transfer_config_for(None).unwrap();
+        let historical = TransferConfig::new(TransferConfig::default().concurrency.get(), None);
+
+        for cfg in [&scheme_cfg, &no_scheme_cfg] {
+            assert_eq!(cfg.max_requests_per_sec, None);
+            assert_eq!(cfg.max_bytes_per_sec, None);
+            assert_eq!(cfg.retry, RetryPolicy::default());
+            assert_eq!(cfg.adaptive, TransferAdaptivePolicy::Off);
+            assert_eq!(cfg.concurrency, historical.concurrency);
+        }
+
+        ratelimit_clear_env();
     }
 }

--- a/crates/snapdir-cli/tests/cmd/help-ancestors.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-ancestors.trycmd
@@ -17,6 +17,8 @@ Options:
 
       --store <URI>
           Store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
 
       --id <ID>
           Snapshot ID to operate on

--- a/crates/snapdir-cli/tests/cmd/help-ancestors.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-ancestors.trycmd
@@ -88,6 +88,18 @@ Options:
           
           [env: SNAPDIR_MAX_JOBS=]
 
+      --max-retries <N>
+          Total retry attempts per network request, including the first (default 5)
+
+      --retry-base-ms <MS>
+          Base backoff delay in milliseconds for request retries (default 250)
+
+      --retry-max-ms <MS>
+          Maximum backoff delay in milliseconds for request retries (default 30000)
+
+      --max-requests <N>
+          Cap request rate (req/s); 0/unset uses the per-backend default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-checkout.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-checkout.trycmd
@@ -92,6 +92,18 @@ Options:
           
           [env: SNAPDIR_MAX_JOBS=]
 
+      --max-retries <N>
+          Total retry attempts per network request, including the first (default 5)
+
+      --retry-base-ms <MS>
+          Base backoff delay in milliseconds for request retries (default 250)
+
+      --retry-max-ms <MS>
+          Maximum backoff delay in milliseconds for request retries (default 30000)
+
+      --max-requests <N>
+          Cap request rate (req/s); 0/unset uses the per-backend default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-checkout.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-checkout.trycmd
@@ -21,6 +21,8 @@ Options:
 
       --store <URI>
           Store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
 
       --id <ID>
           Snapshot ID to operate on

--- a/crates/snapdir-cli/tests/cmd/help-defaults.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-defaults.trycmd
@@ -17,6 +17,8 @@ Options:
 
       --store <URI>
           Store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
 
       --id <ID>
           Snapshot ID to operate on

--- a/crates/snapdir-cli/tests/cmd/help-defaults.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-defaults.trycmd
@@ -88,6 +88,18 @@ Options:
           
           [env: SNAPDIR_MAX_JOBS=]
 
+      --max-retries <N>
+          Total retry attempts per network request, including the first (default 5)
+
+      --retry-base-ms <MS>
+          Base backoff delay in milliseconds for request retries (default 250)
+
+      --retry-max-ms <MS>
+          Maximum backoff delay in milliseconds for request retries (default 30000)
+
+      --max-requests <N>
+          Cap request rate (req/s); 0/unset uses the per-backend default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-fetch.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-fetch.trycmd
@@ -17,6 +17,8 @@ Options:
 
       --store <URI>
           Store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
 
       --id <ID>
           Snapshot ID to operate on

--- a/crates/snapdir-cli/tests/cmd/help-fetch.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-fetch.trycmd
@@ -88,6 +88,18 @@ Options:
           
           [env: SNAPDIR_MAX_JOBS=]
 
+      --max-retries <N>
+          Total retry attempts per network request, including the first (default 5)
+
+      --retry-base-ms <MS>
+          Base backoff delay in milliseconds for request retries (default 250)
+
+      --retry-max-ms <MS>
+          Maximum backoff delay in milliseconds for request retries (default 30000)
+
+      --max-requests <N>
+          Cap request rate (req/s); 0/unset uses the per-backend default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-flush-cache.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-flush-cache.trycmd
@@ -17,6 +17,8 @@ Options:
 
       --store <URI>
           Store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
 
       --id <ID>
           Snapshot ID to operate on

--- a/crates/snapdir-cli/tests/cmd/help-flush-cache.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-flush-cache.trycmd
@@ -88,6 +88,18 @@ Options:
           
           [env: SNAPDIR_MAX_JOBS=]
 
+      --max-retries <N>
+          Total retry attempts per network request, including the first (default 5)
+
+      --retry-base-ms <MS>
+          Base backoff delay in milliseconds for request retries (default 250)
+
+      --retry-max-ms <MS>
+          Maximum backoff delay in milliseconds for request retries (default 30000)
+
+      --max-requests <N>
+          Cap request rate (req/s); 0/unset uses the per-backend default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-id.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-id.trycmd
@@ -92,6 +92,18 @@ Options:
           
           [env: SNAPDIR_MAX_JOBS=]
 
+      --max-retries <N>
+          Total retry attempts per network request, including the first (default 5)
+
+      --retry-base-ms <MS>
+          Base backoff delay in milliseconds for request retries (default 250)
+
+      --retry-max-ms <MS>
+          Maximum backoff delay in milliseconds for request retries (default 30000)
+
+      --max-requests <N>
+          Cap request rate (req/s); 0/unset uses the per-backend default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-id.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-id.trycmd
@@ -21,6 +21,8 @@ Options:
 
       --store <URI>
           Store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
 
       --id <ID>
           Snapshot ID to operate on

--- a/crates/snapdir-cli/tests/cmd/help-locations.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-locations.trycmd
@@ -17,6 +17,8 @@ Options:
 
       --store <URI>
           Store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
 
       --id <ID>
           Snapshot ID to operate on

--- a/crates/snapdir-cli/tests/cmd/help-locations.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-locations.trycmd
@@ -88,6 +88,18 @@ Options:
           
           [env: SNAPDIR_MAX_JOBS=]
 
+      --max-retries <N>
+          Total retry attempts per network request, including the first (default 5)
+
+      --retry-base-ms <MS>
+          Base backoff delay in milliseconds for request retries (default 250)
+
+      --retry-max-ms <MS>
+          Maximum backoff delay in milliseconds for request retries (default 30000)
+
+      --max-requests <N>
+          Cap request rate (req/s); 0/unset uses the per-backend default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-manifest.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-manifest.trycmd
@@ -101,6 +101,18 @@ Options:
           
           [env: SNAPDIR_MAX_JOBS=]
 
+      --max-retries <N>
+          Total retry attempts per network request, including the first (default 5)
+
+      --retry-base-ms <MS>
+          Base backoff delay in milliseconds for request retries (default 250)
+
+      --retry-max-ms <MS>
+          Maximum backoff delay in milliseconds for request retries (default 30000)
+
+      --max-requests <N>
+          Cap request rate (req/s); 0/unset uses the per-backend default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-manifest.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-manifest.trycmd
@@ -30,6 +30,8 @@ Options:
 
       --store <URI>
           Store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
 
       --exclude <PATTERN>
           Exclude paths matching the extended-regex PATTERN (supports the `%system%` / `%common%` macros)

--- a/crates/snapdir-cli/tests/cmd/help-pull.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-pull.trycmd
@@ -92,6 +92,18 @@ Options:
           
           [env: SNAPDIR_MAX_JOBS=]
 
+      --max-retries <N>
+          Total retry attempts per network request, including the first (default 5)
+
+      --retry-base-ms <MS>
+          Base backoff delay in milliseconds for request retries (default 250)
+
+      --retry-max-ms <MS>
+          Maximum backoff delay in milliseconds for request retries (default 30000)
+
+      --max-requests <N>
+          Cap request rate (req/s); 0/unset uses the per-backend default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-pull.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-pull.trycmd
@@ -21,6 +21,8 @@ Options:
 
       --store <URI>
           Store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
 
       --id <ID>
           Snapshot ID to operate on

--- a/crates/snapdir-cli/tests/cmd/help-push.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-push.trycmd
@@ -92,6 +92,18 @@ Options:
           
           [env: SNAPDIR_MAX_JOBS=]
 
+      --max-retries <N>
+          Total retry attempts per network request, including the first (default 5)
+
+      --retry-base-ms <MS>
+          Base backoff delay in milliseconds for request retries (default 250)
+
+      --retry-max-ms <MS>
+          Maximum backoff delay in milliseconds for request retries (default 30000)
+
+      --max-requests <N>
+          Cap request rate (req/s); 0/unset uses the per-backend default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-push.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-push.trycmd
@@ -21,6 +21,8 @@ Options:
 
       --store <URI>
           Store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
 
       --id <ID>
           Snapshot ID to operate on

--- a/crates/snapdir-cli/tests/cmd/help-revisions.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-revisions.trycmd
@@ -17,6 +17,8 @@ Options:
 
       --store <URI>
           Store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
 
       --id <ID>
           Snapshot ID to operate on

--- a/crates/snapdir-cli/tests/cmd/help-revisions.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-revisions.trycmd
@@ -88,6 +88,18 @@ Options:
           
           [env: SNAPDIR_MAX_JOBS=]
 
+      --max-retries <N>
+          Total retry attempts per network request, including the first (default 5)
+
+      --retry-base-ms <MS>
+          Base backoff delay in milliseconds for request retries (default 250)
+
+      --retry-max-ms <MS>
+          Maximum backoff delay in milliseconds for request retries (default 30000)
+
+      --max-requests <N>
+          Cap request rate (req/s); 0/unset uses the per-backend default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-stage.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-stage.trycmd
@@ -92,6 +92,18 @@ Options:
           
           [env: SNAPDIR_MAX_JOBS=]
 
+      --max-retries <N>
+          Total retry attempts per network request, including the first (default 5)
+
+      --retry-base-ms <MS>
+          Base backoff delay in milliseconds for request retries (default 250)
+
+      --retry-max-ms <MS>
+          Maximum backoff delay in milliseconds for request retries (default 30000)
+
+      --max-requests <N>
+          Cap request rate (req/s); 0/unset uses the per-backend default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-stage.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-stage.trycmd
@@ -21,6 +21,8 @@ Options:
 
       --store <URI>
           Store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
 
       --id <ID>
           Snapshot ID to operate on

--- a/crates/snapdir-cli/tests/cmd/help-sync.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-sync.trycmd
@@ -12,6 +12,8 @@ Options:
 
       --from <STORE>
           Source store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
 
       --catalog <NAME>
           Catalog adapter to use
@@ -23,6 +25,8 @@ Options:
 
       --store <URI>
           Store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
 
       --id <ID>
           Snapshot ID to operate on

--- a/crates/snapdir-cli/tests/cmd/help-sync.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-sync.trycmd
@@ -96,6 +96,18 @@ Options:
           
           [env: SNAPDIR_MAX_JOBS=]
 
+      --max-retries <N>
+          Total retry attempts per network request, including the first (default 5)
+
+      --retry-base-ms <MS>
+          Base backoff delay in milliseconds for request retries (default 250)
+
+      --retry-max-ms <MS>
+          Maximum backoff delay in milliseconds for request retries (default 30000)
+
+      --max-requests <N>
+          Cap request rate (req/s); 0/unset uses the per-backend default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-verify-cache.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-verify-cache.trycmd
@@ -17,6 +17,8 @@ Options:
 
       --store <URI>
           Store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
 
       --id <ID>
           Snapshot ID to operate on

--- a/crates/snapdir-cli/tests/cmd/help-verify-cache.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-verify-cache.trycmd
@@ -88,6 +88,18 @@ Options:
           
           [env: SNAPDIR_MAX_JOBS=]
 
+      --max-retries <N>
+          Total retry attempts per network request, including the first (default 5)
+
+      --retry-base-ms <MS>
+          Base backoff delay in milliseconds for request retries (default 250)
+
+      --retry-max-ms <MS>
+          Maximum backoff delay in milliseconds for request retries (default 30000)
+
+      --max-requests <N>
+          Cap request rate (req/s); 0/unset uses the per-backend default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-verify.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-verify.trycmd
@@ -17,6 +17,8 @@ Options:
 
       --store <URI>
           Store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
 
       --id <ID>
           Snapshot ID to operate on

--- a/crates/snapdir-cli/tests/cmd/help-verify.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-verify.trycmd
@@ -88,6 +88,18 @@ Options:
           
           [env: SNAPDIR_MAX_JOBS=]
 
+      --max-retries <N>
+          Total retry attempts per network request, including the first (default 5)
+
+      --retry-base-ms <MS>
+          Base backoff delay in milliseconds for request retries (default 250)
+
+      --retry-max-ms <MS>
+          Maximum backoff delay in milliseconds for request retries (default 30000)
+
+      --max-requests <N>
+          Cap request rate (req/s); 0/unset uses the per-backend default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help.trycmd
@@ -107,6 +107,18 @@ Options:
           
           [env: SNAPDIR_MAX_JOBS=]
 
+      --max-retries <N>
+          Total retry attempts per network request, including the first (default 5)
+
+      --retry-base-ms <MS>
+          Base backoff delay in milliseconds for request retries (default 250)
+
+      --retry-max-ms <MS>
+          Maximum backoff delay in milliseconds for request retries (default 30000)
+
+      --max-requests <N>
+          Cap request rate (req/s); 0/unset uses the per-backend default
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help.trycmd
@@ -36,6 +36,8 @@ Options:
 
       --store <URI>
           Store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
 
       --id <ID>
           Snapshot ID to operate on

--- a/crates/snapdir-cli/tests/path_normalize.rs
+++ b/crates/snapdir-cli/tests/path_normalize.rs
@@ -1,0 +1,273 @@
+//! Integration tests for PATH-argument normalization.
+//!
+//! The directory PATH argument must be normalized so that the four surface
+//! forms `foo`, `./foo`, `foo/`, and `./foo/` all produce the IDENTICAL
+//! manifest and snapshot id. The fix lives entirely in the CLI's `resolve_root`
+//! (lexical normalization of the resolved absolute root); the frozen
+//! `snapdir-core` walk/merkle contract is untouched.
+//!
+//! These drive the compiled `snapdir` binary, running each form from the PARENT
+//! directory (via `current_dir`) so the relative form is meaningful, and assert
+//! four-way byte-equality of `id` and `manifest` output, spec-conformance of the
+//! relative manifest, four-way equality through a `file://` push round-trip, and
+//! a pinned blake3 id for the canonical `foo` form (invariant guard).
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Path to the compiled `snapdir` binary under test.
+fn snapdir_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_snapdir")
+}
+
+/// Creates a unique temp directory and returns its path.
+fn temp_dir(tag: &str) -> PathBuf {
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "snapdir-cli-pathnorm-{tag}-{}-{:?}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// Builds a `<parent>/foo/` subtree with nested files+dirs and fixed perms so
+/// the manifest is fully deterministic:
+///
+/// ```text
+/// foo/a.txt        ("hello", 0o644)
+/// foo/bar.txt      ("",      0o644)
+/// foo/sub/         (0o755)
+/// foo/sub/b.txt    ("world!!", 0o644)
+/// ```
+fn build_foo_tree(parent: &Path) -> PathBuf {
+    let foo_dir = parent.join("foo");
+    fs::create_dir(&foo_dir).unwrap();
+    fs::write(foo_dir.join("a.txt"), b"hello").unwrap();
+    fs::write(foo_dir.join("bar.txt"), b"").unwrap();
+    fs::create_dir(foo_dir.join("sub")).unwrap();
+    fs::write(foo_dir.join("sub").join("b.txt"), b"world!!").unwrap();
+    for (rel, mode) in [
+        ("a.txt", 0o644),
+        ("bar.txt", 0o644),
+        ("sub/b.txt", 0o644),
+        ("sub", 0o755),
+    ] {
+        fs::set_permissions(foo_dir.join(rel), fs::Permissions::from_mode(mode)).unwrap();
+    }
+    fs::set_permissions(&foo_dir, fs::Permissions::from_mode(0o755)).unwrap();
+    fs::set_permissions(parent, fs::Permissions::from_mode(0o755)).unwrap();
+    foo_dir
+}
+
+/// The four equivalent surface forms of the same `foo` subdir.
+const FORMS: [&str; 4] = ["foo", "./foo", "foo/", "./foo/"];
+
+/// Runs `snapdir <args>` from `cwd`, asserting success and returning stdout
+/// verbatim (no trimming — byte-equality matters).
+fn run_from(cwd: &Path, args: &[&str], env: &[(&str, &str)]) -> String {
+    let mut cmd = Command::new(snapdir_bin());
+    cmd.args(args).current_dir(cwd);
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let output = cmd.output().expect("run snapdir");
+    assert!(
+        output.status.success(),
+        "snapdir {args:?} (cwd={}) exited with {:?}\nstderr: {}",
+        cwd.display(),
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout).expect("stdout is UTF-8")
+}
+
+/// (1) `id foo` == `id ./foo` == `id foo/` == `id ./foo/` — all four byte-equal,
+/// each invoked from the parent directory.
+#[test]
+fn path_normalize_id_four_forms_are_byte_equal() {
+    let parent = temp_dir("id");
+    build_foo_tree(&parent);
+
+    let mut ids = Vec::new();
+    for form in FORMS {
+        let id = run_from(&parent, &["id", form], &[]);
+        let id = id.trim_end().to_owned();
+        assert_eq!(
+            id.len(),
+            64,
+            "snapshot id should be 64 hex chars (form {form:?})"
+        );
+        ids.push(id);
+    }
+    for form_id in &ids[1..] {
+        assert_eq!(&ids[0], form_id, "all four id forms must match: {ids:?}");
+    }
+    fs::remove_dir_all(&parent).ok();
+}
+
+/// (2) The `manifest` output is byte-identical across the four forms AND
+/// spec-conformant: root line is `D ... ./`, no absolute-path leakage, every
+/// relative entry starts with `./` (no `.bar` artifact).
+#[test]
+fn path_normalize_manifest_four_forms_byte_equal_and_spec_conformant() {
+    let parent = temp_dir("manifest");
+    build_foo_tree(&parent);
+    let parent_str = parent.to_string_lossy().into_owned();
+
+    let mut outputs = Vec::new();
+    for form in FORMS {
+        outputs.push(run_from(&parent, &["manifest", form], &[]));
+    }
+    for (i, out) in outputs.iter().enumerate().skip(1) {
+        assert_eq!(
+            outputs[0], *out,
+            "manifest must be byte-identical across forms (diff at {:?})",
+            FORMS[i]
+        );
+    }
+
+    // Spec-conformance of the relative manifest (any form; they're equal).
+    let manifest = &outputs[0];
+    let lines: Vec<&str> = manifest.lines().collect();
+    assert!(!lines.is_empty(), "manifest must not be empty");
+
+    // Root line: `D ... ./`.
+    let (head, root_path) = lines[0].rsplit_once(' ').unwrap();
+    assert!(
+        head.starts_with("D "),
+        "root line must be a directory: {:?}",
+        lines[0]
+    );
+    assert_eq!(
+        root_path, "./",
+        "root entry path must be `./`: {:?}",
+        lines[0]
+    );
+
+    for line in &lines {
+        let (_head, path) = line.rsplit_once(' ').unwrap();
+        // No absolute-path leakage (e.g. the temp parent prefix).
+        assert!(
+            !path.starts_with('/'),
+            "relative manifest must not leak absolute paths: {line:?}"
+        );
+        assert!(
+            !path.starts_with(&parent_str),
+            "relative manifest must not leak the parent prefix: {line:?}"
+        );
+        // Every relative entry starts with `./` — no `.bar` trailing-slash artifact.
+        assert!(
+            path.starts_with("./"),
+            "every relative entry must start with `./`: {line:?}"
+        );
+    }
+    // Specifically, the trailing-slash bug produced `./.bar.txt` → `.bar.txt`;
+    // assert the proper form is present.
+    assert!(
+        manifest.contains(" ./bar.txt\n") || manifest.ends_with(" ./bar.txt"),
+        "bar.txt must render as `./bar.txt`, not a `.bar.txt` artifact:\n{manifest}"
+    );
+
+    fs::remove_dir_all(&parent).ok();
+}
+
+/// `--absolute` mode is also consistent across the four forms: identical
+/// normalized absolute prefix, no `/./` artifact.
+#[test]
+fn path_normalize_absolute_four_forms_byte_equal() {
+    let parent = temp_dir("abs");
+    build_foo_tree(&parent);
+
+    let mut outputs = Vec::new();
+    for form in FORMS {
+        outputs.push(run_from(&parent, &["manifest", "--absolute", form], &[]));
+    }
+    for (i, out) in outputs.iter().enumerate().skip(1) {
+        assert_eq!(
+            outputs[0], *out,
+            "--absolute manifest must be byte-identical across forms (diff at {:?})",
+            FORMS[i]
+        );
+    }
+    // No `/./` artifact in the absolute paths.
+    assert!(
+        !outputs[0].contains("/./"),
+        "--absolute manifest must not contain a `/./` artifact:\n{}",
+        outputs[0]
+    );
+    fs::remove_dir_all(&parent).ok();
+}
+
+/// (3) The four-way equality holds through a `file://` push → re-id round-trip:
+/// push each form to a fresh store, then re-`id` the source via each form;
+/// all printed ids (push + re-id) are identical.
+#[test]
+fn path_normalize_push_reid_four_forms_byte_equal() {
+    let parent = temp_dir("push-parent");
+    build_foo_tree(&parent);
+    let cache = temp_dir("push-cache");
+    let cache_str = cache.to_string_lossy().into_owned();
+
+    let mut ids = Vec::new();
+    for form in FORMS {
+        // A fresh store per form keeps the forms independent.
+        let store = temp_dir("push-store");
+        let store_url = format!("file://{}", store.display());
+
+        let pushed = run_from(
+            &parent,
+            &["push", "--store", &store_url, form],
+            &[("SNAPDIR_CACHE_DIR", &cache_str)],
+        );
+        let pushed = pushed.trim_end().to_owned();
+        assert_eq!(
+            pushed.len(),
+            64,
+            "push must print a 64-hex id (form {form:?})"
+        );
+
+        let reid = run_from(&parent, &["id", form], &[("SNAPDIR_CACHE_DIR", &cache_str)]);
+        let reid = reid.trim_end().to_owned();
+        assert_eq!(pushed, reid, "push id must equal re-id (form {form:?})");
+
+        ids.push(pushed);
+        fs::remove_dir_all(&store).ok();
+    }
+    for form_id in &ids[1..] {
+        assert_eq!(
+            &ids[0], form_id,
+            "all four push/re-id forms must match: {ids:?}"
+        );
+    }
+    fs::remove_dir_all(&parent).ok();
+    fs::remove_dir_all(&cache).ok();
+}
+
+/// (4) Pinned blake3 snapshot id for the canonical `foo` form — guards the
+/// invariant that a plain (no trailing slash, no `./`) path's output is
+/// unchanged by the normalization. The value was computed once from this binary
+/// over the fixture tree (`build_foo_tree`).
+#[test]
+fn path_normalize_canonical_foo_id_pinned() {
+    let parent = temp_dir("pinned");
+    build_foo_tree(&parent);
+
+    let id = run_from(&parent, &["id", "foo"], &[]);
+    let id = id.trim_end();
+    assert_eq!(
+        id, PINNED_FOO_ID,
+        "canonical `foo` snapshot id must be byte-stable (invariant guard)"
+    );
+    fs::remove_dir_all(&parent).ok();
+}
+
+/// blake3 snapshot id of the `build_foo_tree` fixture, canonical `foo` form.
+/// Computed once from the current binary; pinned to guard the no-op invariant.
+const PINNED_FOO_ID: &str = "ff83fc0387da6480304710b52094f1d137736908661b01cb4e838116dc37d231";

--- a/crates/snapdir-cli/tests/ratelimit_select.rs
+++ b/crates/snapdir-cli/tests/ratelimit_select.rs
@@ -1,0 +1,56 @@
+//! Integration test: the new rate-limit / retry `SNAPDIR_*` env vars surface in
+//! `snapdir defaults`.
+//!
+//! `snapdir defaults` enumerates every `SNAPDIR*` environment variable
+//! (excluding `*VERSION*`) reformatted into `--option-name=value`. The
+//! rate-limit / retry knobs are plain env vars, so when set they must appear in
+//! that listing — this pins that they are not silently dropped.
+
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+
+/// A `snapdir` command with the inherited environment cleared, then only `PATH`
+/// re-set (so the process loader works). Tests add the `SNAPDIR*` vars under test
+/// so the output is deterministic and never depends on the host env.
+fn snapdir_clean_env() -> Command {
+    let mut cmd = Command::cargo_bin("snapdir").expect("snapdir binary built");
+    cmd.env_clear();
+    if let Ok(path) = std::env::var("PATH") {
+        cmd.env("PATH", path);
+    }
+    cmd
+}
+
+#[test]
+fn ratelimit_defaults_lists_new_env_vars() {
+    let mut cmd = snapdir_clean_env();
+    cmd.env("SNAPDIR_MAX_REQUESTS", "3")
+        .env("SNAPDIR_MAX_RETRIES", "7")
+        .env("SNAPDIR_RETRY_BASE_MS", "100")
+        .env("SNAPDIR_RETRY_MAX_MS", "9000");
+
+    let out = cmd.arg("defaults").output().expect("run snapdir defaults");
+    assert!(
+        out.status.success(),
+        "snapdir defaults failed ({:?})\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    let stdout = String::from_utf8(out.stdout).expect("utf8 stdout");
+    let lines: Vec<&str> = stdout.lines().collect();
+
+    // The env reformat is: leading `SNAPDIR_` -> `--`, `_` -> `-`, lowercased,
+    // emitted as `--option=value`.
+    for expected in [
+        "--max-requests=3",
+        "--max-retries=7",
+        "--retry-base-ms=100",
+        "--retry-max-ms=9000",
+    ] {
+        assert!(
+            lines.contains(&expected),
+            "expected {expected} in `snapdir defaults`:\n{stdout}",
+        );
+    }
+}

--- a/crates/snapdir-cli/tests/store_env.rs
+++ b/crates/snapdir-cli/tests/store_env.rs
@@ -1,0 +1,254 @@
+//! Integration tests for `--store` (and `sync --from`) defaulting to
+//! `$SNAPDIR_STORE` when the flag is omitted.
+//!
+//! Phase 20 bug fix: the global `--store` arg and the `sync --from` arg both
+//! carry `env = "SNAPDIR_STORE"`, so an unset flag falls back to the env var,
+//! while an explicit flag still overrides it. `sync --to` stays REQUIRED (a
+//! sync needs two distinct stores) and the from/to-must-differ check is intact;
+//! with neither flag nor env the existing required/"missing --store" error is
+//! preserved.
+//!
+//! Every fn name contains `store_env` so
+//! `cargo test -p snapdir-cli --locked store_env` selects exactly this suite.
+//! These drive the wired binary against temp `file://` stores (removed on drop)
+//! so they are hermetic and need no network or credentials. Each command
+//! explicitly sets or removes `SNAPDIR_STORE` so the suite never leaks the
+//! developer's environment.
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+use assert_fs::prelude::*;
+use assert_fs::TempDir;
+use predicates::prelude::*;
+
+/// A fresh `snapdir` command with the cache pinned under `cache` (so tests
+/// never touch the user's real cache) and `SNAPDIR_STORE` removed by default,
+/// so leakage from the developer's environment can't mask a bug. Tests that
+/// exercise the env default re-add it explicitly with `.env(...)`.
+fn snapdir(cache: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("snapdir").expect("snapdir binary built");
+    cmd.env("SNAPDIR_CACHE_DIR", cache);
+    cmd.env_remove("SNAPDIR_STORE");
+    cmd
+}
+
+/// Like [`snapdir`] but with `SNAPDIR_STORE` set to `store`, returned by value.
+fn snapdir_with_store(cache: &Path, store: &str) -> Command {
+    let mut cmd = snapdir(cache);
+    cmd.env("SNAPDIR_STORE", store);
+    cmd
+}
+
+/// Builds a known tiny tree with explicit, deterministic permissions so a
+/// checked-out copy must restore them to re-manifest to the same id.
+fn build_tree(dir: &TempDir) {
+    dir.child("a.txt").write_str("hello").unwrap();
+    std::fs::set_permissions(dir.child("a.txt").path(), PermissionsExt::from_mode(0o644)).unwrap();
+    std::fs::set_permissions(dir.path(), PermissionsExt::from_mode(0o755)).unwrap();
+}
+
+/// Runs `snapdir <args>`, asserts success, returns trimmed stdout.
+fn stdout_ok(mut cmd: Command, args: &[&str]) -> String {
+    let out = cmd.args(args).output().expect("run snapdir");
+    assert!(
+        out.status.success(),
+        "snapdir {args:?} failed ({:?})\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8(out.stdout).unwrap().trim_end().to_owned()
+}
+
+/// 1. With `SNAPDIR_STORE` set and `--store` OMITTED, the resolved store equals
+///    the env value: a `push` with no `--store` lands the manifest + object in
+///    the env-named `file://` store, and a `pull` (again no `--store`) restores
+///    it byte-identically (re-manifests to the source id).
+#[test]
+fn store_env_default_used_when_flag_omitted() {
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let store = TempDir::new().unwrap();
+    let dest = TempDir::new().unwrap();
+    build_tree(&src);
+
+    let src_str = src.path().to_string_lossy().into_owned();
+    let dest_str = dest.path().to_string_lossy().into_owned();
+    let store_url = format!("file://{}", store.path().display());
+
+    // Push with NO --store; the env value supplies the store.
+    let id = stdout_ok(
+        snapdir_with_store(cache.path(), &store_url),
+        &["push", &src_str],
+    );
+    assert_eq!(id.len(), 64, "push must print a 64-hex snapshot id");
+
+    // Proof the env store really received the snapshot: the manifest landed.
+    let manifest = store.path().join(format!(
+        ".manifests/{}/{}/{}/{}",
+        &id[0..3],
+        &id[3..6],
+        &id[6..9],
+        &id[9..]
+    ));
+    assert!(
+        manifest.is_file(),
+        "manifest must land in the SNAPDIR_STORE-named store at {}",
+        manifest.display()
+    );
+
+    // Pull with NO --store; the env value supplies the store again.
+    stdout_ok(
+        snapdir_with_store(cache.path(), &store_url),
+        &["pull", "--id", &id, &dest_str],
+    );
+    let dest_id = stdout_ok(snapdir(cache.path()), &["id", &dest_str]);
+    assert_eq!(
+        dest_id, id,
+        "restore from the env store must re-manifest to the source id"
+    );
+}
+
+/// 2. An explicit `--store <other>` OVERRIDES `SNAPDIR_STORE`: the snapshot
+///    lands in the flag store, NOT the env store.
+#[test]
+fn store_env_explicit_flag_overrides_env() {
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let env_store = TempDir::new().unwrap();
+    let flag_store = TempDir::new().unwrap();
+    build_tree(&src);
+
+    let src_str = src.path().to_string_lossy().into_owned();
+    let env_url = format!("file://{}", env_store.path().display());
+    let flag_url = format!("file://{}", flag_store.path().display());
+
+    let id = stdout_ok(
+        snapdir_with_store(cache.path(), &env_url),
+        &["push", "--store", &flag_url, &src_str],
+    );
+
+    let manifest_rel = format!(
+        ".manifests/{}/{}/{}/{}",
+        &id[0..3],
+        &id[3..6],
+        &id[6..9],
+        &id[9..]
+    );
+    assert!(
+        flag_store.path().join(&manifest_rel).is_file(),
+        "explicit --store must receive the snapshot"
+    );
+    assert!(
+        !env_store.path().join(&manifest_rel).exists(),
+        "the SNAPDIR_STORE env store must be left untouched when --store is explicit"
+    );
+}
+
+/// 3a. `sync --from` honors `SNAPDIR_STORE` (so `--from` may be omitted) while
+///     `--to` stays REQUIRED: with the env set, a sync omitting `--from` but
+///     supplying a distinct `--to` succeeds and mirrors the snapshot.
+#[test]
+fn store_env_sync_from_honors_env_to_required() {
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let store_a = TempDir::new().unwrap();
+    let store_b = TempDir::new().unwrap();
+    let dest = TempDir::new().unwrap();
+    build_tree(&src);
+
+    let src_str = src.path().to_string_lossy().into_owned();
+    let dest_str = dest.path().to_string_lossy().into_owned();
+    let a_url = format!("file://{}", store_a.path().display());
+    let b_url = format!("file://{}", store_b.path().display());
+
+    // Seed store A (the env source) via an explicit --store push.
+    let id = stdout_ok(
+        snapdir(cache.path()),
+        &["push", "--store", &a_url, &src_str],
+    );
+
+    // Sync with NO --from; SNAPDIR_STORE supplies the source. --to is explicit.
+    snapdir(cache.path())
+        .env("SNAPDIR_STORE", &a_url)
+        .args(["sync", "--id", &id, "--to", &b_url])
+        .assert()
+        .success();
+
+    // Store B now holds the snapshot: pull it from B and confirm the id.
+    stdout_ok(
+        snapdir(cache.path()),
+        &["pull", "--store", &b_url, "--id", &id, &dest_str],
+    );
+    assert_eq!(
+        stdout_ok(snapdir(cache.path()), &["id", &dest_str]),
+        id,
+        "synced snapshot must re-materialize from store B to the source id"
+    );
+}
+
+/// 3b. Omitting `--to` still errors even when `SNAPDIR_STORE` is set: `--to`
+///     does NOT default to the env (a sync needs two distinct stores).
+#[test]
+fn store_env_sync_to_still_required() {
+    let cache = TempDir::new().unwrap();
+    let a = TempDir::new().unwrap();
+    let a_url = format!("file://{}", a.path().display());
+
+    snapdir(cache.path())
+        .env("SNAPDIR_STORE", &a_url)
+        .args(["sync", "--id", &"0".repeat(64)])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--to"));
+}
+
+/// 3c. With `SNAPDIR_STORE` set and `--to` resolving to the SAME store, the
+///     from/to-must-differ check still fires (env-supplied `--from` == `--to`).
+#[test]
+fn store_env_sync_from_to_must_differ_still_fires() {
+    let cache = TempDir::new().unwrap();
+    let store = TempDir::new().unwrap();
+    let url = format!("file://{}", store.path().display());
+
+    snapdir(cache.path())
+        .env("SNAPDIR_STORE", &url)
+        .args(["sync", "--id", &"0".repeat(64), "--to", &url])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--from and --to must differ"));
+}
+
+/// 4. With NEITHER `--store` flag NOR `SNAPDIR_STORE` env, the existing
+///    "missing --store option" error is preserved exactly (push needs a store).
+#[test]
+fn store_env_missing_flag_and_env_preserves_error() {
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    build_tree(&src);
+    let src_str = src.path().to_string_lossy().into_owned();
+
+    // snapdir() already removes SNAPDIR_STORE, so neither flag nor env is set.
+    snapdir(cache.path())
+        .args(["push", &src_str])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("missing --store option"));
+}
+
+/// 4b. With neither flag nor env, `sync --to <x>` (omitting `--from`) fails on
+///     the clap-required `--from` arg (no env to satisfy it).
+#[test]
+fn store_env_sync_missing_from_flag_and_env_errors() {
+    let cache = TempDir::new().unwrap();
+    let to = TempDir::new().unwrap();
+    let to_url = format!("file://{}", to.path().display());
+
+    snapdir(cache.path())
+        .args(["sync", "--id", &"0".repeat(64), "--to", &to_url])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("--from"));
+}

--- a/crates/snapdir-core/Cargo.toml
+++ b/crates/snapdir-core/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "snapdir core: manifest format, BLAKE3 merkle hashing, store trait, walk, cache."
+readme = "README.md"
 
 [dependencies]
 blake3 = "1.8.5"

--- a/crates/snapdir-core/README.md
+++ b/crates/snapdir-core/README.md
@@ -1,0 +1,19 @@
+# snapdir-core
+
+Core library for [snapdir](https://github.com/snapdir/snapdir) — content-addressable
+directory snapshots.
+
+This crate provides the building blocks shared across the snapdir workspace:
+
+- The manifest format (parse, render, and validate snapdir manifests).
+- BLAKE3 merkle hashing of files and directory trees.
+- The `Store` trait that backends implement.
+- Directory walking and the local object cache.
+
+It is part of the snapdir project. See the
+[canonical repository](https://github.com/snapdir/snapdir) for full documentation,
+the CLI, and the available storage backends.
+
+## License
+
+MIT

--- a/crates/snapdir-stores/Cargo.toml
+++ b/crates/snapdir-stores/Cargo.toml
@@ -8,6 +8,7 @@ license.workspace = true
 repository.workspace = true
 homepage.workspace = true
 description = "snapdir stores: FileStore, S3/B2/GCS native SDK stores + external-store shim."
+readme = "README.md"
 
 [features]
 # Enables the injectable network-retry seam used by the `backoff_wire` tests:

--- a/crates/snapdir-stores/Cargo.toml
+++ b/crates/snapdir-stores/Cargo.toml
@@ -9,6 +9,15 @@ repository.workspace = true
 homepage.workspace = true
 description = "snapdir stores: FileStore, S3/B2/GCS native SDK stores + external-store shim."
 
+[features]
+# Enables the injectable network-retry seam used by the `backoff_wire` tests:
+# the `retry_network` helper and the per-SDK `*_attempt_from_err` extractors are
+# always compiled, but the heavier scripted-`op` fake-injection harness is gated
+# here so both `cargo test` (via `cfg(test)`) and a downstream
+# `--features integration-mock` consumer can drive the retry wiring without any
+# live cloud. Carries no runtime deps; an empty feature.
+integration-mock = []
+
 [dependencies]
 snapdir-core.workspace = true
 thiserror.workspace = true

--- a/crates/snapdir-stores/README.md
+++ b/crates/snapdir-stores/README.md
@@ -1,0 +1,19 @@
+# snapdir-stores
+
+Storage backends for [snapdir](https://github.com/snapdir/snapdir) — content-addressable
+directory snapshots.
+
+This crate provides the concrete `Store` implementations used by snapdir:
+
+- `FileStore` — local filesystem store.
+- S3, Backblaze B2, and Google Cloud Storage stores built on the native cloud
+  SDKs (no shelling out to `aws`, `b2`, or `gcloud`).
+- An external-store shim for delegating to custom backends.
+
+It is part of the snapdir project. See the
+[canonical repository](https://github.com/snapdir/snapdir) for full documentation
+and the CLI.
+
+## License
+
+MIT

--- a/crates/snapdir-stores/src/adaptive.rs
+++ b/crates/snapdir-stores/src/adaptive.rs
@@ -895,6 +895,18 @@ impl ControllerDriver {
     /// injected monotonic clock + p95 object size, then applies the resulting
     /// [`Decision`] to the gate (concurrency), the rate applier (byte-rate), and
     /// the display meter. Returns the decision for tests/inspection.
+    ///
+    /// `now` (the monotonic clock), CPU and RSS are the driver's only impure
+    /// inputs; all are sampled here. Determinism-sensitive tests should instead
+    /// drive [`tick_with`](ControllerDriver::tick_with), supplying every impure
+    /// input explicitly so the controller's time- and load-dependent arms
+    /// (cooldown, re-probe, CPU guardrails) never depend on the machine's
+    /// current clock or load.
+    ///
+    /// The returned [`Decision`] is advisory (the live gate/rate/meter are
+    /// already updated as a side effect); callers may ignore it — hence not
+    /// `#[must_use]`.
+    #[allow(clippy::must_use_candidate)]
     pub fn tick(&self) -> Decision {
         let cpu_pct = self
             .cpu
@@ -903,7 +915,32 @@ impl ControllerDriver {
             .poll();
         let rss = resident_set_bytes();
         let now = self.epoch.elapsed();
+        self.tick_with(now, cpu_pct, rss)
+    }
 
+    /// Fully time-/load-injectable sibling of [`tick`](ControllerDriver::tick):
+    /// advances the controller using the caller-supplied monotonic `now`, CPU
+    /// percentage and RSS instead of sampling the driver's real `epoch` / live
+    /// [`CpuSampler`] / RSS sampler. The gate / rate / meter application step is
+    /// byte-for-byte identical to [`tick`](ControllerDriver::tick), so this
+    /// drives the *same* live wiring — only the impure inputs are injected.
+    ///
+    /// This is the injectable seam (mirroring the controller's own
+    /// `tick(now, cpu, rss, …)` and the crate's injected-clock/sleeper
+    /// convention in [`crate::retry`]): it lets determinism-sensitive tests
+    /// cross the controller's time-dependent thresholds (the 15s post-congestion
+    /// cooldown, the re-probe interval) and pin its CPU guardrails by advancing
+    /// `now` and fixing `cpu_pct` explicitly — with ZERO dependence on the
+    /// machine's wall clock or current load (which is what made driving the live
+    /// gate trajectory flaky under parallel test load). `now` must be
+    /// monotonically non-decreasing across calls, exactly as `epoch.elapsed()`
+    /// would be; `cpu_pct`/`rss` are `Some(_)` to assert a guardrail or `None`
+    /// to skip it, exactly as the live samplers' `Option`s flow.
+    ///
+    /// Like [`tick`](ControllerDriver::tick), the returned [`Decision`] is
+    /// advisory and may be ignored (the gate/rate/meter are already applied).
+    #[allow(clippy::must_use_candidate)]
+    pub fn tick_with(&self, now: MonoTime, cpu_pct: Option<f64>, rss: Option<u64>) -> Decision {
         let decision = {
             let mut controller = self
                 .controller

--- a/crates/snapdir-stores/src/gcs_store.rs
+++ b/crates/snapdir-stores/src/gcs_store.rs
@@ -52,6 +52,7 @@ use std::sync::Arc;
 
 use google_cloud_gax::error::rpc::Code;
 use google_cloud_gax::error::Error as GcsError;
+use google_cloud_gax::retry_policy::NeverRetry;
 use google_cloud_storage::client::{Storage, StorageControl};
 use snapdir_core::manifest::Manifest;
 use snapdir_core::merkle::{Blake3Hasher, Hasher};
@@ -60,8 +61,9 @@ use snapdir_core::Meter;
 
 use crate::fetch::fetch_files_concurrent;
 use crate::push::{push_objects_concurrent, upload_object};
+use crate::retry::{parse_retry_after, retry_network, Attempt, DefaultJitter, TokioSleeper};
 use crate::stream::StreamStore;
-use crate::transfer::{RateLimiter, TransferConfig};
+use crate::transfer::{classify_error, RateLimiter, TransferConfig};
 use tokio::runtime::Runtime;
 
 /// Number of times a fetch is retried when the downloaded bytes fail their
@@ -156,6 +158,10 @@ pub struct GcsStore {
     location: GcsLocation,
     runtime: Arc<Runtime>,
     config: TransferConfig,
+    /// Per-call request-rate limiter (one token per SDK call), built from
+    /// [`TransferConfig::max_requests_per_sec`]. Unlimited (a no-op) by default.
+    /// Shared (clone) so every call paces against one aggregate request budget.
+    req_limiter: RateLimiter,
     /// Optional progress meter; recorded into during transfers. `None` (the
     /// default from every constructor) means zero recording and byte-identical
     /// behavior. Set by the CLI via [`GcsStore::with_meter`].
@@ -192,23 +198,30 @@ impl GcsStore {
         install_ring_provider();
 
         let (storage, control) = runtime.block_on(async {
+            // Disable each SDK client's built-in retry loop (`NeverRetry`) so
+            // snapdir's RetryPolicy is the single backoff authority — no
+            // SDK-retries × ours compounding.
             let storage = Storage::builder()
+                .with_retry_policy(NeverRetry)
                 .build()
                 .await
                 .map_err(|e| backend("building GCS Storage client", e))?;
             let control = StorageControl::builder()
+                .with_retry_policy(NeverRetry)
                 .build()
                 .await
                 .map_err(|e| backend("building GCS StorageControl client", e))?;
             Ok::<_, StoreError>((storage, control))
         })?;
 
+        let req_limiter = RateLimiter::new(config.max_requests_per_sec);
         Ok(Self {
             storage,
             control,
             location,
             runtime: Arc::new(runtime),
             config,
+            req_limiter,
             meter: None,
         })
     }
@@ -224,12 +237,15 @@ impl GcsStore {
         control: StorageControl,
         location: GcsLocation,
     ) -> Result<Self, StoreError> {
+        let config = TransferConfig::default();
+        let req_limiter = RateLimiter::new(config.max_requests_per_sec);
         Ok(Self {
             storage,
             control,
             location,
             runtime: Arc::new(build_runtime()?),
-            config: TransferConfig::default(),
+            config,
+            req_limiter,
             meter: None,
         })
     }
@@ -260,70 +276,116 @@ impl GcsStore {
 
     /// Metadata HEAD on an object key; `Ok(true)` if it exists, `Ok(false)` if
     /// absent (see [`is_not_found`] for what counts as absent).
+    ///
+    /// The single SDK call is wrapped in [`retry_network`]: it acquires one
+    /// request-rate token, then retries a TRANSIENT failure under the store's
+    /// [`RetryPolicy`](crate::retry::RetryPolicy). A not-found is a normal
+    /// `Ok(false)` outcome (not a retry); other errors are classified via
+    /// [`gcs_attempt_from_err`].
     async fn key_exists(&self, key: &str) -> Result<bool, StoreError> {
-        match self
-            .control
-            .get_object()
-            .set_bucket(self.location.bucket_resource())
-            .set_object(key)
-            .send()
-            .await
-        {
-            Ok(_) => Ok(true),
-            Err(err) => {
-                if is_not_found(&err) {
-                    Ok(false)
-                } else {
-                    Err(backend("GCS get_object metadata failed", err))
+        retry_network(
+            &self.config.retry,
+            &self.req_limiter,
+            &TokioSleeper,
+            &DefaultJitter::new(),
+            || async {
+                match self
+                    .control
+                    .get_object()
+                    .set_bucket(self.location.bucket_resource())
+                    .set_object(key)
+                    .send()
+                    .await
+                {
+                    Ok(_) => Ok(true),
+                    Err(err) => {
+                        if is_not_found(&err) {
+                            return Ok(false);
+                        }
+                        Err(gcs_attempt_from_err("GCS get_object metadata failed", err))
+                    }
                 }
-            }
-        }
+            },
+        )
+        .await
     }
 
     /// GET an object key's full body, draining the read stream, or `None` if it
     /// is absent (see [`is_not_found`] for what counts as absent).
+    ///
+    /// Wrapped in [`retry_network`] like [`key_exists`](Self::key_exists): a
+    /// not-found is a normal `Ok(None)`; transient failures retry under the
+    /// store's [`RetryPolicy`](crate::retry::RetryPolicy).
     async fn get_bytes(&self, key: &str) -> Result<Option<Vec<u8>>, StoreError> {
-        let mut resp = match self
-            .storage
-            .read_object(self.location.bucket_resource(), key)
-            .send()
-            .await
-        {
-            Ok(resp) => resp,
-            Err(err) => {
-                if is_not_found(&err) {
-                    return Ok(None);
-                }
-                return Err(backend("GCS read_object failed", err));
-            }
-        };
+        retry_network(
+            &self.config.retry,
+            &self.req_limiter,
+            &TokioSleeper,
+            &DefaultJitter::new(),
+            || async {
+                let mut resp = match self
+                    .storage
+                    .read_object(self.location.bucket_resource(), key)
+                    .send()
+                    .await
+                {
+                    Ok(resp) => resp,
+                    Err(err) => {
+                        if is_not_found(&err) {
+                            return Ok(None);
+                        }
+                        return Err(gcs_attempt_from_err("GCS read_object failed", err));
+                    }
+                };
 
-        let mut buf = Vec::new();
-        while let Some(chunk) = resp.next().await {
-            let chunk = chunk.map_err(|e| backend("reading GCS object body", e))?;
-            buf.extend_from_slice(&chunk);
-        }
-        Ok(Some(buf))
+                let mut buf = Vec::new();
+                while let Some(chunk) = resp.next().await {
+                    // A mid-stream read failure can be transient (connection
+                    // reset); classify it the same way as the initial call.
+                    let chunk =
+                        chunk.map_err(|e| gcs_attempt_from_err("reading GCS object body", e))?;
+                    buf.extend_from_slice(&chunk);
+                }
+                Ok(Some(buf))
+            },
+        )
+        .await
     }
 
     /// PUT `bytes` at `key`. GCS object writes are atomic (the new object is only
     /// visible once fully uploaded), so no temp-key dance is needed — matching
     /// the oracle's reliance on `gcloud storage cp` atomicity.
+    ///
+    /// Wrapped in [`retry_network`]: each (re)try re-sends the full body, so the
+    /// content-addressed bytes that land are unchanged — only transient failures
+    /// retry under the store's [`RetryPolicy`](crate::retry::RetryPolicy).
     async fn put_bytes(&self, key: &str, bytes: Vec<u8>) -> Result<(), StoreError> {
-        // The SDK's upload future is large (>30 KiB); box it so it does not
-        // bloat the enclosing `push` future (clippy::large_futures).
-        let upload = self
-            .storage
-            .write_object(
-                self.location.bucket_resource(),
-                key,
-                bytes::Bytes::from(bytes),
-            )
-            .send_buffered();
-        Box::pin(upload)
-            .await
-            .map_err(|e| backend("GCS write_object failed", e))?;
-        Ok(())
+        retry_network(
+            &self.config.retry,
+            &self.req_limiter,
+            &TokioSleeper,
+            &DefaultJitter::new(),
+            || {
+                let bytes = bytes.clone();
+                async move {
+                    // The SDK's upload future is large (>30 KiB); box it so it
+                    // does not bloat the enclosing future (clippy::large_futures).
+                    let upload = self
+                        .storage
+                        .write_object(
+                            self.location.bucket_resource(),
+                            key,
+                            bytes::Bytes::from(bytes),
+                        )
+                        .send_buffered();
+                    Box::pin(upload)
+                        .await
+                        .map(|_| ())
+                        .map_err(|e| gcs_attempt_from_err("GCS write_object failed", e))
+                }
+            },
+        )
+        .await
     }
 
     /// Downloads `key`, verifying its BLAKE3 against `expected`, retrying up to
@@ -568,6 +630,54 @@ where
     }
 }
 
+/// Builds a retry [`Attempt`] from a concrete `google-cloud-storage`
+/// [`GcsError`], at the boundary where the SDK error still carries its HTTP
+/// status / headers / gRPC status.
+///
+/// - `transient`: true for the retryable signal set — an HTTP `429`/`503`
+///   status, the gRPC `RESOURCE_EXHAUSTED` / `UNAVAILABLE` / `DEADLINE_EXCEEDED`
+///   / `ABORTED` / `INTERNAL` codes, and the transport/timeout classes folded
+///   through the shared [`classify_error`](crate::classify_error) on the mapped
+///   [`StoreError`]. Conservative: unknown / `NOT_FOUND` / `PERMISSION_DENIED`
+///   are NOT transient.
+/// - `retry_after`: extracted from the error's HTTP `Retry-After` header (the
+///   delta-seconds form) when present, else `None`.
+/// - `err`: the mapped [`StoreError::Backend`] (the same value the non-retry
+///   path used to surface).
+fn gcs_attempt_from_err(message: &str, err: GcsError) -> Attempt {
+    let http_status = err.http_status_code();
+    let retry_after = err
+        .http_headers()
+        .and_then(|h| h.get("retry-after"))
+        .and_then(|v| v.to_str().ok())
+        .and_then(parse_retry_after);
+    let code = err.status().map(|s| s.code);
+
+    let store_err = backend(message, err);
+
+    let transient = http_status.is_some_and(|s| s == 429 || s == 503)
+        || matches!(
+            code,
+            Some(
+                Code::ResourceExhausted
+                    | Code::Unavailable
+                    | Code::DeadlineExceeded
+                    | Code::Aborted
+                    | Code::Internal
+            )
+        )
+        || matches!(
+            classify_error(&store_err),
+            crate::adaptive::OpResult::Throttle
+        );
+
+    Attempt {
+        transient,
+        retry_after,
+        err: store_err,
+    }
+}
+
 /// Classifies a `google-cloud-storage` SDK error as "object is absent".
 ///
 /// The SDK reports a missing object two different ways, and the absent-object
@@ -596,6 +706,59 @@ fn is_not_found(err: &GcsError) -> bool {
 mod tests {
     use super::*;
     use snapdir_core::manifest::PathType;
+    use std::time::Duration;
+
+    #[test]
+    fn backoff_wire_gcs_extract_503_retry_after_is_transient_with_hint() {
+        // A 503 carrying `Retry-After: 9` => transient, hint = 9s.
+        let mut headers = http::HeaderMap::new();
+        headers.insert("retry-after", http::HeaderValue::from_static("9"));
+        let err = GcsError::http(503, headers, bytes::Bytes::new());
+        let attempt = gcs_attempt_from_err("GCS op failed", err);
+        assert!(attempt.transient, "HTTP 503 must be transient");
+        assert_eq!(
+            attempt.retry_after,
+            Some(Duration::from_secs(9)),
+            "the Retry-After delta-seconds header must be extracted"
+        );
+    }
+
+    #[test]
+    fn backoff_wire_gcs_extract_resource_exhausted_is_transient_no_hint() {
+        // A service-level RESOURCE_EXHAUSTED (no HTTP status / header) =>
+        // transient with no hint.
+        use google_cloud_gax::error::rpc::Status;
+        let status = Status::default()
+            .set_code(Code::ResourceExhausted)
+            .set_message("quota exceeded");
+        let err = GcsError::service(status);
+        let attempt = gcs_attempt_from_err("GCS op failed", err);
+        assert!(
+            attempt.transient,
+            "RESOURCE_EXHAUSTED must be classified transient"
+        );
+        assert_eq!(attempt.retry_after, None, "no Retry-After header => None");
+    }
+
+    #[test]
+    fn backoff_wire_gcs_extract_not_found_is_not_transient() {
+        use google_cloud_gax::error::rpc::Status;
+
+        // A 404 / NOT_FOUND hard error => NOT transient (conservative).
+        let err = GcsError::http(404, http::HeaderMap::new(), bytes::Bytes::new());
+        let attempt = gcs_attempt_from_err("GCS op failed", err);
+        assert!(
+            !attempt.transient,
+            "a 404/not-found must never be classified transient"
+        );
+
+        let denied = GcsError::service(Status::default().set_code(Code::PermissionDenied));
+        let attempt = gcs_attempt_from_err("GCS op failed", denied);
+        assert!(
+            !attempt.transient,
+            "PERMISSION_DENIED must never be classified transient"
+        );
+    }
 
     /// Strips a leading `./` and a trailing `/` from a manifest path. Kept as a
     /// test-only assertion of the path normalization the orchestrator

--- a/crates/snapdir-stores/src/lib.rs
+++ b/crates/snapdir-stores/src/lib.rs
@@ -15,6 +15,10 @@
 //!   third-party `snapdir-<name>-store` binaries via the documented
 //!   `get-manifest-command` / `get-fetch-files-command` / `get-push-command`
 //!   contract.
+//! - [`limits`] ([`BackendLimits`], [`for_scheme`]) — the published per-backend
+//!   request-rate / bandwidth caps (rate caps only; no retry policy) keyed by
+//!   storage scheme, used to pace transfers under each provider's documented
+//!   limits.
 //! - [`transfer`] ([`TransferConfig`], [`RateLimiter`], [`run_concurrent`]) —
 //!   the concurrency + bandwidth-limiting foundation each store carries via a
 //!   [`TransferConfig`] for the (later) concurrent transfer loops.
@@ -38,6 +42,7 @@ pub mod b2_store;
 pub(crate) mod fetch;
 pub mod file_store;
 pub mod gcs_store;
+pub mod limits;
 pub(crate) mod push;
 pub mod router;
 pub mod s3_store;
@@ -54,6 +59,7 @@ pub use adaptive::{
 pub use b2_store::B2Store;
 pub use file_store::FileStore;
 pub use gcs_store::{GcsLocation, GcsStore};
+pub use limits::{for_scheme, BackendLimits};
 pub use router::{resolve_adapter, Adapter, RouteError};
 pub use s3_store::{S3Location, S3Store};
 pub use shim::ExternalStore;

--- a/crates/snapdir-stores/src/lib.rs
+++ b/crates/snapdir-stores/src/lib.rs
@@ -22,6 +22,11 @@
 //! - [`transfer`] ([`TransferConfig`], [`RateLimiter`], [`run_concurrent`]) —
 //!   the concurrency + bandwidth-limiting foundation each store carries via a
 //!   [`TransferConfig`] for the (later) concurrent transfer loops.
+//! - [`retry`] ([`RetryPolicy`], [`retry_async`], [`retry_blocking`]) — a pure,
+//!   injectable full-jitter exponential-backoff engine (no real clock/sleep of
+//!   its own; the [`Jitter`] source and [`AsyncSleeper`]/[`BlockingSleeper`] are
+//!   injected). SDK-agnostic over an [`Attempt`] outcome; wiring into the
+//!   S3/GCS/B2 call sites is a later gate.
 //! - [`adaptive`] ([`AdaptiveGate`], [`AdaptiveController`]) — pure, injectable
 //!   adaptive control: a resizable concurrency permit pool (async + blocking)
 //!   plus a deterministic slow-start/AIMD controller that turns injected op
@@ -44,6 +49,7 @@ pub mod file_store;
 pub mod gcs_store;
 pub mod limits;
 pub(crate) mod push;
+pub mod retry;
 pub mod router;
 pub mod s3_store;
 pub mod shim;
@@ -60,6 +66,10 @@ pub use b2_store::B2Store;
 pub use file_store::FileStore;
 pub use gcs_store::{GcsLocation, GcsStore};
 pub use limits::{for_scheme, BackendLimits};
+pub use retry::{
+    retry_async, retry_blocking, AsyncSleeper, Attempt, BlockingSleeper, DefaultJitter,
+    FixedJitter, Jitter, RetryPolicy, ThreadSleeper, TokioSleeper,
+};
 pub use router::{resolve_adapter, Adapter, RouteError};
 pub use s3_store::{S3Location, S3Store};
 pub use shim::ExternalStore;

--- a/crates/snapdir-stores/src/lib.rs
+++ b/crates/snapdir-stores/src/lib.rs
@@ -67,8 +67,8 @@ pub use file_store::FileStore;
 pub use gcs_store::{GcsLocation, GcsStore};
 pub use limits::{for_scheme, BackendLimits};
 pub use retry::{
-    retry_async, retry_blocking, AsyncSleeper, Attempt, BlockingSleeper, DefaultJitter,
-    FixedJitter, Jitter, RetryPolicy, ThreadSleeper, TokioSleeper,
+    parse_retry_after, retry_async, retry_blocking, retry_network, AsyncSleeper, Attempt,
+    BlockingSleeper, DefaultJitter, FixedJitter, Jitter, RetryPolicy, ThreadSleeper, TokioSleeper,
 };
 pub use router::{resolve_adapter, Adapter, RouteError};
 pub use s3_store::{S3Location, S3Store};

--- a/crates/snapdir-stores/src/limits.rs
+++ b/crates/snapdir-stores/src/limits.rs
@@ -1,0 +1,197 @@
+//! Per-backend rate-limit table (RATE CAPS ONLY).
+//!
+//! [`BackendLimits`] carries the published per-backend request-rate and
+//! bandwidth ceilings for each storage scheme so the transfer layer can pace
+//! requests/bytes to stay under the backend's documented limits and avoid
+//! provider-side throttling (HTTP 429 / `SlowDown` / `rateLimitExceeded`).
+//!
+//! This module is deliberately **self-contained**: it holds caps only and has
+//! NO notion of retry/backoff (that policy is global and lives in a separate
+//! module added by a later gate). It depends on nothing beyond `std` and the
+//! scheme strings the [`router`](crate::router) already uses.
+//!
+//! The caps are matched on the canonical scheme/adapter names produced by
+//! [`crate::router::Adapter::name`] — `"file"`, `"s3"`, `"b2"`, `"gcs"` (the
+//! `gs://` URL scheme resolves to the `"gcs"` adapter) — plus any unknown /
+//! external scheme, which is treated as unlimited.
+
+/// Published rate caps for a single storage backend.
+///
+/// Every field is a hard ceiling expressed per second; `None` means "no
+/// documented limit" (the transfer layer leaves that dimension unthrottled).
+/// These are **rate caps only** — there is intentionally no retry/backoff
+/// field here (retry policy is global and lives elsewhere).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct BackendLimits {
+    /// Max GET/HEAD requests per second (`None` = unlimited).
+    pub read_rps: Option<u64>,
+    /// Max PUT requests per second (`None` = unlimited).
+    pub write_rps: Option<u64>,
+    /// Max download bytes per second (`None` = unlimited).
+    pub read_bps: Option<u64>,
+    /// Max upload bytes per second (`None` = unlimited).
+    pub write_bps: Option<u64>,
+}
+
+impl BackendLimits {
+    /// The fully-unlimited limit set (every dimension `None`). Used for the
+    /// `file` backend and any unknown / external scheme.
+    pub const UNLIMITED: BackendLimits = BackendLimits {
+        read_rps: None,
+        write_rps: None,
+        read_bps: None,
+        write_bps: None,
+    };
+}
+
+/// Returns the published [`BackendLimits`] for a storage `scheme`.
+///
+/// `scheme` is the canonical adapter name from
+/// [`crate::router::Adapter::name`] (`"file"`, `"s3"`, `"b2"`, `"gcs"`); the
+/// `gs://` URL scheme is also accepted as an alias for `"gcs"`. Any other
+/// (unknown / third-party / external) scheme — including `"file"` — is treated
+/// as unlimited.
+#[must_use]
+pub fn for_scheme(scheme: &str) -> BackendLimits {
+    match scheme {
+        // AWS S3: >=5,500 read and >=3,500 write requests/sec per prefix; no
+        // documented per-prefix bandwidth cap.
+        // https://docs.aws.amazon.com/AmazonS3/latest/userguide/optimizing-performance.html
+        "s3" => BackendLimits {
+            read_rps: Some(5500),
+            write_rps: Some(3500),
+            read_bps: None,
+            write_bps: None,
+        },
+        // Google Cloud Storage: initial ~5,000 read and ~1,000 write
+        // requests/sec per bucket (autoscales upward); no documented bandwidth
+        // cap. 429 rateLimitExceeded is retryable.
+        // https://docs.cloud.google.com/storage/docs/request-rate
+        "gcs" | "gs" => BackendLimits {
+            read_rps: Some(5000),
+            write_rps: Some(1000),
+            read_bps: None,
+            write_bps: None,
+        },
+        // Backblaze B2 (<=10TB accounts), per account: download 1,200 req/min
+        // = 20 req/s & 200Mbit/s = 25MB/s; upload 3,000 req/min = 50 req/s &
+        // 800Mbit/s = 100MB/s.
+        // https://www.backblaze.com/docs/cloud-storage-rate-limits
+        "b2" => BackendLimits {
+            read_rps: Some(20),
+            write_rps: Some(50),
+            read_bps: Some(25 * 1024 * 1024),
+            write_bps: Some(100 * 1024 * 1024),
+        },
+        // Local filesystem + any unknown / external backend: no rate caps.
+        _ => BackendLimits::UNLIMITED,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::transfer::RateLimiter;
+    use std::time::Duration;
+
+    /// Builds a current-thread tokio runtime with time enabled (mirrors the
+    /// `RateLimiter` unit-test harness in `transfer.rs`).
+    fn runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .expect("build tokio runtime")
+    }
+
+    #[test]
+    fn limits_for_scheme_file_is_unlimited() {
+        assert_eq!(for_scheme("file"), BackendLimits::UNLIMITED);
+        let l = for_scheme("file");
+        assert_eq!(l.read_rps, None);
+        assert_eq!(l.write_rps, None);
+        assert_eq!(l.read_bps, None);
+        assert_eq!(l.write_bps, None);
+    }
+
+    #[test]
+    fn limits_for_scheme_unknown_is_unlimited() {
+        // External / third-party schemes carry no documented caps.
+        assert_eq!(for_scheme("mock"), BackendLimits::UNLIMITED);
+        assert_eq!(for_scheme("azure"), BackendLimits::UNLIMITED);
+        assert_eq!(for_scheme(""), BackendLimits::UNLIMITED);
+    }
+
+    #[test]
+    fn limits_for_scheme_s3() {
+        let l = for_scheme("s3");
+        assert_eq!(l.read_rps, Some(5500));
+        assert_eq!(l.write_rps, Some(3500));
+        assert_eq!(l.read_bps, None);
+        assert_eq!(l.write_bps, None);
+    }
+
+    #[test]
+    fn limits_for_scheme_gcs() {
+        let expected = BackendLimits {
+            read_rps: Some(5000),
+            write_rps: Some(1000),
+            read_bps: None,
+            write_bps: None,
+        };
+        assert_eq!(for_scheme("gcs"), expected);
+        // The `gs://` URL scheme is an accepted alias for the `gcs` adapter.
+        assert_eq!(for_scheme("gs"), expected);
+    }
+
+    #[test]
+    fn limits_for_scheme_b2() {
+        let l = for_scheme("b2");
+        assert_eq!(l.read_rps, Some(20));
+        assert_eq!(l.write_rps, Some(50));
+        assert_eq!(l.read_bps, Some(25 * 1024 * 1024));
+        assert_eq!(l.write_bps, Some(100 * 1024 * 1024));
+    }
+
+    /// An unlimited request limiter (`None`) is a no-op: acquiring many request
+    /// tokens returns essentially instantly.
+    #[test]
+    fn limits_request_limiter_unlimited_is_noop() {
+        let rt = runtime();
+        rt.block_on(async {
+            let limiter = RateLimiter::new(None);
+            let start = tokio::time::Instant::now();
+            for _ in 0..1000 {
+                limiter.acquire(1).await; // one token == one request
+            }
+            assert!(
+                start.elapsed() < Duration::from_millis(200),
+                "unlimited request limiter must not pace requests"
+            );
+        });
+    }
+
+    /// A request limiter built from a req/s rate paces requests: with the
+    /// "tokens are requests" mapping, `acquire(1)` per request, issuing 2x one
+    /// second's burst must wait ~1s for the bucket to refill. Mirrors the
+    /// `transfer::tests::transfer_config_rate_limiter` pacing pattern, but the
+    /// budget unit is requests, not bytes.
+    #[test]
+    fn limits_request_limiter_paces_requests() {
+        let rt = runtime();
+        rt.block_on(async {
+            // 5 requests/sec. The bucket starts full (5), so the first 5
+            // `acquire(1)` calls are free; the next 5 must wait ~1s to refill.
+            let rps = 5;
+            let limiter = RateLimiter::new(Some(rps));
+            let start = tokio::time::Instant::now();
+            for _ in 0..(rps * 2) {
+                limiter.acquire(1).await; // one token == one request
+            }
+            let elapsed = start.elapsed();
+            assert!(
+                elapsed >= Duration::from_millis(900),
+                "a request limiter fed {rps} req/s should pace 2x burst to ~1s, took {elapsed:?}"
+            );
+        });
+    }
+}

--- a/crates/snapdir-stores/src/retry.rs
+++ b/crates/snapdir-stores/src/retry.rs
@@ -1,0 +1,748 @@
+//! Reusable retry/backoff engine for the network stores.
+//!
+//! This module is the **core** of snapdir's transient-failure retry policy: an
+//! SDK-agnostic loop that re-runs a fallible operation under a *full-jitter*
+//! exponential backoff schedule, honouring a server-supplied `Retry-After`
+//! hint. Like [`crate::adaptive`], it performs **no** real I/O and reads **no**
+//! real clock itself — the two impure dependencies (the jitter source and the
+//! sleep) are *injected* via the [`Jitter`] and [`AsyncSleeper`] /
+//! [`BlockingSleeper`] traits, so the engine and its backoff math are fully
+//! deterministic under test.
+//!
+//! Three pieces:
+//!
+//! - [`RetryPolicy`] — the schedule (attempt budget + base/cap durations) and
+//!   the [`backoff`](RetryPolicy::backoff) math (full-jitter exp with a server
+//!   hint floor).
+//! - [`Jitter`] — a `[0,1)` source. Production: [`DefaultJitter`], a tiny
+//!   hand-rolled **`SplitMix64`** PRNG (no new dependency). Tests inject a fixed
+//!   value.
+//! - [`AsyncSleeper`] / [`BlockingSleeper`] — the (async/blocking) sleep, plus
+//!   production impls ([`TokioSleeper`] / [`ThreadSleeper`]) and a recording
+//!   test fake.
+//!
+//! The engine itself — [`retry_async`] / [`retry_blocking`] — drives an
+//! operation that yields `Ok(T)` or `Err(`[`Attempt`]`)`; an [`Attempt`] carries
+//! the [`StoreError`], whether it is `transient`, and an optional
+//! `retry_after`. The next gate (`stores-backoff-wire`) feeds those from
+//! [`classify_error`](crate::classify_error) at the call sites; this gate ships
+//! only the engine + its unit tests and wires into nothing.
+
+// The backoff math works in `f64` seconds-space and the jitter PRNG maps a
+// `u64` to a `[0,1)` double; both are *advisory* timing signals (never a
+// correctness path), so the pedantic cast lints are allowed module-wide,
+// matching the `adaptive` controller's convention.
+#![allow(
+    clippy::cast_precision_loss,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
+
+use std::future::Future;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use snapdir_core::StoreError;
+
+// ---------------------------------------------------------------------------
+// RetryPolicy + backoff math.
+// ---------------------------------------------------------------------------
+
+/// The retry schedule: how many attempts to make and the exponential-backoff
+/// base/cap bounding each inter-attempt delay.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct RetryPolicy {
+    /// Total number of attempts, **including the first** (so `max_attempts = 5`
+    /// means one try plus up to four retries). Clamped to at least 1 by the
+    /// engine.
+    pub max_attempts: u32,
+    /// The base delay; the un-jittered exponential is `base × 2^n` for the
+    /// 0-based attempt index `n`.
+    pub base: Duration,
+    /// The hard ceiling on the un-jittered exponential (and therefore on the
+    /// jittered delay, absent a larger server hint).
+    pub cap: Duration,
+}
+
+impl Default for RetryPolicy {
+    fn default() -> Self {
+        Self {
+            max_attempts: 5,
+            base: Duration::from_millis(250),
+            cap: Duration::from_secs(30),
+        }
+    }
+}
+
+impl RetryPolicy {
+    /// Computes the inter-attempt delay before the retry that follows the
+    /// 0-based failed-attempt index `n`, under full-jitter exponential backoff.
+    ///
+    /// 1. `exp = min(cap, base × 2^n)` — the un-jittered envelope, saturated at
+    ///    `cap` (the `2^n` growth is computed in `f64` and clamped, so it can
+    ///    never overflow).
+    /// 2. `jittered = jitter01 × exp` — full jitter spreads the delay uniformly
+    ///    over `[0, exp)` (`jitter01 ∈ [0, 1)` is supplied by the [`Jitter`]
+    ///    source so tests are deterministic).
+    /// 3. `delay = max(server_hint.unwrap_or(0), jittered)` — a server
+    ///    `Retry-After` acts as a floor: we never retry sooner than the server
+    ///    asked, but may wait longer if the jittered exponential is larger.
+    #[must_use]
+    fn backoff(&self, n: u32, server_hint: Option<Duration>, jitter01: f64) -> Duration {
+        let cap = self.cap;
+        // exp = min(cap, base * 2^n), overflow-safe.
+        // `2f64.powi` saturates to +inf for large n; min(cap_secs, ..) clamps it
+        // before it ever leaves f64 space, so the cast back to Duration is safe.
+        let base_secs = self.base.as_secs_f64();
+        let cap_secs = cap.as_secs_f64();
+        // n as i32 for powi; for n beyond i32::MAX (impossible here) saturate.
+        let exp_secs = if n >= 1024 {
+            // 2^1024 already overflows f64 to +inf; short-circuit to the cap.
+            cap_secs
+        } else {
+            let factor = 2f64.powi(n as i32);
+            (base_secs * factor).min(cap_secs)
+        };
+        // Defensive clamp: NaN/negative -> 0, and never exceed the cap.
+        let exp_secs = if exp_secs.is_finite() {
+            exp_secs.clamp(0.0, cap_secs)
+        } else {
+            cap_secs
+        };
+        // Full jitter over [0, exp). jitter01 is contractually in [0,1); clamp
+        // defensively so a misbehaving source can never exceed the envelope.
+        let frac = if jitter01.is_finite() {
+            jitter01.clamp(0.0, 1.0)
+        } else {
+            0.0
+        };
+        let jittered = Duration::from_secs_f64(exp_secs * frac);
+
+        // Server hint is a floor (we honour "wait at least this long"). Without
+        // a hint the delay is `jittered` (<= exp <= cap); with a hint it is
+        // `max(hint, jittered)`, which the hint is allowed to push above cap.
+        match server_hint {
+            Some(hint) => hint.max(jittered),
+            None => jittered,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Jitter — [0,1) source (production SplitMix64 + injectable test stub).
+// ---------------------------------------------------------------------------
+
+/// A source of uniform `[0, 1)` fractions used to spread retry delays
+/// (full-jitter). Injected so the backoff sequence is deterministic in tests.
+pub trait Jitter {
+    /// Returns the next jitter fraction in `[0, 1)`.
+    fn jitter01(&self) -> f64;
+}
+
+/// Process-wide seed counter mixed into each [`DefaultJitter`] so two instances
+/// constructed in the same nanosecond still diverge.
+static JITTER_SEED_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// Production [`Jitter`]: a tiny, hand-rolled **`SplitMix64`** PRNG (no external
+/// dependency).
+///
+/// Seeded once at construction from a one-time nanosecond clock sample `XOR`ed
+/// with a monotonically advancing process counter; each
+/// [`jitter01`](Jitter::jitter01) advances the 64-bit state and maps the top 53
+/// bits to a `[0, 1)` double. `SplitMix64` is the standard seeding PRNG (it is
+/// what `rand`'s `SeedableRng::seed_from_u64` uses internally) and is more than
+/// adequate for *jitter* — this is decorrelation, not cryptography.
+///
+/// Interior mutability ([`AtomicU64`]) lets `jitter01` take `&self` (matching
+/// the trait) while still advancing the stream, so a single instance can be
+/// shared across the retry loop.
+#[derive(Debug)]
+pub struct DefaultJitter {
+    state: AtomicU64,
+}
+
+impl DefaultJitter {
+    /// Builds a jitter source seeded from the current nanosecond clock `XOR`ed
+    /// with a process-wide counter (so concurrent constructions diverge).
+    #[must_use]
+    pub fn new() -> Self {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_or(0, |d| d.as_nanos() as u64);
+        let counter = JITTER_SEED_COUNTER.fetch_add(1, Ordering::Relaxed);
+        // Mix the counter in via SplitMix64 so adjacent seeds aren't adjacent
+        // states.
+        let seed = nanos ^ splitmix64_mix(counter.wrapping_add(0x9E37_79B9_7F4A_7C15));
+        Self {
+            state: AtomicU64::new(seed),
+        }
+    }
+}
+
+impl Default for DefaultJitter {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl Jitter for DefaultJitter {
+    fn jitter01(&self) -> f64 {
+        // Advance the SplitMix64 state and map the result to [0,1).
+        let z = self
+            .state
+            .fetch_add(0x9E37_79B9_7F4A_7C15, Ordering::Relaxed)
+            .wrapping_add(0x9E37_79B9_7F4A_7C15);
+        let bits = splitmix64_mix(z);
+        u64_to_unit_f64(bits)
+    }
+}
+
+/// The `SplitMix64` finalizing mix (the avalanche step of the `SplitMix64` PRNG).
+#[inline]
+fn splitmix64_mix(mut z: u64) -> u64 {
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    z ^ (z >> 31)
+}
+
+/// Maps a uniformly random `u64` to a `[0, 1)` double using its top 53 bits
+/// (the mantissa width), the standard unbiased construction.
+#[inline]
+fn u64_to_unit_f64(bits: u64) -> f64 {
+    // 53 high bits / 2^53 lands in [0, 1).
+    ((bits >> 11) as f64) / (1u64 << 53) as f64
+}
+
+/// A deterministic [`Jitter`] for tests: always returns the same fixed
+/// fraction (clamped to `[0, 1)`).
+#[derive(Clone, Copy, Debug)]
+pub struct FixedJitter(pub f64);
+
+impl Jitter for FixedJitter {
+    fn jitter01(&self) -> f64 {
+        // Keep within the [0,1) contract (strictly below 1.0).
+        self.0.clamp(0.0, 1.0 - f64::EPSILON)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Sleeper — async + blocking sleep (production + recording test fake).
+// ---------------------------------------------------------------------------
+
+/// An async sleep, injected so the [`retry_async`] engine can be driven without
+/// real waits in tests.
+pub trait AsyncSleeper {
+    /// Sleeps for `dur` (asynchronously).
+    fn sleep(&self, dur: Duration) -> impl Future<Output = ()> + Send;
+}
+
+/// An OS-thread-blocking sleep, injected so the [`retry_blocking`] engine can be
+/// driven without real waits in tests. Mirrors the blocking transfer path
+/// ([`BlockingRateLimiter`](crate::BlockingRateLimiter)), which parks the thread
+/// with [`std::thread::sleep`].
+pub trait BlockingSleeper {
+    /// Sleeps for `dur` (parks the calling thread).
+    fn sleep(&self, dur: Duration);
+}
+
+/// Production [`AsyncSleeper`] backed by [`tokio::time::sleep`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct TokioSleeper;
+
+impl AsyncSleeper for TokioSleeper {
+    fn sleep(&self, dur: Duration) -> impl Future<Output = ()> + Send {
+        tokio::time::sleep(dur)
+    }
+}
+
+/// Production [`BlockingSleeper`] backed by [`std::thread::sleep`].
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ThreadSleeper;
+
+impl BlockingSleeper for ThreadSleeper {
+    fn sleep(&self, dur: Duration) {
+        std::thread::sleep(dur);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Engine — SDK-agnostic over an attempt outcome.
+// ---------------------------------------------------------------------------
+
+/// The outcome of a single failed attempt, handed back to the retry engine.
+///
+/// The caller (a store operation) decides whether the failure is `transient`
+/// (worth retrying) and threads through any server `retry_after` hint. The
+/// next gate populates these from
+/// [`classify_error`](crate::classify_error); the engine itself is SDK-agnostic.
+#[derive(Debug)]
+pub struct Attempt {
+    /// The error this attempt produced (surfaced to the caller if retries are
+    /// exhausted or the error is non-transient).
+    pub err: StoreError,
+    /// Whether the error is transient (throttle / timeout-class) and therefore
+    /// retryable.
+    pub transient: bool,
+    /// An optional server-supplied minimum delay (`Retry-After`); acts as a
+    /// floor on the next backoff.
+    pub retry_after: Option<Duration>,
+}
+
+/// The most attempts the engine will ever make (defensive clamp on
+/// [`RetryPolicy::max_attempts`]).
+#[inline]
+fn clamped_max_attempts(policy: &RetryPolicy) -> u32 {
+    policy.max_attempts.max(1)
+}
+
+/// Runs `op` under `policy`'s full-jitter backoff, retrying transient failures.
+///
+/// The operation is invoked up to `policy.max_attempts` times. On `Ok(T)` the
+/// value is returned immediately. On `Err(`[`Attempt`]`)`: if the attempt is
+/// `transient` **and** attempts remain, the engine sleeps for
+/// [`RetryPolicy::backoff`] (with the attempt's `retry_after` hint and a fresh
+/// jitter sample) via `sleeper`, then retries; otherwise the attempt's
+/// [`StoreError`] is returned. A non-transient error short-circuits on the
+/// first failure (no sleep).
+///
+/// `sleeper` and `jitter` are injected so tests can record the delay sequence
+/// without real waits.
+///
+/// # Errors
+///
+/// Returns the last [`Attempt`]'s [`StoreError`] when the operation does not
+/// succeed within the attempt budget (or fails non-transiently).
+pub async fn retry_async<T, F, Fut>(
+    policy: &RetryPolicy,
+    sleeper: &impl AsyncSleeper,
+    jitter: &impl Jitter,
+    mut op: F,
+) -> Result<T, StoreError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, Attempt>>,
+{
+    let max = clamped_max_attempts(policy);
+    let mut n: u32 = 0;
+    loop {
+        match op().await {
+            Ok(value) => return Ok(value),
+            Err(attempt) => {
+                let attempts_used = n + 1;
+                if attempt.transient && attempts_used < max {
+                    let delay = policy.backoff(n, attempt.retry_after, jitter.jitter01());
+                    sleeper.sleep(delay).await;
+                    n += 1;
+                } else {
+                    return Err(attempt.err);
+                }
+            }
+        }
+    }
+}
+
+/// Blocking sibling of [`retry_async`]: same control flow over a synchronous
+/// `op`, sleeping on the calling thread via a [`BlockingSleeper`]. Used by the
+/// rayon store-to-store sync path.
+///
+/// # Errors
+///
+/// Returns the last [`Attempt`]'s [`StoreError`] when the operation does not
+/// succeed within the attempt budget (or fails non-transiently).
+pub fn retry_blocking<T, F>(
+    policy: &RetryPolicy,
+    sleeper: &impl BlockingSleeper,
+    jitter: &impl Jitter,
+    mut op: F,
+) -> Result<T, StoreError>
+where
+    F: FnMut() -> Result<T, Attempt>,
+{
+    let max = clamped_max_attempts(policy);
+    let mut n: u32 = 0;
+    loop {
+        match op() {
+            Ok(value) => return Ok(value),
+            Err(attempt) => {
+                let attempts_used = n + 1;
+                if attempt.transient && attempts_used < max {
+                    let delay = policy.backoff(n, attempt.retry_after, jitter.jitter01());
+                    sleeper.sleep(delay);
+                    n += 1;
+                } else {
+                    return Err(attempt.err);
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    use std::sync::Mutex;
+
+    // ----- helpers ----------------------------------------------------------
+
+    /// A recording fake [`AsyncSleeper`] / [`BlockingSleeper`]: never sleeps for
+    /// real, just appends each requested duration so tests can assert the exact
+    /// backoff sequence.
+    #[derive(Default)]
+    struct RecordingSleeper {
+        delays: Mutex<Vec<Duration>>,
+    }
+
+    impl RecordingSleeper {
+        fn recorded(&self) -> Vec<Duration> {
+            self.delays.lock().unwrap().clone()
+        }
+    }
+
+    impl AsyncSleeper for RecordingSleeper {
+        fn sleep(&self, dur: Duration) -> impl Future<Output = ()> + Send {
+            self.delays.lock().unwrap().push(dur);
+            std::future::ready(())
+        }
+    }
+
+    impl BlockingSleeper for RecordingSleeper {
+        fn sleep(&self, dur: Duration) {
+            self.delays.lock().unwrap().push(dur);
+        }
+    }
+
+    /// A deterministic [`Jitter`] returning a fixed fraction (no clamping
+    /// surprises — kept strictly in `[0,1)`).
+    struct StubJitter(f64);
+    impl Jitter for StubJitter {
+        fn jitter01(&self) -> f64 {
+            self.0
+        }
+    }
+
+    fn boom() -> StoreError {
+        StoreError::Backend {
+            message: "boom".into(),
+            source: None,
+        }
+    }
+
+    fn transient_attempt(retry_after: Option<Duration>) -> Attempt {
+        Attempt {
+            err: boom(),
+            transient: true,
+            retry_after,
+        }
+    }
+
+    fn hard_attempt() -> Attempt {
+        Attempt {
+            err: boom(),
+            transient: false,
+            retry_after: None,
+        }
+    }
+
+    fn runtime() -> tokio::runtime::Runtime {
+        tokio::runtime::Builder::new_current_thread()
+            .enable_time()
+            .build()
+            .expect("build tokio runtime")
+    }
+
+    fn small_policy() -> RetryPolicy {
+        // 5 attempts (=> up to 4 sleeps), tiny base/cap so jittered delays are
+        // easy to reason about.
+        RetryPolicy {
+            max_attempts: 5,
+            base: Duration::from_millis(100),
+            cap: Duration::from_secs(10),
+        }
+    }
+
+    // ----- (1) exact attempt count on persistent transient failure ----------
+
+    #[test]
+    fn retry_async_persistent_transient_uses_full_attempt_budget() {
+        let rt = runtime();
+        rt.block_on(async {
+            let policy = small_policy();
+            let sleeper = RecordingSleeper::default();
+            let jitter = StubJitter(0.5);
+            let calls = AtomicUsize::new(0);
+
+            let result: Result<(), StoreError> = retry_async(&policy, &sleeper, &jitter, || {
+                calls.fetch_add(1, AtomicOrdering::SeqCst);
+                async { Err(transient_attempt(None)) }
+            })
+            .await;
+
+            assert!(result.is_err(), "persistent transient => surfaces the err");
+            assert_eq!(
+                calls.load(AtomicOrdering::SeqCst),
+                policy.max_attempts as usize,
+                "op invoked exactly max_attempts times"
+            );
+            assert_eq!(
+                sleeper.recorded().len(),
+                (policy.max_attempts - 1) as usize,
+                "max_attempts-1 sleeps recorded (no sleep after the last attempt)"
+            );
+        });
+    }
+
+    // ----- (2) immediate return on hard (non-transient) error ---------------
+
+    #[test]
+    fn retry_async_hard_error_returns_immediately_without_sleeping() {
+        let rt = runtime();
+        rt.block_on(async {
+            let policy = small_policy();
+            let sleeper = RecordingSleeper::default();
+            let jitter = StubJitter(0.5);
+            let calls = AtomicUsize::new(0);
+
+            let result: Result<(), StoreError> = retry_async(&policy, &sleeper, &jitter, || {
+                calls.fetch_add(1, AtomicOrdering::SeqCst);
+                async { Err(hard_attempt()) }
+            })
+            .await;
+
+            assert!(result.is_err(), "hard error surfaces");
+            assert_eq!(
+                calls.load(AtomicOrdering::SeqCst),
+                1,
+                "non-transient error => op called exactly once"
+            );
+            assert!(
+                sleeper.recorded().is_empty(),
+                "no sleeps for a non-transient error"
+            );
+        });
+    }
+
+    // ----- (3) success after k transient failures ---------------------------
+
+    #[test]
+    fn retry_async_success_after_k_transient_fails() {
+        let rt = runtime();
+        rt.block_on(async {
+            let policy = small_policy();
+            let sleeper = RecordingSleeper::default();
+            let jitter = StubJitter(0.25);
+            let calls = AtomicUsize::new(0);
+            let k = 3usize;
+
+            let result: Result<u32, StoreError> = retry_async(&policy, &sleeper, &jitter, || {
+                let prev = calls.fetch_add(1, AtomicOrdering::SeqCst);
+                async move {
+                    if prev < k {
+                        Err(transient_attempt(None))
+                    } else {
+                        Ok(42)
+                    }
+                }
+            })
+            .await;
+
+            assert_eq!(result.unwrap(), 42, "succeeds on the (k+1)-th attempt");
+            assert_eq!(
+                calls.load(AtomicOrdering::SeqCst),
+                k + 1,
+                "op invoked k+1 times"
+            );
+            assert_eq!(
+                sleeper.recorded().len(),
+                k,
+                "exactly k sleeps recorded (one before each retry)"
+            );
+        });
+    }
+
+    // ----- (4) Retry-After honoured as a floor ------------------------------
+
+    #[test]
+    fn retry_async_retry_after_is_a_floor() {
+        let rt = runtime();
+        rt.block_on(async {
+            let policy = small_policy();
+            let sleeper = RecordingSleeper::default();
+            // jitter01 = 0 => jittered exp = 0, so the hint dominates entirely.
+            let jitter = StubJitter(0.0);
+            // A hint far larger than the first jittered exp (base*2^0 = 100ms).
+            let hint = Duration::from_secs(5);
+            let calls = AtomicUsize::new(0);
+
+            let _result: Result<(), StoreError> = retry_async(&policy, &sleeper, &jitter, || {
+                calls.fetch_add(1, AtomicOrdering::SeqCst);
+                async move { Err(transient_attempt(Some(hint))) }
+            })
+            .await;
+
+            let recorded = sleeper.recorded();
+            assert!(!recorded.is_empty(), "at least one retry happened");
+            for d in &recorded {
+                assert!(
+                    *d >= hint,
+                    "recorded delay {d:?} must be >= the server hint {hint:?}"
+                );
+            }
+        });
+    }
+
+    // ----- (5) cap respected (no hint) --------------------------------------
+
+    #[test]
+    fn retry_async_cap_respected_for_large_n() {
+        let rt = runtime();
+        rt.block_on(async {
+            // Many attempts so n grows large; base*2^n would blow past cap.
+            let policy = RetryPolicy {
+                max_attempts: 12,
+                base: Duration::from_millis(250),
+                cap: Duration::from_secs(2),
+            };
+            let sleeper = RecordingSleeper::default();
+            // jitter01 just below 1 => jittered ~ exp, the worst case for the cap.
+            let jitter = StubJitter(0.999_999);
+
+            let _result: Result<(), StoreError> =
+                retry_async(&policy, &sleeper, &jitter, || async {
+                    Err(transient_attempt(None))
+                })
+                .await;
+
+            for d in sleeper.recorded() {
+                assert!(
+                    d <= policy.cap,
+                    "delay {d:?} must never exceed cap {:?} (no hint)",
+                    policy.cap
+                );
+            }
+        });
+    }
+
+    // ----- (6) full-jitter bounds: delay == jitter01 * min(cap, base*2^n) ----
+
+    #[test]
+    fn backoff_full_jitter_lands_in_envelope() {
+        let policy = RetryPolicy {
+            max_attempts: 10,
+            base: Duration::from_millis(100),
+            cap: Duration::from_secs(30),
+        };
+        for n in 0..8u32 {
+            let frac = 0.37;
+            let delay = policy.backoff(n, None, frac);
+            let exp = policy
+                .base
+                .as_secs_f64()
+                .mul_add(2f64.powi(n as i32), 0.0)
+                .min(policy.cap.as_secs_f64());
+            let expected = exp * frac;
+            // delay == frac * min(cap, base*2^n) (within float tolerance).
+            assert!(
+                (delay.as_secs_f64() - expected).abs() < 1e-9,
+                "n={n}: delay {delay:?} != jitter01*envelope {expected}"
+            );
+            // and it lands in [0, min(cap, base*2^n)).
+            assert!(
+                delay.as_secs_f64() >= 0.0 && delay.as_secs_f64() < exp + 1e-9,
+                "n={n}: delay {delay:?} outside [0, {exp})"
+            );
+        }
+    }
+
+    #[test]
+    fn backoff_saturates_at_cap_for_huge_n() {
+        let policy = RetryPolicy {
+            max_attempts: 99,
+            base: Duration::from_millis(250),
+            cap: Duration::from_secs(30),
+        };
+        // jitter01 ~ 1 so the jittered delay tracks the (capped) envelope.
+        let d = policy.backoff(2000, None, 0.999_999);
+        assert!(
+            d <= policy.cap,
+            "huge n must saturate at the cap, got {d:?}"
+        );
+        assert!(
+            d.as_secs_f64() > 29.0,
+            "with jitter ~1 the delay should be near the cap, got {d:?}"
+        );
+    }
+
+    #[test]
+    fn default_jitter_is_in_unit_interval() {
+        let j = DefaultJitter::new();
+        for _ in 0..10_000 {
+            let x = j.jitter01();
+            assert!((0.0..1.0).contains(&x), "jitter {x} outside [0,1)");
+        }
+        // And two instances produce different streams (seed divergence).
+        let a = DefaultJitter::new();
+        let b = DefaultJitter::new();
+        let sa: Vec<f64> = (0..4).map(|_| a.jitter01()).collect();
+        let sb: Vec<f64> = (0..4).map(|_| b.jitter01()).collect();
+        assert_ne!(sa, sb, "distinct instances should diverge");
+    }
+
+    // ----- (7) blocking engine smoke tests ----------------------------------
+
+    #[test]
+    fn retry_blocking_persistent_transient_uses_full_budget() {
+        let policy = small_policy();
+        let sleeper = RecordingSleeper::default();
+        let jitter = StubJitter(0.5);
+        let calls = AtomicUsize::new(0);
+
+        let result: Result<(), StoreError> = retry_blocking(&policy, &sleeper, &jitter, || {
+            calls.fetch_add(1, AtomicOrdering::SeqCst);
+            Err(transient_attempt(None))
+        });
+
+        assert!(result.is_err());
+        assert_eq!(
+            calls.load(AtomicOrdering::SeqCst),
+            policy.max_attempts as usize,
+            "blocking: op invoked max_attempts times"
+        );
+        assert_eq!(
+            sleeper.recorded().len(),
+            (policy.max_attempts - 1) as usize,
+            "blocking: max_attempts-1 sleeps"
+        );
+    }
+
+    #[test]
+    fn retry_blocking_success_after_k_transient() {
+        let policy = small_policy();
+        let sleeper = RecordingSleeper::default();
+        let jitter = StubJitter(0.5);
+        let calls = AtomicUsize::new(0);
+        let k = 2usize;
+
+        let result: Result<&str, StoreError> = retry_blocking(&policy, &sleeper, &jitter, || {
+            let prev = calls.fetch_add(1, AtomicOrdering::SeqCst);
+            if prev < k {
+                Err(transient_attempt(None))
+            } else {
+                Ok("done")
+            }
+        });
+
+        assert_eq!(result.unwrap(), "done");
+        assert_eq!(calls.load(AtomicOrdering::SeqCst), k + 1);
+        assert_eq!(sleeper.recorded().len(), k, "blocking: k sleeps");
+    }
+
+    #[test]
+    fn default_policy_values() {
+        let p = RetryPolicy::default();
+        assert_eq!(p.max_attempts, 5);
+        assert_eq!(p.base, Duration::from_millis(250));
+        assert_eq!(p.cap, Duration::from_secs(30));
+    }
+}

--- a/crates/snapdir-stores/src/retry.rs
+++ b/crates/snapdir-stores/src/retry.rs
@@ -45,6 +45,8 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use snapdir_core::StoreError;
 
+use crate::transfer::RateLimiter;
+
 // ---------------------------------------------------------------------------
 // RetryPolicy + backoff math.
 // ---------------------------------------------------------------------------
@@ -376,6 +378,85 @@ where
             }
         }
     }
+}
+
+// ---------------------------------------------------------------------------
+// retry_network — the per-call boundary the network stores wrap each SDK call
+// in: acquire one request-rate token, then run the operation under the retry
+// engine. This is the single injectable seam the `backoff_wire` tests drive
+// (with a scripted `op` + recording sleeper), so the wiring is exercised with
+// NO live cloud.
+// ---------------------------------------------------------------------------
+
+/// Runs a single network operation through the full retry/limiter wiring.
+///
+/// Before **every** attempt this acquires one token from `req_limiter` (the
+/// per-call request-rate bucket — `acquire(1)`, a no-op when the limiter is
+/// unlimited), then drives `op` under [`retry_async`] with `policy`'s
+/// full-jitter backoff. `op` is the SDK call: it returns `Ok(T)` on success or
+/// `Err(`[`Attempt`]`)` carrying the mapped [`StoreError`], whether the failure
+/// is `transient`, and any server `retry_after` hint extracted from the
+/// concrete SDK error.
+///
+/// The real stores pass an `op` that performs the SDK call and builds the
+/// `Attempt` on error (via the per-SDK `*_attempt_from_err` extractors); the
+/// `backoff_wire` tests pass an `op` that replays a scripted sequence of
+/// `Attempt`s, so the retry/limiter wiring is exercised without any network.
+///
+/// # Errors
+///
+/// Returns the last [`Attempt`]'s [`StoreError`] when `op` does not succeed
+/// within the attempt budget (or fails non-transiently).
+pub async fn retry_network<T, F, Fut>(
+    policy: &RetryPolicy,
+    req_limiter: &RateLimiter,
+    sleeper: &impl AsyncSleeper,
+    jitter: &impl Jitter,
+    mut op: F,
+) -> Result<T, StoreError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = Result<T, Attempt>>,
+{
+    // This mirrors [`retry_async`]'s control flow exactly, but inlines the
+    // per-attempt request-token acquire so it can call `op` directly each
+    // iteration (the `FnMut() -> Fut` bound on `retry_async` is non-lending, so
+    // an `op` wrapper future that re-borrows `op`/`req_limiter` cannot escape
+    // its closure — driving the loop here sidesteps that).
+    let max = clamped_max_attempts(policy);
+    let mut n: u32 = 0;
+    loop {
+        // Pace each (re)try through the per-call request-rate limiter (a no-op
+        // when unlimited), then run the operation.
+        req_limiter.acquire(1).await;
+        match op().await {
+            Ok(value) => return Ok(value),
+            Err(attempt) => {
+                let attempts_used = n + 1;
+                if attempt.transient && attempts_used < max {
+                    let delay = policy.backoff(n, attempt.retry_after, jitter.jitter01());
+                    sleeper.sleep(delay).await;
+                    n += 1;
+                } else {
+                    return Err(attempt.err);
+                }
+            }
+        }
+    }
+}
+
+/// Parses an HTTP `Retry-After` header value into a [`Duration`].
+///
+/// Honours the **delta-seconds** form (`Retry-After: 120`) — by far the common
+/// case for `429`/`503` throttling from S3/GCS — returning `Some(120s)`. The
+/// HTTP-date form is intentionally NOT parsed (it would need a date crate and a
+/// wall-clock read; the backoff engine already provides a sane delay when the
+/// hint is absent), so a non-numeric value yields `None`. A value of `0` maps
+/// to `Some(Duration::ZERO)` (a valid "retry now" floor).
+#[must_use]
+pub fn parse_retry_after(value: &str) -> Option<Duration> {
+    let trimmed = value.trim();
+    trimmed.parse::<u64>().ok().map(Duration::from_secs)
 }
 
 #[cfg(test)]

--- a/crates/snapdir-stores/src/s3_store.rs
+++ b/crates/snapdir-stores/src/s3_store.rs
@@ -42,10 +42,12 @@ use std::sync::Arc;
 
 use aws_config::BehaviorVersion;
 use aws_sdk_s3::config::Region;
+use aws_sdk_s3::error::{ProvideErrorMetadata, SdkError};
 use aws_sdk_s3::Client;
 use aws_smithy_http_client::tls::rustls_provider::CryptoMode;
 use aws_smithy_http_client::tls::Provider as TlsProvider;
 use aws_smithy_http_client::Builder as HttpClientBuilder;
+use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
 use snapdir_core::manifest::Manifest;
 use snapdir_core::merkle::{Blake3Hasher, Hasher};
 use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
@@ -53,9 +55,11 @@ use snapdir_core::Meter;
 
 use crate::fetch::fetch_files_concurrent;
 use crate::push::{push_objects_concurrent, upload_object};
+use crate::retry::{parse_retry_after, retry_network, Attempt, DefaultJitter, TokioSleeper};
 use crate::stream::StreamStore;
-use crate::transfer::{RateLimiter, TransferConfig};
+use crate::transfer::{classify_error, RateLimiter, TransferConfig};
 
+use std::error::Error as StdError;
 use tokio::runtime::Runtime;
 
 /// Number of times a fetch is retried when the downloaded bytes fail their
@@ -141,6 +145,10 @@ pub struct S3Store {
     location: S3Location,
     runtime: Arc<Runtime>,
     config: TransferConfig,
+    /// Per-call request-rate limiter (one token per SDK call), built from
+    /// [`TransferConfig::max_requests_per_sec`]. Unlimited (a no-op) by default.
+    /// Shared (clone) so every call paces against one aggregate request budget.
+    req_limiter: RateLimiter,
     /// Optional progress meter; recorded into during transfers. `None` (the
     /// default from every constructor) means zero recording and byte-identical
     /// behavior. Set by the CLI via [`S3Store::with_meter`].
@@ -183,8 +191,11 @@ impl S3Store {
         let http_client = ring_https_client();
         let endpoint = endpoint_url.map(ToOwned::to_owned);
         let client = runtime.block_on(async move {
-            let mut loader =
-                aws_config::defaults(BehaviorVersion::latest()).http_client(http_client.clone());
+            let mut loader = aws_config::defaults(BehaviorVersion::latest())
+                .http_client(http_client.clone())
+                // Disable the SDK's own retry loop so snapdir's RetryPolicy is
+                // the single backoff authority (no SDK-3x × ours-5x compounding).
+                .retry_config(aws_config::retry::RetryConfig::disabled());
             if let Some(ep) = endpoint.as_deref() {
                 loader = loader.endpoint_url(ep);
             }
@@ -202,11 +213,13 @@ impl S3Store {
             Client::from_conf(builder.build())
         });
 
+        let req_limiter = RateLimiter::new(config.max_requests_per_sec);
         Ok(Self {
             client,
             location,
             runtime: Arc::new(runtime),
             config,
+            req_limiter,
             meter: None,
         })
     }
@@ -219,11 +232,14 @@ impl S3Store {
     ///
     /// [`StoreError::Backend`] if the tokio runtime cannot be created.
     pub fn from_client(client: Client, location: S3Location) -> Result<Self, StoreError> {
+        let config = TransferConfig::default();
+        let req_limiter = RateLimiter::new(config.max_requests_per_sec);
         Ok(Self {
             client,
             location,
             runtime: Arc::new(build_runtime()?),
-            config: TransferConfig::default(),
+            config,
+            req_limiter,
             meter: None,
         })
     }
@@ -253,68 +269,120 @@ impl S3Store {
     }
 
     /// HEAD an object key; `Ok(true)` if it exists, `Ok(false)` if absent.
+    ///
+    /// The single SDK call is wrapped in [`retry_network`]: it acquires one
+    /// request-rate token, then retries a TRANSIENT failure under the store's
+    /// [`RetryPolicy`]. A `404`/not-found is a normal `Ok(false)` outcome (not a
+    /// retry); any other error is classified via [`s3_attempt_from_err`].
     async fn key_exists(&self, key: &str) -> Result<bool, StoreError> {
-        match self
-            .client
-            .head_object()
-            .bucket(&self.location.bucket)
-            .key(key)
-            .send()
-            .await
-        {
-            Ok(_) => Ok(true),
-            Err(err) => {
-                let svc = err.into_service_error();
-                if svc.is_not_found() {
-                    Ok(false)
-                } else {
-                    Err(backend("S3 HEAD object failed", svc))
+        retry_network(
+            &self.config.retry,
+            &self.req_limiter,
+            &TokioSleeper,
+            &DefaultJitter::new(),
+            || async {
+                match self
+                    .client
+                    .head_object()
+                    .bucket(&self.location.bucket)
+                    .key(key)
+                    .send()
+                    .await
+                {
+                    Ok(_) => Ok(true),
+                    Err(err) => {
+                        // A genuine "absent" is a successful outcome of the op,
+                        // not a retry: peek the concrete service error first.
+                        if err.as_service_error().is_some_and(
+                            aws_sdk_s3::operation::head_object::HeadObjectError::is_not_found,
+                        ) {
+                            return Ok(false);
+                        }
+                        Err(s3_attempt_from_err("S3 HEAD object failed", err))
+                    }
                 }
-            }
-        }
+            },
+        )
+        .await
     }
 
     /// GET an object key's full body, or `None` if it is absent.
+    ///
+    /// The SDK call is wrapped in [`retry_network`] exactly like
+    /// [`key_exists`](Self::key_exists). A `NoSuchKey` is a normal `Ok(None)`
+    /// outcome; transient failures retry under the store's [`RetryPolicy`](crate::retry::RetryPolicy).
     async fn get_bytes(&self, key: &str) -> Result<Option<Vec<u8>>, StoreError> {
-        match self
-            .client
-            .get_object()
-            .bucket(&self.location.bucket)
-            .key(key)
-            .send()
-            .await
-        {
-            Ok(resp) => {
-                let data = resp
-                    .body
-                    .collect()
+        retry_network(
+            &self.config.retry,
+            &self.req_limiter,
+            &TokioSleeper,
+            &DefaultJitter::new(),
+            || async {
+                match self
+                    .client
+                    .get_object()
+                    .bucket(&self.location.bucket)
+                    .key(key)
+                    .send()
                     .await
-                    .map_err(|e| backend("reading S3 object body", e))?;
-                Ok(Some(data.into_bytes().to_vec()))
-            }
-            Err(err) => {
-                let svc = err.into_service_error();
-                if svc.is_no_such_key() {
-                    Ok(None)
-                } else {
-                    Err(backend("S3 GET object failed", svc))
+                {
+                    Ok(resp) => {
+                        // Draining the streamed body can itself fail transiently
+                        // (connection reset mid-download); classify it too.
+                        let data = resp.body.collect().await.map_err(|e| {
+                            let err = backend("reading S3 object body", e);
+                            let transient =
+                                matches!(classify_error(&err), crate::adaptive::OpResult::Throttle);
+                            Attempt {
+                                transient,
+                                retry_after: None,
+                                err,
+                            }
+                        })?;
+                        Ok(Some(data.into_bytes().to_vec()))
+                    }
+                    Err(err) => {
+                        if err.as_service_error().is_some_and(
+                            aws_sdk_s3::operation::get_object::GetObjectError::is_no_such_key,
+                        ) {
+                            return Ok(None);
+                        }
+                        Err(s3_attempt_from_err("S3 GET object failed", err))
+                    }
                 }
-            }
-        }
+            },
+        )
+        .await
     }
 
     /// PUT `bytes` at `key`. S3 PUT is atomic, so no temp-key dance is needed
     /// (the oracle relies on the same atomicity for manifests/objects).
+    ///
+    /// Wrapped in [`retry_network`]: each (re)try re-sends the full body, so the
+    /// content-addressed bytes that land are unchanged — only transient failures
+    /// retry under the store's [`RetryPolicy`](crate::retry::RetryPolicy).
     async fn put_bytes(&self, key: &str, bytes: Vec<u8>) -> Result<(), StoreError> {
-        self.client
-            .put_object()
-            .bucket(&self.location.bucket)
-            .key(key)
-            .body(bytes.into())
-            .send()
-            .await
-            .map_err(|e| backend("S3 PUT object failed", e))?;
-        Ok(())
+        retry_network(
+            &self.config.retry,
+            &self.req_limiter,
+            &TokioSleeper,
+            &DefaultJitter::new(),
+            || {
+                let bytes = bytes.clone();
+                async move {
+                    self.client
+                        .put_object()
+                        .bucket(&self.location.bucket)
+                        .key(key)
+                        .body(bytes.into())
+                        .send()
+                        .await
+                        .map(|_| ())
+                        .map_err(|err| s3_attempt_from_err("S3 PUT object failed", err))
+                }
+            },
+        )
+        .await
     }
 
     /// Downloads `key`, verifying its BLAKE3 against `expected`, retrying up to
@@ -559,10 +627,131 @@ where
     }
 }
 
+/// Builds a retry [`Attempt`] from a concrete aws-sdk-s3 [`SdkError`], at the
+/// boundary where the SDK error still carries its raw HTTP response.
+///
+/// - `transient`: true for the retryable signal set — an HTTP `429`/`503`
+///   status on the raw response, the throttle error codes
+///   (`SlowDown`/`Throttling`/`RequestTimeout`/`ServiceUnavailable`/…), and the
+///   transport/timeout classes — folded through the shared
+///   [`classify_error`](crate::classify_error) on the mapped [`StoreError`].
+///   Conservative: an unknown error is NOT transient.
+/// - `retry_after`: extracted from the raw response's `Retry-After` header (the
+///   delta-seconds form) when present, else `None`.
+/// - `err`: the mapped [`StoreError::Backend`] (the same value the non-retry
+///   path used to surface).
+fn s3_attempt_from_err<E>(message: &str, err: SdkError<E, HttpResponse>) -> Attempt
+where
+    E: ProvideErrorMetadata + StdError + Send + Sync + 'static,
+{
+    // Extract status code + Retry-After off the raw HTTP response (present on
+    // ServiceError / ResponseError variants) BEFORE we consume the error.
+    let (http_status, retry_after) = match err.raw_response() {
+        Some(resp) => {
+            let status = resp.status().as_u16();
+            let hint = resp
+                .headers()
+                .get("retry-after")
+                .and_then(parse_retry_after);
+            (Some(status), hint)
+        }
+        None => (None, None),
+    };
+
+    // The SDK error code (e.g. "SlowDown", "ServiceUnavailable") rides in the
+    // error metadata; fold it (plus the status) into the mapped StoreError's
+    // text so the shared classifier sees the transient signals.
+    let code = err.code().unwrap_or_default().to_owned();
+    let store_err = backend(message, err);
+
+    let transient = http_status.is_some_and(|s| s == 429 || s == 503)
+        || matches!(
+            classify_error(&store_err),
+            crate::adaptive::OpResult::Throttle
+        )
+        || {
+            let c = code.to_ascii_lowercase();
+            c.contains("slowdown")
+                || c.contains("throttl")
+                || c.contains("requesttimeout")
+                || c.contains("serviceunavailable")
+                || c.contains("internalerror")
+        };
+
+    Attempt {
+        transient,
+        retry_after,
+        err: store_err,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use aws_sdk_s3::error::ErrorMetadata;
+    use aws_sdk_s3::operation::head_object::HeadObjectError;
+    use aws_sdk_s3::primitives::SdkBody;
+    use aws_smithy_runtime_api::http::StatusCode;
     use snapdir_core::manifest::PathType;
+    use std::time::Duration;
+
+    /// Builds a raw S3 [`HttpResponse`] with the given status and optional
+    /// `Retry-After` header, for exercising [`s3_attempt_from_err`] without a
+    /// live SDK call.
+    fn raw_response(status: u16, retry_after: Option<&str>) -> HttpResponse {
+        let mut resp = HttpResponse::new(
+            StatusCode::try_from(status).expect("valid status"),
+            SdkBody::empty(),
+        );
+        if let Some(v) = retry_after {
+            resp.headers_mut().insert("retry-after", v.to_owned());
+        }
+        resp
+    }
+
+    /// Wraps an S3 service error (carrying `code`) plus a raw response into the
+    /// concrete `SdkError` the store methods see, so the extractor runs on a
+    /// real SDK error shape.
+    fn s3_service_error(code: &str, status: u16, retry_after: Option<&str>) -> Attempt {
+        let meta = ErrorMetadata::builder().code(code).build();
+        let svc = HeadObjectError::generic(meta);
+        let err = SdkError::service_error(svc, raw_response(status, retry_after));
+        s3_attempt_from_err("S3 op failed", err)
+    }
+
+    #[test]
+    fn backoff_wire_s3_extract_503_retry_after_is_transient_with_hint() {
+        // A 503 SlowDown carrying `Retry-After: 12` => transient, hint = 12s.
+        let attempt = s3_service_error("SlowDown", 503, Some("12"));
+        assert!(attempt.transient, "503/SlowDown must be transient");
+        assert_eq!(
+            attempt.retry_after,
+            Some(Duration::from_secs(12)),
+            "the Retry-After delta-seconds header must be extracted"
+        );
+    }
+
+    #[test]
+    fn backoff_wire_s3_extract_429_without_header_is_transient_no_hint() {
+        // A 429 with no Retry-After header => still transient, but no hint.
+        let attempt = s3_service_error("Throttling", 429, None);
+        assert!(attempt.transient, "429 must be transient");
+        assert_eq!(
+            attempt.retry_after, None,
+            "absent Retry-After header => None (backoff handles the delay)"
+        );
+    }
+
+    #[test]
+    fn backoff_wire_s3_extract_404_is_not_transient() {
+        // A 404 NoSuchKey-style hard error => NOT transient (conservative).
+        let attempt = s3_service_error("NoSuchKey", 404, None);
+        assert!(
+            !attempt.transient,
+            "a 404/not-found must never be classified transient"
+        );
+        assert_eq!(attempt.retry_after, None);
+    }
 
     /// Strips a leading `./` and a trailing `/` from a manifest path. Kept as a
     /// test-only assertion of the path normalization the orchestrator

--- a/crates/snapdir-stores/src/transfer.rs
+++ b/crates/snapdir-stores/src/transfer.rs
@@ -23,6 +23,7 @@ use snapdir_core::store::StoreError;
 use tokio::sync::Mutex;
 
 use crate::adaptive::{AdaptiveGate, OpResult};
+use crate::retry::RetryPolicy;
 
 /// Upper bound on the auto-detected default concurrency.
 const DEFAULT_CONCURRENCY_CAP: usize = 16;
@@ -80,6 +81,13 @@ pub struct TransferConfig {
     /// Whether to tune concurrency / rate adaptively. [`AdaptivePolicy::Off`]
     /// (the default) keeps the historical fixed-concurrency path byte-for-byte.
     pub adaptive: AdaptivePolicy,
+    /// The transient-failure retry schedule wrapped around each network SDK
+    /// call (`key_exists` / `get_bytes` / `put_bytes`) via
+    /// [`retry_network`](crate::retry::retry_network). Defaults to
+    /// [`RetryPolicy::default`] (5 attempts, 250ms base, 30s cap); this is the
+    /// CONFIG SEAM the CLI sets later. The per-object integrity-mismatch retry
+    /// in `fetch_verified` is independent of this and unchanged.
+    pub retry: RetryPolicy,
 }
 
 impl TransferConfig {
@@ -95,6 +103,7 @@ impl TransferConfig {
             max_bytes_per_sec,
             max_requests_per_sec: None,
             adaptive: AdaptivePolicy::Off,
+            retry: RetryPolicy::default(),
         }
     }
 
@@ -103,6 +112,15 @@ impl TransferConfig {
     #[must_use]
     pub fn with_adaptive(mut self, policy: AdaptivePolicy) -> Self {
         self.adaptive = policy;
+        self
+    }
+
+    /// Returns this config with its network-retry schedule set to `policy`
+    /// (builder style). Defaults to [`RetryPolicy::default`]; the CLI uses this
+    /// to install an operator-configured policy.
+    #[must_use]
+    pub fn with_retry(mut self, policy: RetryPolicy) -> Self {
+        self.retry = policy;
         self
     }
 }
@@ -118,6 +136,7 @@ impl Default for TransferConfig {
             max_bytes_per_sec: None,
             max_requests_per_sec: None,
             adaptive: AdaptivePolicy::Off,
+            retry: RetryPolicy::default(),
         }
     }
 }

--- a/crates/snapdir-stores/src/transfer.rs
+++ b/crates/snapdir-stores/src/transfer.rs
@@ -70,6 +70,13 @@ pub struct TransferConfig {
     /// unlimited. In the adaptive path this is the rate *cap* (`max_rate`); the
     /// controller may target a lower live rate.
     pub max_bytes_per_sec: Option<u64>,
+    /// Optional aggregate request-rate cap, in requests per second. `None`
+    /// means unlimited. A later gate wires this into the live store call sites
+    /// (`key_exists` / `get_bytes` / `put_bytes`) by pacing each request through
+    /// a [`RateLimiter`] / [`BlockingRateLimiter`] whose "tokens" are requests
+    /// (`acquire(1)` per request). The per-backend defaults live in
+    /// [`crate::limits::for_scheme`].
+    pub max_requests_per_sec: Option<u64>,
     /// Whether to tune concurrency / rate adaptively. [`AdaptivePolicy::Off`]
     /// (the default) keeps the historical fixed-concurrency path byte-for-byte.
     pub adaptive: AdaptivePolicy,
@@ -86,6 +93,7 @@ impl TransferConfig {
         Self {
             concurrency: NonZeroUsize::new(concurrency.max(1)).unwrap_or(NonZeroUsize::MIN),
             max_bytes_per_sec,
+            max_requests_per_sec: None,
             adaptive: AdaptivePolicy::Off,
         }
     }
@@ -108,6 +116,7 @@ impl Default for TransferConfig {
             // `detected` is >= 1, so the NonZeroUsize is always Some.
             concurrency: NonZeroUsize::new(detected).unwrap_or(NonZeroUsize::MIN),
             max_bytes_per_sec: None,
+            max_requests_per_sec: None,
             adaptive: AdaptivePolicy::Off,
         }
     }
@@ -595,6 +604,7 @@ mod tests {
             cfg.concurrency.get()
         );
         assert_eq!(cfg.max_bytes_per_sec, None);
+        assert_eq!(cfg.max_requests_per_sec, None);
 
         // The clamping ctor never yields 0.
         assert_eq!(TransferConfig::new(0, None).concurrency.get(), 1);

--- a/crates/snapdir-stores/tests/adaptive_wire.rs
+++ b/crates/snapdir-stores/tests/adaptive_wire.rs
@@ -1,0 +1,424 @@
+//! Live-path coverage for the adaptive transfer wiring (`adaptive-wire-live`).
+//!
+//! The `AdaptiveController` is already wired into the transfer loops shipped in
+//! snapdir 1.3.0: `fetch.rs::run_adaptive_downloads` and
+//! `push.rs::run_adaptive_objects` select `run_adaptive(items, &gate, op)` when
+//! `AdaptivePolicy::On`, feeding a `ControllerDriver` per-op `OpSample`s built
+//! from `classify_error()`, while a background tick driver resizes the shared
+//! `AdaptiveGate`. `AdaptivePolicy::Off` (the default) stays on `run_concurrent`.
+//!
+//! These tests are TEST-ONLY and exercise the *same* public primitives the live
+//! path uses, asserting the observable behavior of that wiring:
+//!
+//! 1. AIMD multiplicative-decrease under sustained Throttle, then additive
+//!    recovery under sustained Success — driven exactly as the production
+//!    closures drive it (classify an injected transient `StoreError` ->
+//!    `OpResult::Throttle`, `record_op`, `tick`), asserting the real
+//!    `AdaptiveGate`'s live limit trajectory.
+//! 2. The default `TransferConfig` is `AdaptivePolicy::Off`, and the `Off` path
+//!    uses `run_concurrent` (peak in-flight = full fixed concurrency, no gate /
+//!    no resizing) — observably distinct from the gated adaptive path.
+//! 3. First-error-wins and completion-independent ordering still hold on the
+//!    `run_adaptive` (`AdaptivePolicy::On`) path.
+//!
+//! All inputs are injected (op outcomes + the driver's internal clock advances
+//! via ticks). No wall-clock-sensitive assertions, no network, no env needed.
+
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+use std::time::Duration;
+
+use snapdir_core::store::StoreError;
+use snapdir_stores::transfer::{AdaptivePolicy as TransferAdaptivePolicy, TransferConfig};
+use snapdir_stores::{
+    classify_error, run_adaptive, run_concurrent, AdaptiveGate, AdaptivePolicy, ControllerDriver,
+    OpResult, OpSample,
+};
+
+/// Current-thread tokio runtime with time enabled (mirrors the in-crate test
+/// harness style; keeps tokio's feature set minimal, no `#[tokio::test]`).
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .expect("build tokio runtime")
+}
+
+/// Drives `driver` exactly like the live `run_adaptive_*` per-op closure does
+/// for one operation whose store result is `outcome`: build the `OpSample` from
+/// `classify_error()` on failure (success => `OpResult::Ok` with the moved
+/// bytes), then `record_op`. This is byte-for-byte the production mapping in
+/// `fetch.rs::run_adaptive_downloads` / `push.rs::run_adaptive_objects`.
+fn record_like_live(driver: &ControllerDriver, bytes: u64, outcome: &Result<(), StoreError>) {
+    let (bytes, result) = match outcome {
+        Ok(()) => (bytes, OpResult::Ok),
+        Err(err) => (0, classify_error(err)),
+    };
+    driver.record_op(OpSample {
+        bytes,
+        latency: Duration::from_millis(40),
+        result,
+    });
+}
+
+/// A transient backend error whose message `classify_error` maps to
+/// `OpResult::Throttle` (503 / "slow down" / timeout class).
+fn transient_err(msg: &str) -> StoreError {
+    StoreError::Backend {
+        message: msg.to_owned(),
+        source: None,
+    }
+}
+
+/// Sanity: the messages we inject as "transient" really do classify as
+/// `Throttle` (so the AIMD test is exercising the congestion branch, not a
+/// silent `HardErr`). Confirms the live `classify_error` -> `Throttle` path.
+#[test]
+fn adaptive_wire_classify_injected_transient_is_throttle() {
+    for msg in [
+        "GET object failed: 503 Service Unavailable",
+        "S3 PUT failed: SlowDown, reduce your request rate",
+        "request timeout while downloading object",
+        "connection reset by peer",
+    ] {
+        assert_eq!(
+            classify_error(&transient_err(msg)),
+            OpResult::Throttle,
+            "live wiring relies on {msg:?} classifying as Throttle",
+        );
+    }
+    // A non-transient backend error stays a hard error (won't trigger backoff).
+    assert_eq!(
+        classify_error(&transient_err("permission denied")),
+        OpResult::HardErr,
+    );
+}
+
+/// (1) AIMD: sustained Throttle multiplicatively shrinks the *real* gate the
+/// adaptive transfer path resizes, and sustained Success then recovers it.
+///
+/// We drive the production `ControllerDriver` + `AdaptiveGate` pair the same way
+/// `run_adaptive_downloads`/`run_adaptive_objects` do — feeding `OpSample`s
+/// derived from `classify_error()` on injected transient `StoreError`s and
+/// advancing the controller via `tick()` (which resizes the gate live). The
+/// observable is the gate's `limit()` trajectory: grow -> shrink-on-throttle ->
+/// recover-on-success. Determinism comes from injected outcomes + the driver's
+/// own monotonic clock advanced one tick at a time (no wall-clock assertions).
+#[test]
+fn adaptive_wire_aimd_shrinks_on_throttle_then_recovers() {
+    // Generous ceiling + huge RAM so neither the ceiling nor the memory budget
+    // masks the AIMD behavior under test.
+    let gate = AdaptiveGate::new(2, 32);
+    let policy = AdaptivePolicy::new(0.8, 32, u64::MAX, None);
+    let driver = ControllerDriver::new(policy, gate.clone(), 4096, None, None);
+
+    // --- grow: a healthy stream of successful ops raises the live gate limit.
+    for _ in 0..10 {
+        for _ in 0..4 {
+            record_like_live(&driver, 2_000_000, &Ok(()));
+        }
+        driver.tick();
+    }
+    let grown = gate.limit();
+    assert!(
+        grown > 2,
+        "a healthy stream should grow the live gate above the seed of 2, got {grown}",
+    );
+
+    // --- shrink: a single sustained Throttle event halves the gate (AIMD
+    //     multiplicative-decrease) on the very next tick.
+    record_like_live(&driver, 0, &Err(transient_err("503 Service Unavailable")));
+    driver.tick();
+    let after_throttle = gate.limit();
+    assert!(
+        after_throttle < grown,
+        "sustained Throttle must multiplicatively shrink the live gate: {after_throttle} >= {grown}",
+    );
+    // Multiplicative decrease is ~0.5x; allow +1 rounding slack.
+    assert!(
+        after_throttle <= grown / 2 + 1,
+        "Throttle backoff should at least halve the gate: before {grown}, after {after_throttle}",
+    );
+
+    // --- recover: after the 15s post-congestion cooldown, sustained Success
+    //     additively grows the gate back above the backed-off floor. We advance
+    //     the driver's own clock by ticking past the cooldown window (each tick
+    //     injects `epoch.elapsed()`, so spacing ticks over real time crosses the
+    //     15s cooldown without any wall-clock assertion).
+    //
+    // To keep the test fast yet deterministic we cannot fast-forward the
+    // driver's real `Instant`, so instead we assert recovery via a *fresh*
+    // driver+gate seeded at the backed-off limit and fed an uninterrupted
+    // healthy stream: the live gate must climb. This isolates the
+    // additive-increase recovery arm of AIMD using the same production wiring.
+    let recover_gate = AdaptiveGate::new(after_throttle.max(1), 32);
+    let recover_policy = AdaptivePolicy::new(0.8, 32, u64::MAX, None);
+    let recover_driver =
+        ControllerDriver::new(recover_policy, recover_gate.clone(), 4096, None, None);
+    let recover_start = recover_gate.limit();
+    for _ in 0..12 {
+        for _ in 0..4 {
+            record_like_live(&recover_driver, 3_000_000, &Ok(()));
+        }
+        recover_driver.tick();
+    }
+    assert!(
+        recover_gate.limit() > recover_start,
+        "sustained Success must additively grow the live gate back up: {} <= {recover_start}",
+        recover_gate.limit(),
+    );
+}
+
+/// (1b) The same AIMD shrink, but proving the *whole* live closure runs: we
+/// invoke `run_adaptive` over a batch where every op returns an injected
+/// transient `StoreError`, feeding the driver from inside the op exactly as the
+/// production closure does. `run_adaptive` aborts on the first error
+/// (first-error-wins), and the recorded Throttle must have shrunk the gate.
+#[test]
+fn adaptive_wire_run_adaptive_closure_records_throttle_and_shrinks_gate() {
+    let rt = runtime();
+    let gate = AdaptiveGate::new(4, 16);
+    let policy = AdaptivePolicy::new(0.8, 16, u64::MAX, None);
+    let driver = ControllerDriver::new(policy, gate.clone(), 4096, None, None);
+
+    let before = gate.limit();
+    assert_eq!(before, 4, "gate seeds at the configured concurrency");
+
+    let result: Result<Vec<()>, StoreError> = rt.block_on({
+        let gate = gate.clone();
+        let driver = driver.clone();
+        async move {
+            run_adaptive(0..8, &gate, |item| {
+                let driver = &driver;
+                async move {
+                    // Every op throttles (transient 503). Mirror the live
+                    // closure: time it, classify on error, record, return.
+                    let outcome: Result<(), StoreError> =
+                        Err(transient_err("got HTTP 503 from backend"));
+                    record_like_live(driver, item, &outcome);
+                    outcome
+                }
+            })
+            .await
+        }
+    });
+
+    // First-error-wins: the injected transient error is surfaced.
+    let err = result.expect_err("an all-error batch must surface the first error");
+    assert!(
+        matches!(err, StoreError::Backend { ref message, .. } if message.contains("503")),
+        "unexpected error: {err:?}",
+    );
+
+    // The recorded Throttle(s), applied by a tick, shrink the live gate.
+    driver.tick();
+    assert!(
+        gate.limit() < before,
+        "throttled ops recorded through the live closure must shrink the gate: {} >= {before}",
+        gate.limit(),
+    );
+}
+
+/// (2) Off path: the default `TransferConfig` is `AdaptivePolicy::Off`, and the
+/// fixed-concurrency engine (`run_concurrent`) the `Off` arm selects runs at the
+/// full configured concurrency with no gate / no resizing — peak in-flight is
+/// exactly `min(concurrency, items)`, observably distinct from the gated
+/// adaptive path (which would cap at the live limit).
+#[test]
+fn adaptive_wire_off_path_uses_run_concurrent_no_gate() {
+    // Default config is Off (no behavior change / opt-in adaptive).
+    assert_eq!(
+        TransferConfig::default().adaptive,
+        TransferAdaptivePolicy::Off,
+        "the default transfer policy MUST stay Off (adaptive is opt-in)",
+    );
+    assert_eq!(
+        TransferConfig::new(8, None).adaptive,
+        TransferAdaptivePolicy::Off,
+    );
+
+    // The Off arm runs `run_concurrent(.., config.concurrency, ..)`: peak
+    // in-flight reaches the full fixed concurrency (no gate throttling it down).
+    let concurrency = NonZeroUsize::new(6).unwrap();
+    let items = 24usize;
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let high = Arc::new(AtomicUsize::new(0));
+
+    let rt = runtime();
+    let result: Result<Vec<()>, StoreError> = rt.block_on({
+        let in_flight = Arc::clone(&in_flight);
+        let high = Arc::clone(&high);
+        async move {
+            run_concurrent(0..items, concurrency, move |_item| {
+                let in_flight = Arc::clone(&in_flight);
+                let high = Arc::clone(&high);
+                async move {
+                    let cur = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    high.fetch_max(cur, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(20)).await;
+                    in_flight.fetch_sub(1, Ordering::SeqCst);
+                    Ok::<(), StoreError>(())
+                }
+            })
+            .await
+        }
+    });
+    assert!(result.is_ok());
+    assert_eq!(
+        high.load(Ordering::SeqCst),
+        concurrency.get(),
+        "the Off path (run_concurrent) runs at the full fixed concurrency, not a gated limit",
+    );
+}
+
+/// (3a) First-error-wins on the `AdaptivePolicy::On` path: an injected *hard*
+/// error (one that classifies as `HardErr`, not throttle) aborts `run_adaptive`
+/// and is the returned error, even with other ops succeeding concurrently.
+#[test]
+fn adaptive_wire_on_path_first_error_wins() {
+    let rt = runtime();
+    let gate = AdaptiveGate::new(3, 8);
+
+    let result: Result<Vec<()>, StoreError> = rt.block_on({
+        let gate = gate.clone();
+        async move {
+            run_adaptive(0..12, &gate, |item| async move {
+                if item == 5 {
+                    Err(transient_err("permission denied")) // HardErr, aborts
+                } else {
+                    tokio::time::sleep(Duration::from_millis(5)).await;
+                    Ok::<(), StoreError>(())
+                }
+            })
+            .await
+        }
+    });
+
+    let err = result.expect_err("the hard error must abort the adaptive batch");
+    assert!(
+        matches!(err, StoreError::Backend { ref message, .. } if message == "permission denied"),
+        "first-error-wins must surface the injected hard error, got {err:?}",
+    );
+    // It really was a hard error (not a throttle) — confirms we tested the
+    // abort path, not the backoff path.
+    assert_eq!(
+        classify_error(&transient_err("permission denied")),
+        OpResult::HardErr
+    );
+}
+
+/// (3b) Completion-independent collection on the `AdaptivePolicy::On` path:
+/// `run_adaptive` (like `run_concurrent`) is completion-*independent* in the
+/// sense that every item's result is collected exactly once regardless of the
+/// order ops finish — it does NOT block on slow earlier items to preserve input
+/// order (it uses `buffer_unordered`). We make later items finish first
+/// (descending sleep) so completions are scrambled relative to input order, and
+/// assert the collected set is complete (all 8 items, each once). This is the
+/// invariant the live transfer loops depend on: no dropped/duplicated objects
+/// however the network reorders completions.
+#[test]
+fn adaptive_wire_on_path_completion_independent_collection() {
+    let rt = runtime();
+    let gate = AdaptiveGate::new(8, 8); // window wide enough for full overlap
+
+    let mut collected: Vec<usize> = rt.block_on({
+        let gate = gate.clone();
+        async move {
+            run_adaptive(0..8usize, &gate, |item| async move {
+                // Earlier items sleep longer => they complete LAST, scrambling
+                // completion order relative to input order.
+                let delay = (8 - item as u64) * 5;
+                tokio::time::sleep(Duration::from_millis(delay)).await;
+                Ok::<usize, StoreError>(item)
+            })
+            .await
+            .expect("all ops succeed")
+        }
+    });
+
+    // Every item is collected exactly once, independent of completion order.
+    assert_eq!(
+        collected.len(),
+        8,
+        "all items must be collected exactly once"
+    );
+    collected.sort_unstable();
+    assert_eq!(
+        collected,
+        (0..8usize).collect::<Vec<_>>(),
+        "run_adaptive must collect every item's result regardless of completion order",
+    );
+}
+
+/// (3c) Gating invariant on the `On` path: with the live gate limit below the
+/// buffered window (ceiling), `run_adaptive` never runs more ops simultaneously
+/// than the gate's current limit — the property the live transfer loops rely on
+/// for the controller to actually bound concurrency. Mirrors
+/// `transfer.rs::run_adaptive_respects_gate_limit` from an external vantage.
+#[test]
+fn adaptive_wire_on_path_respects_gate_limit() {
+    let rt = runtime();
+    let gate = AdaptiveGate::new(2, 16); // window 16, live limit 2
+    let in_flight = Arc::new(AtomicUsize::new(0));
+    let high = Arc::new(AtomicUsize::new(0));
+
+    let result: Result<Vec<()>, StoreError> = rt.block_on({
+        let gate = gate.clone();
+        let in_flight = Arc::clone(&in_flight);
+        let high = Arc::clone(&high);
+        async move {
+            run_adaptive(0..24, &gate, move |_item| {
+                let in_flight = Arc::clone(&in_flight);
+                let high = Arc::clone(&high);
+                async move {
+                    let cur = in_flight.fetch_add(1, Ordering::SeqCst) + 1;
+                    high.fetch_max(cur, Ordering::SeqCst);
+                    tokio::time::sleep(Duration::from_millis(15)).await;
+                    in_flight.fetch_sub(1, Ordering::SeqCst);
+                    Ok::<(), StoreError>(())
+                }
+            })
+            .await
+        }
+    });
+    assert!(result.is_ok());
+    assert!(
+        high.load(Ordering::SeqCst) <= 2,
+        "the live gate limit (2) must bound effective concurrency despite the 16-wide window, got {}",
+        high.load(Ordering::SeqCst),
+    );
+}
+
+/// Defensive cross-check: a `ControllerDriver` whose injected ops are all
+/// *successful* never shrinks the gate below its seed via a spurious Throttle —
+/// i.e. our AIMD shrink in the throttle test is genuinely caused by the
+/// classified congestion signal, not by ticking alone. Uses the Mutex<usize>
+/// sink pattern to also confirm a rate applier is exercised on the live path.
+#[test]
+fn adaptive_wire_healthy_stream_does_not_spuriously_shrink() {
+    let gate = AdaptiveGate::new(4, 32);
+    let applied: Arc<Mutex<Option<Option<u64>>>> = Arc::new(Mutex::new(None));
+    let sink = Arc::clone(&applied);
+    let rate_applier: Arc<dyn Fn(Option<u64>) + Send + Sync> =
+        Arc::new(move |r| *sink.lock().unwrap() = Some(r));
+    let policy = AdaptivePolicy::new(0.8, 32, u64::MAX, None);
+    let driver = ControllerDriver::new(policy, gate.clone(), 4096, Some(rate_applier), None);
+
+    let seed = gate.limit();
+    for _ in 0..8 {
+        for _ in 0..4 {
+            record_like_live(&driver, 2_000_000, &Ok(()));
+        }
+        driver.tick();
+    }
+    assert!(
+        gate.limit() >= seed,
+        "a purely healthy stream must never shrink the live gate below its seed: {} < {seed}",
+        gate.limit(),
+    );
+    assert!(
+        applied.lock().unwrap().is_some(),
+        "the live rate applier must be invoked by the driver's tick",
+    );
+}

--- a/crates/snapdir-stores/tests/adaptive_wire.rs
+++ b/crates/snapdir-stores/tests/adaptive_wire.rs
@@ -21,8 +21,8 @@
 //! 3. First-error-wins and completion-independent ordering still hold on the
 //!    `run_adaptive` (`AdaptivePolicy::On`) path.
 //!
-//! All inputs are injected (op outcomes + the driver's internal clock advances
-//! via ticks). No wall-clock-sensitive assertions, no network, no env needed.
+//! All inputs are injected (op outcomes + an explicit monotonic clock supplied
+//! to `tick_at`). No wall-clock-sensitive assertions, no network, no env needed.
 
 use std::num::NonZeroUsize;
 use std::sync::atomic::{AtomicUsize, Ordering};
@@ -100,25 +100,47 @@ fn adaptive_wire_classify_injected_transient_is_throttle() {
 ///
 /// We drive the production `ControllerDriver` + `AdaptiveGate` pair the same way
 /// `run_adaptive_downloads`/`run_adaptive_objects` do — feeding `OpSample`s
-/// derived from `classify_error()` on injected transient `StoreError`s and
-/// advancing the controller via `tick()` (which resizes the gate live). The
-/// observable is the gate's `limit()` trajectory: grow -> shrink-on-throttle ->
-/// recover-on-success. Determinism comes from injected outcomes + the driver's
-/// own monotonic clock advanced one tick at a time (no wall-clock assertions).
+/// derived from `classify_error()` on injected transient `StoreError`s — but
+/// advance the controller via the fully-injectable `tick_with(now, cpu, rss)`
+/// seam instead of `tick()` (which samples the real `epoch.elapsed()` AND the
+/// live CPU/RSS samplers). Injecting ALL impure inputs makes the observable gate
+/// trajectory (grow -> shrink-on-throttle -> recover-on-success) fully
+/// DETERMINISTIC: the time-dependent arms (the 15s post-congestion cooldown and
+/// additive-increase recovery) are crossed by explicit `now` advances, and the
+/// CPU guardrails are pinned to a calm value — so the trajectory no longer
+/// depends on how fast this test loop runs OR how loaded the machine is under
+/// parallel test load (the two sources that made the live `tick()` flaky).
+///
+/// `tick_with` applies the very same `Decision` to the real gate that the live
+/// `tick()` does (`gate.set_limit(decision.limit)` + rate/meter); only the
+/// impure inputs differ (injected vs sampled), so this exercises the identical
+/// production wiring. CPU is pinned at a calm 20% (`< 85`) so neither the
+/// no-increase nor the hard-decrease guardrail bites; RSS is `Some(0)` (RAM is
+/// `u64::MAX`, so the memory budget is disabled).
 #[test]
 fn adaptive_wire_aimd_shrinks_on_throttle_then_recovers() {
+    // Calm injected CPU + zero RSS: pins the load-dependent guardrails off so the
+    // gate trajectory depends only on the injected ops + clock (deterministic).
+    const CALM_CPU: Option<f64> = Some(20.0);
+    const NO_RSS: Option<u64> = Some(0);
+
     // Generous ceiling + huge RAM so neither the ceiling nor the memory budget
     // masks the AIMD behavior under test.
     let gate = AdaptiveGate::new(2, 32);
     let policy = AdaptivePolicy::new(0.8, 32, u64::MAX, None);
     let driver = ControllerDriver::new(policy, gate.clone(), 4096, None, None);
 
+    // Injected monotonic clock: advance one second per tick, deterministically.
+    let mut now = Duration::ZERO;
+    let step = Duration::from_secs(1);
+
     // --- grow: a healthy stream of successful ops raises the live gate limit.
     for _ in 0..10 {
         for _ in 0..4 {
             record_like_live(&driver, 2_000_000, &Ok(()));
         }
-        driver.tick();
+        driver.tick_with(now, CALM_CPU, NO_RSS);
+        now += step;
     }
     let grown = gate.limit();
     assert!(
@@ -127,10 +149,12 @@ fn adaptive_wire_aimd_shrinks_on_throttle_then_recovers() {
     );
 
     // --- shrink: a single sustained Throttle event halves the gate (AIMD
-    //     multiplicative-decrease) on the very next tick.
+    //     multiplicative-decrease) on the very next tick, and arms the 15s
+    //     post-congestion cooldown deadline (now + 15s).
     record_like_live(&driver, 0, &Err(transient_err("503 Service Unavailable")));
-    driver.tick();
+    driver.tick_with(now, CALM_CPU, NO_RSS);
     let after_throttle = gate.limit();
+    now += step;
     assert!(
         after_throttle < grown,
         "sustained Throttle must multiplicatively shrink the live gate: {after_throttle} >= {grown}",
@@ -141,32 +165,41 @@ fn adaptive_wire_aimd_shrinks_on_throttle_then_recovers() {
         "Throttle backoff should at least halve the gate: before {grown}, after {after_throttle}",
     );
 
-    // --- recover: after the 15s post-congestion cooldown, sustained Success
-    //     additively grows the gate back above the backed-off floor. We advance
-    //     the driver's own clock by ticking past the cooldown window (each tick
-    //     injects `epoch.elapsed()`, so spacing ticks over real time crosses the
-    //     15s cooldown without any wall-clock assertion).
-    //
-    // To keep the test fast yet deterministic we cannot fast-forward the
-    // driver's real `Instant`, so instead we assert recovery via a *fresh*
-    // driver+gate seeded at the backed-off limit and fed an uninterrupted
-    // healthy stream: the live gate must climb. This isolates the
-    // additive-increase recovery arm of AIMD using the same production wiring.
-    let recover_gate = AdaptiveGate::new(after_throttle.max(1), 32);
-    let recover_policy = AdaptivePolicy::new(0.8, 32, u64::MAX, None);
-    let recover_driver =
-        ControllerDriver::new(recover_policy, recover_gate.clone(), 4096, None, None);
-    let recover_start = recover_gate.limit();
+    // --- cooldown: while inside the 15s post-congestion window, even a
+    //     sustained-healthy stream must NOT grow the gate (the controller's
+    //     no-increase guard). Tick a few healthy seconds still inside the
+    //     window and assert the gate never climbs above the backed-off floor.
+    for _ in 0..5 {
+        for _ in 0..4 {
+            record_like_live(&driver, 3_000_000, &Ok(()));
+        }
+        driver.tick_with(now, CALM_CPU, NO_RSS);
+        now += step;
+        assert!(
+            gate.limit() <= after_throttle,
+            "no increase during the 15s cooldown: {} > {after_throttle}",
+            gate.limit(),
+        );
+    }
+
+    // --- recover: jump the injected clock decisively PAST the 15s cooldown
+    //     deadline, then feed the same uninterrupted healthy stream. Now the
+    //     additive-increase arm is allowed to fire and the live gate must climb
+    //     back above the backed-off floor. This crossing is deterministic — it
+    //     depends only on the injected `now`/CPU, never on wall-clock elapsed
+    //     time or the machine's current load.
+    now += Duration::from_secs(20); // well past the 15s cooldown from the throttle
     for _ in 0..12 {
         for _ in 0..4 {
-            record_like_live(&recover_driver, 3_000_000, &Ok(()));
+            record_like_live(&driver, 3_000_000, &Ok(()));
         }
-        recover_driver.tick();
+        driver.tick_with(now, CALM_CPU, NO_RSS);
+        now += step;
     }
     assert!(
-        recover_gate.limit() > recover_start,
-        "sustained Success must additively grow the live gate back up: {} <= {recover_start}",
-        recover_gate.limit(),
+        gate.limit() > after_throttle,
+        "after the cooldown, sustained Success must additively grow the live gate back up: {} <= {after_throttle}",
+        gate.limit(),
     );
 }
 

--- a/crates/snapdir-stores/tests/backoff_wire.rs
+++ b/crates/snapdir-stores/tests/backoff_wire.rs
@@ -1,0 +1,302 @@
+//! `backoff_wire` integration tests: exercise the network-store retry wiring
+//! (`retry_network` + the per-call request-rate limiter + `parse_retry_after`)
+//! with NO live cloud.
+//!
+//! The injectable seam is [`snapdir_stores::retry_network`]: it acquires one
+//! token from a [`RateLimiter`] then drives a caller-supplied `op` through the
+//! full-jitter backoff engine. Each test passes an `op` closure that replays a
+//! scripted sequence of [`Attempt`]s and asserts the retry/limiter/backoff
+//! behavior using a recording sleeper + a deterministic jitter (the same fakes
+//! the engine's own unit tests use, re-implemented here against the public API).
+//!
+//! These run under both `cargo test` and `cargo test --features
+//! integration-mock` (the feature gates the heavier fake-SDK injection seam in
+//! the store modules; the public `retry_network` path is always available).
+
+use std::future::Future;
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Mutex;
+use std::time::Duration;
+
+use snapdir_core::StoreError;
+use snapdir_stores::{
+    parse_retry_after, retry_network, AsyncSleeper, Attempt, Jitter, RateLimiter, RetryPolicy,
+};
+
+// --- test fakes -------------------------------------------------------------
+
+/// A recording [`AsyncSleeper`]: never sleeps for real, just appends each
+/// requested delay so a test can assert the exact backoff sequence.
+#[derive(Default)]
+struct RecordingSleeper {
+    delays: Mutex<Vec<Duration>>,
+}
+
+impl RecordingSleeper {
+    fn recorded(&self) -> Vec<Duration> {
+        self.delays.lock().unwrap().clone()
+    }
+}
+
+impl AsyncSleeper for RecordingSleeper {
+    fn sleep(&self, dur: Duration) -> impl Future<Output = ()> + Send {
+        self.delays.lock().unwrap().push(dur);
+        std::future::ready(())
+    }
+}
+
+/// A deterministic [`Jitter`] returning a fixed `[0,1)` fraction.
+struct FixedJitter(f64);
+impl Jitter for FixedJitter {
+    fn jitter01(&self) -> f64 {
+        self.0
+    }
+}
+
+fn runtime() -> tokio::runtime::Runtime {
+    tokio::runtime::Builder::new_current_thread()
+        .enable_time()
+        .build()
+        .expect("build tokio runtime")
+}
+
+fn boom() -> StoreError {
+    StoreError::Backend {
+        message: "boom".into(),
+        source: None,
+    }
+}
+
+fn transient(retry_after: Option<Duration>) -> Attempt {
+    Attempt {
+        err: boom(),
+        transient: true,
+        retry_after,
+    }
+}
+
+fn hard() -> Attempt {
+    Attempt {
+        err: boom(),
+        transient: false,
+        retry_after: None,
+    }
+}
+
+fn small_policy() -> RetryPolicy {
+    RetryPolicy {
+        max_attempts: 5,
+        base: Duration::from_millis(100),
+        cap: Duration::from_secs(10),
+    }
+}
+
+// --- (1) k transient then success ------------------------------------------
+
+#[test]
+fn backoff_wire_success_after_k_transient_retries() {
+    let rt = runtime();
+    rt.block_on(async {
+        let policy = small_policy();
+        let limiter = RateLimiter::new(None); // unlimited request rate
+        let sleeper = RecordingSleeper::default();
+        let jitter = FixedJitter(0.5);
+        let calls = AtomicUsize::new(0);
+        let k = 3usize;
+
+        let result: Result<u32, StoreError> =
+            retry_network(&policy, &limiter, &sleeper, &jitter, || {
+                let prev = calls.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    if prev < k {
+                        Err(transient(None))
+                    } else {
+                        Ok(7)
+                    }
+                }
+            })
+            .await;
+
+        assert_eq!(result.unwrap(), 7, "succeeds on the (k+1)-th attempt");
+        assert_eq!(calls.load(Ordering::SeqCst), k + 1, "op invoked k+1 times");
+
+        // Exactly k sleeps, and the backoff is monotonic-ish (each within the
+        // capped envelope; with a fixed jitter the un-capped values grow).
+        let recorded = sleeper.recorded();
+        assert_eq!(recorded.len(), k, "one sleep before each of the k retries");
+        for d in &recorded {
+            assert!(*d <= policy.cap, "sleep {d:?} must respect the cap");
+        }
+        // base*2^n * 0.5 grows until the cap: 50ms, 100ms, 200ms (all < 10s cap).
+        assert!(recorded[1] >= recorded[0], "backoff should grow");
+        assert!(recorded[2] >= recorded[1], "backoff should grow");
+    });
+}
+
+// --- (2) hard error returns immediately, no sleeps -------------------------
+
+#[test]
+fn backoff_wire_hard_error_surfaces_without_retry() {
+    let rt = runtime();
+    rt.block_on(async {
+        let policy = small_policy();
+        let limiter = RateLimiter::new(None);
+        let sleeper = RecordingSleeper::default();
+        let jitter = FixedJitter(0.5);
+        let calls = AtomicUsize::new(0);
+
+        let result: Result<(), StoreError> =
+            retry_network(&policy, &limiter, &sleeper, &jitter, || {
+                calls.fetch_add(1, Ordering::SeqCst);
+                async { Err(hard()) }
+            })
+            .await;
+
+        let err = result.expect_err("hard error surfaces");
+        assert!(
+            matches!(err, StoreError::Backend { ref message, .. } if message == "boom"),
+            "the StoreError must surface: {err:?}"
+        );
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            1,
+            "non-transient => op called exactly once"
+        );
+        assert!(
+            sleeper.recorded().is_empty(),
+            "no sleeps for a non-transient error"
+        );
+    });
+}
+
+// --- (3) Retry-After hint dominates the jittered exponential ---------------
+
+#[test]
+fn backoff_wire_retry_after_hint_is_a_floor() {
+    let rt = runtime();
+    rt.block_on(async {
+        let policy = small_policy();
+        let limiter = RateLimiter::new(None);
+        let sleeper = RecordingSleeper::default();
+        // jitter01 = 0 => the jittered exponential collapses to 0, so a hint
+        // larger than the exp must dominate every recorded sleep.
+        let jitter = FixedJitter(0.0);
+        let hint = Duration::from_secs(5);
+
+        let _r: Result<(), StoreError> =
+            retry_network(&policy, &limiter, &sleeper, &jitter, || async move {
+                Err(transient(Some(hint)))
+            })
+            .await;
+
+        let recorded = sleeper.recorded();
+        assert!(!recorded.is_empty(), "at least one retry happened");
+        for d in &recorded {
+            assert!(
+                *d >= hint,
+                "recorded delay {d:?} must be >= the server hint {hint:?}"
+            );
+        }
+    });
+}
+
+// --- (4) persistent transient exhausts exactly max_attempts ----------------
+
+#[test]
+fn backoff_wire_persistent_transient_exhausts_budget() {
+    let rt = runtime();
+    rt.block_on(async {
+        let policy = small_policy();
+        let limiter = RateLimiter::new(None);
+        let sleeper = RecordingSleeper::default();
+        let jitter = FixedJitter(0.5);
+        let calls = AtomicUsize::new(0);
+
+        let result: Result<(), StoreError> =
+            retry_network(&policy, &limiter, &sleeper, &jitter, || {
+                calls.fetch_add(1, Ordering::SeqCst);
+                async { Err(transient(None)) }
+            })
+            .await;
+
+        assert!(result.is_err(), "persistent transient surfaces the err");
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            policy.max_attempts as usize,
+            "op invoked exactly max_attempts times"
+        );
+        assert_eq!(
+            sleeper.recorded().len(),
+            (policy.max_attempts - 1) as usize,
+            "max_attempts-1 sleeps (none after the final attempt)"
+        );
+    });
+}
+
+// --- (5) parse_retry_after extraction (delta-seconds) ----------------------
+
+#[test]
+fn backoff_wire_parse_retry_after_delta_seconds() {
+    assert_eq!(parse_retry_after("125"), Some(Duration::from_secs(125)));
+    assert_eq!(parse_retry_after("  7 "), Some(Duration::from_secs(7)));
+    assert_eq!(parse_retry_after("0"), Some(Duration::ZERO));
+    // The HTTP-date form is intentionally not parsed (returns None; backoff
+    // handles the absent-hint case).
+    assert_eq!(parse_retry_after("Wed, 21 Oct 2015 07:28:00 GMT"), None);
+    assert_eq!(parse_retry_after("not-a-number"), None);
+    assert_eq!(parse_retry_after(""), None);
+}
+
+// --- (6) the request-rate limiter is acquired per call ---------------------
+
+#[test]
+fn backoff_wire_request_limiter_paces_each_call() {
+    let rt = runtime();
+    rt.block_on(async {
+        // A tiny request rate: 2 req/s. The bucket starts full (2), so the
+        // first two attempts are free; with 4 total attempts (3 transient +
+        // success), the limiter must wait ~1s for the bucket to refill twice.
+        // The recording sleeper makes the *backoff* sleeps free, so the only
+        // real wall-clock wait comes from the request limiter — proving it is
+        // acquired per call.
+        let policy = RetryPolicy {
+            max_attempts: 5,
+            base: Duration::from_millis(1),
+            cap: Duration::from_millis(1),
+        };
+        let limiter = RateLimiter::new(Some(2)); // 2 requests/sec
+        let sleeper = RecordingSleeper::default();
+        let jitter = FixedJitter(0.0);
+        let calls = AtomicUsize::new(0);
+        let k = 3usize;
+
+        let start = tokio::time::Instant::now();
+        let result: Result<u32, StoreError> =
+            retry_network(&policy, &limiter, &sleeper, &jitter, || {
+                let prev = calls.fetch_add(1, Ordering::SeqCst);
+                async move {
+                    if prev < k {
+                        Err(transient(None))
+                    } else {
+                        Ok(1)
+                    }
+                }
+            })
+            .await;
+        let elapsed = start.elapsed();
+
+        assert_eq!(result.unwrap(), 1);
+        assert_eq!(
+            calls.load(Ordering::SeqCst),
+            k + 1,
+            "four total attempts (= four request-token acquisitions)"
+        );
+        // 4 acquisitions at 2 req/s with a 2-token initial burst: tokens 3 and 4
+        // each wait ~0.5s => ~1s total of real waiting attributable solely to
+        // the per-call request limiter.
+        assert!(
+            elapsed >= Duration::from_millis(900),
+            "the per-call request limiter must pace each attempt, took {elapsed:?}"
+        );
+    });
+}

--- a/deny.toml
+++ b/deny.toml
@@ -21,6 +21,13 @@ ignore = [
     # `iai-callgrind 0.16.1` (the bench instruction-count perf tooling), is never
     # shipped in any published crate or the CLI binary, and has no fix available.
     "RUSTSEC-2025-0141",
+    # proc-macro-error2 2.0.1 "unmaintained" — NOT a vulnerability (the author
+    # confirmed it's no longer maintained; "No safe upgrade is available"). Same
+    # situation/origin as the bincode entry above: it enters the tree ONLY as a
+    # transitive dev-dependency via `iai-callgrind-macros -> iai-callgrind 0.16.1`
+    # (the bench perf tooling), and is never shipped in any published crate or the
+    # CLI binary.
+    "RUSTSEC-2026-0173",
 ]
 
 [licenses]

--- a/docs/rust-port/CHANGELOG.md
+++ b/docs/rust-port/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] — 2026-06-09
+
 ### Added
 
 - **Transient-failure retries with full-jitter exponential backoff.** Network
@@ -30,6 +32,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   caps for `file://`/local (sources: AWS S3, GCS, Backblaze B2). Precedence,
   highest to lowest: `--flag` > `SNAPDIR_*` env > per-backend default > global
   default.
+
+### Fixed
+
+- **Input-path normalization.** `snapdir push`/`manifest`/`id`/`stage` now treat
+  `foo`, `./foo`, `foo/`, and `./foo/` identically — every form produces the same
+  manifest and snapshot id. Previously a trailing slash or a `./` prefix could
+  leak absolute paths or a malformed entry into the manifest.
+- **`--store` and `sync --from` default to `$SNAPDIR_STORE`.** When the flag is
+  omitted and the env var is set, snapdir uses it; an explicit flag still wins.
+  `sync --to` stays explicit (a sync needs two distinct stores).
+- **crates.io crate pages now render a README.** Each published crate
+  (`snapdir-core`/`-catalog`/`-stores`/`-cli`) ships its own README, so the
+  crates.io pages are no longer blank.
 
 These additions pull in **no new dependencies** and leave the manifest
 byte-format and content-addressed layout unchanged, so snapshots stay fully
@@ -265,7 +280,8 @@ Bash-written caches and remote buckets stay mutually readable.
   `gcloud`) in the shipped binary. External tools are used only by the test
   suite.
 
-[Unreleased]: https://github.com/snapdir/snapdir/compare/v1.3.0...HEAD
+[Unreleased]: https://github.com/snapdir/snapdir/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/snapdir/snapdir/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/snapdir/snapdir/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/snapdir/snapdir/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/snapdir/snapdir/compare/v1.0.1...v1.1.0

--- a/docs/rust-port/CHANGELOG.md
+++ b/docs/rust-port/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Transient-failure retries with full-jitter exponential backoff.** Network
+  store calls (`s3://`, `gs://`, `b2://`) now retry transient failures — HTTP
+  `429`/`503`, S3 `SlowDown`, GCS `RESOURCE_EXHAUSTED`, request timeouts, and
+  connection reset/closed — under full-jitter exponential backoff, while a
+  non-transient error (e.g. `404` not-found) fails immediately. A server
+  `Retry-After` header (or GCS backoff hint) is honored as a floor on the wait.
+  Each SDK's built-in retries are disabled so snapdir's policy is the single
+  authority. Defaults are **5 total attempts** (the first try plus up to four
+  retries), **250 ms** base, doubling, capped at **30 s**; configurable via
+  `--max-retries`/`SNAPDIR_MAX_RETRIES`, `--retry-base-ms`/`SNAPDIR_RETRY_BASE_MS`,
+  and `--retry-max-ms`/`SNAPDIR_RETRY_MAX_MS`. The local `file://` store does no
+  network retrying.
+- **Per-second request-rate limiting (`--max-requests`/`SNAPDIR_MAX_REQUESTS`).**
+  Complements the existing aggregate byte-throughput cap
+  (`--limit-rate`/`SNAPDIR_LIMIT_RATE`) with a requests-per-second cap for the
+  network stores. When unset, a conservative **per-backend default** applies,
+  taken as the lower of each provider's published read/write limits:
+  `s3://` 3500 req/s, `gs://` 1000 req/s, `b2://` 20 req/s + 25 MiB/s, and no
+  caps for `file://`/local (sources: AWS S3, GCS, Backblaze B2). Precedence,
+  highest to lowest: `--flag` > `SNAPDIR_*` env > per-backend default > global
+  default.
+
+These additions pull in **no new dependencies** and leave the manifest
+byte-format and content-addressed layout unchanged, so snapshots stay fully
+interoperable with 1.x.
+
 ## [1.3.0]
 
 ### Added


### PR DESCRIPTION
## snapdir 1.4.0

Ships three areas of work; **no new dependencies**, the manifest byte-format and content-addressed layout are unchanged (fully interoperable with 1.x).

### Added — rate limiting & exponential-backoff retries
- Transient network failures (HTTP `429`/`503`, S3 `SlowDown`, GCS `RESOURCE_EXHAUSTED`, timeouts, connection reset/closed) retry under **full-jitter exponential backoff**; a non-transient error (e.g. `404`) fails immediately. Server `Retry-After` is honored as a floor. Each SDK's built-in retries are disabled so snapdir's policy is authoritative. Defaults 5 attempts / 250 ms base / ×2 / 30 s cap; configurable via `--max-retries`/`--retry-base-ms`/`--retry-max-ms` (+ `SNAPDIR_*`).
- Per-second **request-rate limiting** (`--max-requests`/`SNAPDIR_MAX_REQUESTS`) alongside the existing `--limit-rate` byte cap, with conservative **per-backend defaults** (s3 3500, gcs 1000, b2 20 req/s + 25 MiB/s; precedence flag > env > backend > global).

### Fixed
- **Input-path normalization** — `push`/`manifest`/`id`/`stage` treat `foo`, `./foo`, `foo/`, `./foo/` identically (same snapshot id).
- `--store` and `sync --from` default to `$SNAPDIR_STORE`.
- crates.io crate pages now render a per-crate README.

Adaptive concurrency remains opt-in (`--adaptive`), default off. Verified: full workspace tests + fmt + clippy + cargo-deny green; bench-verify (determinism + iai + criterion) green.
