### PR TITLE
release: 1.5.0

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -139,11 +139,24 @@ jobs:
         with:
           key: ${{ matrix.rust }}
 
+      # The snapdir-ssh-store loopback suite (tests/loopback_sshd.rs) spawns a
+      # REAL sshd. macOS runners ship /usr/sbin/sshd; ubuntu images only have
+      # the ssh client, so install the server.
+      - name: Install openssh-server (loopback sshd suite)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends openssh-server
+
       - name: Build (workspace, locked)
         run: cargo build --workspace --all-features --locked
 
       - name: Test (workspace, locked)
         run: cargo test --workspace --all-features --locked
+        env:
+          # Forbid the loopback sshd suite's environmental eprintln-skip so the
+          # T2 gate can't rot into all-skips on CI (sshd is guaranteed above).
+          SNAPDIR_SSH_TEST_REQUIRE: "1"
 
       # Compile-only gate so the criterion + iai-callgrind benches can't
       # bit-rot. The real valgrind instruction-count run lives in the
@@ -276,11 +289,22 @@ jobs:
         with:
           tool: cargo-llvm-cov
 
+      # cargo llvm-cov RUNS the workspace tests, including the snapdir-ssh-store
+      # loopback sshd suite — install the server so it exercises (and covers)
+      # the real-sshd paths instead of eprintln-skipping.
+      - name: Install openssh-server (loopback sshd suite)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends openssh-server
+
       - name: Generate coverage (lcov + fail-under)
         run: |
           cargo llvm-cov --workspace --all-features --locked \
             --fail-under-lines 75 \
             --lcov --output-path lcov.info
+        env:
+          # Same no-skip guarantee as the test matrix (sshd installed above).
+          SNAPDIR_SSH_TEST_REQUIRE: "1"
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,10 @@
 name: Release
 
 # Rust-port release pipeline. Triggered by semver tags (v*). Builds the
-# `snapdir` binary for every distribution target (incl. static musl), generates
-# shell completions + a man page, packs per-target archives with checksums,
-# attaches them to the GitHub release, and publishes the library crates to
-# crates.io.
+# `snapdir` binary plus the `snapdir-ssh-store`/`snapdir-sftp-store` helper
+# bins for every distribution target (incl. static musl), generates shell
+# completions + a man page, packs per-target archives with checksums, attaches
+# them to the GitHub release, and publishes the library crates to crates.io.
 #
 # Packaging config of record: packaging/dist-workspace.toml (cargo-dist). This
 # workflow is the hand-rolled matrix that implements the same plan with full
@@ -39,6 +39,11 @@ env:
   CARGO_TERM_COLOR: always
   BIN_NAME: snapdir
   CLI_CRATE: snapdir-cli
+  # External-store helper bins shipped ALONGSIDE `snapdir` in every archive.
+  # Built from crates/snapdir-ssh-store (std + snapdir-core only, so the
+  # musl-static legs stay trivially clean).
+  SSH_STORE_CRATE: snapdir-ssh-store
+  SSH_STORE_BINS: "snapdir-ssh-store snapdir-sftp-store"
   CARGO_PROFILE: dist
 
 jobs:
@@ -150,7 +155,7 @@ jobs:
         if: matrix.cross
         run: |
           cross build --locked --profile "${CARGO_PROFILE}" \
-            -p "${CLI_CRATE}" --bin "${BIN_NAME}" \
+            -p "${CLI_CRATE}" -p "${SSH_STORE_CRATE}" --bins \
             --target "${{ matrix.target }}"
 
       - name: Build (native)
@@ -158,7 +163,7 @@ jobs:
         shell: bash
         run: |
           cargo build --locked --profile "${CARGO_PROFILE}" \
-            -p "${CLI_CRATE}" --bin "${BIN_NAME}" \
+            -p "${CLI_CRATE}" -p "${SSH_STORE_CRATE}" --bins \
             --target "${{ matrix.target }}"
 
       - name: Stage archive contents
@@ -176,6 +181,10 @@ jobs:
           mkdir -p "dist/${name}"
 
           cp "target/${{ matrix.target }}/${CARGO_PROFILE}/${BIN_NAME}" "dist/${name}/"
+          # External-store helper bins ride in the same per-target archive.
+          for bin in ${SSH_STORE_BINS}; do
+            cp "target/${{ matrix.target }}/${CARGO_PROFILE}/${bin}" "dist/${name}/"
+          done
 
           cp README.md LICENSE "dist/${name}/"
           cp docs/rust-port/CHANGELOG.md "dist/${name}/CHANGELOG.md"
@@ -256,14 +265,29 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   # ---------------------------------------------------------------------------
-  # 4. Publish library crates to crates.io (core -> catalog/stores -> cli).
+  # 4. Publish library crates to crates.io
+  #    (core -> catalog/stores -> ssh-store -> cli).
   #    Order respects the internal dependency graph. The CLI binary is shipped
   #    via the archives above; publishing it is optional and kept last.
   # ---------------------------------------------------------------------------
   # Trusted Publishing — register the publisher on crates.io for each crate
-  # (snapdir-core/-catalog/-stores/-cli): crate Settings -> Trusted Publishing ->
-  # GitHub -> repo `snapdir/snapdir`, workflow `release.yml`. No stored token
-  # needed once registered.
+  # (snapdir-core/-catalog/-stores/-ssh-store/-cli): crate Settings ->
+  # Trusted Publishing -> GitHub -> repo `snapdir/snapdir`, workflow
+  # `release.yml`. No stored token needed once registered.
+  #
+  # *** RELEASE-TIME OPERATOR TODO (first release shipping snapdir-ssh-store) ***
+  # `snapdir-ssh-store` is a NEW crate name: Trusted Publishing can only be
+  # registered on crates.io AFTER the crate exists, and this job authenticates
+  # EXCLUSIVELY via the TP OIDC exchange below (crates-io-auth-action — there is
+  # no stored-token fallback). The first `cargo publish` of a brand-new crate
+  # name with a TP token works because the publisher (this repo + workflow) is
+  # asserted by the OIDC exchange; if crates.io rejects it, publish the first
+  # version manually with a scoped API token (`cargo publish -p snapdir-ssh-store
+  # --locked --no-verify`), then re-run this workflow — the idempotent skip-guard
+  # below makes the re-run safe. Either way, IMMEDIATELY after the first publish
+  # register Trusted Publishing for `snapdir-ssh-store` (crate Settings ->
+  # Trusted Publishing -> GitHub -> repo `snapdir/snapdir`, workflow
+  # `release.yml`) so subsequent releases need no operator step.
   crates-io:
     name: Publish crates.io
     needs: release
@@ -297,12 +321,18 @@ jobs:
           # so a partial release (e.g. one crate up, others 403'd) re-runs safely
           # instead of dying on the already-published crate under `pipefail`.
           #
-          # NOTE: Trusted Publishing must be registered on crates.io for
-          # snapdir-catalog/-stores/-cli too — currently only snapdir-core is
-          # registered, so the other three 403 on their first publish. Register
-          # them (crate Settings -> Trusted Publishing) to fix that; until then
-          # the skip-guard keeps a re-run from dying on the already-published ones.
-          for crate in snapdir-core snapdir-catalog snapdir-stores snapdir-cli; do
+          # NOTE: Trusted Publishing is registered on crates.io for the four
+          # original crates (snapdir-core/-catalog/-stores/-cli, done for 1.2.0).
+          # *** snapdir-ssh-store is NEW — see the RELEASE-TIME OPERATOR TODO in
+          # the job header above: its first publish needs the operator to mind
+          # the TP bootstrap; the skip-guard keeps a partial-release re-run from
+          # dying on the already-published crates. ***
+          #
+          # Ordering: snapdir-ssh-store's only runtime dep is snapdir-core, but
+          # its dev-dep on snapdir-stores is recorded (with this version) in the
+          # index metadata, so it publishes AFTER snapdir-stores and before the
+          # leaf consumer snapdir-cli.
+          for crate in snapdir-core snapdir-catalog snapdir-stores snapdir-ssh-store snapdir-cli; do
             echo "::group::publish ${crate}"
             # Sparse-index shard for a crate name >= 4 chars: <c1c2>/<c3c4>/<name>.
             # All four snapdir crate names are >= 4 chars, so this is uniform.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3501,6 +3501,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "snapdir-ssh-store"
+version = "1.4.0"
+dependencies = [
+ "snapdir-core",
+]
+
+[[package]]
 name = "snapdir-stores"
 version = "1.4.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3505,6 +3505,7 @@ name = "snapdir-ssh-store"
 version = "1.4.0"
 dependencies = [
  "snapdir-core",
+ "snapdir-stores",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3450,7 +3450,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-benches"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "criterion",
  "iai-callgrind",
@@ -3461,7 +3461,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-catalog"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "redb",
  "serde",
@@ -3471,7 +3471,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-cli"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3489,7 +3489,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-core"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "blake3",
  "libc",
@@ -3502,7 +3502,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-ssh-store"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "snapdir-core",
  "snapdir-stores",
@@ -3510,7 +3510,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-stores"
-version = "1.4.0"
+version = "1.5.0"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3508,6 +3508,7 @@ dependencies = [
  "aws-sdk-s3",
  "aws-smithy-http-client",
  "aws-smithy-runtime-api",
+ "blake3",
  "bytes",
  "futures",
  "google-cloud-gax",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.4.0"
+version = "1.5.0"
 edition = "2021"
 rust-version = "1.91.1"
 authors = ["Bermi Ferrer <bermi@bermilabs.com>"]
@@ -23,9 +23,9 @@ categories = ["command-line-utilities", "filesystem"]
 
 [workspace.dependencies]
 # Internal crates
-snapdir-core = { path = "crates/snapdir-core", version = "1.4.0" }
-snapdir-catalog = { path = "crates/snapdir-catalog", version = "1.4.0" }
-snapdir-stores = { path = "crates/snapdir-stores", version = "1.4.0" }
+snapdir-core = { path = "crates/snapdir-core", version = "1.5.0" }
+snapdir-catalog = { path = "crates/snapdir-catalog", version = "1.5.0" }
+snapdir-stores = { path = "crates/snapdir-stores", version = "1.5.0" }
 
 # Errors: thiserror in libs, anyhow (+ context) in the bin.
 thiserror = "2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/snapdir-catalog",
     "crates/snapdir-stores",
     "crates/snapdir-cli",
+    "crates/snapdir-ssh-store",
     "benches",
 ]
 

--- a/README.md
+++ b/README.md
@@ -105,8 +105,33 @@ Pick a backend by `--store` URI scheme:
 | `s3://`   | Amazon S3        | AWS credential chain (env / profiles / SSO / metadata)   |
 | `b2://`   | Backblaze B2     | B2 application key as `AWS_*` over the S3-compatible API  |
 | `gs://`   | Google Cloud Storage | ADC / `GOOGLE_APPLICATION_CREDENTIALS` / metadata     |
+| `ssh://`  | Any host with SSH shell access | SSH keys / agent via the system OpenSSH client |
+| `sftp://` | Any SFTP server (incl. restricted/chroot accounts) | SSH keys / agent via the system OpenSSH client |
 
-Cloud backends use native SDKs and standard credential chains — no bespoke env vars, no CLI shell-outs. Any other scheme dispatches to a `snapdir-<scheme>-store` binary on `PATH`.
+Cloud backends use native SDKs and standard credential chains — no bespoke env vars, no CLI shell-outs. Any other scheme dispatches to a `snapdir-<scheme>-store` binary on `PATH`; the `ssh://` and `sftp://` stores ship as two such binaries (`cargo install snapdir-ssh-store` provides both).
+
+### SSH & SFTP stores
+
+Store URLs take the form `ssh://[user@]host[:port]/abs/base/path` (likewise `sftp://`). Use `ssh://` when the remote gives you a shell — and it auto-accelerates when snapdir is installed remotely; use `sftp://` for restricted/chroot accounts (it speaks pure SFTP, so it works even under `ForceCommand internal-sftp` with no remote shell at all). Both require the `snapdir-ssh-store`/`snapdir-sftp-store` binaries on `PATH` and drive your system `ssh`/`sftp` client, so your `~/.ssh/config`, keys, agent, and `ProxyJump` setups keep working. Embedded passwords (`user:password@`) are rejected — authenticate with a key or an agent.
+
+Each scheme reads its own env family — `SNAPDIR_SSH_STORE_*` for `ssh://`, `SNAPDIR_SFTP_STORE_*` for `sftp://`:
+
+| Variable (suffix) | Default | Meaning |
+| --- | --- | --- |
+| `IDENTITY_FILE` | — | Private key path; also sets `IdentitiesOnly=yes` |
+| `KNOWN_HOSTS` | — | `UserKnownHostsFile` override |
+| `PORT` | — | Remote port (a port in the URL wins) |
+| `CONNECT_TIMEOUT` | `10` | `ConnectTimeout` seconds |
+| `JOBS` | `4` | Transfer parallelism (falls back to `SNAPDIR_JOBS`, then `SNAPDIR_MAX_JOBS`) |
+| `CONTROL_PERSIST` | `60` | `ControlMaster` linger seconds (one TCP+auth handshake per operation) |
+| `UMASK` | `077` | Umask for remote writes (`ssh://` only; `sftp://` uses explicit `chmod 600`) |
+| `EXTRA_OPTS` | — | Extra `Key=Value` ssh options, appended **last** |
+
+Both engines enforce an **un-weakenable, modern-only security floor** on every `ssh`/`sftp` invocation: modern-only key exchange (post-quantum hybrid `sntrup761x25519` first, then X25519), AEAD-only ciphers (ChaCha20-Poly1305, AES-GCM), Ed25519/RSA-SHA-2/ECDSA host keys (SHA-1 `ssh-rsa` and DSS excluded), `StrictHostKeyChecking=yes` always, `BatchMode=yes` (never an interactive prompt), and no password or keyboard-interactive auth. OpenSSH **≥ 8.5** is required locally (checked via `ssh -V`, fail-closed). Because OpenSSH takes the first value obtained for each option and the floor is always emitted first, `EXTRA_OPTS` structurally **cannot weaken the floor** — e.g. `EXTRA_OPTS="StrictHostKeyChecking=no"` is inert; extras can only add options the floor doesn't set.
+
+When the remote host has a wire-compatible `snapdir` on its `PATH`, `ssh://` transfers automatically switch to a pack-stream protocol that diffs objects remotely and streams only what's missing in O(1) round trips (falling back gracefully otherwise). Runtime toggles: `SNAPDIR_SSH_NO_ACCEL=1` forces the plain path, `SNAPDIR_SSH_FORCE_ACCEL=1` errors instead of falling back, and `SNAPDIR_SSH_PULL_SENDALL=1` makes an accelerated fetch request the full object list. Protocol details: [docs/rust-port/ssh-wire-protocol.md](docs/rust-port/ssh-wire-protocol.md).
+
+Limitation: `snapdir sync` does not support `ssh://`/`sftp://` stores (they have no in-process streaming surface) — `push`, `fetch`, `pull`, and `checkout` all work.
 
 ## Rate limiting & retries
 

--- a/crates/snapdir-cli/src/cli.rs
+++ b/crates/snapdir-cli/src/cli.rs
@@ -14,7 +14,7 @@
 //! prints the effective default settings + environment, mirroring the oracle's
 //! `snapdir_defaults`. All 14 subcommands are now wired — none remain stubs.
 
-use std::io::IsTerminal;
+use std::io::{BufRead, IsTerminal, Read, Write};
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
@@ -29,11 +29,12 @@ use snapdir_catalog::{
 use snapdir_core::{
     cache, expand_excludes, snapshot_id, walk_with_meter, Blake3Hasher, Blake3KeyedHasher,
     ExcludeMatcher, ExpandedExclude, FollowMode, Hasher, Manifest, ManifestEntry, Md5Hasher, Meter,
-    PathMode, PathType, Phase, Sha256Hasher, Store, WalkOptions,
+    PathMode, PathType, Phase, Sha256Hasher, Store, StoreError, WalkOptions,
 };
 use snapdir_stores::{
-    limits, resolve_adapter, Adapter, B2Store, ExternalStore, FileStore, GcsStore, RetryPolicy,
-    S3Store, StreamStore, TransferAdaptivePolicy, TransferConfig,
+    is_hex64, limits, read_pack, resolve_adapter, write_pack, Adapter, B2Store, ExternalStore,
+    FileSink, FileStore, GcsStore, PackReadReport, PackSink, RetryPolicy, S3Store, StreamSink,
+    StreamStore, TransferAdaptivePolicy, TransferConfig, WIRE_CAPS, WIRE_VERSION,
 };
 
 /// Upper bound for the adaptive concurrency ceiling (`--max-jobs` / `--jobs`
@@ -312,7 +313,20 @@ pub enum Command {
     },
 
     /// Print the version.
-    Version,
+    Version {
+        /// Also print the wire protocol version + plumbing capabilities.
+        ///
+        /// HIDDEN: the ssh:// acceleration probe runs `snapdir version
+        /// --capabilities` on the REMOTE snapdir and keys the accelerate/dumb
+        /// decision on the `wire=<N>` integer (exact match against
+        /// [`WIRE_VERSION`], never semver). Older remote snapdirs clap-error on
+        /// this unknown flag, which the probe treats as "no acceleration" —
+        /// clean degradation with no code on that path. Plain `snapdir
+        /// version` output stays byte-identical, and the hidden flag keeps the
+        /// trycmd `--help` snapshots byte-stable (CLI-compat freeze).
+        #[arg(long, hide = true)]
+        capabilities: bool,
+    },
 
     /// Generate a shell-completion script to stdout.
     ///
@@ -331,6 +345,51 @@ pub enum Command {
     /// pipeline calls as `snapdir man` to bundle the man page into each archive.
     #[command(hide = true)]
     Man,
+
+    /// Print the subset of the checksums offered on stdin that the store does
+    /// NOT hold, one per line, in first-occurrence order.
+    ///
+    /// Hidden wire plumbing (SNAPPACK acceleration, see
+    /// [`snapdir_stores::pack`]): the diff round trip of the upcoming `ssh://`
+    /// store — the local end offers a snapshot's full object list and the
+    /// remote `snapdir objects-needed --store file://<base>` answers with
+    /// exactly the absent objects, so only those ride the pack stream.
+    /// Fail-closed: ANY malformed stdin line errors before the first store
+    /// query and prints NOTHING.
+    #[command(hide = true)]
+    ObjectsNeeded,
+
+    /// Emit a SNAPPACK stream of the listed objects (+ optional manifest,
+    /// last) from the store to raw stdout.
+    ///
+    /// Hidden wire plumbing: the sending half of
+    /// `snapdir send-pack | ssh host 'snapdir receive-pack'`. Any failure —
+    /// including a missing object — aborts BEFORE the `end` trailer
+    /// ([`write_pack`]), so a consumer of the partial stream fails too.
+    #[command(hide = true)]
+    SendPack {
+        /// File listing one object checksum per line (`-` reads stdin).
+        #[arg(long, value_name = "FILE|-")]
+        ids: PathBuf,
+
+        /// Snapshot id whose manifest rides the pack as the LAST record.
+        #[arg(long, value_name = "ID")]
+        manifest_id: Option<String>,
+    },
+
+    /// Consume a SNAPPACK stream from stdin into the store.
+    ///
+    /// Hidden wire plumbing: the receiving half of the acceleration pipe.
+    /// Every payload is incrementally BLAKE3-verified against its claimed
+    /// checksum and the manifest commits only after the verified `end`
+    /// trailer ([`read_pack`]) — truncation files verified objects but never
+    /// publishes the snapshot. Summary on stderr; stdout stays silent.
+    #[command(hide = true)]
+    ReceivePack {
+        /// Fail unless the stream committed exactly this manifest id.
+        #[arg(long, value_name = "ID")]
+        require_manifest: Option<String>,
+    },
 }
 
 impl Cli {
@@ -415,8 +474,21 @@ impl Cli {
             Command::Locations => self.run_locations(),
             Command::Ancestors => self.run_ancestors(),
             Command::Revisions => self.run_revisions(),
-            Command::Version => {
-                println!("snapdir {}", env!("CARGO_PKG_VERSION"));
+            Command::Version { capabilities } => {
+                if *capabilities {
+                    // The acceleration probe's capability line: space-separated
+                    // `key=value` fields, consumers ignore unknown fields and
+                    // negotiate on the exact `wire` integer only (baked from
+                    // pack::WIRE_VERSION — NEVER from semver).
+                    println!(
+                        "snapdir {} wire={WIRE_VERSION} caps={}",
+                        env!("CARGO_PKG_VERSION"),
+                        WIRE_CAPS.join(",")
+                    );
+                } else {
+                    // CLI-compat frozen: plain `version` stays byte-identical.
+                    println!("snapdir {}", env!("CARGO_PKG_VERSION"));
+                }
                 Ok(())
             }
             Command::Defaults => run_defaults(),
@@ -435,6 +507,13 @@ impl Cli {
                     .render(&mut std::io::stdout())
                     .context("rendering the man page")?;
                 Ok(())
+            }
+            Command::ObjectsNeeded => self.run_objects_needed(),
+            Command::SendPack { ids, manifest_id } => {
+                self.run_send_pack(ids, manifest_id.as_deref())
+            }
+            Command::ReceivePack { require_manifest } => {
+                self.run_receive_pack(require_manifest.as_deref())
             }
         }
     }
@@ -1439,6 +1518,165 @@ impl Cli {
         Ok(())
     }
 
+    /// `snapdir objects-needed --store <url>` (hidden plumbing): read candidate
+    /// checksums from stdin (one per line) and print the subset the store does
+    /// NOT hold, one per line, preserving first-occurrence order.
+    ///
+    /// Fail-closed: every line is validated against `^[0-9a-f]{64}$` BEFORE the
+    /// store is even resolved — a malformed request errors with NOTHING on
+    /// stdout (it must never be partially answered). Empty input is valid and
+    /// prints nothing. Dedup happens here because the lib's
+    /// [`StreamStore::objects_needed`] documents dedup as the caller's job.
+    fn run_objects_needed(&self) -> Result<()> {
+        // Read to EOF + validate everything FIRST (fail closed, no output yet).
+        let ids = read_checksum_lines(std::io::stdin().lock())
+            .context("reading object checksums from stdin")?;
+        let ids = dedupe_preserving_order(ids);
+        let store = self.resolve_stream_store()?;
+        let needed = store
+            .objects_needed(&ids)
+            .context("querying the store for absent objects")?;
+        // Only now does anything reach stdout: the exact absent subset, in
+        // first-occurrence input order (the contract the accel diff relies on).
+        let stdout = std::io::stdout();
+        let mut out = stdout.lock();
+        for id in needed {
+            writeln!(out, "{id}")?;
+        }
+        Ok(())
+    }
+
+    /// `snapdir send-pack --store <url> --ids <FILE|-> [--manifest-id <id>]`
+    /// (hidden plumbing): emit a SNAPPACK stream of the listed objects (and the
+    /// optional manifest, last) to RAW stdout — progress/log lines go to stderr
+    /// only, the byte stream is the entire stdout contract.
+    ///
+    /// The id list gets the same fail-closed validation as `objects-needed`
+    /// (and is deduped — [`write_pack`] documents dedup as the caller's job).
+    /// Any failure, including a missing object, makes [`write_pack`] abort
+    /// BEFORE the `end` trailer, so the piped `receive-pack` fails too: no
+    /// silent partial transfer.
+    fn run_send_pack(&self, ids: &Path, manifest_id: Option<&str>) -> Result<()> {
+        // Read + validate the id list (file path or `-` = stdin) before any
+        // store work; a malformed list emits not a single pack byte.
+        let ids = if ids == Path::new("-") {
+            read_checksum_lines(std::io::stdin().lock())
+                .context("reading object checksums from stdin")?
+        } else {
+            let file = std::fs::File::open(ids)
+                .with_context(|| format!("opening --ids file {}", ids.display()))?;
+            read_checksum_lines(std::io::BufReader::new(file))
+                .with_context(|| format!("reading object checksums from {}", ids.display()))?
+        };
+        let ids = dedupe_preserving_order(ids);
+        if let Some(id) = manifest_id {
+            anyhow::ensure!(
+                is_hex64(id),
+                "invalid --manifest-id {id:?}: expected 64 lowercase hex characters"
+            );
+        }
+        let store = self.resolve_stream_store()?;
+        let stdout = std::io::stdout();
+        let report = write_pack(&*store, &ids, manifest_id, stdout.lock())
+            .context("writing pack stream to stdout")?;
+        if !self.globals.quiet {
+            eprintln!(
+                "sent pack: {} object(s){}",
+                report.objects_written,
+                if report.manifest_written {
+                    " + manifest"
+                } else {
+                    ""
+                }
+            );
+        }
+        Ok(())
+    }
+
+    /// `snapdir receive-pack --store <url> [--require-manifest <id>]` (hidden
+    /// plumbing): consume a SNAPPACK stream from stdin into the store.
+    ///
+    /// `file://` stores (the hot ssh path) stream each payload through
+    /// [`FileSink`]'s O(1)-memory temp-sibling discipline; every other
+    /// [`StreamStore`] goes through the generic buffered [`StreamSink`]. All
+    /// verification (incremental BLAKE3, manifest-commits-only-after-`end`)
+    /// lives in [`read_pack`] — the CLI adds nothing to the wire logic.
+    ///
+    /// `--require-manifest <id>` fails the command (after the read) unless the
+    /// stream committed a manifest with EXACTLY that id; without the flag an
+    /// objects-only stream is success. Summary goes to stderr; stdout stays
+    /// silent.
+    fn run_receive_pack(&self, require_manifest: Option<&str>) -> Result<()> {
+        // Validate the required id up front (fail closed, before any read).
+        if let Some(id) = require_manifest {
+            anyhow::ensure!(
+                is_hex64(id),
+                "invalid --require-manifest {id:?}: expected 64 lowercase hex characters"
+            );
+        }
+        let store_url = self
+            .globals
+            .store
+            .as_deref()
+            .context("missing --store option")?;
+        let adapter = resolve_adapter(store_url).context("resolving --store protocol")?;
+        let config = self.transfer_config_for(Some(adapter.name()))?;
+        let stdin = std::io::stdin();
+
+        let (report, committed) = if matches!(adapter, Adapter::File) {
+            // file:// — the hot ssh path: stream payloads straight to disk.
+            let store = FileStore::new_with_config(store_url, config);
+            let mut sink = FileSink::new(&store);
+            read_pack_recording(stdin.lock(), &mut sink)?
+        } else {
+            // Any other StreamStore: one buffered record at a time. External
+            // `snapdir-*-store` URLs are rejected by the resolver below.
+            let store = stream_store_for_adapter(&adapter, store_url, config, None)?;
+            let mut sink = StreamSink::new(&*store);
+            read_pack_recording(stdin.lock(), &mut sink)?
+        };
+
+        if let Some(required) = require_manifest {
+            match committed.as_deref() {
+                Some(id) if id == required => {}
+                Some(other) => anyhow::bail!(
+                    "pack committed manifest {other}, but --require-manifest expected {required}"
+                ),
+                None => anyhow::bail!(
+                    "pack stream carried no manifest record, but --require-manifest {required} \
+                     was given"
+                ),
+            }
+        }
+        if !self.globals.quiet {
+            eprintln!(
+                "received pack: {} object(s) written, {} skipped{}",
+                report.objects_written,
+                report.objects_skipped,
+                match &committed {
+                    Some(id) => format!(", manifest {id}"),
+                    None => String::new(),
+                }
+            );
+        }
+        Ok(())
+    }
+
+    /// Resolves the global `--store` to a concrete [`StreamStore`] for the
+    /// plumbing subcommands, via the same [`stream_store_for_adapter`] router
+    /// `sync` uses (external `snapdir-*-store` URLs are rejected there — they
+    /// have no in-process streaming surface).
+    fn resolve_stream_store(&self) -> Result<Box<dyn StreamStore + Sync>> {
+        let store_url = self
+            .globals
+            .store
+            .as_deref()
+            .context("missing --store option")?;
+        let adapter = resolve_adapter(store_url).context("resolving --store protocol")?;
+        let config = self.transfer_config_for(Some(adapter.name()))?;
+        stream_store_for_adapter(&adapter, store_url, config, None)
+    }
+
     /// The local cache as a `file://`-shaped store, rooted at the resolved cache
     /// directory. The cache uses the identical sharded layout as a `FileStore`.
     /// Cache copies honor `--jobs` / `--limit-rate` via the [`TransferConfig`].
@@ -1639,6 +1877,94 @@ fn stream_store_for_adapter(
              external `snapdir-*-store` URLs are not supported: {store_url}"
         )),
     }
+}
+
+/// Reads newline-separated object checksums to EOF, validating EVERY non-empty
+/// line against `^[0-9a-f]{64}$` ([`is_hex64`]) — any malformed line is a hard
+/// error (fail closed: the plumbing commands must validate the whole request
+/// before their first store query / first emitted byte). Empty lines are
+/// skipped; order is preserved; duplicates are kept (dedup is a separate,
+/// explicit step — [`dedupe_preserving_order`]).
+fn read_checksum_lines(reader: impl BufRead) -> Result<Vec<String>> {
+    let mut ids = Vec::new();
+    for line in reader.lines() {
+        let line = line.context("reading checksum list")?;
+        if line.is_empty() {
+            continue;
+        }
+        anyhow::ensure!(
+            is_hex64(&line),
+            "invalid object checksum {line:?}: expected 64 lowercase hex characters"
+        );
+        ids.push(line);
+    }
+    Ok(ids)
+}
+
+/// Drops duplicate checksums, keeping the FIRST occurrence of each and the
+/// relative order of survivors. The pack/diff libs document deduplication as
+/// the caller's job ([`StreamStore::objects_needed`], [`write_pack`]), so the
+/// CLI is where it happens.
+fn dedupe_preserving_order(ids: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::with_capacity(ids.len());
+    ids.into_iter()
+        .filter(|id| seen.insert(id.clone()))
+        .collect()
+}
+
+/// A [`PackSink`] decorator that records WHICH manifest id the stream
+/// committed: [`read_pack`]'s report only says WHETHER a manifest committed,
+/// but `receive-pack --require-manifest <id>` must compare the actual id (a
+/// pre-existing manifest in the store could otherwise mask a stream that
+/// carried the wrong one). Pure delegation — no wire logic lives here.
+struct RecordingSink<'a> {
+    inner: &'a mut dyn PackSink,
+    manifest_id: Option<String>,
+}
+
+impl PackSink for RecordingSink<'_> {
+    fn has_object(&mut self, checksum: &str) -> Result<bool, StoreError> {
+        self.inner.has_object(checksum)
+    }
+
+    fn stage_object(
+        &mut self,
+        checksum: &str,
+        len: u64,
+        payload: &mut dyn Read,
+    ) -> Result<(), StoreError> {
+        self.inner.stage_object(checksum, len, payload)
+    }
+
+    fn commit_object(&mut self, checksum: &str) -> Result<(), StoreError> {
+        self.inner.commit_object(checksum)
+    }
+
+    fn abort_object(&mut self, checksum: &str) {
+        self.inner.abort_object(checksum);
+    }
+
+    fn put_manifest(&mut self, id: &str, manifest: &Manifest) -> Result<(), StoreError> {
+        // Record only after the inner sink actually committed (an error here
+        // must not look like a committed manifest to --require-manifest).
+        self.inner.put_manifest(id, manifest)?;
+        self.manifest_id = Some(id.to_owned());
+        Ok(())
+    }
+}
+
+/// Runs [`read_pack`] through a [`RecordingSink`], returning the read report
+/// plus the id of the committed manifest (if any).
+fn read_pack_recording(
+    input: impl Read,
+    sink: &mut dyn PackSink,
+) -> Result<(PackReadReport, Option<String>)> {
+    let mut recording = RecordingSink {
+        inner: sink,
+        manifest_id: None,
+    };
+    let report = read_pack(input, &mut recording).context("reading pack stream from stdin")?;
+    Ok((report, recording.manifest_id))
 }
 
 /// Parses a wget-style byte-rate string into bytes/second.

--- a/crates/snapdir-cli/src/cli.rs
+++ b/crates/snapdir-cli/src/cli.rs
@@ -557,13 +557,27 @@ impl Cli {
                 m.set_phase(Phase::Transfer);
             }
             let store = self.resolve_store(meter.clone())?;
-            let scratch = ScratchDir::new("push")?;
-            cache
-                .fetch_files(&manifest, scratch.path())
-                .with_context(|| format!("materializing staged snapshot {id}"))?;
-            store
-                .push(&manifest, scratch.path())
-                .with_context(|| format!("pushing snapshot {id} to store"))?;
+            if self.store_is_external()? {
+                // External adapters' emit-command contract expects --staging-dir
+                // to be a SHARDED store root (`.objects/<sharded>` +
+                // `.manifests/<sharded>`) — exactly the cache's layout, and the
+                // staged snapshot already lives there in full (the cache's
+                // manifest-written-last invariant: a present manifest implies
+                // its objects are present, proven by `get_manifest` above).
+                // Hand the cache root over directly; a scratch TREE would be
+                // the wrong shape for the emitted script.
+                store
+                    .push(&manifest, &self.cache_dir())
+                    .with_context(|| format!("pushing snapshot {id} to store"))?;
+            } else {
+                let scratch = ScratchDir::new("push")?;
+                cache
+                    .fetch_files(&manifest, scratch.path())
+                    .with_context(|| format!("materializing staged snapshot {id}"))?;
+                store
+                    .push(&manifest, scratch.path())
+                    .with_context(|| format!("pushing snapshot {id} to store"))?;
+            }
             reporter.finish();
             println!("{id}");
             self.log_event("push", id, store_url)?;
@@ -606,9 +620,27 @@ impl Cli {
             m.set_phase(Phase::Transfer);
         }
         let store = self.resolve_store(meter.clone())?;
-        store
-            .push(&manifest, &root)
-            .with_context(|| format!("pushing snapshot {id} to store"))?;
+        if self.store_is_external()? {
+            // External adapters' emit-command contract expects --staging-dir to
+            // be a SHARDED store root, not the source tree (the bash oracle
+            // always pushes from the local cache, so its staging dir IS the
+            // cache). Stage into the cache first — the same idempotent,
+            // manifest-written-last write `stage` performs — then hand the
+            // cache root to the shim: the emitted script reads only
+            // `.manifests/<sharded id>` and that manifest's objects, so the
+            // cache holding other snapshots (a superset) is fine.
+            let cache = self.cache_store_with_meter(meter.clone())?;
+            cache
+                .push(&manifest, &root)
+                .with_context(|| format!("staging snapshot {id} into the local cache"))?;
+            store
+                .push(&manifest, &self.cache_dir())
+                .with_context(|| format!("pushing snapshot {id} to store"))?;
+        } else {
+            store
+                .push(&manifest, &root)
+                .with_context(|| format!("pushing snapshot {id} to store"))?;
+        }
         reporter.finish();
         println!("{id}");
         // Mirror the oracle's `_snapdir_log_event "push" "$id" "$store"` (L359):
@@ -685,17 +717,36 @@ impl Cli {
             m.set_total(total_object_bytes(&manifest));
         }
 
-        // Materialize the verified objects into a scratch tree, then push that
-        // tree into the cache store. This reuses the store's verify/atomic
-        // persist on both legs and lands the cache in the same sharded layout.
-        let scratch = ScratchDir::new("fetch")?;
-        store
-            .fetch_files(&manifest, scratch.path())
-            .with_context(|| format!("fetching objects for snapshot {id}"))?;
+        if self.store_is_external()? {
+            // External adapters' emit-command contract expects --cache-dir to
+            // be a SHARDED store root: the emitted script writes objects
+            // straight to `.objects/<sharded>` under the dir it is handed (NOT
+            // a dest tree). Point it at the cache root directly — no scratch
+            // double-copy — then commit the manifest LAST via the cache's
+            // `put_manifest` (which re-verifies the manifest hashes back to
+            // `id`). This preserves the cache's manifest-written-last
+            // invariant: a failed external fetch leaves orphan objects but
+            // never a manifest claiming the snapshot is complete.
+            store
+                .fetch_files(&manifest, &self.cache_dir())
+                .with_context(|| format!("fetching objects for snapshot {id}"))?;
+            cache
+                .put_manifest(id, &manifest)
+                .with_context(|| format!("saving snapshot {id} to the local cache"))?;
+        } else {
+            // Materialize the verified objects into a scratch tree, then push
+            // that tree into the cache store. This reuses the store's verify/
+            // atomic persist on both legs and lands the cache in the same
+            // sharded layout.
+            let scratch = ScratchDir::new("fetch")?;
+            store
+                .fetch_files(&manifest, scratch.path())
+                .with_context(|| format!("fetching objects for snapshot {id}"))?;
 
-        cache
-            .push(&manifest, scratch.path())
-            .with_context(|| format!("saving snapshot {id} to the local cache"))?;
+            cache
+                .push(&manifest, scratch.path())
+                .with_context(|| format!("saving snapshot {id} to the local cache"))?;
+        }
         if self.globals.verbose && !self.globals.quiet {
             eprintln!("SAVED: {id}");
         }
@@ -1055,6 +1106,33 @@ impl Cli {
         let adapter = resolve_adapter(store_url).context("resolving --store protocol")?;
         let config = self.transfer_config_for(Some(adapter.name()))?;
         store_for_adapter(&adapter, store_url, config, meter)
+    }
+
+    /// `true` when the resolved `--store` URL routes to a third-party
+    /// `snapdir-<proto>-store` binary ([`Adapter::External`]).
+    ///
+    /// The external emit-command contract hands `--staging-dir`/`--cache-dir`
+    /// to the emitted scripts as SHARDED store roots (`.objects/<sharded>` +
+    /// `.manifests/<sharded>` — the local cache's exact layout), not the
+    /// source/dest TREES the in-process stores take; `run_push` and
+    /// `fetch_inner` branch on this to swap the tree for the cache root.
+    /// Delegates the scheme decision to the same [`resolve_adapter`] router
+    /// [`Self::resolve_store`] uses, so the CLI never re-encodes the scheme
+    /// map.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error when `--store` is missing or its protocol is invalid —
+    /// the identical errors `resolve_store` surfaces, so calling this after a
+    /// successful `resolve_store` introduces no new failure mode.
+    fn store_is_external(&self) -> Result<bool> {
+        let store_url = self
+            .globals
+            .store
+            .as_deref()
+            .context("missing --store option")?;
+        let adapter = resolve_adapter(store_url).context("resolving --store protocol")?;
+        Ok(matches!(adapter, Adapter::External { .. }))
     }
 
     /// Builds the [`TransferConfig`] from the global `--jobs` / `--limit-rate`

--- a/crates/snapdir-cli/tests/external_store_roundtrip.rs
+++ b/crates/snapdir-cli/tests/external_store_roundtrip.rs
@@ -1,0 +1,272 @@
+//! End-to-end integration tests for `push`/`fetch`/`pull` against an EXTERNAL
+//! `snapdir-<proto>-store` adapter (the emit-command shim), driving the real
+//! `snapdir` binary against the `snapdir-mock-store` fixture from
+//! crates/snapdir-stores/tests/.
+//!
+//! The external contract differs from the in-process stores: the
+//! `--staging-dir`/`--cache-dir` values handed to the emitted scripts are
+//! SHARDED store roots (`.objects/<sharded>` + `.manifests/<sharded>`), NOT
+//! source/dest trees, so the CLI must route external transfers through the
+//! local cache (stage-then-push on the way out; fetch-into-cache with the
+//! manifest committed LAST on the way in). These tests pin that wiring
+//! end-to-end — it used to be silently broken because no CLI test drove
+//! `mock://`.
+//!
+//! Hermetic: temp dirs only, no network; the shim shells out to `bash`, which
+//! is present on every supported platform/CI runner.
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use snapdir_core::{Blake3Hasher, Hasher};
+
+/// Path to the compiled `snapdir` binary under test.
+fn snapdir_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_snapdir")
+}
+
+/// `PATH` with the directory holding the `snapdir-mock-store` fixture
+/// prepended, so the router resolves the external adapter binary for
+/// `mock://` URLs (and `bash` etc. stay resolvable from the original PATH).
+fn path_with_mock_store() -> String {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("../snapdir-stores/tests/snapdir-mock-store")
+        .canonicalize()
+        .expect("snapdir-mock-store fixture exists");
+    let dir = fixture.parent().expect("fixture has a parent directory");
+    format!(
+        "{}:{}",
+        dir.display(),
+        std::env::var("PATH").unwrap_or_default()
+    )
+}
+
+/// Creates a unique temp directory and returns its path.
+fn temp_dir(tag: &str) -> PathBuf {
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "snapdir-cli-external-{tag}-{}-{:?}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// Runs the `snapdir` binary with the mock store on PATH, returning the raw
+/// output (no success assertion — for the failure-path tests).
+fn run_snapdir_raw(args: &[&str], cache: &Path) -> Output {
+    Command::new(snapdir_bin())
+        .args(args)
+        .env("SNAPDIR_CACHE_DIR", cache)
+        .env("PATH", path_with_mock_store())
+        .output()
+        .expect("run snapdir")
+}
+
+/// Runs the `snapdir` binary, asserting success and returning trimmed stdout.
+fn run_snapdir(args: &[&str], cache: &Path) -> String {
+    let output = run_snapdir_raw(args, cache);
+    assert!(
+        output.status.success(),
+        "snapdir {args:?} exited with {:?}\nstderr: {}",
+        output.status.code(),
+        String::from_utf8_lossy(&output.stderr),
+    );
+    String::from_utf8(output.stdout)
+        .expect("stdout is UTF-8")
+        .trim_end()
+        .to_owned()
+}
+
+/// `.objects/<h[0..3]>/<h[3..6]>/<h[6..9]>/<h[9..]>` — the frozen sharded layout.
+fn sharded(prefix: &str, hex: &str) -> String {
+    format!(
+        "{prefix}/{}/{}/{}/{}",
+        &hex[0..3],
+        &hex[3..6],
+        &hex[6..9],
+        &hex[9..]
+    )
+}
+
+/// The (relative path, bytes) pairs of the shared source tree: a top-level
+/// file, a subdir file, and a file with spaces in its name.
+const TREE_FILES: [(&str, &[u8]); 3] = [
+    ("a.txt", b"hello external"),
+    ("sub/b.txt", b"world!!"),
+    ("with space.txt", b"spaced out"),
+];
+
+/// Builds the shared multi-file source tree with explicit, deterministic
+/// permissions so a checked-out copy must restore them to re-manifest to the
+/// same snapshot id.
+fn build_source_tree(src: &Path) {
+    fs::create_dir(src.join("sub")).unwrap();
+    fs::set_permissions(src.join("sub"), fs::Permissions::from_mode(0o755)).unwrap();
+    for (rel, bytes) in TREE_FILES {
+        let target = src.join(rel);
+        fs::write(&target, bytes).unwrap();
+        fs::set_permissions(&target, fs::Permissions::from_mode(0o644)).unwrap();
+    }
+    fs::set_permissions(src, fs::Permissions::from_mode(0o755)).unwrap();
+}
+
+/// (a) + (c): push a multi-file tree to a `mock://` store — the snapshot id
+/// lands on stdout, the mock store dir contains the sharded manifest + every
+/// object — and a second identical push is an idempotent no-op printing the
+/// same id.
+#[test]
+fn external_push_lands_sharded_manifest_and_objects() {
+    let src = temp_dir("push-src");
+    let store = temp_dir("push-store");
+    let cache = temp_dir("push-cache");
+    build_source_tree(&src);
+
+    // `mock://` + absolute path: the mock strips the literal `mock://` prefix,
+    // so the embedded absolute path supplies the third slash (`mock:///abs/…`).
+    let store_url = format!("mock://{}", store.display());
+    let src_str = src.to_string_lossy().into_owned();
+
+    // The id the source tree manifests to (independent of the store).
+    let src_id = run_snapdir(&["id", &src_str], &cache);
+    assert_eq!(src_id.len(), 64, "snapshot id should be 64 hex chars");
+
+    // Push through the external adapter; the printed id must equal the
+    // source id (the scriptable id-on-stdout contract).
+    let pushed_id = run_snapdir(&["push", "--store", &store_url, &src_str], &cache);
+    assert_eq!(pushed_id, src_id, "push must print the source snapshot id");
+
+    // The manifest landed in the MOCK STORE at its exact sharded key — proof
+    // the emitted script received a sharded staging dir, not a source tree.
+    let manifest_key = store.join(sharded(".manifests", &src_id));
+    assert!(
+        manifest_key.is_file(),
+        "manifest must land at sharded key {}",
+        manifest_key.display()
+    );
+
+    // Every file object landed at its content-addressed sharded key with
+    // matching bytes.
+    for (rel, bytes) in TREE_FILES {
+        let sum = Blake3Hasher::new().hash_hex(bytes);
+        let obj = store.join(sharded(".objects", &sum));
+        assert!(
+            obj.is_file(),
+            "object for {rel} must land at {}",
+            obj.display()
+        );
+        assert_eq!(fs::read(&obj).unwrap(), bytes, "object bytes for {rel}");
+    }
+
+    // (c) Second push of the same tree: idempotent no-op (the mock emits
+    // "Manifest already exists on store."), exit 0, same id.
+    let repushed_id = run_snapdir(&["push", "--store", &store_url, &src_str], &cache);
+    assert_eq!(repushed_id, src_id, "re-push must print the same id");
+
+    for dir in [&src, &store, &cache] {
+        fs::remove_dir_all(dir).ok();
+    }
+}
+
+/// (b) + (e): fetch the pushed snapshot with a FRESH cache (a second logical
+/// client), checkout, and get a byte-identical tree that re-manifests to the
+/// same id; the fresh cache holds the sharded manifest afterwards — proof the
+/// external fetch arm committed the manifest via `put_manifest` (manifest
+/// LAST) rather than routing the cache dir through a tree-shaped `push`.
+#[test]
+fn external_fetch_fresh_cache_then_checkout_reproduces_tree() {
+    let src = temp_dir("fetch-src");
+    let store = temp_dir("fetch-store");
+    let dest = temp_dir("fetch-dest");
+    let push_cache = temp_dir("fetch-cache-pusher");
+    let fetch_cache = temp_dir("fetch-cache-fetcher");
+    build_source_tree(&src);
+
+    let store_url = format!("mock://{}", store.display());
+    let src_str = src.to_string_lossy().into_owned();
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    let id = run_snapdir(&["push", "--store", &store_url, &src_str], &push_cache);
+
+    // Fetch with a FRESH cache: every object must travel store → cache through
+    // the external adapter (no local shortcut exists).
+    run_snapdir(&["fetch", "--store", &store_url, "--id", &id], &fetch_cache);
+
+    // (e) The fresh cache holds the sharded manifest — the put-manifest-last
+    // arm ran (and `checkout` below works offline from this cache alone).
+    let cache_manifest = fetch_cache.join(sharded(".manifests", &id));
+    assert!(
+        cache_manifest.is_file(),
+        "external fetch must commit the manifest into the cache at {}",
+        cache_manifest.display()
+    );
+    // …and every object at its sharded content address.
+    for (rel, bytes) in TREE_FILES {
+        let sum = Blake3Hasher::new().hash_hex(bytes);
+        let obj = fetch_cache.join(sharded(".objects", &sum));
+        assert!(
+            obj.is_file(),
+            "external fetch must file the object for {rel} at {}",
+            obj.display()
+        );
+    }
+
+    // (b) Checkout from the populated cache reproduces the tree byte-for-byte.
+    run_snapdir(&["checkout", "--id", &id, &dest_str], &fetch_cache);
+    for (rel, bytes) in TREE_FILES {
+        assert_eq!(
+            fs::read(dest.join(rel)).unwrap(),
+            bytes,
+            "checked-out bytes for {rel}"
+        );
+    }
+
+    // And the checked-out tree re-manifests to the SAME snapshot id (contents
+    // + permissions round-tripped through the external store).
+    let dest_id = run_snapdir(&["id", &dest_str], &fetch_cache);
+    assert_eq!(
+        dest_id, id,
+        "checked-out tree must re-manifest to the pushed snapshot id"
+    );
+
+    for dir in [&src, &store, &dest, &push_cache, &fetch_cache] {
+        fs::remove_dir_all(dir).ok();
+    }
+}
+
+/// (d): fetching an unknown (well-formed 64-hex) id from an external store
+/// fails with a non-zero exit and a "not found" error on stderr — the shim's
+/// `ManifestNotFound` mapping surfaces through the CLI.
+#[test]
+fn external_fetch_unknown_id_fails_with_not_found() {
+    let store = temp_dir("unknown-store");
+    let cache = temp_dir("unknown-cache");
+    let store_url = format!("mock://{}", store.display());
+    let unknown = "0".repeat(64); // valid shape, never pushed
+
+    let output = run_snapdir_raw(&["fetch", "--store", &store_url, "--id", &unknown], &cache);
+    assert!(
+        !output.status.success(),
+        "fetch of an unknown id must fail, not succeed silently"
+    );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("not found"),
+        "stderr should report the manifest as not found; got: {stderr}"
+    );
+    // Nothing may have been committed to the cache for the unknown id.
+    assert!(
+        !cache.join(sharded(".manifests", &unknown)).exists(),
+        "a failed fetch must not commit a cache manifest"
+    );
+
+    for dir in [&store, &cache] {
+        fs::remove_dir_all(dir).ok();
+    }
+}

--- a/crates/snapdir-cli/tests/plumbing.rs
+++ b/crates/snapdir-cli/tests/plumbing.rs
@@ -1,0 +1,620 @@
+//! Gate tests for the hidden SNAPPACK plumbing subcommands
+//! (`version --capabilities`, `objects-needed`, `send-pack`, `receive-pack`)
+//! that power the upcoming `ssh://` store acceleration
+//! (`<local> snapdir send-pack | ssh host 'snapdir receive-pack'`).
+//!
+//! Everything here drives the REAL binary (`env!("CARGO_BIN_EXE_snapdir")`)
+//! against temp `file://` stores, mirroring how the existing e2e tests build
+//! fixtures: snapshot fixtures are pushed with the binary itself; raw object
+//! fixtures are seeded via the `snapdir-stores` `FileStore`/`StreamStore`
+//! helpers (regular dependencies, available to integration tests). Hermetic —
+//! no network, no credentials, every temp dir removed on drop.
+
+use std::io::Write as _;
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::{Command, Output, Stdio};
+
+use assert_fs::prelude::*;
+use assert_fs::TempDir;
+use snapdir_core::{manifest_path, object_path, Blake3Hasher, Hasher, Store};
+use snapdir_stores::{FileStore, StreamStore, WIRE_CAPS, WIRE_VERSION};
+
+/// The real binary under test.
+fn snapdir_bin() -> &'static str {
+    env!("CARGO_BIN_EXE_snapdir")
+}
+
+/// A fresh `snapdir` command with the cache pinned under `cache` and the
+/// store-selecting env cleared, so a leaked `SNAPDIR_STORE` (clap `env` flag)
+/// can never perturb a test.
+fn snapdir(cache: &Path) -> Command {
+    let mut cmd = Command::new(snapdir_bin());
+    cmd.env("SNAPDIR_CACHE_DIR", cache);
+    cmd.env_remove("SNAPDIR_STORE");
+    cmd
+}
+
+/// Runs `snapdir <args>` with `stdin_bytes` piped in, returning the full
+/// `Output` (the caller asserts status/stdout/stderr).
+fn run_with_stdin(cache: &Path, args: &[&str], stdin_bytes: &[u8]) -> Output {
+    let mut child = snapdir(cache)
+        .args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn snapdir");
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(stdin_bytes)
+        .expect("write stdin");
+    child.wait_with_output().expect("snapdir output")
+}
+
+/// Runs `snapdir <args>`, asserts success, returns trimmed stdout (the same
+/// helper shape e2e.rs uses).
+fn stdout_ok(cache: &Path, args: &[&str]) -> String {
+    let out = snapdir(cache).args(args).output().expect("run snapdir");
+    assert!(
+        out.status.success(),
+        "snapdir {args:?} failed ({:?})\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8(out.stdout).unwrap().trim_end().to_owned()
+}
+
+/// Builds a small deterministic tree (multiple distinct objects + explicit
+/// perms) for binary-driven push fixtures, like e2e.rs's `build_tree`.
+fn build_tree(dir: &TempDir) {
+    dir.child("a.txt").write_str("plumbing alpha").unwrap();
+    dir.child("sub/b.txt")
+        .write_str("plumbing bravo!!")
+        .unwrap();
+    dir.child("sub/c.bin")
+        .write_str("plumbing charlie payload")
+        .unwrap();
+    for (rel, mode) in [("a.txt", 0o644), ("sub/b.txt", 0o600), ("sub/c.bin", 0o644)] {
+        std::fs::set_permissions(dir.child(rel).path(), PermissionsExt::from_mode(mode)).unwrap();
+    }
+    std::fs::set_permissions(dir.child("sub").path(), PermissionsExt::from_mode(0o755)).unwrap();
+    std::fs::set_permissions(dir.path(), PermissionsExt::from_mode(0o755)).unwrap();
+}
+
+/// Pushes `build_tree` into a fresh `file://` store via the binary, returning
+/// `(store_dir, snapshot_id, object_ids)` — the object ids come from the
+/// stored manifest's File entries (deduped, manifest order).
+fn pushed_fixture(cache: &Path) -> (TempDir, String, Vec<String>) {
+    let src = TempDir::new().unwrap();
+    let store = TempDir::new().unwrap();
+    build_tree(&src);
+    let src_str = src.path().to_string_lossy().into_owned();
+    let store_url = format!("file://{}", store.path().display());
+    let id = stdout_ok(cache, &["push", "--store", &store_url, &src_str]);
+
+    let manifest = FileStore::from_root(store.path())
+        .get_manifest(&id)
+        .expect("manifest in pushed store");
+    let mut object_ids: Vec<String> = Vec::new();
+    for entry in manifest.entries() {
+        if entry.path_type == snapdir_core::PathType::File && !object_ids.contains(&entry.checksum)
+        {
+            object_ids.push(entry.checksum.clone());
+        }
+    }
+    assert!(object_ids.len() >= 3, "fixture must carry several objects");
+    (store, id, object_ids)
+}
+
+/// BLAKE3 of `bytes` as the 64-hex content address.
+fn hex_of(bytes: &[u8]) -> String {
+    Blake3Hasher::new().hash_hex(bytes)
+}
+
+/// Recursively collects every regular file under `dir` (empty if absent) —
+/// used to prove a rejected stream filed nothing (not even temp litter).
+fn files_under(dir: &Path) -> Vec<std::path::PathBuf> {
+    let mut files = Vec::new();
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return files;
+    };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            files.extend(files_under(&path));
+        } else {
+            files.push(path);
+        }
+    }
+    files
+}
+
+// ---------------------------------------------------------------------------
+// version --capabilities
+// ---------------------------------------------------------------------------
+
+/// The capability line is EXACTLY `snapdir <semver> wire=1
+/// caps=objects-needed,send-pack,receive-pack\n` — pinned both to the literal
+/// wire-1 grammar the remote probe matches AND to the lib constants it must
+/// bake in (so a constant bump can't silently desync the CLI).
+#[test]
+fn plumbing_capabilities_line_exact() {
+    let cache = TempDir::new().unwrap();
+    let out = snapdir(cache.path())
+        .args(["version", "--capabilities"])
+        .output()
+        .expect("run snapdir");
+    assert!(out.status.success());
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    // Literal wire-1 pin (the probe negotiates on this exact integer).
+    assert_eq!(
+        stdout,
+        format!(
+            "snapdir {} wire=1 caps=objects-needed,send-pack,receive-pack\n",
+            env!("CARGO_PKG_VERSION")
+        )
+    );
+    // And the same line re-derived from the lib constants.
+    assert_eq!(
+        stdout,
+        format!(
+            "snapdir {} wire={WIRE_VERSION} caps={}\n",
+            env!("CARGO_PKG_VERSION"),
+            WIRE_CAPS.join(",")
+        )
+    );
+}
+
+/// Plain `snapdir version` stays byte-identical to the frozen surface.
+#[test]
+fn plumbing_plain_version_unchanged() {
+    let cache = TempDir::new().unwrap();
+    let out = snapdir(cache.path())
+        .arg("version")
+        .output()
+        .expect("run snapdir");
+    assert!(out.status.success());
+    assert_eq!(
+        String::from_utf8(out.stdout).unwrap(),
+        format!("snapdir {}\n", env!("CARGO_PKG_VERSION"))
+    );
+}
+
+// ---------------------------------------------------------------------------
+// objects-needed
+// ---------------------------------------------------------------------------
+
+/// Seed a store with a SUBSET of objects, then offer the full ordered list
+/// (with duplicates) on stdin: stdout must be the EXACT complement, deduped,
+/// in first-occurrence order.
+#[test]
+fn plumbing_objects_needed_prints_exact_complement_in_order() {
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = FileStore::from_root(store_dir.path());
+
+    // Present: two seeded objects. Absent: two valid-but-unseeded addresses.
+    let present: Vec<String> = [b"seeded one".as_slice(), b"seeded two".as_slice()]
+        .iter()
+        .map(|payload| {
+            let checksum = hex_of(payload);
+            store
+                .put_object(&checksum, payload.to_vec())
+                .expect("seed object");
+            checksum
+        })
+        .collect();
+    let absent_a = hex_of(b"absent a");
+    let absent_b = hex_of(b"absent b");
+
+    // Full ordered list with duplicates of both kinds sprinkled in.
+    let stdin = format!(
+        "{p0}\n{a}\n{p0}\n{p1}\n{b}\n{a}\n{p1}\n",
+        p0 = present[0],
+        p1 = present[1],
+        a = absent_a,
+        b = absent_b,
+    );
+    let store_url = format!("file://{}", store_dir.path().display());
+    let out = run_with_stdin(
+        cache.path(),
+        &["objects-needed", "--store", &store_url],
+        stdin.as_bytes(),
+    );
+    assert!(
+        out.status.success(),
+        "objects-needed failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(out.stdout).unwrap(),
+        format!("{absent_a}\n{absent_b}\n"),
+        "stdout must be the exact absent complement in first-occurrence order"
+    );
+}
+
+/// ANY malformed line (uppercase / 63-char / non-hex) fails the WHOLE request
+/// with a non-zero exit and an EMPTY stdout — even when valid absent ids
+/// precede it (fail closed: validation happens before the first store query).
+#[test]
+fn plumbing_objects_needed_malformed_line_fails_closed() {
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store_url = format!("file://{}", store_dir.path().display());
+    let valid_absent = hex_of(b"valid but absent");
+    let hex = "0123456789abcdef".repeat(4);
+
+    for bad in [
+        hex.to_uppercase(),        // uppercase
+        hex[..63].to_owned(),      // 63 chars
+        format!("g{}", &hex[1..]), // non-hex char
+    ] {
+        let stdin = format!("{valid_absent}\n{bad}\n");
+        let out = run_with_stdin(
+            cache.path(),
+            &["objects-needed", "--store", &store_url],
+            stdin.as_bytes(),
+        );
+        assert!(
+            !out.status.success(),
+            "malformed line {bad:?} must fail the request"
+        );
+        assert!(
+            out.stdout.is_empty(),
+            "malformed line {bad:?} must print NOTHING to stdout, got: {}",
+            String::from_utf8_lossy(&out.stdout)
+        );
+    }
+}
+
+/// Empty stdin is a valid (empty) request: exit 0, empty stdout.
+#[test]
+fn plumbing_objects_needed_empty_input_is_ok() {
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store_url = format!("file://{}", store_dir.path().display());
+    let out = run_with_stdin(
+        cache.path(),
+        &["objects-needed", "--store", &store_url],
+        b"",
+    );
+    assert!(out.status.success(), "empty input must succeed");
+    assert!(out.stdout.is_empty(), "empty input must print nothing");
+}
+
+// ---------------------------------------------------------------------------
+// send-pack | receive-pack round trip (real OS pipe between the two binaries)
+// ---------------------------------------------------------------------------
+
+/// `send-pack --store file://A --ids - --manifest-id <id>` piped into
+/// `receive-pack --store file://B --require-manifest <id>`: B ends up with the
+/// manifest + byte-equal objects at the identical sharded on-disk paths, and
+/// receive-pack's stdout stays silent.
+#[test]
+fn plumbing_pack_roundtrip_via_pipe() {
+    let cache = TempDir::new().unwrap();
+    let (store_a, id, object_ids) = pushed_fixture(cache.path());
+    let store_b = TempDir::new().unwrap();
+    let url_a = format!("file://{}", store_a.path().display());
+    let url_b = format!("file://{}", store_b.path().display());
+
+    // Spawn the sender, feed the id list on ITS stdin, and connect its stdout
+    // to the receiver's stdin via a real OS pipe (process plumbing — exactly
+    // the future `| ssh host 'snapdir receive-pack'` shape).
+    let mut send = snapdir(cache.path())
+        .args([
+            "send-pack",
+            "--store",
+            &url_a,
+            "--ids",
+            "-",
+            "--manifest-id",
+            &id,
+        ])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn send-pack");
+    send.stdin
+        .take()
+        .expect("send-pack stdin")
+        .write_all(format!("{}\n", object_ids.join("\n")).as_bytes())
+        .expect("write id list");
+    let pack_pipe = send.stdout.take().expect("send-pack stdout");
+
+    let recv = snapdir(cache.path())
+        .args(["receive-pack", "--store", &url_b, "--require-manifest", &id])
+        .stdin(Stdio::from(pack_pipe))
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .output()
+        .expect("run receive-pack");
+    let send_out = send.wait_with_output().expect("send-pack exit");
+
+    assert!(
+        send_out.status.success(),
+        "send-pack failed: {}",
+        String::from_utf8_lossy(&send_out.stderr)
+    );
+    assert!(
+        recv.status.success(),
+        "receive-pack failed: {}",
+        String::from_utf8_lossy(&recv.stderr)
+    );
+    assert!(
+        recv.stdout.is_empty(),
+        "receive-pack must print nothing to stdout"
+    );
+
+    // B holds the manifest at its sharded path, byte-equal to A's...
+    let man_rel = manifest_path(&id);
+    assert_eq!(
+        std::fs::read(store_b.path().join(&man_rel)).expect("manifest in B"),
+        std::fs::read(store_a.path().join(&man_rel)).expect("manifest in A"),
+        "manifest must be byte-equal at the identical sharded path"
+    );
+    // ...and every object, byte-equal at the identical sharded paths.
+    for checksum in &object_ids {
+        let rel = object_path(checksum);
+        assert_eq!(
+            std::fs::read(store_b.path().join(&rel)).expect("object in B"),
+            std::fs::read(store_a.path().join(&rel)).expect("object in A"),
+            "object {rel} must be byte-equal"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// receive-pack security
+// ---------------------------------------------------------------------------
+
+/// A hand-crafted stream claiming checksum X over bytes hashing to Y must be
+/// rejected: exit != 0, NOTHING filed at X's sharded path, no manifest, no
+/// temp litter anywhere in the store.
+#[test]
+fn plumbing_receive_pack_rejects_hash_mismatch() {
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store_url = format!("file://{}", store_dir.path().display());
+
+    let claimed = hex_of(b"good bytes");
+    let evil = b"evil bytes"; // same length, different content
+    let mut stream = b"SNAPPACK 1\n".to_vec();
+    stream.extend_from_slice(format!("obj {claimed} {}\n", evil.len()).as_bytes());
+    stream.extend_from_slice(evil);
+    stream.extend_from_slice(b"end\n");
+
+    let out = run_with_stdin(
+        cache.path(),
+        &["receive-pack", "--store", &store_url],
+        &stream,
+    );
+    assert!(!out.status.success(), "mismatched payload must be rejected");
+    assert!(out.stdout.is_empty(), "stdout must stay silent");
+    assert!(
+        !store_dir.path().join(object_path(&claimed)).exists(),
+        "nothing may be filed at the claimed checksum's sharded path"
+    );
+    assert_eq!(
+        files_under(store_dir.path()),
+        Vec::<std::path::PathBuf>::new(),
+        "no file (object, manifest, or temp) may survive the rejected stream"
+    );
+}
+
+/// A `../`-flavored / non-hex header line is rejected outright (the path is
+/// only ever derived from a VALIDATED checksum, so the traversal class is
+/// structurally absent — this pins the validation actually firing).
+#[test]
+fn plumbing_receive_pack_rejects_traversal_and_non_hex_headers() {
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store_url = format!("file://{}", store_dir.path().display());
+
+    for bad_checksum in [
+        "../../../../etc/passwd",
+        "..%2f..%2fescape00000000000000000000000000000000000000000000000000",
+        &format!("{}/../x", &"0123456789abcdef".repeat(4)[..32]),
+    ] {
+        let stream = format!("SNAPPACK 1\nobj {bad_checksum} 0\nend\n");
+        let out = run_with_stdin(
+            cache.path(),
+            &["receive-pack", "--store", &store_url],
+            stream.as_bytes(),
+        );
+        assert!(
+            !out.status.success(),
+            "header checksum {bad_checksum:?} must be rejected"
+        );
+        assert_eq!(
+            files_under(store_dir.path()),
+            Vec::<std::path::PathBuf>::new(),
+            "rejected header {bad_checksum:?} must file nothing"
+        );
+    }
+}
+
+/// TRUNCATED stream (cut before `end`, after complete obj records): exit != 0,
+/// the verified objects ARE filed (a retry resumes incrementally), the
+/// manifest is NOT committed (manifest-last survives truncation). Then —
+/// idempotency — re-running the FULL send-pack|receive-pack into the SAME
+/// store succeeds and lands the manifest, completing the interrupted push.
+#[test]
+fn plumbing_receive_pack_truncation_then_full_rerun_completes() {
+    let cache = TempDir::new().unwrap();
+    let (store_a, id, object_ids) = pushed_fixture(cache.path());
+    let store_b = TempDir::new().unwrap();
+    let url_a = format!("file://{}", store_a.path().display());
+    let url_b = format!("file://{}", store_b.path().display());
+    let ids_stdin = format!("{}\n", object_ids.join("\n"));
+
+    // Capture a full valid pack from the sender binary...
+    let send = run_with_stdin(
+        cache.path(),
+        &[
+            "send-pack",
+            "--store",
+            &url_a,
+            "--ids",
+            "-",
+            "--manifest-id",
+            &id,
+        ],
+        ids_stdin.as_bytes(),
+    );
+    assert!(send.status.success(), "fixture send-pack must succeed");
+    let pack = send.stdout;
+    assert!(pack.ends_with(b"end\n"), "full pack ends with the trailer");
+
+    // ...and cut it just before the `end` trailer (every obj record + the
+    // manifest record are complete; only the commit trigger is missing).
+    let cut = &pack[..pack.len() - b"end\n".len()];
+    let out = run_with_stdin(
+        cache.path(),
+        &["receive-pack", "--store", &url_b, "--require-manifest", &id],
+        cut,
+    );
+    assert!(!out.status.success(), "truncated stream must fail");
+
+    // The verified objects ARE filed...
+    for checksum in &object_ids {
+        let rel = object_path(checksum);
+        assert!(
+            store_b.path().join(&rel).exists(),
+            "verified object {rel} must be filed despite the truncation"
+        );
+    }
+    // ...but the manifest must NOT be committed (manifest-last).
+    assert!(
+        !store_b.path().join(manifest_path(&id)).exists(),
+        "truncated stream must never commit the manifest"
+    );
+
+    // Idempotent completion: the FULL pack into the same (partially filled)
+    // store succeeds — duplicates verified-then-skipped — and commits the
+    // manifest, finishing the interrupted push.
+    let out = run_with_stdin(
+        cache.path(),
+        &["receive-pack", "--store", &url_b, "--require-manifest", &id],
+        &pack,
+    );
+    assert!(
+        out.status.success(),
+        "full re-run must complete the interrupted push: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let man_rel = manifest_path(&id);
+    assert_eq!(
+        std::fs::read(store_b.path().join(&man_rel)).expect("manifest in B"),
+        std::fs::read(store_a.path().join(&man_rel)).expect("manifest in A"),
+        "completed push must land the byte-equal manifest"
+    );
+}
+
+/// `--require-manifest <other>` against a stream carrying manifest id M fails
+/// with a non-zero exit (the committed id is compared, not just "a manifest
+/// was committed").
+#[test]
+fn plumbing_receive_pack_require_manifest_mismatch_fails() {
+    let cache = TempDir::new().unwrap();
+    let (store_a, id, object_ids) = pushed_fixture(cache.path());
+    let store_b = TempDir::new().unwrap();
+    let url_a = format!("file://{}", store_a.path().display());
+    let url_b = format!("file://{}", store_b.path().display());
+
+    let send = run_with_stdin(
+        cache.path(),
+        &[
+            "send-pack",
+            "--store",
+            &url_a,
+            "--ids",
+            "-",
+            "--manifest-id",
+            &id,
+        ],
+        format!("{}\n", object_ids.join("\n")).as_bytes(),
+    );
+    assert!(send.status.success());
+
+    let other = hex_of(b"some other manifest id");
+    assert_ne!(other, id);
+    let out = run_with_stdin(
+        cache.path(),
+        &[
+            "receive-pack",
+            "--store",
+            &url_b,
+            "--require-manifest",
+            &other,
+        ],
+        &send.stdout,
+    );
+    assert!(
+        !out.status.success(),
+        "manifest id mismatch must fail receive-pack"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// send-pack fail-closed
+// ---------------------------------------------------------------------------
+
+/// An id absent from the source store fails send-pack (exit != 0) and the
+/// emitted bytes do NOT end with `end\n` — so a piped receive-pack of the
+/// partial stream fails too (no silent partial transfer). Uses the `--ids
+/// <FILE>` form to cover the file-path branch.
+#[test]
+fn plumbing_send_pack_missing_object_aborts_before_end() {
+    let cache = TempDir::new().unwrap();
+    let (store_a, _id, mut object_ids) = pushed_fixture(cache.path());
+    let url_a = format!("file://{}", store_a.path().display());
+
+    // A syntactically valid but ABSENT object id, appended after real ones.
+    object_ids.push(hex_of(b"never stored anywhere"));
+    let ids_file = TempDir::new().unwrap();
+    ids_file
+        .child("ids.txt")
+        .write_str(&format!("{}\n", object_ids.join("\n")))
+        .unwrap();
+    let ids_path = ids_file
+        .child("ids.txt")
+        .path()
+        .to_string_lossy()
+        .into_owned();
+
+    let out = snapdir(cache.path())
+        .args(["send-pack", "--store", &url_a, "--ids", &ids_path])
+        .output()
+        .expect("run send-pack");
+    assert!(!out.status.success(), "missing object must fail send-pack");
+    assert!(
+        !out.stdout.ends_with(b"end\n"),
+        "the partial stream must NOT carry the end trailer"
+    );
+}
+
+/// A malformed id in the list fails send-pack BEFORE a single pack byte is
+/// emitted (fail closed, same validation as objects-needed).
+#[test]
+fn plumbing_send_pack_malformed_id_emits_nothing() {
+    let cache = TempDir::new().unwrap();
+    let (store_a, _id, object_ids) = pushed_fixture(cache.path());
+    let url_a = format!("file://{}", store_a.path().display());
+
+    let stdin = format!("{}\nNOT-A-CHECKSUM\n", object_ids[0]);
+    let out = run_with_stdin(
+        cache.path(),
+        &["send-pack", "--store", &url_a, "--ids", "-"],
+        stdin.as_bytes(),
+    );
+    assert!(!out.status.success(), "malformed id must fail send-pack");
+    assert!(
+        out.stdout.is_empty(),
+        "fail closed: not a single pack byte may be emitted"
+    );
+}

--- a/crates/snapdir-ssh-store/Cargo.toml
+++ b/crates/snapdir-ssh-store/Cargo.toml
@@ -1,0 +1,29 @@
+[package]
+name = "snapdir-ssh-store"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+homepage.workspace = true
+description = "snapdir ssh/sftp external stores: ssh:// + sftp:// over the system OpenSSH client."
+readme = "README.md"
+
+[[bin]]
+name = "snapdir-ssh-store"
+path = "src/bin/snapdir-ssh-store.rs"
+
+[[bin]]
+name = "snapdir-sftp-store"
+path = "src/bin/snapdir-sftp-store.rs"
+
+[dependencies]
+# The ONLY dependency: frozen sharded-path helpers (`object_path` /
+# `manifest_path`) and (in later gates) manifest parsing. Argument parsing is
+# std-only by design — the contract grammar is 3 subcommands x <=3 flags, so
+# clap would be pure weight.
+snapdir-core.workspace = true
+
+[lints]
+workspace = true

--- a/crates/snapdir-ssh-store/Cargo.toml
+++ b/crates/snapdir-ssh-store/Cargo.toml
@@ -20,10 +20,17 @@ path = "src/bin/snapdir-sftp-store.rs"
 
 [dependencies]
 # The ONLY dependency: frozen sharded-path helpers (`object_path` /
-# `manifest_path`) and (in later gates) manifest parsing. Argument parsing is
-# std-only by design — the contract grammar is 3 subcommands x <=3 flags, so
-# clap would be pure weight.
+# `manifest_path`) and manifest parsing. Argument parsing is std-only by
+# design — the contract grammar is 3 subcommands x <=3 flags, so clap would
+# be pure weight.
 snapdir-core.workspace = true
+
+[dev-dependencies]
+# Parity harness only: `ExternalStore::with_binary` drives the emitted
+# scripts end-to-end against tests/fixtures/fake-sftp (the harness lives
+# here, not in snapdir-stores, because `CARGO_BIN_EXE_*` only resolves in
+# the defining crate).
+snapdir-stores.workspace = true
 
 [lints]
 workspace = true

--- a/crates/snapdir-ssh-store/README.md
+++ b/crates/snapdir-ssh-store/README.md
@@ -3,21 +3,153 @@
 `ssh://` and `sftp://` external stores for
 [snapdir](https://github.com/snapdir/snapdir) — content-addressable directory
 snapshots — driving the **system OpenSSH client** (no SSH reimplementation,
-zero crypto dependencies) through snapdir's documented emit-command store
-contract.
+zero crypto dependencies) through snapdir's emit-command external-store
+contract: each subcommand transfers nothing itself, it *prints a bash script*
+on stdout that the snapdir CLI runs.
 
-Ships two binaries:
+Ships two binaries (install both with `cargo install snapdir-ssh-store`; they
+must be on `PATH` where the snapdir CLI runs):
 
-- `snapdir-ssh-store` — the `ssh://` engine; requires a POSIX shell on the
-  remote host and (in a later phase) accelerates transfers when a compatible
-  `snapdir` exists remotely.
-- `snapdir-sftp-store` — the `sftp://` engine; speaks pure SFTP and works
-  against restricted accounts (`ForceCommand internal-sftp` chroots).
+- `snapdir-ssh-store` — the `ssh://` engine. Requires a POSIX shell on the
+  remote host; transfers run as a batched existence probe plus a single
+  `tar | ssh` pipeline, and **auto-accelerate** to a SNAPPACK pack stream when
+  a wire-compatible `snapdir` is installed on the remote (graceful fallback
+  otherwise).
+- `snapdir-sftp-store` — the `sftp://` engine. Speaks pure SFTP — no remote
+  shell, no `tar` — so it works against restricted accounts, including
+  `ForceCommand internal-sftp` chroots.
 
-Both enforce an un-weakenable modern-only security floor (OpenSSH >= 8.5,
-pinned key-exchange/cipher/host-key algorithm lists, `BatchMode`,
-`StrictHostKeyChecking`) — user-supplied extra options can never weaken it.
+`ssh://` and `sftp://` are distinct schemes, not aliases. Use `ssh://` when
+the remote gives you a shell; use `sftp://` for restricted accounts.
+
+## URL grammar
+
+```text
+ssh://[user@]host[:port]/abs/base/path
+sftp://[user@]host[:port]/abs/base/path
+```
+
+- Embedded passwords (`user:pw@`) are rejected — authenticate with an SSH key
+  (`IDENTITY_FILE`) or an ssh-agent (`BatchMode=yes` would make a password
+  unusable anyway).
+- `user`: `[A-Za-z0-9._-]+`, not starting with `-`; `host`:
+  `[A-Za-z0-9.-]+`, not starting with `-`, or a bracketed IPv6 literal
+  (`[::1]`); `port`: 1–65535.
+- The base path is taken as literal bytes (never percent-decoded), the
+  trailing `/` is trimmed, control characters are rejected, and the bare root
+  `/` is rejected.
+
+## Configuration
+
+Each engine reads its own env family: `SNAPDIR_SSH_STORE_*` for `ssh://`,
+`SNAPDIR_SFTP_STORE_*` for `sftp://`.
+
+| Variable (suffix) | Default | Meaning |
+| --- | --- | --- |
+| `IDENTITY_FILE` | — | Private key path; also sets `IdentitiesOnly=yes` |
+| `KNOWN_HOSTS` | — | `UserKnownHostsFile` override |
+| `PORT` | — | Remote port; a port in the store URL wins |
+| `CONNECT_TIMEOUT` | `10` | `ConnectTimeout` seconds |
+| `JOBS` | `4` | Transfer parallelism; falls back to `SNAPDIR_JOBS`, then `SNAPDIR_MAX_JOBS` |
+| `CONTROL_PERSIST` | `60` | `ControlMaster` linger seconds |
+| `UMASK` | `077` | Umask for remote writes (`ssh://` engine only; the sftp engine uses explicit `chmod 600` instead) |
+| `EXTRA_OPTS` | — | Whitespace-separated `Key=Value` ssh options, appended **last** |
+
+Every operation multiplexes its ssh/sftp invocations over one
+`ControlMaster=auto` connection (one TCP + auth handshake per operation),
+closed on exit with `ControlPersist` as the leak backstop. Anything the
+engines don't set — `ProxyJump`, agent, `~/.ssh/config` host blocks — keeps
+working.
+
+## The security floor
+
+Every `ssh`/`sftp` invocation starts with this exact ordered flag list:
+
+```text
+-o BatchMode=yes
+-o StrictHostKeyChecking=yes
+-o PasswordAuthentication=no
+-o KbdInteractiveAuthentication=no
+-o ClearAllForwardings=yes
+-o KexAlgorithms=sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org
+-o Ciphers=chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com
+-o HostKeyAlgorithms=ssh-ed25519-cert-v01@openssh.com,ssh-ed25519,rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,rsa-sha2-512,rsa-sha2-256,ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,ecdsa-sha2-nistp521-cert-v01@openssh.com,ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521
+-o ConnectTimeout=<CONNECT_TIMEOUT>
+```
+
+Config-derived options (`Port`, `User`, `IdentityFile` + `IdentitiesOnly`,
+`UserKnownHostsFile`) come next, and `EXTRA_OPTS` tokens always come **last**.
+OpenSSH resolves every option first-obtained-value-wins (and command-line
+options beat `~/.ssh/config`), so the floor structurally cannot be weakened:
+`EXTRA_OPTS="StrictHostKeyChecking=no"` is inert because the floor's `=yes`
+was already obtained. `MACs` is deliberately not pinned — every floor cipher
+is AEAD, so OpenSSH ignores MAC negotiation for them.
+
+### OpenSSH ≥ 8.5 policy
+
+The local `ssh -V` is checked at emit time and anything older than **8.5** —
+or unparsable, including non-OpenSSH clients — **fails closed**, with no
+override env. 8.5 (March 2021) is the oldest release shipping every algorithm
+on the floor (notably `sntrup761x25519-sha512@openssh.com`). This excludes,
+for example, the stock clients of RHEL/CentOS 8 (OpenSSH 8.0), Ubuntu 20.04
+(8.2), Debian 11 (8.4), and macOS 11 and older; upgrade the local
+OpenSSH client to use these stores. The remote *server* is not version-gated
+— it only needs to offer at least one algorithm from each pinned list.
+
+## Acceleration (`ssh://` only)
+
+The emitted `ssh://` scripts embed both a "dumb" tar-pipeline path and an
+accelerated SNAPPACK path, and pick one at runtime. A push probes the remote
+in ONE round trip (manifest presence + `snapdir version --capabilities`); the
+accelerated path is taken only when the remote's capability line carries the
+exact `wire=1` token and the needed capabilities
+(`objects-needed`/`receive-pack` for push, `send-pack` for fetch) — wire
+negotiation is an exact integer match, never a semver comparison. Accelerated
+push then diffs the object list remotely (`snapdir objects-needed`) and
+streams only the missing objects through one
+`snapdir send-pack | ssh 'snapdir receive-pack'` pipe, with the manifest as
+the last record, committed remotely only after the verified `end` trailer.
+Accelerated fetch streams `ssh 'snapdir send-pack --ids -'` into a local
+`snapdir receive-pack`, which BLAKE3-verifies every record — the remote
+stream is untrusted. Full protocol:
+[docs/rust-port/ssh-wire-protocol.md](https://github.com/snapdir/snapdir/blob/main/docs/rust-port/ssh-wire-protocol.md).
+
+Probe or diff failures (ssh reachable, plumbing absent) fall back to the dumb
+path — nothing has been written yet and both paths produce byte-identical
+stores. A failure of the pack stream itself exits nonzero and is never
+silently retried on the dumb path; re-running the push/fetch resumes
+incrementally.
+
+Runtime toggles (read by the emitted script):
+
+| Variable | Effect |
+| --- | --- |
+| `SNAPDIR_SSH_NO_ACCEL=1` | Always use the dumb path |
+| `SNAPDIR_SSH_FORCE_ACCEL=1` | Error (exit 1) instead of falling back when the remote lacks the plumbing |
+| `SNAPDIR_SSH_PULL_SENDALL=1` | Accelerated fetch requests the FULL object list instead of the local cache diff |
+| `SNAPDIR_SSH_LOCAL_SNAPDIR=<path>` | Test/debug: which LOCAL `snapdir` binary anchors the pipe ends (default: `snapdir` on `PATH`) |
+
+## Troubleshooting
+
+- **`SNAPDIR_SSH_FORCE_ACCEL=1, but <host> does not offer the accelerated
+  plumbing`** — the remote has no `snapdir` on `PATH`, or one that predates
+  (or postdates) `wire=1`. The error echoes what the probe returned; install
+  or upgrade snapdir on the host, or unset `SNAPDIR_SSH_FORCE_ACCEL`.
+- **Host-key failures are fail-closed by design.** `StrictHostKeyChecking=yes`
+  is part of the un-weakenable floor, so an unknown or changed host key always
+  fails — `EXTRA_OPTS="StrictHostKeyChecking=no"` cannot bypass it. Add the
+  host key to your known-hosts file (point `KNOWN_HOSTS` at a custom one if
+  needed) before pushing.
+- **`cannot parse OpenSSH version` / `OpenSSH <x>.<y> is too old`** — the
+  local client is below the 8.5 floor (or isn't OpenSSH); upgrade it. There is
+  no override.
+- **`snapdir sync` rejects ssh/sftp stores** — by design: external stores have
+  no in-process streaming surface. Use `push`/`fetch`/`pull`/`checkout`.
 
 It is part of the snapdir project. Full documentation and the CLI are at
 **[snapdir.org](https://snapdir.org)**; the source lives in the
 [canonical repository](https://github.com/snapdir/snapdir).
+
+## License
+
+MIT

--- a/crates/snapdir-ssh-store/README.md
+++ b/crates/snapdir-ssh-store/README.md
@@ -1,0 +1,23 @@
+# snapdir-ssh-store
+
+`ssh://` and `sftp://` external stores for
+[snapdir](https://github.com/snapdir/snapdir) — content-addressable directory
+snapshots — driving the **system OpenSSH client** (no SSH reimplementation,
+zero crypto dependencies) through snapdir's documented emit-command store
+contract.
+
+Ships two binaries:
+
+- `snapdir-ssh-store` — the `ssh://` engine; requires a POSIX shell on the
+  remote host and (in a later phase) accelerates transfers when a compatible
+  `snapdir` exists remotely.
+- `snapdir-sftp-store` — the `sftp://` engine; speaks pure SFTP and works
+  against restricted accounts (`ForceCommand internal-sftp` chroots).
+
+Both enforce an un-weakenable modern-only security floor (OpenSSH >= 8.5,
+pinned key-exchange/cipher/host-key algorithm lists, `BatchMode`,
+`StrictHostKeyChecking`) — user-supplied extra options can never weaken it.
+
+It is part of the snapdir project. Full documentation and the CLI are at
+**[snapdir.org](https://snapdir.org)**; the source lives in the
+[canonical repository](https://github.com/snapdir/snapdir).

--- a/crates/snapdir-ssh-store/src/args.rs
+++ b/crates/snapdir-ssh-store/src/args.rs
@@ -1,0 +1,190 @@
+//! Std-only parsing of the emit-command contract's argument grammar.
+//!
+//! Mirrors the reference grammar exercised by
+//! `crates/snapdir-stores/tests/snapdir-mock-store`:
+//!
+//! - subcommand token: `get-manifest-command` | `get-push-command` |
+//!   `get-fetch-files-command` (position-independent);
+//! - options as `--key value` **and** `--key=value`;
+//! - `-v` | `--version` | `version` short-circuits to a version print.
+//!
+//! **Documented divergences from the mock** (the mock is bash and maximally
+//! tolerant; this parser is deliberately *rejected-with-clear-error* so user
+//! typos surface instead of silently changing behavior):
+//!
+//! - unknown `--options` and stray positional tokens are **rejected** (the
+//!   mock silently skips/stores them);
+//! - a trailing `--key` with no value is **rejected** (the mock defaults it
+//!   to `true`);
+//! - repeated options and repeated subcommands are **rejected** (the mock is
+//!   last-wins).
+
+use std::ffi::OsString;
+
+use crate::Error;
+
+/// The three interface subcommands of the emit-command store contract.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Subcommand {
+    /// Emit the script that prints the stored manifest (or a not-found error).
+    GetManifestCommand,
+    /// Emit the script that pushes staged objects then the manifest (last).
+    GetPushCommand,
+    /// Emit the script that fetches the manifest's objects into the cache.
+    GetFetchFilesCommand,
+}
+
+impl Subcommand {
+    /// The literal token this subcommand is spelled as on the command line.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::GetManifestCommand => "get-manifest-command",
+            Self::GetPushCommand => "get-push-command",
+            Self::GetFetchFilesCommand => "get-fetch-files-command",
+        }
+    }
+
+    fn from_token(token: &str) -> Option<Self> {
+        match token {
+            "get-manifest-command" => Some(Self::GetManifestCommand),
+            "get-push-command" => Some(Self::GetPushCommand),
+            "get-fetch-files-command" => Some(Self::GetFetchFilesCommand),
+            _ => None,
+        }
+    }
+}
+
+/// A fully validated contract invocation (subcommand + its options).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CommandArgs {
+    /// Which script to emit.
+    pub subcommand: Subcommand,
+    /// `--id`: the snapshot id (required by every subcommand).
+    pub id: String,
+    /// `--store`: the full store URL, passed back verbatim by the
+    /// orchestrator (required by every subcommand).
+    pub store: String,
+    /// `--staging-dir`: the local sharded staging root (required by
+    /// `get-push-command`).
+    pub staging_dir: Option<String>,
+    /// `--cache-dir`: the local sharded cache root (required by
+    /// `get-fetch-files-command`).
+    pub cache_dir: Option<String>,
+}
+
+/// What a command line asked for.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Invocation {
+    /// `-v` / `--version` / `version`: print `snapdir-<scheme>-store <ver>`.
+    Version,
+    /// One of the three emit subcommands.
+    Command(CommandArgs),
+}
+
+/// Parses contract arguments (program name already stripped).
+///
+/// # Errors
+///
+/// Rejects non-UTF-8 arguments, unknown/duplicate options, stray positional
+/// tokens, a `--key` missing its value, a missing subcommand, and missing
+/// required options for the given subcommand.
+pub fn parse<I>(args: I) -> Result<Invocation, Error>
+where
+    I: IntoIterator<Item = OsString>,
+{
+    let mut subcommand: Option<Subcommand> = None;
+    let mut id: Option<String> = None;
+    let mut store: Option<String> = None;
+    let mut staging_dir: Option<String> = None;
+    let mut cache_dir: Option<String> = None;
+
+    let mut iter = args.into_iter();
+    while let Some(raw) = iter.next() {
+        let arg = into_utf8(raw)?;
+        // Version short-circuits wherever it appears, like the mock.
+        if matches!(arg.as_str(), "-v" | "--version" | "version") {
+            return Ok(Invocation::Version);
+        }
+        if let Some(sub) = Subcommand::from_token(&arg) {
+            if subcommand.is_some() {
+                return Err(Error::new(format!(
+                    "multiple subcommands given (second was '{arg}')"
+                )));
+            }
+            subcommand = Some(sub);
+            continue;
+        }
+        let Some(rest) = arg.strip_prefix("--") else {
+            // Divergence: the mock silently skips stray tokens.
+            return Err(Error::new(format!("unexpected argument '{arg}'")));
+        };
+        let (key, value) = if let Some((key, value)) = rest.split_once('=') {
+            (key.to_owned(), value.to_owned())
+        } else {
+            let value = iter
+                .next()
+                .ok_or_else(|| Error::new(format!("missing value for '--{rest}'")))?;
+            (rest.to_owned(), into_utf8(value)?)
+        };
+        let slot = match key.as_str() {
+            "id" => &mut id,
+            "store" => &mut store,
+            "staging-dir" => &mut staging_dir,
+            "cache-dir" => &mut cache_dir,
+            // Divergence: the mock stores unknown options and never reads them.
+            _ => return Err(Error::new(format!("unknown option '--{key}'"))),
+        };
+        if slot.is_some() {
+            // Divergence: the mock is last-wins on repeated options.
+            return Err(Error::new(format!("option '--{key}' given more than once")));
+        }
+        *slot = Some(value);
+    }
+
+    let subcommand = subcommand.ok_or_else(|| {
+        Error::new(
+            "missing subcommand: expected get-manifest-command, get-push-command, \
+             or get-fetch-files-command",
+        )
+    })?;
+    let id = require(id, "--id")?;
+    let store = require(store, "--store")?;
+    match subcommand {
+        Subcommand::GetPushCommand if staging_dir.is_none() => {
+            return Err(missing("--staging-dir", subcommand));
+        }
+        Subcommand::GetFetchFilesCommand if cache_dir.is_none() => {
+            return Err(missing("--cache-dir", subcommand));
+        }
+        _ => {}
+    }
+
+    Ok(Invocation::Command(CommandArgs {
+        subcommand,
+        id,
+        store,
+        staging_dir,
+        cache_dir,
+    }))
+}
+
+fn into_utf8(raw: OsString) -> Result<String, Error> {
+    raw.into_string().map_err(|bad| {
+        Error::new(format!(
+            "argument '{}' is not valid UTF-8",
+            bad.to_string_lossy()
+        ))
+    })
+}
+
+fn require(value: Option<String>, option: &str) -> Result<String, Error> {
+    value.ok_or_else(|| Error::new(format!("missing required option {option}")))
+}
+
+fn missing(option: &str, subcommand: Subcommand) -> Error {
+    Error::new(format!(
+        "missing required option {option} for {}",
+        subcommand.as_str()
+    ))
+}

--- a/crates/snapdir-ssh-store/src/bin/snapdir-sftp-store.rs
+++ b/crates/snapdir-ssh-store/src/bin/snapdir-sftp-store.rs
@@ -1,0 +1,10 @@
+//! The `sftp://` external-store binary: a thin shim into the library.
+
+fn main() -> std::process::ExitCode {
+    let code = snapdir_ssh_store::run(
+        snapdir_ssh_store::Engine::Sftp,
+        std::env::args_os(),
+        std::io::stdin().lock(),
+    );
+    std::process::ExitCode::from(code)
+}

--- a/crates/snapdir-ssh-store/src/bin/snapdir-ssh-store.rs
+++ b/crates/snapdir-ssh-store/src/bin/snapdir-ssh-store.rs
@@ -1,0 +1,10 @@
+//! The `ssh://` external-store binary: a thin shim into the library.
+
+fn main() -> std::process::ExitCode {
+    let code = snapdir_ssh_store::run(
+        snapdir_ssh_store::Engine::Ssh,
+        std::env::args_os(),
+        std::io::stdin().lock(),
+    );
+    std::process::ExitCode::from(code)
+}

--- a/crates/snapdir-ssh-store/src/config.rs
+++ b/crates/snapdir-ssh-store/src/config.rs
@@ -1,0 +1,283 @@
+//! Env-family configuration + the **un-weakenable security-floor** flag
+//! builder.
+//!
+//! Each engine reads its own prefix family ([`crate::Engine::env_prefix`]):
+//! `SNAPDIR_SSH_STORE_*` for `ssh://`, `SNAPDIR_SFTP_STORE_*` for `sftp://`.
+//!
+//! # The ordering invariant (why extras can never weaken the floor)
+//!
+//! OpenSSH resolves every `-o Key=Value` option **first-obtained-value-wins**
+//! across the whole command line (and command-line options beat
+//! `~/.ssh/config`). [`Config::flag_args`] therefore emits, in order:
+//!
+//! 1. the **security floor** (`BatchMode`, `StrictHostKeyChecking`, no
+//!    password/keyboard-interactive auth, `ClearAllForwardings`, pinned
+//!    modern-only Kex/Cipher/HostKey algorithm lists, `ConnectTimeout`) —
+//!    always first;
+//! 2. config-derived options (`Port` — URL beats env —, `User`,
+//!    `IdentityFile` + `IdentitiesOnly`, `UserKnownHostsFile`);
+//! 3. `EXTRA_OPTS` tokens — always **last**.
+//!
+//! So a hostile/typo'd `EXTRA_OPTS="StrictHostKeyChecking=no"` is structurally
+//! inert: the floor's `=yes` was already obtained. Extras can only *add*
+//! options the floor doesn't set (`ProxyJump`, `Compression`,
+//! `ServerAlive*`, …).
+//!
+//! # Why no `MACs` pin
+//!
+//! Every cipher on the floor list is AEAD (chacha20-poly1305, AES-GCM), and
+//! OpenSSH ignores the MAC negotiation entirely for AEAD ciphers — pinning
+//! `MACs` would add a breakage surface for exactly zero security gain.
+
+use crate::url::SshUrl;
+use crate::{Engine, Error};
+
+/// Pinned key-exchange floor: post-quantum hybrid first, then X25519.
+/// All names exist in OpenSSH 8.5+ (the [`crate::version`] floor).
+pub const FLOOR_KEX_ALGORITHMS: &str =
+    "sntrup761x25519-sha512@openssh.com,curve25519-sha256,curve25519-sha256@libssh.org";
+
+/// Pinned cipher floor: AEAD-only (see the module docs on why `MACs` is
+/// deliberately not pinned).
+pub const FLOOR_CIPHERS: &str =
+    "chacha20-poly1305@openssh.com,aes256-gcm@openssh.com,aes128-gcm@openssh.com";
+
+/// Pinned host-key floor: Ed25519 preferred, RSA only as SHA-2, ECDSA kept at
+/// the tail (not broken; since the floor is un-weakenable, excluding it would
+/// strand ecdsa-only hosts). `ssh-rsa` (SHA-1) and DSS are excluded.
+pub const FLOOR_HOST_KEY_ALGORITHMS: &str = "ssh-ed25519-cert-v01@openssh.com,ssh-ed25519,\
+     rsa-sha2-512-cert-v01@openssh.com,rsa-sha2-256-cert-v01@openssh.com,\
+     rsa-sha2-512,rsa-sha2-256,\
+     ecdsa-sha2-nistp256-cert-v01@openssh.com,ecdsa-sha2-nistp384-cert-v01@openssh.com,\
+     ecdsa-sha2-nistp521-cert-v01@openssh.com,\
+     ecdsa-sha2-nistp256,ecdsa-sha2-nistp384,ecdsa-sha2-nistp521";
+
+/// Default `CONNECT_TIMEOUT` (seconds).
+pub const DEFAULT_CONNECT_TIMEOUT: u32 = 10;
+
+/// Default `JOBS` when neither the engine family nor the global
+/// `SNAPDIR_JOBS` / `SNAPDIR_MAX_JOBS` fallbacks are set.
+pub const DEFAULT_JOBS: u32 = 4;
+
+/// Default `CONTROL_PERSIST` (seconds) — the `ControlMaster` leak backstop.
+pub const DEFAULT_CONTROL_PERSIST: u32 = 60;
+
+/// Default `UMASK` for remote writes (`ssh://` engine only; the sftp engine
+/// uses explicit `chmod 600` instead).
+pub const DEFAULT_UMASK: &str = "077";
+
+/// Engine configuration read from the `SNAPDIR_<SSH|SFTP>_STORE_*` env family.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Config {
+    /// `IDENTITY_FILE` — private key path; also turns on `IdentitiesOnly=yes`.
+    pub identity_file: Option<String>,
+    /// `PORT` — remote port; a port in the store URL beats it.
+    pub port: Option<u16>,
+    /// `KNOWN_HOSTS` — `UserKnownHostsFile` override.
+    pub known_hosts: Option<String>,
+    /// `CONNECT_TIMEOUT` — seconds, default 10.
+    pub connect_timeout: u32,
+    /// `JOBS` — transfer parallelism; falls back to `SNAPDIR_JOBS`, then
+    /// `SNAPDIR_MAX_JOBS`, then 4.
+    pub jobs: u32,
+    /// `CONTROL_PERSIST` — `ControlMaster` linger seconds, default 60.
+    pub control_persist: u32,
+    /// `UMASK` — octal string applied by the remote shell engine, default
+    /// `"077"`.
+    pub umask: String,
+    /// `EXTRA_OPTS` — validated `Key=Value` ssh options, appended **last**
+    /// (see the module docs: extras can never weaken the floor).
+    pub extra_opts: Vec<String>,
+}
+
+impl Config {
+    /// Reads `engine`'s env family from the process environment.
+    ///
+    /// # Errors
+    ///
+    /// Propagates the validation errors of [`Config::from_lookup`].
+    pub fn from_env(engine: Engine) -> Result<Self, Error> {
+        Self::from_lookup(engine, |name| std::env::var(name).ok())
+    }
+
+    /// Reads `engine`'s env family through an injected `lookup` (the pure,
+    /// table-testable core of [`Config::from_env`]).
+    ///
+    /// # Errors
+    ///
+    /// Rejects unparsable numbers (`PORT`, `CONNECT_TIMEOUT`, `JOBS`,
+    /// `CONTROL_PERSIST`), a non-octal `UMASK`, and malformed `EXTRA_OPTS`
+    /// tokens, naming the offending variable.
+    pub fn from_lookup<F>(engine: Engine, lookup: F) -> Result<Self, Error>
+    where
+        F: Fn(&str) -> Option<String>,
+    {
+        let prefix = engine.env_prefix();
+        let var = |suffix: &str| format!("{prefix}{suffix}");
+
+        let port = match lookup(&var("PORT")) {
+            Some(raw) => Some(parse_port(&var("PORT"), &raw)?),
+            None => None,
+        };
+        let connect_timeout = parse_or_default(
+            &var("CONNECT_TIMEOUT"),
+            lookup(&var("CONNECT_TIMEOUT")),
+            DEFAULT_CONNECT_TIMEOUT,
+        )?;
+        let control_persist = parse_or_default(
+            &var("CONTROL_PERSIST"),
+            lookup(&var("CONTROL_PERSIST")),
+            DEFAULT_CONTROL_PERSIST,
+        )?;
+        let (jobs_var, jobs_raw) = [
+            var("JOBS"),
+            "SNAPDIR_JOBS".into(),
+            "SNAPDIR_MAX_JOBS".into(),
+        ]
+        .into_iter()
+        .find_map(|name| lookup(&name).map(|raw| (name, Some(raw))))
+        .unwrap_or((var("JOBS"), None));
+        let jobs = parse_or_default(&jobs_var, jobs_raw, DEFAULT_JOBS)?;
+        let umask = match lookup(&var("UMASK")) {
+            Some(raw) => parse_umask(&var("UMASK"), &raw)?,
+            None => DEFAULT_UMASK.to_owned(),
+        };
+        let extra_opts = match lookup(&var("EXTRA_OPTS")) {
+            Some(raw) => parse_extra_opts(&var("EXTRA_OPTS"), &raw)?,
+            None => Vec::new(),
+        };
+
+        Ok(Self {
+            identity_file: lookup(&var("IDENTITY_FILE")),
+            port,
+            known_hosts: lookup(&var("KNOWN_HOSTS")),
+            connect_timeout,
+            jobs,
+            control_persist,
+            umask,
+            extra_opts,
+        })
+    }
+
+    /// Builds the ordered `-o`-flag argv list for every `ssh`/`sftp`
+    /// invocation: **floor first, config-derived next, `EXTRA_OPTS` last**
+    /// (first-obtained-wins — see the module docs for why this ordering is
+    /// the security property).
+    ///
+    /// Returned as alternating `["-o", "Key=Value", …]` pairs.
+    #[must_use]
+    pub fn flag_args(&self, url: &SshUrl) -> Vec<String> {
+        let mut flags = Vec::new();
+        let mut opt = |value: String| {
+            flags.push("-o".to_owned());
+            flags.push(value);
+        };
+
+        // 1. The security floor — ALWAYS first.
+        opt("BatchMode=yes".to_owned());
+        opt("StrictHostKeyChecking=yes".to_owned());
+        opt("PasswordAuthentication=no".to_owned());
+        opt("KbdInteractiveAuthentication=no".to_owned());
+        opt("ClearAllForwardings=yes".to_owned());
+        opt(format!("KexAlgorithms={FLOOR_KEX_ALGORITHMS}"));
+        opt(format!("Ciphers={FLOOR_CIPHERS}"));
+        opt(format!("HostKeyAlgorithms={FLOOR_HOST_KEY_ALGORITHMS}"));
+        opt(format!("ConnectTimeout={}", self.connect_timeout));
+
+        // 2. Config-derived options. URL port beats env port.
+        if let Some(port) = url.port.or(self.port) {
+            opt(format!("Port={port}"));
+        }
+        if let Some(user) = &url.user {
+            opt(format!("User={user}"));
+        }
+        if let Some(identity_file) = &self.identity_file {
+            opt(format!("IdentityFile={identity_file}"));
+            opt("IdentitiesOnly=yes".to_owned());
+        }
+        if let Some(known_hosts) = &self.known_hosts {
+            opt(format!("UserKnownHostsFile={known_hosts}"));
+        }
+
+        // 3. EXTRA_OPTS — ALWAYS last (already validated Key=Value tokens).
+        for extra in &self.extra_opts {
+            opt(extra.clone());
+        }
+
+        flags
+    }
+}
+
+fn parse_port(name: &str, raw: &str) -> Result<u16, Error> {
+    match raw.trim().parse::<u16>() {
+        Ok(0) | Err(_) => Err(Error::new(format!(
+            "{name}: invalid port '{raw}' (expected 1-65535)"
+        ))),
+        Ok(port) => Ok(port),
+    }
+}
+
+fn parse_or_default(name: &str, raw: Option<String>, default: u32) -> Result<u32, Error> {
+    let Some(raw) = raw else {
+        return Ok(default);
+    };
+    match raw.trim().parse::<u32>() {
+        Ok(0) | Err(_) => Err(Error::new(format!(
+            "{name}: invalid value '{raw}' (expected a positive integer)"
+        ))),
+        Ok(value) => Ok(value),
+    }
+}
+
+fn parse_umask(name: &str, raw: &str) -> Result<String, Error> {
+    let raw = raw.trim();
+    let valid = (1..=4).contains(&raw.len()) && raw.chars().all(|c| ('0'..='7').contains(&c));
+    if valid {
+        Ok(raw.to_owned())
+    } else {
+        Err(Error::new(format!(
+            "{name}: invalid umask '{raw}' (expected 1-4 octal digits, e.g. 077)"
+        )))
+    }
+}
+
+/// Splits `EXTRA_OPTS` on whitespace into `Key=Value` tokens and validates
+/// their shape: the key is an ssh option name (`[A-Za-z][A-Za-z0-9]*`) and
+/// the value is drawn from a conservative allowlist that excludes every shell
+/// metacharacter (quotes, `$`, backticks, `;`, `&`, `|`, redirects, globs,
+/// braces, whitespace, control chars) — the tokens are re-emitted inside
+/// generated bash, so the charset is the injection defense.
+fn parse_extra_opts(name: &str, raw: &str) -> Result<Vec<String>, Error> {
+    raw.split_whitespace()
+        .map(|token| {
+            let err = |why: &str| {
+                Error::new(format!(
+                    "{name}: invalid token '{token}' ({why}); expected \
+                     whitespace-separated Key=Value ssh options"
+                ))
+            };
+            let Some((key, value)) = token.split_once('=') else {
+                return Err(err("missing '='"));
+            };
+            let key_ok = key.chars().next().is_some_and(|c| c.is_ascii_alphabetic())
+                && key.chars().all(|c| c.is_ascii_alphanumeric());
+            if !key_ok {
+                return Err(err("invalid option name"));
+            }
+            let value_ok = !value.is_empty()
+                && value.chars().all(|c| {
+                    c.is_ascii_alphanumeric()
+                        || matches!(
+                            c,
+                            '.' | ',' | ':' | '/' | '_' | '@' | '+' | '%' | '-' | '~' | '=' | '^'
+                        )
+                });
+            if !value_ok {
+                return Err(err(
+                    "the value contains characters outside [A-Za-z0-9.,:/_@+%-~=^]",
+                ));
+            }
+            Ok(token.to_owned())
+        })
+        .collect()
+}

--- a/crates/snapdir-ssh-store/src/lib.rs
+++ b/crates/snapdir-ssh-store/src/lib.rs
@@ -27,9 +27,9 @@
 //! ([`url`]), env-family configuration + the un-weakenable security-floor
 //! flag builder ([`config`]), `ssh -V` floor check ([`version`]), and the
 //! emitted-script skeleton/quoting helpers ([`script`]) — are fully
-//! implemented and table-tested. The transport engines (the actual
-//! `ssh`/`sftp` script bodies) land in later gates; until then the
-//! subcommands fail closed with a clear "not implemented" error.
+//! implemented and table-tested. The `sftp://` transport engine
+//! ([`sftp_engine`]) is implemented; the `ssh://` engine lands in a later
+//! gate and until then fails closed with a clear "not implemented" error.
 
 use std::ffi::OsString;
 use std::fmt;
@@ -38,6 +38,7 @@ use std::io::{Read, Write};
 pub mod args;
 pub mod config;
 pub mod script;
+pub mod sftp_engine;
 pub mod url;
 pub mod version;
 
@@ -134,10 +135,9 @@ where
 ///
 /// `args` must include the program name as its first element (it is
 /// skipped). `stdin` carries the manifest text for
-/// `get-fetch-files-command`; the scaffold does not read it yet (the
-/// transport engines, which bake stdin-derived object lists into the emitted
-/// scripts, are later gates).
-pub fn run_with<I, R, W, E>(engine: Engine, args: I, _stdin: R, out: &mut W, err: &mut E) -> u8
+/// `get-fetch-files-command` (read to EOF at emit time; the engines bake the
+/// stdin-derived object lists into the emitted scripts).
+pub fn run_with<I, R, W, E>(engine: Engine, args: I, mut stdin: R, out: &mut W, err: &mut E) -> u8
 where
     I: IntoIterator<Item = OsString>,
     R: Read,
@@ -176,14 +176,55 @@ where
             return 1;
         }
     };
-    // The skeleton/flag layers are real; only the per-subcommand script
-    // bodies are missing. Fail closed until the engine gates land.
-    let _ = (&parsed_url, &cfg);
-    let _ = writeln!(
-        err,
-        "{bin}: {}: the {}:// transport engine is not implemented yet",
-        command.subcommand.as_str(),
-        engine.scheme()
-    );
-    1
+    let result = match engine {
+        Engine::Sftp => match command.subcommand {
+            args::Subcommand::GetManifestCommand => {
+                sftp_engine::get_manifest_script(&parsed_url, &cfg, &command.id, &command.store)
+            }
+            args::Subcommand::GetPushCommand => command
+                .staging_dir
+                .as_deref()
+                .ok_or_else(|| Error::new("missing required option --staging-dir"))
+                .and_then(|staging| {
+                    sftp_engine::get_push_script(&parsed_url, &cfg, &command.id, staging)
+                }),
+            args::Subcommand::GetFetchFilesCommand => {
+                // The manifest text arrives on the emitting binary's stdin.
+                let mut manifest_text = String::new();
+                match stdin.read_to_string(&mut manifest_text) {
+                    Err(e) => Err(Error::new(format!(
+                        "failed to read the manifest from stdin: {e}"
+                    ))),
+                    Ok(_) => command
+                        .cache_dir
+                        .as_deref()
+                        .ok_or_else(|| Error::new("missing required option --cache-dir"))
+                        .and_then(|cache| {
+                            sftp_engine::get_fetch_files_script(
+                                &parsed_url,
+                                &cfg,
+                                &manifest_text,
+                                cache,
+                            )
+                        }),
+                }
+            }
+        },
+        // The ssh:// engine is the next gate; fail closed until it lands.
+        Engine::Ssh => Err(Error::new(format!(
+            "{}: the {}:// transport engine is not implemented yet",
+            command.subcommand.as_str(),
+            engine.scheme()
+        ))),
+    };
+    match result {
+        Ok(script) => {
+            let _ = out.write_all(script.as_bytes());
+            0
+        }
+        Err(e) => {
+            let _ = writeln!(err, "{bin}: {e}");
+            1
+        }
+    }
 }

--- a/crates/snapdir-ssh-store/src/lib.rs
+++ b/crates/snapdir-ssh-store/src/lib.rs
@@ -5,8 +5,9 @@
 //! crypto dependencies):
 //!
 //! - `ssh://` ([`Engine::Ssh`], binary `snapdir-ssh-store`) — requires a POSIX
-//!   shell on the remote host; later phases add a remote-`snapdir`
-//!   acceleration path with graceful fallback.
+//!   shell on the remote host; the emitted scripts negotiate a remote-
+//!   `snapdir` SNAPPACK acceleration path at runtime, with graceful fallback
+//!   to the dumb tar pipeline (see [`ssh_engine`]).
 //! - `sftp://` ([`Engine::Sftp`], binary `snapdir-sftp-store`) — speaks pure
 //!   SFTP, so it works against restricted accounts (chroots with
 //!   `ForceCommand internal-sftp`) with no remote shell at all.
@@ -28,9 +29,8 @@
 //! flag builder ([`config`]), `ssh -V` floor check ([`version`]), and the
 //! emitted-script skeleton/quoting helpers ([`script`]) — are fully
 //! implemented and table-tested. Both transport engines are implemented:
-//! the `sftp://` engine ([`sftp_engine`]) and the `ssh://` dumb engine
-//! ([`ssh_engine`]; the remote-`snapdir` acceleration branch lands in a
-//! later gate).
+//! the `sftp://` engine ([`sftp_engine`]) and the `ssh://` engine
+//! ([`ssh_engine`], dumb path + runtime-negotiated SNAPPACK acceleration).
 
 use std::ffi::OsString;
 use std::fmt;

--- a/crates/snapdir-ssh-store/src/lib.rs
+++ b/crates/snapdir-ssh-store/src/lib.rs
@@ -1,0 +1,189 @@
+//! snapdir ssh/sftp external stores.
+//!
+//! Implements snapdir's *emit-command* external-store contract for two
+//! schemes over the **system OpenSSH client** (no SSH reimplementation, zero
+//! crypto dependencies):
+//!
+//! - `ssh://` ([`Engine::Ssh`], binary `snapdir-ssh-store`) — requires a POSIX
+//!   shell on the remote host; later phases add a remote-`snapdir`
+//!   acceleration path with graceful fallback.
+//! - `sftp://` ([`Engine::Sftp`], binary `snapdir-sftp-store`) — speaks pure
+//!   SFTP, so it works against restricted accounts (chroots with
+//!   `ForceCommand internal-sftp`) with no remote shell at all.
+//!
+//! Per the contract (see the shim in `snapdir-stores`), each interface
+//! subcommand does not transfer anything itself: it **prints a bash script**
+//! on stdout and the orchestrator runs it wrapped in
+//! `set -eEuo pipefail; trap 'kill 0' INT; <script>` followed by `wait`.
+//! The three subcommands are:
+//!
+//! ```text
+//! <bin> get-manifest-command     --id <id> --store <url>
+//! <bin> get-push-command         --id <id> --staging-dir <dir> --store <url>
+//! <bin> get-fetch-files-command  --id <id> --store <url> --cache-dir <dir>   (manifest on stdin)
+//! ```
+//!
+//! This crate's pure layers — argument grammar ([`args`]), URL parsing
+//! ([`url`]), env-family configuration + the un-weakenable security-floor
+//! flag builder ([`config`]), `ssh -V` floor check ([`version`]), and the
+//! emitted-script skeleton/quoting helpers ([`script`]) — are fully
+//! implemented and table-tested. The transport engines (the actual
+//! `ssh`/`sftp` script bodies) land in later gates; until then the
+//! subcommands fail closed with a clear "not implemented" error.
+
+use std::ffi::OsString;
+use std::fmt;
+use std::io::{Read, Write};
+
+pub mod args;
+pub mod config;
+pub mod script;
+pub mod url;
+pub mod version;
+
+/// Which transport engine a binary shim runs as.
+///
+/// `ssh://` and `sftp://` are **distinct schemes, not aliases**: the ssh
+/// engine needs a remote POSIX shell, the sftp engine speaks pure SFTP. They
+/// share the URL grammar, env-family shape, security floor, and script
+/// skeleton, but each reads its own env prefix and rejects the other's
+/// scheme.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Engine {
+    /// The `ssh://` engine (`snapdir-ssh-store`).
+    Ssh,
+    /// The `sftp://` engine (`snapdir-sftp-store`).
+    Sftp,
+}
+
+impl Engine {
+    /// The store-URL scheme this engine serves.
+    #[must_use]
+    pub const fn scheme(self) -> &'static str {
+        match self {
+            Self::Ssh => "ssh",
+            Self::Sftp => "sftp",
+        }
+    }
+
+    /// The `snapdir-<scheme>-store` binary name this engine ships as.
+    #[must_use]
+    pub const fn binary_name(self) -> &'static str {
+        match self {
+            Self::Ssh => "snapdir-ssh-store",
+            Self::Sftp => "snapdir-sftp-store",
+        }
+    }
+
+    /// The env-var family prefix this engine reads its configuration from
+    /// (matching the `SNAPDIR_S3_STORE_ENDPOINT_URL` naming convention).
+    #[must_use]
+    pub const fn env_prefix(self) -> &'static str {
+        match self {
+            Self::Ssh => "SNAPDIR_SSH_STORE_",
+            Self::Sftp => "SNAPDIR_SFTP_STORE_",
+        }
+    }
+}
+
+/// Error type shared by every pure layer in this crate.
+///
+/// A plain diagnostic message: the binaries' only error channel is stderr +
+/// exit 1 (the orchestrator surfaces stderr verbatim), so a message-carrying
+/// newtype keeps the std-only crate small while staying `std::error::Error`-
+/// compatible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Error {
+    message: String,
+}
+
+impl Error {
+    /// Builds an error from a diagnostic message.
+    pub(crate) fn new(message: impl Into<String>) -> Self {
+        Self {
+            message: message.into(),
+        }
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.message)
+    }
+}
+
+impl std::error::Error for Error {}
+
+/// Entry point shared by both binary shims: parses `args` (including the
+/// program name as the first element, as produced by [`std::env::args_os`]),
+/// dispatches, and returns the process exit code.
+///
+/// Output goes to the real stdout/stderr; see [`run_with`] for the
+/// writer-injected core used by tests.
+pub fn run<I, R>(engine: Engine, args: I, stdin: R) -> u8
+where
+    I: IntoIterator<Item = OsString>,
+    R: Read,
+{
+    let mut out = std::io::stdout();
+    let mut err = std::io::stderr();
+    run_with(engine, args, stdin, &mut out, &mut err)
+}
+
+/// [`run`] with injectable stdout/stderr writers (the testable core).
+///
+/// `args` must include the program name as its first element (it is
+/// skipped). `stdin` carries the manifest text for
+/// `get-fetch-files-command`; the scaffold does not read it yet (the
+/// transport engines, which bake stdin-derived object lists into the emitted
+/// scripts, are later gates).
+pub fn run_with<I, R, W, E>(engine: Engine, args: I, _stdin: R, out: &mut W, err: &mut E) -> u8
+where
+    I: IntoIterator<Item = OsString>,
+    R: Read,
+    W: Write,
+    E: Write,
+{
+    let bin = engine.binary_name();
+    let invocation = match args::parse(args.into_iter().skip(1)) {
+        Ok(invocation) => invocation,
+        Err(e) => {
+            let _ = writeln!(err, "{bin}: {e}");
+            return 1;
+        }
+    };
+    let command = match invocation {
+        args::Invocation::Version => {
+            let _ = writeln!(out, "{bin} {}", env!("CARGO_PKG_VERSION"));
+            return 0;
+        }
+        args::Invocation::Command(command) => command,
+    };
+
+    // Validate everything pure up front so configuration/URL mistakes fail
+    // with precise diagnostics even before the engines exist.
+    let parsed_url = match url::SshUrl::parse(engine, &command.store) {
+        Ok(parsed) => parsed,
+        Err(e) => {
+            let _ = writeln!(err, "{bin}: {e}");
+            return 1;
+        }
+    };
+    let cfg = match config::Config::from_env(engine) {
+        Ok(cfg) => cfg,
+        Err(e) => {
+            let _ = writeln!(err, "{bin}: {e}");
+            return 1;
+        }
+    };
+    // The skeleton/flag layers are real; only the per-subcommand script
+    // bodies are missing. Fail closed until the engine gates land.
+    let _ = (&parsed_url, &cfg);
+    let _ = writeln!(
+        err,
+        "{bin}: {}: the {}:// transport engine is not implemented yet",
+        command.subcommand.as_str(),
+        engine.scheme()
+    );
+    1
+}

--- a/crates/snapdir-ssh-store/src/lib.rs
+++ b/crates/snapdir-ssh-store/src/lib.rs
@@ -27,9 +27,10 @@
 //! ([`url`]), env-family configuration + the un-weakenable security-floor
 //! flag builder ([`config`]), `ssh -V` floor check ([`version`]), and the
 //! emitted-script skeleton/quoting helpers ([`script`]) — are fully
-//! implemented and table-tested. The `sftp://` transport engine
-//! ([`sftp_engine`]) is implemented; the `ssh://` engine lands in a later
-//! gate and until then fails closed with a clear "not implemented" error.
+//! implemented and table-tested. Both transport engines are implemented:
+//! the `sftp://` engine ([`sftp_engine`]) and the `ssh://` dumb engine
+//! ([`ssh_engine`]; the remote-`snapdir` acceleration branch lands in a
+//! later gate).
 
 use std::ffi::OsString;
 use std::fmt;
@@ -39,6 +40,7 @@ pub mod args;
 pub mod config;
 pub mod script;
 pub mod sftp_engine;
+pub mod ssh_engine;
 pub mod url;
 pub mod version;
 
@@ -176,46 +178,52 @@ where
             return 1;
         }
     };
-    let result = match engine {
-        Engine::Sftp => match command.subcommand {
-            args::Subcommand::GetManifestCommand => {
+    let result = match command.subcommand {
+        args::Subcommand::GetManifestCommand => match engine {
+            Engine::Ssh => {
+                ssh_engine::get_manifest_script(&parsed_url, &cfg, &command.id, &command.store)
+            }
+            Engine::Sftp => {
                 sftp_engine::get_manifest_script(&parsed_url, &cfg, &command.id, &command.store)
             }
-            args::Subcommand::GetPushCommand => command
-                .staging_dir
-                .as_deref()
-                .ok_or_else(|| Error::new("missing required option --staging-dir"))
-                .and_then(|staging| {
-                    sftp_engine::get_push_script(&parsed_url, &cfg, &command.id, staging)
-                }),
-            args::Subcommand::GetFetchFilesCommand => {
-                // The manifest text arrives on the emitting binary's stdin.
-                let mut manifest_text = String::new();
-                match stdin.read_to_string(&mut manifest_text) {
-                    Err(e) => Err(Error::new(format!(
-                        "failed to read the manifest from stdin: {e}"
-                    ))),
-                    Ok(_) => command
-                        .cache_dir
-                        .as_deref()
-                        .ok_or_else(|| Error::new("missing required option --cache-dir"))
-                        .and_then(|cache| {
-                            sftp_engine::get_fetch_files_script(
-                                &parsed_url,
-                                &cfg,
-                                &manifest_text,
-                                cache,
-                            )
-                        }),
-                }
-            }
         },
-        // The ssh:// engine is the next gate; fail closed until it lands.
-        Engine::Ssh => Err(Error::new(format!(
-            "{}: the {}:// transport engine is not implemented yet",
-            command.subcommand.as_str(),
-            engine.scheme()
-        ))),
+        args::Subcommand::GetPushCommand => command
+            .staging_dir
+            .as_deref()
+            .ok_or_else(|| Error::new("missing required option --staging-dir"))
+            .and_then(|staging| match engine {
+                Engine::Ssh => ssh_engine::get_push_script(&parsed_url, &cfg, &command.id, staging),
+                Engine::Sftp => {
+                    sftp_engine::get_push_script(&parsed_url, &cfg, &command.id, staging)
+                }
+            }),
+        args::Subcommand::GetFetchFilesCommand => {
+            // The manifest text arrives on the emitting binary's stdin.
+            let mut manifest_text = String::new();
+            match stdin.read_to_string(&mut manifest_text) {
+                Err(e) => Err(Error::new(format!(
+                    "failed to read the manifest from stdin: {e}"
+                ))),
+                Ok(_) => command
+                    .cache_dir
+                    .as_deref()
+                    .ok_or_else(|| Error::new("missing required option --cache-dir"))
+                    .and_then(|cache| match engine {
+                        Engine::Ssh => ssh_engine::get_fetch_files_script(
+                            &parsed_url,
+                            &cfg,
+                            &manifest_text,
+                            cache,
+                        ),
+                        Engine::Sftp => sftp_engine::get_fetch_files_script(
+                            &parsed_url,
+                            &cfg,
+                            &manifest_text,
+                            cache,
+                        ),
+                    }),
+            }
+        }
     };
     match result {
         Ok(script) => {

--- a/crates/snapdir-ssh-store/src/script.rs
+++ b/crates/snapdir-ssh-store/src/script.rs
@@ -1,0 +1,139 @@
+//! Shared emitted-script building blocks: the connection-multiplexing
+//! skeleton, POSIX/sftp quoting, heredoc emission, and the remote sharded
+//! path helpers (reusing `snapdir_core::store` — the frozen interop layout is
+//! never reimplemented here).
+//!
+//! Everything emitted must be **bash-3.2-clean** (macOS ships bash 3.2): no
+//! associative arrays, no `${var^^}`/`${var,,}`, no `readarray`. The
+//! orchestrator wraps emitted scripts in `set -eEuo pipefail; trap 'kill 0'
+//! INT; <script>` + `wait`, so the skeleton composes with `set -u` and never
+//! traps `INT` itself (the orchestrator owns it).
+
+use crate::config::Config;
+use crate::url::SshUrl;
+
+/// Quotes `s` for POSIX shells: wraps in single quotes, escaping embedded
+/// single quotes as `'\''`. Safe for any byte sequence without NUL (URL and
+/// config validation already rejected control characters upstream).
+#[must_use]
+pub fn sh_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('\'');
+    for c in s.chars() {
+        if c == '\'' {
+            out.push_str("'\\''");
+        } else {
+            out.push(c);
+        }
+    }
+    out.push('\'');
+    out
+}
+
+/// Quotes `s` for `sftp -b` batchfile arguments: wraps in double quotes,
+/// backslash-escaping embedded `"` and `\` (the quoting grammar of OpenSSH's
+/// sftp batch parser).
+#[must_use]
+pub fn sftp_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        if c == '"' || c == '\\' {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out.push('"');
+    out
+}
+
+/// Emits `command <<'DELIM'` feeding `lines` as a quoted (no-expansion)
+/// heredoc, with a **collision-safe delimiter**: the base `SNAPDIR_EOF` grows
+/// trailing underscores until it equals no line.
+///
+/// `lines` must not contain newlines (callers feed validated relative store
+/// paths / checksums; URL and config validation rejects control characters).
+#[must_use]
+pub fn heredoc(command: &str, lines: &[String]) -> String {
+    debug_assert!(
+        lines.iter().all(|line| !line.contains('\n')),
+        "heredoc lines must not contain newlines"
+    );
+    let mut delimiter = String::from("SNAPDIR_EOF");
+    while lines.iter().any(|line| line == &delimiter) {
+        delimiter.push('_');
+    }
+    let mut out = format!("{command} <<'{delimiter}'\n");
+    for line in lines {
+        out.push_str(line);
+        out.push('\n');
+    }
+    out.push_str(&delimiter);
+    out.push('\n');
+    out
+}
+
+/// The remote path of a snapshot manifest under `base`, using the frozen
+/// sharded layout from [`snapdir_core::store::manifest_path`].
+#[must_use]
+pub fn remote_manifest_path(base: &str, snapshot_id: &str) -> String {
+    format!("{base}/{}", snapdir_core::store::manifest_path(snapshot_id))
+}
+
+/// The remote path of a content object under `base`, using the frozen
+/// sharded layout from [`snapdir_core::store::object_path`].
+#[must_use]
+pub fn remote_object_path(base: &str, checksum: &str) -> String {
+    format!("{base}/{}", snapdir_core::store::object_path(checksum))
+}
+
+/// Builds the shared script skeleton every emitted script starts with:
+///
+/// - a private `0700` temp dir (keeps the `ControlPath` socket short —
+///   `sun_path` limit — and unreadable to others);
+/// - `_snapdir_cleanup` (closes the `ControlMaster` via `ssh -O exit`, removes
+///   the temp dir) wired to `trap … EXIT TERM HUP` — never `INT`, which the
+///   orchestrator wrapper owns; `ControlPersist` self-reaps the master on
+///   the signal paths bash skips the EXIT trap for;
+/// - `_snapdir_ssh` / `_snapdir_sftp` wrappers carrying
+///   `ControlMaster=auto` + `ControlPath` + `ControlPersist` and the full
+///   ordered flag list ([`Config::flag_args`]: floor, then config, then
+///   extras) ahead of `-- <host>`, so every invocation multiplexes one
+///   TCP+auth handshake and none can fall below the floor.
+#[must_use]
+pub fn skeleton(url: &SshUrl, cfg: &Config) -> String {
+    let flags = render_opt_flags(&cfg.flag_args(url));
+    let host = sh_quote(&url.host_arg());
+    let persist = cfg.control_persist;
+    let mux = "-o ControlMaster=auto -o ControlPath=\"$snapdir_tmp/cm\"";
+    format!(
+        r#"snapdir_tmp="$(mktemp -d "${{TMPDIR:-/tmp}}/snapdir-ssh-store.XXXXXX")"
+chmod 700 "$snapdir_tmp"
+_snapdir_cleanup() {{
+  command ssh {flags} -o ControlPath="$snapdir_tmp/cm" -O exit -- {host} 2>/dev/null || true
+  rm -rf "$snapdir_tmp"
+}}
+trap _snapdir_cleanup EXIT TERM HUP
+_snapdir_ssh() {{
+  command ssh {mux} -o ControlPersist={persist} {flags} -- {host} "$@"
+}}
+_snapdir_sftp() {{
+  command sftp {mux} -o ControlPersist={persist} {flags} -b "$1" -- {host}
+}}
+"#
+    )
+}
+
+/// Renders a [`Config::flag_args`] list (alternating `-o`/token pairs) as
+/// shell text, single-quoting each token.
+fn render_opt_flags(flags: &[String]) -> String {
+    flags
+        .chunks(2)
+        .map(|pair| {
+            debug_assert_eq!(pair.len(), 2, "flag_args yields -o/token pairs");
+            debug_assert_eq!(pair[0], "-o");
+            format!("-o {}", sh_quote(&pair[1]))
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}

--- a/crates/snapdir-ssh-store/src/sftp_engine.rs
+++ b/crates/snapdir-ssh-store/src/sftp_engine.rs
@@ -436,8 +436,9 @@ fn mkdir_chain(remote_file: &str) -> Vec<String> {
 /// Collects the manifest's `F`-entry checksums, deduped and sorted
 /// (`BTreeSet`), each validated as 64 lowercase hex characters — checksums
 /// become remote path segments inside emitted text, so the charset is the
-/// injection defense.
-fn file_checksums(manifest: &Manifest) -> Result<Vec<String>, Error> {
+/// injection defense. (Shared with [`crate::ssh_engine`]: the contract
+/// semantics are engine-independent.)
+pub(crate) fn file_checksums(manifest: &Manifest) -> Result<Vec<String>, Error> {
     let mut set = BTreeSet::new();
     for entry in manifest.entries() {
         if entry.path_type == PathType::File {
@@ -470,7 +471,9 @@ fn is_hex64(s: &str) -> bool {
             .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
 }
 
-fn validate_id(id: &str) -> Result<(), Error> {
+/// Validates a snapshot id as 64 lowercase hex characters (shared with
+/// [`crate::ssh_engine`] — ids are embedded in emitted text on both paths).
+pub(crate) fn validate_id(id: &str) -> Result<(), Error> {
     if is_hex64(id) {
         Ok(())
     } else {
@@ -482,8 +485,9 @@ fn validate_id(id: &str) -> Result<(), Error> {
 
 /// Local directories are embedded in emitted text (via `sh_quote` /
 /// `sftp_quote`, which handle any byte but newlines break heredoc lines), so
-/// control characters are rejected outright.
-fn validate_local_dir(option: &str, value: &str) -> Result<(), Error> {
+/// control characters are rejected outright. (Shared with
+/// [`crate::ssh_engine`].)
+pub(crate) fn validate_local_dir(option: &str, value: &str) -> Result<(), Error> {
     if value.is_empty() || value.trim_end_matches('/').is_empty() {
         return Err(Error::new(format!(
             "{option} must be a non-root directory path"

--- a/crates/snapdir-ssh-store/src/sftp_engine.rs
+++ b/crates/snapdir-ssh-store/src/sftp_engine.rs
@@ -1,0 +1,538 @@
+//! The `sftp://` transport engine: emits bash scripts that drive
+//! `sftp -b <batchfile>` over the shared `ControlMaster` (the
+//! [`crate::script::skeleton`]'s `_snapdir_sftp` wrapper).
+//!
+//! **Pure SFTP protocol** — no remote shell, no `tar`, no acceleration — so
+//! every emitted script works against restricted accounts (`ForceCommand
+//! internal-sftp` chroots). `sftp -b` semantics drive the whole design: an
+//! unprefixed batch command that fails aborts the batch with exit 1, while a
+//! `-` prefix tolerates the failure and continues.
+//!
+//! All batchfiles are written by the **emitted script** into `$snapdir_tmp`
+//! (content baked at emit time in Rust, after validation — unvalidated
+//! strings are never interpolated). The only runtime-generated batch content
+//! is local destination paths under `mktemp -d` results, assembled with
+//! `printf` from emit-time-quoted remote tokens.
+//!
+//! Engine invariants (mirroring the built-in stores and the mock contract):
+//!
+//! - **Probe before trusting absence.** The manifest probe (`ls
+//!   <manifest_path>`) is disambiguated by a `pwd` liveness batch over the
+//!   live master: connectivity failure NEVER maps to "not found" and never
+//!   triggers a silent re-push.
+//! - **Objects before manifest.** Push uploads missing objects in `JOBS`
+//!   parallel batches (each object: `-mkdir` ancestors, `put` to a
+//!   `.tmp.<nonce>` sibling, `-rm` + `rename` into place, `chmod 600`), and
+//!   commits the manifest LAST in its own batch with the same discipline. A
+//!   killed transfer leaves only `.tmp.<nonce>` files and no manifest; a
+//!   retry is idempotent (manifest probe short-circuits; the per-object
+//!   `-ls` probe skips objects already present).
+//! - **Degrade to upload-all on parse anomalies.** The `-ls` existence-probe
+//!   stdout is parsed in the script (dropping `sftp> `-echoed lines; a line
+//!   exactly matching a probed path means present). Any unrecognized listing
+//!   line degrades to uploading everything — correctness over bandwidth.
+//! - **Exact contract wordings.** Absence: `ID '<id>' not found on --store
+//!   '<store>'.` on stderr + exit 1. Missing object after fetch:
+//!   `ERROR: missing object <checksum>`. Push no-op: `Manifest already
+//!   exists on store.`
+
+use std::collections::BTreeSet;
+use std::fmt::Write as _;
+use std::path::Path;
+
+use snapdir_core::manifest::{Manifest, PathType};
+use snapdir_core::store::{manifest_path, object_path};
+
+use crate::config::Config;
+use crate::script::{
+    heredoc, remote_manifest_path, remote_object_path, sftp_quote, sh_quote, skeleton,
+};
+use crate::url::SshUrl;
+use crate::Error;
+
+/// Emits the `get-manifest-command` script: probe the manifest over the
+/// master, print the exact not-found wording on absence, otherwise `get` it
+/// into `$snapdir_tmp` (sftp chatter redirected away from stdout — stdout
+/// carries ONLY manifest bytes) and `cat` it.
+///
+/// # Errors
+///
+/// Rejects a snapshot id that is not 64 lowercase hex characters (ids are
+/// embedded in emitted text; the charset is the injection defense).
+pub fn get_manifest_script(
+    url: &SshUrl,
+    cfg: &Config,
+    id: &str,
+    store: &str,
+) -> Result<String, Error> {
+    validate_id(id)?;
+    let remote_manifest = remote_manifest_path(&url.base, id);
+    let not_found = format!("ID '{id}' not found on --store '{store}'.");
+
+    let mut script = skeleton(url, cfg);
+    script.push_str(&probe_block(&remote_manifest));
+    let _ = write!(
+        script,
+        r#"if [ "$snapdir_manifest_present" -ne 1 ]; then
+  printf '%s\n' {msg} >&2
+  exit 1
+fi
+printf 'get %s "%s/manifest"\n' {remote} "$snapdir_tmp" >"$snapdir_tmp/manifest.batch"
+_snapdir_sftp "$snapdir_tmp/manifest.batch" >/dev/null
+cat "$snapdir_tmp/manifest"
+"#,
+        msg = sh_quote(&not_found),
+        remote = sh_quote(&sftp_quote(&remote_manifest)),
+    );
+    Ok(script)
+}
+
+/// Emits the `get-push-command` script. The staged manifest is read **at
+/// emit time** from `<staging_dir>/.manifests/<sharded id>`; its `F`-entry
+/// checksums (deduped, sorted, hex64-validated) become the candidate object
+/// set baked into the script.
+///
+/// Script flow: manifest probe (present → exact no-op wording, exit 0) →
+/// ONE tolerated `-ls` batch probing every candidate → runtime parse
+/// (anomalies degrade to upload-all) → missing objects distributed
+/// round-robin over `JOBS` parallel chunk batches (each chunk: deduped
+/// sorted `-mkdir` ancestors first, then per-object
+/// `put`-tmp/`-rm`/`rename`/`chmod 600`) → backgrounded with explicit
+/// per-pid `wait` status collection → manifest LAST in its own final batch.
+///
+/// # Errors
+///
+/// Rejects an invalid id, a `--staging-dir` containing control characters,
+/// a staged manifest that is absent or unparsable, and non-hex64 object
+/// checksums.
+pub fn get_push_script(
+    url: &SshUrl,
+    cfg: &Config,
+    id: &str,
+    staging_dir: &str,
+) -> Result<String, Error> {
+    validate_id(id)?;
+    validate_local_dir("--staging-dir", staging_dir)?;
+    let staging = staging_dir.trim_end_matches('/');
+    let staged_manifest = format!("{staging}/{}", manifest_path(id));
+    let manifest_text = std::fs::read_to_string(&staged_manifest).map_err(|e| {
+        Error::new(format!(
+            "staged manifest for id '{id}' not found at '{staged_manifest}': {e}"
+        ))
+    })?;
+    let manifest = Manifest::parse(&manifest_text)
+        .map_err(|e| Error::new(format!("invalid staged manifest '{staged_manifest}': {e}")))?;
+    let checksums = file_checksums(&manifest)?;
+
+    let base = &url.base;
+    let remote_manifest = remote_manifest_path(base, id);
+    let nonce = emit_nonce();
+
+    let mut script = skeleton(url, cfg);
+    script.push_str(&probe_block(&remote_manifest));
+    // The exact no-op wording (`store` is irrelevant to it; the probe already
+    // proved the manifest is present, which implies its objects are too).
+    script.push_str(
+        "if [ \"$snapdir_manifest_present\" -eq 1 ]; then\n  \
+         echo 'Manifest already exists on store.'\n  exit 0\nfi\n",
+    );
+
+    if !checksums.is_empty() {
+        script.push_str(&push_object_tables(&checksums, base, staging, &nonce));
+        script.push_str(&push_objects_runtime(cfg.jobs));
+    }
+    script.push_str(&push_manifest_batch(
+        &staged_manifest,
+        &remote_manifest,
+        &nonce,
+    ));
+    Ok(script)
+}
+
+/// Emits the `get-fetch-files-command` script. The manifest text arrives on
+/// the **binary's stdin** (passed here already read); its `F` entries are
+/// deduped by checksum and filtered against `--cache-dir` at emit time
+/// (objects already cached are not re-fetched).
+///
+/// Script flow: `ltmp=$(mktemp -d <cache>/.snapdir-incoming.XXXXXX)` →
+/// chunked batches of tolerated `-get <remote> <ltmp>/<checksum>` (flat
+/// names), backgrounded and waited per-pid with per-chunk exit IGNORED (the
+/// post-check decides) → epilogue loop over the full needed set: present →
+/// `mkdir -p` shard + `mv -f` into the cache layout; missing → exact
+/// `ERROR: missing object <checksum>` on stderr → `rm -rf $ltmp` → exit
+/// nonzero if anything was missing.
+///
+/// # Errors
+///
+/// Rejects a `--cache-dir` containing control characters, `"` or `\`
+/// (it is interpolated into batch lines at runtime, so the charset is the
+/// quoting defense), an unparsable manifest, and non-hex64 checksums.
+pub fn get_fetch_files_script(
+    url: &SshUrl,
+    cfg: &Config,
+    manifest_text: &str,
+    cache_dir: &str,
+) -> Result<String, Error> {
+    validate_local_dir("--cache-dir", cache_dir)?;
+    if cache_dir.contains('"') || cache_dir.contains('\\') {
+        return Err(Error::new(format!(
+            "--cache-dir '{cache_dir}' contains '\"' or '\\', which cannot be \
+             quoted safely inside sftp batchfiles"
+        )));
+    }
+    let manifest = Manifest::parse(manifest_text)
+        .map_err(|e| Error::new(format!("invalid manifest on stdin: {e}")))?;
+    let checksums = file_checksums(&manifest)?;
+    let cache = cache_dir.trim_end_matches('/');
+    let needed: Vec<&String> = checksums
+        .iter()
+        .filter(|sum| !Path::new(cache).join(object_path(sum)).is_file())
+        .collect();
+
+    let mut script = skeleton(url, cfg);
+    // Extend the cleanup trap so an aborted run does not strand the incoming
+    // temp dir inside the user's cache.
+    let _ = write!(
+        script,
+        r#"snapdir_cache={cache_q}
+snapdir_ltmp=""
+_snapdir_fetch_cleanup() {{
+  if [ -n "$snapdir_ltmp" ]; then
+    rm -rf "$snapdir_ltmp"
+  fi
+  _snapdir_cleanup
+}}
+trap _snapdir_fetch_cleanup EXIT TERM HUP
+mkdir -p "$snapdir_cache"
+snapdir_ltmp="$(mktemp -d "$snapdir_cache/.snapdir-incoming.XXXXXX")"
+"#,
+        cache_q = sh_quote(cache),
+    );
+
+    if !needed.is_empty() {
+        let jobs = usize::try_from(cfg.jobs).unwrap_or(usize::MAX).max(1);
+        let chunk_count = needed.len().min(jobs);
+        let mut chunks: Vec<Vec<String>> = vec![Vec::new(); chunk_count];
+        for (i, sum) in needed.iter().enumerate() {
+            let remote = remote_object_path(&url.base, sum);
+            // `<checksum> <sftp-quoted remote>`: the remote token is quoted at
+            // emit time so the runtime printf only splices it between literals.
+            chunks[i % chunk_count].push(format!("{sum} {}", sftp_quote(&remote)));
+        }
+        for (i, chunk) in chunks.iter().enumerate() {
+            script.push_str(&heredoc(
+                &format!("cat >\"$snapdir_tmp/want.{i}.list\""),
+                chunk,
+            ));
+        }
+        script.push_str(
+            r#"snapdir_pids=""
+for snapdir_want in "$snapdir_tmp"/want.*.list; do
+  [ -e "$snapdir_want" ] || continue
+  snapdir_batch="${snapdir_want%.list}.batch"
+  while IFS= read -r snapdir_line; do
+    snapdir_sum="${snapdir_line%% *}"
+    snapdir_remote="${snapdir_line#* }"
+    printf -- '-get %s "%s/%s"\n' "$snapdir_remote" "$snapdir_ltmp" "$snapdir_sum" >>"$snapdir_batch"
+  done <"$snapdir_want"
+  _snapdir_sftp "$snapdir_batch" >/dev/null &
+  snapdir_pids="$snapdir_pids $!"
+done
+for snapdir_pid in $snapdir_pids; do
+  wait "$snapdir_pid" || true
+done
+"#,
+        );
+    }
+
+    // Epilogue: the post-check is the verify discipline — per-chunk exits
+    // were ignored above; only the presence of every needed object decides.
+    let needed_lines: Vec<String> = needed
+        .iter()
+        .map(|sum| format!("{sum} {}", object_path(sum)))
+        .collect();
+    script.push_str(&heredoc("cat >\"$snapdir_tmp/needed\"", &needed_lines));
+    script.push_str(
+        r#"snapdir_missing=0
+while IFS= read -r snapdir_line; do
+  snapdir_sum="${snapdir_line%% *}"
+  snapdir_rel="${snapdir_line#* }"
+  if [ -f "$snapdir_ltmp/$snapdir_sum" ]; then
+    mkdir -p "$snapdir_cache/${snapdir_rel%/*}"
+    mv -f "$snapdir_ltmp/$snapdir_sum" "$snapdir_cache/$snapdir_rel"
+  else
+    printf 'ERROR: missing object %s\n' "$snapdir_sum" >&2
+    snapdir_missing=1
+  fi
+done <"$snapdir_tmp/needed"
+rm -rf "$snapdir_ltmp"
+snapdir_ltmp=""
+if [ "$snapdir_missing" -ne 0 ]; then
+  exit 1
+fi
+"#,
+    );
+    Ok(script)
+}
+
+/// The shared manifest probe: `ls <manifest>` in a single-command batch; on
+/// failure a `pwd` liveness batch over the live master disambiguates
+/// "missing" (pwd ok → `snapdir_manifest_present=0`) from "unreachable"
+/// (pwd fails → the probe's stderr is surfaced and the script exits with the
+/// failure — connectivity NEVER maps to not-found).
+fn probe_block(remote_manifest: &str) -> String {
+    let probe = heredoc(
+        "cat >\"$snapdir_tmp/probe.batch\"",
+        &[format!("ls {}", sftp_quote(remote_manifest))],
+    );
+    let liveness = heredoc("cat >\"$snapdir_tmp/liveness.batch\"", &["pwd".to_owned()]);
+    format!(
+        r#"{probe}{liveness}snapdir_manifest_present=0
+if _snapdir_sftp "$snapdir_tmp/probe.batch" >/dev/null 2>"$snapdir_tmp/probe.err"; then
+  snapdir_manifest_present=1
+elif ! _snapdir_sftp "$snapdir_tmp/liveness.batch" >/dev/null 2>&1; then
+  cat "$snapdir_tmp/probe.err" >&2
+  exit 1
+fi
+"#
+    )
+}
+
+/// Emits the baked push tables: the raw candidate remote paths (for the
+/// anomaly check), the `<idx> <remote>` spool (for distribution), the single
+/// tolerated `-ls` probe batch, and per-object `-mkdir`/transfer command
+/// files assembled into chunks at runtime.
+fn push_object_tables(checksums: &[String], base: &str, staging: &str, nonce: &str) -> String {
+    let mut out = String::new();
+    let remotes: Vec<String> = checksums
+        .iter()
+        .map(|sum| remote_object_path(base, sum))
+        .collect();
+
+    out.push_str(&heredoc("cat >\"$snapdir_tmp/candidates\"", &remotes));
+    let spool: Vec<String> = remotes
+        .iter()
+        .enumerate()
+        .map(|(i, remote)| format!("{i} {remote}"))
+        .collect();
+    out.push_str(&heredoc("cat >\"$snapdir_tmp/spool\"", &spool));
+    let probe: Vec<String> = remotes
+        .iter()
+        .map(|remote| format!("-ls {}", sftp_quote(remote)))
+        .collect();
+    out.push_str(&heredoc(
+        "cat >\"$snapdir_tmp/probe-objects.batch\"",
+        &probe,
+    ));
+
+    for (i, (sum, remote)) in checksums.iter().zip(&remotes).enumerate() {
+        out.push_str(&heredoc(
+            &format!("cat >\"$snapdir_tmp/o.{i}.mkdir\""),
+            &mkdir_chain(remote),
+        ));
+        let staged = format!("{staging}/{}", object_path(sum));
+        let tmp = format!("{remote}.tmp.{nonce}");
+        out.push_str(&heredoc(
+            &format!("cat >\"$snapdir_tmp/o.{i}.cmds\""),
+            &[
+                format!("put {} {}", sftp_quote(&staged), sftp_quote(&tmp)),
+                format!("-rm {}", sftp_quote(remote)),
+                format!("rename {} {}", sftp_quote(&tmp), sftp_quote(remote)),
+                format!("chmod 600 {}", sftp_quote(remote)),
+            ],
+        ));
+    }
+    out
+}
+
+/// The runtime half of the push object transfer: parse the `-ls` probe
+/// output, distribute missing objects round-robin over `jobs` chunk batches
+/// (deduped sorted `-mkdir` ancestors first), run the chunks backgrounded
+/// over the master, and collect every chunk's exit status with explicit
+/// per-pid `wait` (the orchestrator's trailing bare `wait` finds nothing
+/// unchecked).
+fn push_objects_runtime(jobs: u32) -> String {
+    format!(
+        r#"_snapdir_sftp "$snapdir_tmp/probe-objects.batch" >"$snapdir_tmp/probe-objects.out"
+grep -v '^sftp> ' "$snapdir_tmp/probe-objects.out" >"$snapdir_tmp/probe-objects.listing" || true
+snapdir_upload_all=0
+while IFS= read -r snapdir_line; do
+  [ -n "$snapdir_line" ] || continue
+  if ! grep -qxF -- "$snapdir_line" "$snapdir_tmp/candidates"; then
+    snapdir_upload_all=1
+    break
+  fi
+done <"$snapdir_tmp/probe-objects.listing"
+snapdir_chunk=0
+while IFS= read -r snapdir_line; do
+  snapdir_idx="${{snapdir_line%% *}}"
+  snapdir_remote="${{snapdir_line#* }}"
+  if [ "$snapdir_upload_all" -ne 1 ] && grep -qxF -- "$snapdir_remote" "$snapdir_tmp/probe-objects.listing"; then
+    continue
+  fi
+  cat "$snapdir_tmp/o.$snapdir_idx.mkdir" >>"$snapdir_tmp/chunk.$snapdir_chunk.mkdir"
+  cat "$snapdir_tmp/o.$snapdir_idx.cmds" >>"$snapdir_tmp/chunk.$snapdir_chunk.cmds"
+  snapdir_chunk=$(( (snapdir_chunk + 1) % {jobs} ))
+done <"$snapdir_tmp/spool"
+snapdir_pids=""
+for snapdir_cmds in "$snapdir_tmp"/chunk.*.cmds; do
+  [ -e "$snapdir_cmds" ] || continue
+  snapdir_batch="${{snapdir_cmds%.cmds}}.batch"
+  sort -u "${{snapdir_cmds%.cmds}}.mkdir" >"$snapdir_batch"
+  cat "$snapdir_cmds" >>"$snapdir_batch"
+  _snapdir_sftp "$snapdir_batch" >/dev/null &
+  snapdir_pids="$snapdir_pids $!"
+done
+snapdir_failed=0
+for snapdir_pid in $snapdir_pids; do
+  wait "$snapdir_pid" || snapdir_failed=1
+done
+if [ "$snapdir_failed" -ne 0 ]; then
+  echo 'snapdir-sftp-store: object upload failed' >&2
+  exit 1
+fi
+"#
+    )
+}
+
+/// The final manifest commit batch (manifest LAST, objects-before-manifest):
+/// `-mkdir` ancestors, `put` to a `.tmp.<nonce>` sibling, `-rm` + `rename`
+/// into place, `chmod 600`.
+fn push_manifest_batch(staged_manifest: &str, remote_manifest: &str, nonce: &str) -> String {
+    let tmp = format!("{remote_manifest}.tmp.{nonce}");
+    let mut lines = mkdir_chain(remote_manifest);
+    lines.push(format!(
+        "put {} {}",
+        sftp_quote(staged_manifest),
+        sftp_quote(&tmp)
+    ));
+    lines.push(format!("-rm {}", sftp_quote(remote_manifest)));
+    lines.push(format!(
+        "rename {} {}",
+        sftp_quote(&tmp),
+        sftp_quote(remote_manifest)
+    ));
+    lines.push(format!("chmod 600 {}", sftp_quote(remote_manifest)));
+    let mut out = heredoc("cat >\"$snapdir_tmp/manifest.batch\"", &lines);
+    out.push_str("_snapdir_sftp \"$snapdir_tmp/manifest.batch\" >/dev/null\n");
+    out
+}
+
+/// The tolerated `-mkdir` ancestor chain of a remote **file** path, shortest
+/// prefix first (every directory component including the store base, so a
+/// fresh base is created level by level — sftp `mkdir` is single-level).
+fn mkdir_chain(remote_file: &str) -> Vec<String> {
+    let components: Vec<&str> = remote_file.split('/').filter(|c| !c.is_empty()).collect();
+    let mut prefix = String::new();
+    let mut lines = Vec::new();
+    for dir in &components[..components.len().saturating_sub(1)] {
+        prefix.push('/');
+        prefix.push_str(dir);
+        lines.push(format!("-mkdir {}", sftp_quote(&prefix)));
+    }
+    lines
+}
+
+/// Collects the manifest's `F`-entry checksums, deduped and sorted
+/// (`BTreeSet`), each validated as 64 lowercase hex characters — checksums
+/// become remote path segments inside emitted text, so the charset is the
+/// injection defense.
+fn file_checksums(manifest: &Manifest) -> Result<Vec<String>, Error> {
+    let mut set = BTreeSet::new();
+    for entry in manifest.entries() {
+        if entry.path_type == PathType::File {
+            if !is_hex64(&entry.checksum) {
+                return Err(Error::new(format!(
+                    "invalid object checksum '{}' in manifest (expected 64 \
+                     lowercase hex characters)",
+                    entry.checksum
+                )));
+            }
+            set.insert(entry.checksum.clone());
+        }
+    }
+    Ok(set.into_iter().collect())
+}
+
+/// An emit-time uniqueness token for `.tmp.<nonce>` siblings: pid + clock
+/// nanos. A killed transfer's orphaned tmp files never collide with a retry
+/// (which mints a fresh nonce) and are trivially identifiable.
+fn emit_nonce() -> String {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map_or(0, |d| d.as_nanos());
+    format!("{}.{nanos:x}", std::process::id())
+}
+
+fn is_hex64(s: &str) -> bool {
+    s.len() == 64
+        && s.bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+fn validate_id(id: &str) -> Result<(), Error> {
+    if is_hex64(id) {
+        Ok(())
+    } else {
+        Err(Error::new(format!(
+            "invalid snapshot id '{id}' (expected 64 lowercase hex characters)"
+        )))
+    }
+}
+
+/// Local directories are embedded in emitted text (via `sh_quote` /
+/// `sftp_quote`, which handle any byte but newlines break heredoc lines), so
+/// control characters are rejected outright.
+fn validate_local_dir(option: &str, value: &str) -> Result<(), Error> {
+    if value.is_empty() || value.trim_end_matches('/').is_empty() {
+        return Err(Error::new(format!(
+            "{option} must be a non-root directory path"
+        )));
+    }
+    if value.chars().any(char::is_control) {
+        return Err(Error::new(format!(
+            "{option} '{}' contains control characters",
+            value.escape_debug()
+        )));
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mkdir_chain_walks_every_ancestor_shortest_first() {
+        let sum = "49dc870df1de7fd60794cebce449f5ccdae575affaa67a24b62acb03e039db92";
+        let chain = mkdir_chain(&remote_object_path("/srv/snap", sum));
+        assert_eq!(
+            chain,
+            vec![
+                "-mkdir \"/srv\"",
+                "-mkdir \"/srv/snap\"",
+                "-mkdir \"/srv/snap/.objects\"",
+                "-mkdir \"/srv/snap/.objects/49d\"",
+                "-mkdir \"/srv/snap/.objects/49d/c87\"",
+                "-mkdir \"/srv/snap/.objects/49d/c87/0df\"",
+            ]
+        );
+    }
+
+    #[test]
+    fn hex64_validation_is_strict() {
+        assert!(is_hex64(&"a".repeat(64)));
+        assert!(!is_hex64(&"A".repeat(64)));
+        assert!(!is_hex64(&"a".repeat(63)));
+        assert!(!is_hex64(&format!("{}g", "a".repeat(63))));
+        assert!(validate_id("not-an-id").is_err());
+    }
+
+    #[test]
+    fn local_dir_validation_rejects_control_chars_and_root() {
+        assert!(validate_local_dir("--cache-dir", "/tmp/cache").is_ok());
+        assert!(validate_local_dir("--cache-dir", "").is_err());
+        assert!(validate_local_dir("--cache-dir", "/").is_err());
+        assert!(validate_local_dir("--cache-dir", "/tmp/\ncache").is_err());
+    }
+}

--- a/crates/snapdir-ssh-store/src/ssh_engine.rs
+++ b/crates/snapdir-ssh-store/src/ssh_engine.rs
@@ -1,0 +1,430 @@
+//! The `ssh://` transport engine (dumb path): emits bash scripts that drive
+//! `_snapdir_ssh` remote shell commands over the shared `ControlMaster`
+//! (the [`crate::script::skeleton`] wrapper).
+//!
+//! Requires a **POSIX shell** on the remote (the remote may be `dash` — no
+//! bashisms in remote command strings) plus `tar`, `mktemp`, and `find`. The
+//! manifest is parsed **at emit time** in Rust (push: from
+//! `--staging-dir/.manifests/<sharded id>`; fetch: from the binary's own
+//! stdin); every checksum is hex64-validated and the sharded relpath lists
+//! are baked into the emitted script as quoted heredocs — unvalidated
+//! strings never reach emitted text.
+//!
+//! The dumb push/fetch bodies live in shell functions
+//! (`_snapdir_dumb_push` / `_snapdir_dumb_fetch`) invoked from a tiny main
+//! dispatch, so the acceleration gate can later add a capability probe and
+//! branch in that dispatch without touching the bodies.
+//!
+//! Engine invariants (mirroring the sftp engine and the mock contract):
+//!
+//! - **Probe before trusting absence.** The manifest probe is a
+//!   `test -f <path>` with exit-code discipline: 0 = present, 1 = absent,
+//!   anything else (255 = connection failure, 127 = no shell, …) surfaces
+//!   the real exit code — connectivity NEVER masquerades as "not found" and
+//!   never triggers a silent re-push.
+//! - **Objects before manifest.** Push runs ONE batched remote existence
+//!   probe, streams the missing objects in a single `tar | ssh 'tar -x'`
+//!   pipeline that extracts into a remote `.snapdir-incoming.XXXXXX` temp
+//!   dir and `mv`s each object into its final sharded path (same-filesystem
+//!   rename — atomic per object), then commits the manifest LAST in its own
+//!   call with the same mktemp+`mv -f` discipline. A killed transfer leaves
+//!   no manifest and no partials at final paths; a retry is idempotent.
+//! - **Never extract an untrusted tar blindly.** Fetch saves the remote tar
+//!   to a local file and gates extraction on an **exact-match allowlist**:
+//!   `tar -tf` output is compared against the client-generated expected-path
+//!   list with `LC_ALL=C grep -vxF`; ANY unexpected entry name (which is how
+//!   `../`, absolute-path, and symlink-entry attacks from a malicious remote
+//!   must manifest) aborts before extraction.
+//! - **Exact contract wordings.** Absence: `ID '<id>' not found on --store
+//!   '<store>'.` on stderr + exit 1. Missing object: `ERROR: missing object
+//!   <checksum>` (both in the pre-transfer remote check and the local
+//!   ensure-no-errors epilogue). Push no-op: `Manifest already exists on
+//!   store.`
+
+use std::fmt::Write as _;
+use std::path::Path;
+
+use snapdir_core::manifest::Manifest;
+use snapdir_core::store::{manifest_path, object_path};
+
+use crate::config::Config;
+use crate::script::{heredoc, remote_manifest_path, sh_quote, skeleton};
+use crate::sftp_engine::{file_checksums, validate_id, validate_local_dir};
+use crate::url::SshUrl;
+use crate::Error;
+
+/// Emits the `get-manifest-command` script: `test -f` probe with exit-code
+/// discipline (absent → exact not-found wording on stderr + exit 1; any
+/// non-0/1 exit → connectivity error with the real exit code), then
+/// `cat <manifest>` — stdout carries ONLY manifest bytes.
+///
+/// # Errors
+///
+/// Rejects a snapshot id that is not 64 lowercase hex characters (ids are
+/// embedded in emitted text; the charset is the injection defense).
+pub fn get_manifest_script(
+    url: &SshUrl,
+    cfg: &Config,
+    id: &str,
+    store: &str,
+) -> Result<String, Error> {
+    validate_id(id)?;
+    let remote_manifest = remote_manifest_path(&url.base, id);
+    let not_found = format!("ID '{id}' not found on --store '{store}'.");
+
+    let mut script = skeleton(url, cfg);
+    script.push_str(&probe_block(&remote_manifest));
+    let cat_cmd = format!("cat {}", sh_quote(&remote_manifest));
+    let _ = write!(
+        script,
+        r#"if [ "$snapdir_manifest_present" -ne 1 ]; then
+  printf '%s\n' {msg} >&2
+  exit 1
+fi
+_snapdir_ssh {cat}
+"#,
+        msg = sh_quote(&not_found),
+        cat = sh_quote(&cat_cmd),
+    );
+    Ok(script)
+}
+
+/// Emits the `get-push-command` script. The staged manifest is read **at
+/// emit time** from `<staging_dir>/.manifests/<sharded id>`; its `F`-entry
+/// checksums (deduped, sorted, hex64-validated) become the candidate object
+/// set baked into the script.
+///
+/// Script flow: manifest probe (present → exact no-op wording, exit 0) →
+/// `_snapdir_dumb_push`: (a) ONE batched remote existence probe (candidate
+/// relpath heredoc piped to a remote `while read` loop under `umask <U>`,
+/// missing paths captured locally); (b) if anything is missing, one
+/// `tar -C <staging> -cf - -T missing | ssh 'tar -x into temp + mv -f'`
+/// pipeline (atomic per object via same-filesystem rename; failure
+/// propagates under the orchestrator's `pipefail`); (c) manifest LAST in a
+/// separate call (`mktemp` sibling + `cat` + `mv -f`).
+///
+/// # Errors
+///
+/// Rejects an invalid id, a `--staging-dir` containing control characters,
+/// a staged manifest that is absent or unparsable, and non-hex64 object
+/// checksums.
+pub fn get_push_script(
+    url: &SshUrl,
+    cfg: &Config,
+    id: &str,
+    staging_dir: &str,
+) -> Result<String, Error> {
+    validate_id(id)?;
+    validate_local_dir("--staging-dir", staging_dir)?;
+    let staging = staging_dir.trim_end_matches('/');
+    let staged_manifest = format!("{staging}/{}", manifest_path(id));
+    let manifest_text = std::fs::read_to_string(&staged_manifest).map_err(|e| {
+        Error::new(format!(
+            "staged manifest for id '{id}' not found at '{staged_manifest}': {e}"
+        ))
+    })?;
+    let manifest = Manifest::parse(&manifest_text)
+        .map_err(|e| Error::new(format!("invalid staged manifest '{staged_manifest}': {e}")))?;
+    let checksums = file_checksums(&manifest)?;
+
+    let base = &url.base;
+    let umask = &cfg.umask;
+    let remote_manifest = remote_manifest_path(base, id);
+
+    let mut script = skeleton(url, cfg);
+    script.push_str(&probe_block(&remote_manifest));
+    // The exact no-op wording (the probe already proved the manifest is
+    // present, which implies its objects are too).
+    script.push_str(
+        "if [ \"$snapdir_manifest_present\" -eq 1 ]; then\n  \
+         echo 'Manifest already exists on store.'\n  exit 0\nfi\n",
+    );
+
+    // The dumb body, wrapped in a function so the accel gate can add a
+    // capability probe + branch in the dispatch below without touching it.
+    let mut body = String::new();
+    if !checksums.is_empty() {
+        let relpaths: Vec<String> = checksums.iter().map(|sum| object_path(sum)).collect();
+        body.push_str(&heredoc("cat >\"$snapdir_tmp/candidates\"", &relpaths));
+        // (a) ONE batched existence probe: candidates on the remote loop's
+        // stdin, missing relpaths on its stdout. POSIX-sh only — the remote
+        // shell may be dash.
+        let probe_cmd = format!(
+            "umask {umask} && mkdir -p {base_q} && cd {base_q} && \
+             while IFS= read -r p; do [ -e \"$p\" ] || printf '%s\\n' \"$p\"; done",
+            base_q = sh_quote(base),
+        );
+        let _ = writeln!(
+            body,
+            "_snapdir_ssh {} <\"$snapdir_tmp/candidates\" >\"$snapdir_tmp/missing\"",
+            sh_quote(&probe_cmd),
+        );
+        // (b) one tar pipeline for every missing object: extract into a
+        // remote same-filesystem temp dir, then mv -f each object into its
+        // final sharded path (atomic rename). The relpaths are literal
+        // [0-9a-f/.]-only, so `-T` is portable across GNU tar and bsdtar
+        // (no wildcard or option-injection surface). Runs under the
+        // orchestrator's `set -eEuo pipefail`, so either side failing fails
+        // the push.
+        let extract_cmd = format!(
+            "umask {umask} && cd {base_q} && \
+             t=$(mktemp -d .snapdir-incoming.XXXXXX) && tar -C \"$t\" -xf - && \
+             (cd \"$t\" && find .objects -type f) | \
+             while IFS= read -r p; do mkdir -p \"${{p%/*}}\" && mv -f \"$t/$p\" \"$p\"; done && \
+             rm -rf \"$t\"",
+            base_q = sh_quote(base),
+        );
+        let _ = writeln!(
+            body,
+            "if [ -s \"$snapdir_tmp/missing\" ]; then\n  \
+             tar -C {staging_q} -cf - -T \"$snapdir_tmp/missing\" | _snapdir_ssh {extract}\nfi",
+            staging_q = sh_quote(staging),
+            extract = sh_quote(&extract_cmd),
+        );
+    }
+    // (c) manifest LAST, in its own call: mktemp sibling in the manifest's
+    // shard dir, fill from the staged manifest on stdin, mv -f into place.
+    let mandir = remote_manifest
+        .rsplit_once('/')
+        .map_or("/", |(dir, _)| dir)
+        .to_owned();
+    let commit_cmd = format!(
+        "umask {umask} && mkdir -p {mandir_q} && \
+         t=$(mktemp {mandir_q}/.snapdir-manifest.XXXXXX) && cat >\"$t\" && \
+         mv -f \"$t\" {manifest_q}",
+        mandir_q = sh_quote(&mandir),
+        manifest_q = sh_quote(&remote_manifest),
+    );
+    let _ = writeln!(
+        body,
+        "_snapdir_ssh {} <{}",
+        sh_quote(&commit_cmd),
+        sh_quote(&staged_manifest),
+    );
+
+    script.push_str("_snapdir_dumb_push() {\n");
+    script.push_str(&body);
+    script.push_str("}\n_snapdir_dumb_push\n");
+    Ok(script)
+}
+
+/// Emits the `get-fetch-files-command` script. The manifest text arrives on
+/// the **binary's stdin** (passed here already read); its `F` entries are
+/// deduped by checksum and filtered against `--cache-dir` at emit time
+/// (objects already cached are not re-fetched).
+///
+/// Script flow (`_snapdir_dumb_fetch`): (a) baked `checksum relpath` pair
+/// heredoc; (b) batched remote existence check emitting exact
+/// `ERROR: missing object <checksum>` lines — any line aborts on stderr
+/// BEFORE any transfer; (c) one remote `tar -cf -` of the needed relpaths
+/// saved to `$snapdir_tmp/objects.tar`; (d) exact-match allowlist gate
+/// (`tar -tf` vs the expected list via `LC_ALL=C grep -vxF`) — any
+/// unexpected entry name aborts with the entry named, NO extraction;
+/// (e) extract into `mktemp -d <cache>/.snapdir-incoming.XXXXXX`, then
+/// per-pair `mkdir -p` shard + `mv -f` into the cache; (f) ensure-no-errors
+/// epilogue re-checking every expected object in the cache with the exact
+/// ERROR wording, exit nonzero on any.
+///
+/// # Errors
+///
+/// Rejects a `--cache-dir` containing control characters, an unparsable
+/// manifest, and non-hex64 checksums.
+pub fn get_fetch_files_script(
+    url: &SshUrl,
+    cfg: &Config,
+    manifest_text: &str,
+    cache_dir: &str,
+) -> Result<String, Error> {
+    validate_local_dir("--cache-dir", cache_dir)?;
+    let manifest = Manifest::parse(manifest_text)
+        .map_err(|e| Error::new(format!("invalid manifest on stdin: {e}")))?;
+    let checksums = file_checksums(&manifest)?;
+    let cache = cache_dir.trim_end_matches('/');
+    let needed: Vec<&String> = checksums
+        .iter()
+        .filter(|sum| !Path::new(cache).join(object_path(sum)).is_file())
+        .collect();
+
+    let mut script = skeleton(url, cfg);
+    // Extend the cleanup trap so an aborted run does not strand the incoming
+    // temp dir inside the user's cache (same pattern as the sftp engine).
+    let _ = write!(
+        script,
+        r#"snapdir_cache={cache_q}
+snapdir_ltmp=""
+_snapdir_fetch_cleanup() {{
+  if [ -n "$snapdir_ltmp" ]; then
+    rm -rf "$snapdir_ltmp"
+  fi
+  _snapdir_cleanup
+}}
+trap _snapdir_fetch_cleanup EXIT TERM HUP
+mkdir -p "$snapdir_cache"
+"#,
+        cache_q = sh_quote(cache),
+    );
+
+    let mut body = String::new();
+    // (a) `<checksum> <relpath>` pairs, baked at emit time (also drives the
+    // epilogue, so it is emitted even when nothing needs transferring).
+    let pairs: Vec<String> = needed
+        .iter()
+        .map(|sum| format!("{sum} {}", object_path(sum)))
+        .collect();
+    body.push_str(&heredoc("cat >\"$snapdir_tmp/pairs\"", &pairs));
+
+    if !needed.is_empty() {
+        let expected: Vec<String> = needed.iter().map(|sum| object_path(sum)).collect();
+        body.push_str(&heredoc("cat >\"$snapdir_tmp/expected\"", &expected));
+
+        // (b) batched remote existence check — exact ERROR wording, fail
+        // BEFORE any transfer.
+        let preflight_cmd = format!(
+            "cd {base_q} && while read -r sum p; do \
+             [ -f \"$p\" ] || printf 'ERROR: missing object %s\\n' \"$sum\"; done",
+            base_q = sh_quote(&url.base),
+        );
+        let _ = writeln!(
+            body,
+            "_snapdir_ssh {} <\"$snapdir_tmp/pairs\" >\"$snapdir_tmp/preflight-missing\"",
+            sh_quote(&preflight_cmd),
+        );
+        body.push_str(
+            r#"if [ -s "$snapdir_tmp/preflight-missing" ]; then
+  cat "$snapdir_tmp/preflight-missing" >&2
+  exit 1
+fi
+"#,
+        );
+
+        // (c) one remote tar of the needed relpaths, saved locally (NEVER
+        // piped straight into extraction). The remote spool file preserves
+        // tar's exit status past the cleanup `rm`.
+        let tar_cmd = format!(
+            "cd {base_q} && t=$(mktemp) && \
+             {{ cat >\"$t\" && tar -cf - -T \"$t\"; s=$?; rm -f \"$t\"; exit $s; }}",
+            base_q = sh_quote(&url.base),
+        );
+        let _ = writeln!(
+            body,
+            "_snapdir_ssh {} <\"$snapdir_tmp/expected\" >\"$snapdir_tmp/objects.tar\"",
+            sh_quote(&tar_cmd),
+        );
+
+        // (d) ALLOWLIST GATE: every entry name must exactly match an
+        // expected relpath. `../`, absolute paths, and symlink entries from
+        // a malicious remote all fail the same exact-match property —
+        // refuse to extract and name the offender.
+        body.push_str(
+            r#"tar -tf "$snapdir_tmp/objects.tar" >"$snapdir_tmp/entries"
+if LC_ALL=C grep -vxF -f "$snapdir_tmp/expected" "$snapdir_tmp/entries" >"$snapdir_tmp/unexpected"; then
+  printf 'snapdir-ssh-store: unexpected entry in remote tar (refusing to extract):\n' >&2
+  cat "$snapdir_tmp/unexpected" >&2
+  exit 1
+fi
+"#,
+        );
+
+        // (e) extract into an incoming temp dir under the cache (same
+        // filesystem), then mv -f each object into its sharded final path.
+        body.push_str(
+            r#"snapdir_ltmp="$(mktemp -d "$snapdir_cache/.snapdir-incoming.XXXXXX")"
+tar -C "$snapdir_ltmp" -xf "$snapdir_tmp/objects.tar"
+while IFS= read -r snapdir_line; do
+  snapdir_sum="${snapdir_line%% *}"
+  snapdir_rel="${snapdir_line#* }"
+  if [ -f "$snapdir_ltmp/$snapdir_rel" ]; then
+    mkdir -p "$snapdir_cache/${snapdir_rel%/*}"
+    mv -f "$snapdir_ltmp/$snapdir_rel" "$snapdir_cache/$snapdir_rel"
+  fi
+done <"$snapdir_tmp/pairs"
+rm -rf "$snapdir_ltmp"
+snapdir_ltmp=""
+"#,
+        );
+    }
+
+    // (f) ensure-no-errors epilogue: re-check every needed object in the
+    // cache with the exact wording; exit nonzero on any.
+    body.push_str(
+        r#"snapdir_missing=0
+while IFS= read -r snapdir_line; do
+  snapdir_sum="${snapdir_line%% *}"
+  snapdir_rel="${snapdir_line#* }"
+  if [ ! -f "$snapdir_cache/$snapdir_rel" ]; then
+    printf 'ERROR: missing object %s\n' "$snapdir_sum" >&2
+    snapdir_missing=1
+  fi
+done <"$snapdir_tmp/pairs"
+if [ "$snapdir_missing" -ne 0 ]; then
+  exit 1
+fi
+"#,
+    );
+
+    script.push_str("_snapdir_dumb_fetch() {\n");
+    script.push_str(&body);
+    script.push_str("}\n_snapdir_dumb_fetch\n");
+    Ok(script)
+}
+
+/// The shared manifest probe: `_snapdir_ssh 'test -f <path>'` with strict
+/// exit-code discipline — 0 → `snapdir_manifest_present=1`; 1 → absent
+/// (`snapdir_manifest_present=0`); anything else (255 = connection failure,
+/// 127 = no remote shell, …) → the real exit code is surfaced on stderr and
+/// the script exits with it. Connectivity NEVER maps to not-found.
+fn probe_block(remote_manifest: &str) -> String {
+    let probe_cmd = format!("test -f {}", sh_quote(remote_manifest));
+    format!(
+        r#"snapdir_manifest_present=0
+snapdir_probe_status=0
+_snapdir_ssh {probe} || snapdir_probe_status=$?
+if [ "$snapdir_probe_status" -eq 0 ]; then
+  snapdir_manifest_present=1
+elif [ "$snapdir_probe_status" -ne 1 ]; then
+  printf 'snapdir-ssh-store: failed to reach the store (ssh exit %s)\n' "$snapdir_probe_status" >&2
+  exit "$snapdir_probe_status"
+fi
+"#,
+        probe = sh_quote(&probe_cmd),
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Engine;
+
+    fn url() -> SshUrl {
+        SshUrl::parse(Engine::Ssh, "ssh://example.com/srv/snap").unwrap()
+    }
+
+    fn cfg() -> Config {
+        Config::from_lookup(Engine::Ssh, |_| None).unwrap()
+    }
+
+    #[test]
+    fn probe_block_distinguishes_absent_from_unreachable() {
+        let block = probe_block("/srv/snap/.manifests/abc/def/xyz");
+        assert!(block.contains("test -f"));
+        assert!(block.contains("-ne 1"), "non-0/1 exits are connectivity");
+        assert!(block.contains("exit \"$snapdir_probe_status\""));
+        assert!(
+            !block.contains("not found"),
+            "connectivity wording must never look like not-found"
+        );
+    }
+
+    #[test]
+    fn get_manifest_rejects_invalid_id() {
+        let err = get_manifest_script(&url(), &cfg(), "not-hex", "ssh://example.com/srv/snap")
+            .unwrap_err();
+        assert!(err.to_string().contains("invalid snapshot id"));
+    }
+
+    #[test]
+    fn fetch_rejects_garbage_manifest() {
+        let err = get_fetch_files_script(&url(), &cfg(), "not a manifest", "/tmp/c").unwrap_err();
+        assert!(err.to_string().contains("invalid manifest on stdin"));
+    }
+}

--- a/crates/snapdir-ssh-store/src/ssh_engine.rs
+++ b/crates/snapdir-ssh-store/src/ssh_engine.rs
@@ -11,9 +11,42 @@
 //! strings never reach emitted text.
 //!
 //! The dumb push/fetch bodies live in shell functions
-//! (`_snapdir_dumb_push` / `_snapdir_dumb_fetch`) invoked from a tiny main
-//! dispatch, so the acceleration gate can later add a capability probe and
-//! branch in that dispatch without touching the bodies.
+//! (`_snapdir_dumb_push` / `_snapdir_dumb_fetch`); the main dispatch probes
+//! the remote for a wire-compatible `snapdir` **at script runtime** (emit
+//! time has no connection) and branches into `_snapdir_accel_push` /
+//! `_snapdir_accel_fetch` when the negotiation succeeds, falling back to the
+//! dumb bodies otherwise. Both paths are always embedded.
+//!
+//! Acceleration (runtime-negotiated, ssh:// only):
+//!
+//! - **Push** probes manifest presence AND capabilities in ONE round trip
+//!   (`test -f …; command -v snapdir && snapdir version --capabilities ||
+//!   echo 'caps none'`), then either short-circuits (manifest present),
+//!   streams a SNAPPACK (`snapdir objects-needed` diff → local `snapdir
+//!   send-pack | ssh 'snapdir receive-pack --require-manifest <id>'`; the
+//!   manifest rides the pack LAST, committed remotely only after the
+//!   verified `end` trailer), or runs `_snapdir_dumb_push`.
+//! - **Fetch** uses a caps-only probe and streams `ssh 'snapdir send-pack
+//!   --ids -' | snapdir receive-pack --store file://<cache>` — the remote
+//!   stream is untrusted, so the LOCAL receive-pack verifies every record.
+//! - **Negotiation** keys on the exact ` wire=1` token (a literal baked at
+//!   emit time from this module's [`WIRE_VERSION`], pinned by test to
+//!   `snapdir_stores::WIRE_VERSION` — never parsed from the semver) plus the
+//!   required entries of the `caps=` comma list.
+//! - **Runtime env knobs** (read by the emitted script, not this binary):
+//!   `SNAPDIR_SSH_NO_ACCEL=1` forces the dumb path;
+//!   `SNAPDIR_SSH_FORCE_ACCEL=1` errors instead of falling back when the
+//!   remote lacks the plumbing; `SNAPDIR_SSH_PULL_SENDALL=1` makes an
+//!   accelerated fetch request the FULL object list (both id lists are
+//!   baked, picked at runtime); `SNAPDIR_SSH_LOCAL_SNAPDIR=<abs path>` is
+//!   test/debug plumbing overriding which LOCAL `snapdir` binary anchors the
+//!   pipe ends (default: `snapdir` on `PATH`; a missing local binary
+//!   gracefully degrades to the dumb path).
+//! - **Fallback policy**: probe/diff failures (ssh reachable, plumbing not)
+//!   fall back to the dumb path — nothing has been written, the dumb path is
+//!   idempotent. A failure of the send|receive STREAM itself exits nonzero
+//!   with a retry hint and NEVER silently retries dumb (the failure is
+//!   likely environmental; a retry resumes incrementally for free).
 //!
 //! Engine invariants (mirroring the sftp engine and the mock contract):
 //!
@@ -52,6 +85,217 @@ use crate::script::{heredoc, remote_manifest_path, sh_quote, skeleton};
 use crate::sftp_engine::{file_checksums, validate_id, validate_local_dir};
 use crate::url::SshUrl;
 use crate::Error;
+
+/// The SNAPPACK wire version the emitted scripts negotiate on, baked into
+/// the script text as the literal ` wire=1` token (an exact integer match —
+/// NEVER derived from the remote's semver at runtime).
+///
+/// The shipped lib deliberately depends only on `snapdir-core`, so this is a
+/// local constant; the `wire_version_matches_snapdir_stores` unit test pins
+/// it to `snapdir_stores::WIRE_VERSION` (a dev-dependency) so a wire bump
+/// cannot silently desync the probe.
+const WIRE_VERSION: u32 = 1;
+
+/// The caps the push dispatch requires of the remote `snapdir`.
+const PUSH_CAPS: &str = "objects-needed,receive-pack";
+
+/// The cap the fetch dispatch requires of the remote `snapdir`.
+const FETCH_CAPS: &str = "send-pack";
+
+/// The shell that aborts on any probe transport failure: a nonzero
+/// `_snapdir_ssh` exit is connectivity (the probe's remote command itself
+/// always exits 0), surfaced with the real exit code — it NEVER maps to
+/// not-found or "no capabilities".
+const PROBE_GUARD: &str = r#"if [ "$snapdir_probe_status" -ne 0 ]; then
+  printf 'snapdir-ssh-store: failed to reach the store (ssh exit %s)\n' "$snapdir_probe_status" >&2
+  exit "$snapdir_probe_status"
+fi
+"#;
+
+/// The combined push probe — ONE round trip answering both "is the manifest
+/// already there?" (`manifest=0|1` line) and "what plumbing does the remote
+/// offer?" (a `snapdir <semver> wire=N caps=…` line, or `caps none` when
+/// `snapdir` is absent or predates `version --capabilities`).
+fn combined_probe_block(remote_manifest: &str) -> String {
+    let probe_cmd = format!(
+        "if test -f {man_q}; then echo manifest=1; else echo manifest=0; fi; \
+         command -v snapdir >/dev/null 2>&1 && snapdir version --capabilities || echo 'caps none'",
+        man_q = sh_quote(remote_manifest),
+    );
+    format!(
+        "snapdir_probe_status=0\n\
+         _snapdir_ssh {probe} >\"$snapdir_tmp/probe\" || snapdir_probe_status=$?\n\
+         {PROBE_GUARD}",
+        probe = sh_quote(&probe_cmd),
+    )
+}
+
+/// The caps-only fetch probe (fetch has no manifest to test — the manifest
+/// already arrived via `get-manifest-command`).
+fn caps_probe_block() -> String {
+    let probe_cmd = "command -v snapdir >/dev/null 2>&1 && \
+                     snapdir version --capabilities || echo 'caps none'";
+    format!(
+        "snapdir_probe_status=0\n\
+         _snapdir_ssh {probe} >\"$snapdir_tmp/probe\" || snapdir_probe_status=$?\n\
+         {PROBE_GUARD}",
+        probe = sh_quote(probe_cmd),
+    )
+}
+
+/// The runtime accel prelude: resolves the LOCAL `snapdir` binary
+/// (`SNAPDIR_SSH_LOCAL_SNAPDIR` override, else `snapdir` on `PATH`; absence
+/// flips `snapdir_local_ok=0` → graceful dumb fallback) and defines
+/// `_snapdir_caps_ok <cap>…`, the bash-3.2/POSIX capability check: the first
+/// probe line starting `snapdir ` must carry the exact ` wire=<N>` token
+/// (baked literal from [`WIRE_VERSION`]) and every required cap as a
+/// word-bounded member of the `caps=` comma list.
+fn accel_prelude() -> String {
+    format!(
+        r#"snapdir_local="${{SNAPDIR_SSH_LOCAL_SNAPDIR:-snapdir}}"
+snapdir_local_ok=0
+if command -v "$snapdir_local" >/dev/null 2>&1; then
+  snapdir_local_ok=1
+fi
+_snapdir_caps_ok() {{
+  snapdir_caps_line=''
+  while IFS= read -r snapdir_probe_line; do
+    case "$snapdir_probe_line" in
+    'snapdir '*)
+      snapdir_caps_line="$snapdir_probe_line"
+      break
+      ;;
+    esac
+  done <"$snapdir_tmp/probe"
+  if [ -z "$snapdir_caps_line" ]; then
+    return 1
+  fi
+  case " $snapdir_caps_line " in
+  *' wire={WIRE_VERSION} '*) ;;
+  *) return 1 ;;
+  esac
+  snapdir_caps_csv=''
+  for snapdir_caps_tok in $snapdir_caps_line; do
+    case "$snapdir_caps_tok" in
+    caps=*) snapdir_caps_csv=",${{snapdir_caps_tok#caps=}}," ;;
+    esac
+  done
+  for snapdir_cap in "$@"; do
+    case "$snapdir_caps_csv" in
+    *",$snapdir_cap,"*) ;;
+    *) return 1 ;;
+    esac
+  done
+  return 0
+}}
+"#
+    )
+}
+
+/// The `SNAPDIR_SSH_FORCE_ACCEL=1`-but-no-caps error body (emitted inside an
+/// `elif … then` arm): names the host, the required wire/caps, echoes what
+/// the probe actually returned, and lists the remedies. Exit 1.
+fn force_accel_error_block(host: &str, required_caps: &str) -> String {
+    format!(
+        r#"  {{
+    printf 'snapdir-ssh-store: SNAPDIR_SSH_FORCE_ACCEL=1, but %s does not offer the accelerated plumbing\n' {host_q}
+    printf 'required: snapdir on the remote PATH with wire={WIRE_VERSION} and caps %s\n' '{required_caps}'
+    printf 'the probe returned:\n'
+    cat "$snapdir_tmp/probe"
+    printf 'remedies: install or upgrade snapdir on %s, or unset SNAPDIR_SSH_FORCE_ACCEL\n' {host_q}
+  }} >&2
+  exit 1
+"#,
+        host_q = sh_quote(host),
+    )
+}
+
+/// `_snapdir_accel_push`: round trips 2+3 of the accelerated push. The baked
+/// want list (the manifest's deduped F-checksums) is diffed remotely via
+/// `snapdir objects-needed` (failure here → `_snapdir_dumb_push`, nothing
+/// written yet), then ONE local `send-pack | ssh 'receive-pack'` pipe
+/// streams the missing objects with the manifest as the LAST record — the
+/// remote commits it only after the verified `end` trailer. An EMPTY missing
+/// set still streams the manifest-only pack (completes an interrupted push).
+/// A stream failure exits nonzero with a retry hint — never a silent dumb
+/// retry mid-stream.
+fn accel_push_fn(base: &str, staging_abs: &str, id: &str, checksums: &[String]) -> String {
+    let store_url_q = sh_quote(&format!("file://{base}"));
+    let objects_needed_cmd = format!("snapdir objects-needed --store {store_url_q}");
+    let receive_cmd = format!(
+        "snapdir receive-pack --store {store_url_q} --require-manifest {}",
+        sh_quote(id),
+    );
+    let mut body = heredoc("cat >\"$snapdir_tmp/want\"", checksums);
+    let _ = write!(
+        body,
+        r#"if [ -s "$snapdir_tmp/want" ]; then
+  snapdir_need_status=0
+  _snapdir_ssh {objneed} <"$snapdir_tmp/want" >"$snapdir_tmp/need" || snapdir_need_status=$?
+  if [ "$snapdir_need_status" -ne 0 ]; then
+    _snapdir_dumb_push
+    return 0
+  fi
+else
+  : >"$snapdir_tmp/need"
+fi
+snapdir_stream_status=0
+"$snapdir_local" send-pack --store {staging_url} --ids "$snapdir_tmp/need" --manifest-id {id_q} | _snapdir_ssh {recv} || snapdir_stream_status=$?
+if [ "$snapdir_stream_status" -ne 0 ]; then
+  printf 'snapdir-ssh-store: accelerated push stream failed (exit %s); retrying the push resumes incrementally\n' "$snapdir_stream_status" >&2
+  exit "$snapdir_stream_status"
+fi
+"#,
+        objneed = sh_quote(&objects_needed_cmd),
+        staging_url = sh_quote(&format!("file://{staging_abs}")),
+        id_q = sh_quote(id),
+        recv = sh_quote(&receive_cmd),
+    );
+    format!("_snapdir_accel_push() {{\n{body}}}\n")
+}
+
+/// `_snapdir_accel_fetch`: one round trip streaming the runtime-chosen id
+/// list (`$snapdir_ids`, picked by the dispatch — the emit-time cache diff,
+/// or the full list under `SNAPDIR_SSH_PULL_SENDALL=1`) through `ssh
+/// 'snapdir send-pack --ids -' | snapdir receive-pack --store
+/// file://<cache>`. The remote stream is UNTRUSTED: the local receive-pack
+/// hash-verifies every record. Stream failure exits nonzero (no silent dumb
+/// fallback mid-stream).
+fn accel_fetch_fn(base: &str, cache_abs: &str) -> String {
+    let send_cmd = format!(
+        "snapdir send-pack --store {} --ids -",
+        sh_quote(&format!("file://{base}")),
+    );
+    format!(
+        r#"_snapdir_accel_fetch() {{
+snapdir_stream_status=0
+_snapdir_ssh {send} <"$snapdir_ids" | "$snapdir_local" receive-pack --store {cache_url} || snapdir_stream_status=$?
+if [ "$snapdir_stream_status" -ne 0 ]; then
+  printf 'snapdir-ssh-store: accelerated fetch stream failed (exit %s); retrying the fetch resumes incrementally\n' "$snapdir_stream_status" >&2
+  exit "$snapdir_stream_status"
+fi
+}}
+"#,
+        send = sh_quote(&send_cmd),
+        cache_url = sh_quote(&format!("file://{cache_abs}")),
+    )
+}
+
+/// Returns `dir` made absolute against the current working directory (the
+/// accel pipe ends hand it to `--store file://…`, which must be absolute;
+/// the orchestrator already passes absolute staging/cache dirs — this is
+/// defensive).
+fn absolute_dir(dir: &str) -> String {
+    let path = Path::new(dir);
+    if path.is_absolute() {
+        dir.to_owned()
+    } else {
+        std::env::current_dir().map_or_else(
+            |_| dir.to_owned(),
+            |cwd| cwd.join(path).display().to_string(),
+        )
+    }
+}
 
 /// Emits the `get-manifest-command` script: `test -f` probe with exit-code
 /// discipline (absent → exact not-found wording on stderr + exit 1; any
@@ -94,14 +338,16 @@ _snapdir_ssh {cat}
 /// checksums (deduped, sorted, hex64-validated) become the candidate object
 /// set baked into the script.
 ///
-/// Script flow: manifest probe (present → exact no-op wording, exit 0) →
-/// `_snapdir_dumb_push`: (a) ONE batched remote existence probe (candidate
-/// relpath heredoc piped to a remote `while read` loop under `umask <U>`,
-/// missing paths captured locally); (b) if anything is missing, one
-/// `tar -C <staging> -cf - -T missing | ssh 'tar -x into temp + mv -f'`
-/// pipeline (atomic per object via same-filesystem rename; failure
-/// propagates under the orchestrator's `pipefail`); (c) manifest LAST in a
-/// separate call (`mktemp` sibling + `cat` + `mv -f`).
+/// Script flow: ONE combined probe round trip (manifest presence + remote
+/// capabilities; present → exact no-op wording, exit 0), then the runtime
+/// dispatch (see the module docs) into either `_snapdir_accel_push`
+/// ([`accel_push_fn`]) or `_snapdir_dumb_push`: (a) ONE batched remote
+/// existence probe (candidate relpath heredoc piped to a remote `while
+/// read` loop under `umask <U>`, missing paths captured locally); (b) if
+/// anything is missing, one `tar -C <staging> -cf - -T missing | ssh 'tar
+/// -x into temp + mv -f'` pipeline (atomic per object via same-filesystem
+/// rename; failure propagates under the orchestrator's `pipefail`); (c)
+/// manifest LAST in a separate call (`mktemp` sibling + `cat` + `mv -f`).
 ///
 /// # Errors
 ///
@@ -130,15 +376,18 @@ pub fn get_push_script(
     let base = &url.base;
     let umask = &cfg.umask;
     let remote_manifest = remote_manifest_path(base, id);
+    let staging_abs = absolute_dir(staging);
 
     let mut script = skeleton(url, cfg);
-    script.push_str(&probe_block(&remote_manifest));
+    // ONE combined round trip: manifest presence + remote capabilities.
+    script.push_str(&combined_probe_block(&remote_manifest));
     // The exact no-op wording (the probe already proved the manifest is
     // present, which implies its objects are too).
     script.push_str(
-        "if [ \"$snapdir_manifest_present\" -eq 1 ]; then\n  \
+        "if grep -q '^manifest=1$' \"$snapdir_tmp/probe\"; then\n  \
          echo 'Manifest already exists on store.'\n  exit 0\nfi\n",
     );
+    script.push_str(&accel_prelude());
 
     // The dumb body, wrapped in a function so the accel gate can add a
     // capability probe + branch in the dispatch below without touching it.
@@ -204,7 +453,24 @@ pub fn get_push_script(
 
     script.push_str("_snapdir_dumb_push() {\n");
     script.push_str(&body);
-    script.push_str("}\n_snapdir_dumb_push\n");
+    script.push_str("}\n");
+    script.push_str(&accel_push_fn(base, &staging_abs, id, &checksums));
+    // Dispatch: NO_ACCEL (or no usable local snapdir — accel is impossible
+    // without one, so degrade gracefully) → dumb; negotiated caps → accel;
+    // FORCE_ACCEL without caps → designed error; else → dumb.
+    let _ = write!(
+        script,
+        r#"if [ "${{SNAPDIR_SSH_NO_ACCEL:-0}}" = "1" ] || [ "$snapdir_local_ok" -ne 1 ]; then
+  _snapdir_dumb_push
+elif _snapdir_caps_ok objects-needed receive-pack; then
+  _snapdir_accel_push
+elif [ "${{SNAPDIR_SSH_FORCE_ACCEL:-0}}" = "1" ]; then
+{err}else
+  _snapdir_dumb_push
+fi
+"#,
+        err = force_accel_error_block(&url.host_arg(), PUSH_CAPS),
+    );
     Ok(script)
 }
 
@@ -213,7 +479,12 @@ pub fn get_push_script(
 /// deduped by checksum and filtered against `--cache-dir` at emit time
 /// (objects already cached are not re-fetched).
 ///
-/// Script flow (`_snapdir_dumb_fetch`): (a) baked `checksum relpath` pair
+/// Script flow: the runtime dispatch (see the module docs; the caps-only
+/// probe round trip is skipped entirely when there is nothing to fetch)
+/// branches into `_snapdir_accel_fetch` ([`accel_fetch_fn`], fed the
+/// runtime-chosen baked id list) or `_snapdir_dumb_fetch`.
+///
+/// The dumb path (`_snapdir_dumb_fetch`): (a) baked `checksum relpath` pair
 /// heredoc; (b) batched remote existence check emitting exact
 /// `ERROR: missing object <checksum>` lines — any line aborts on stderr
 /// BEFORE any transfer; (c) one remote `tar -cf -` of the needed relpaths
@@ -364,7 +635,40 @@ fi
 
     script.push_str("_snapdir_dumb_fetch() {\n");
     script.push_str(&body);
-    script.push_str("}\n_snapdir_dumb_fetch\n");
+    script.push_str("}\n");
+
+    // Accel plumbing: BOTH id lists are baked (the emit-time cache diff and
+    // the full F-checksum list); the dispatch picks one at runtime.
+    let cache_abs = absolute_dir(cache);
+    let needed_ids: Vec<String> = needed.iter().map(|sum| (*sum).clone()).collect();
+    script.push_str(&accel_prelude());
+    script.push_str(&heredoc("cat >\"$snapdir_tmp/ids\"", &needed_ids));
+    script.push_str(&heredoc("cat >\"$snapdir_tmp/ids_all\"", &checksums));
+    script.push_str(&accel_fetch_fn(&url.base, &cache_abs));
+    // Dispatch: pick the id list (SENDALL → full), then NO_ACCEL / no local
+    // snapdir / nothing-to-fetch → dumb (the dumb body with an empty needed
+    // set makes no remote call and its epilogue passes trivially, so the
+    // probe round trip is skipped entirely); else probe caps and branch.
+    let _ = write!(
+        script,
+        r#"snapdir_ids="$snapdir_tmp/ids"
+if [ "${{SNAPDIR_SSH_PULL_SENDALL:-0}}" = "1" ]; then
+  snapdir_ids="$snapdir_tmp/ids_all"
+fi
+if [ "${{SNAPDIR_SSH_NO_ACCEL:-0}}" = "1" ] || [ "$snapdir_local_ok" -ne 1 ] || [ ! -s "$snapdir_ids" ]; then
+  _snapdir_dumb_fetch
+else
+{probe}if _snapdir_caps_ok send-pack; then
+  _snapdir_accel_fetch
+elif [ "${{SNAPDIR_SSH_FORCE_ACCEL:-0}}" = "1" ]; then
+{err}else
+  _snapdir_dumb_fetch
+fi
+fi
+"#,
+        probe = caps_probe_block(),
+        err = force_accel_error_block(&url.host_arg(), FETCH_CAPS),
+    );
     Ok(script)
 }
 
@@ -401,6 +705,25 @@ mod tests {
 
     fn cfg() -> Config {
         Config::from_lookup(Engine::Ssh, |_| None).unwrap()
+    }
+
+    #[test]
+    fn wire_version_matches_snapdir_stores() {
+        // The shipped lib depends only on snapdir-core, so the wire version
+        // is a local constant — this pin (against the dev-dependency that
+        // OWNS the protocol) is what keeps a future wire bump from silently
+        // desyncing the emitted probes.
+        assert_eq!(WIRE_VERSION, snapdir_stores::WIRE_VERSION);
+    }
+
+    #[test]
+    fn required_caps_are_advertised_by_the_cli_constants() {
+        for cap in PUSH_CAPS.split(',').chain(FETCH_CAPS.split(',')) {
+            assert!(
+                snapdir_stores::WIRE_CAPS.contains(&cap),
+                "required cap {cap:?} must be one the CLI advertises"
+            );
+        }
     }
 
     #[test]

--- a/crates/snapdir-ssh-store/src/url.rs
+++ b/crates/snapdir-ssh-store/src/url.rs
@@ -1,0 +1,187 @@
+//! Store-URL parsing for `ssh://[user@]host[:port]/abs/base` (and `sftp://`).
+//!
+//! The grammar is deliberately strict — user/host charsets double as
+//! shell-injection defense, because both end up inside emitted bash text:
+//!
+//! - the scheme must match the engine (`ssh://` vs `sftp://` are distinct
+//!   stores, not aliases);
+//! - embedded passwords (`user:pw@`) are rejected outright (use an
+//!   `IdentityFile` key or an ssh-agent — `BatchMode=yes` would make a
+//!   password unusable anyway);
+//! - user: `[A-Za-z0-9._-]+`, not starting with `-` (argv-option smuggling);
+//! - host: `[A-Za-z0-9.-]+`, not starting with `-`, **or** a bracketed IPv6
+//!   literal `[...]` (brackets stripped for storage, content `[0-9a-fA-F:]+`);
+//! - port: 1–65535;
+//! - base path: the literal bytes from the first `/` (NO percent-decoding),
+//!   trailing `/` trimmed, control characters (incl. NUL) rejected, and the
+//!   bare root `/` rejected (refusing to scatter `.objects/` over `/`).
+
+use crate::{Engine, Error};
+
+/// A parsed `ssh://` / `sftp://` store URL.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SshUrl {
+    /// The remote user, if given (`-o User=<user>`).
+    pub user: Option<String>,
+    /// The remote host: a hostname or an IPv6 literal **without** brackets.
+    pub host: String,
+    /// The URL port, if given. Beats any env-configured port.
+    pub port: Option<u16>,
+    /// The absolute base directory on the remote, leading `/` kept and
+    /// trailing `/` trimmed. Literal bytes — never percent-decoded; always
+    /// shell-quoted at emission.
+    pub base: String,
+}
+
+impl SshUrl {
+    /// Parses `input` as a store URL for `engine`'s scheme.
+    ///
+    /// # Errors
+    ///
+    /// Returns a diagnostic [`Error`] for a scheme mismatch, an embedded
+    /// password, an invalid user/host/port, or a missing/bare/`control`-char
+    /// base path. See the module docs for the exact grammar.
+    pub fn parse(engine: Engine, input: &str) -> Result<Self, Error> {
+        let scheme = engine.scheme();
+        let Some(rest) = input
+            .strip_prefix(scheme)
+            .and_then(|r| r.strip_prefix("://"))
+        else {
+            return Err(Error::new(format!(
+                "invalid store URL '{input}': expected scheme '{scheme}://' \
+                 (the {} binary serves only {scheme}:// stores)",
+                engine.binary_name()
+            )));
+        };
+
+        let Some(slash) = rest.find('/') else {
+            return Err(Error::new(format!(
+                "invalid store URL '{input}': missing absolute base path \
+                 (expected {scheme}://[user@]host[:port]/abs/base)"
+            )));
+        };
+        let (authority, raw_base) = rest.split_at(slash);
+        let base = parse_base(input, raw_base)?;
+
+        let (user, host_port) = match authority.rsplit_once('@') {
+            Some((user, host_port)) => (Some(parse_user(input, user)?), host_port),
+            None => (None, authority),
+        };
+        let (host, port) = parse_host_port(input, host_port)?;
+
+        Ok(Self {
+            user,
+            host,
+            port,
+            base,
+        })
+    }
+
+    /// The host as it should appear as the ssh/sftp destination argument:
+    /// IPv6 literals get their brackets back (sftp would otherwise read the
+    /// colons as its `host:path` separator).
+    #[must_use]
+    pub fn host_arg(&self) -> String {
+        if self.host.contains(':') {
+            format!("[{}]", self.host)
+        } else {
+            self.host.clone()
+        }
+    }
+}
+
+fn parse_base(input: &str, raw_base: &str) -> Result<String, Error> {
+    let base = raw_base.trim_end_matches('/');
+    if base.is_empty() {
+        return Err(Error::new(format!(
+            "invalid store URL '{input}': the base path must be an absolute \
+             directory below the root, not '/' itself"
+        )));
+    }
+    if base.chars().any(char::is_control) {
+        return Err(Error::new(format!(
+            "invalid store URL '{input}': the base path contains control characters"
+        )));
+    }
+    Ok(base.to_owned())
+}
+
+fn parse_user(input: &str, user: &str) -> Result<String, Error> {
+    if user.contains(':') {
+        return Err(Error::new(format!(
+            "invalid store URL '{input}': embedded passwords (user:password@) are \
+             not supported — authenticate with an SSH key (IdentityFile / \
+             SNAPDIR_SSH_STORE_IDENTITY_FILE) or an ssh-agent instead"
+        )));
+    }
+    let valid = !user.is_empty()
+        && !user.starts_with('-')
+        && user
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '_' | '-'));
+    if !valid {
+        return Err(Error::new(format!(
+            "invalid store URL '{input}': invalid user '{user}' \
+             (allowed: [A-Za-z0-9._-]+, not starting with '-')"
+        )));
+    }
+    Ok(user.to_owned())
+}
+
+fn parse_host_port(input: &str, host_port: &str) -> Result<(String, Option<u16>), Error> {
+    if let Some(after_bracket) = host_port.strip_prefix('[') {
+        // Bracketed IPv6 literal: [content][:port]
+        let Some((content, tail)) = after_bracket.split_once(']') else {
+            return Err(Error::new(format!(
+                "invalid store URL '{input}': unterminated '[' in IPv6 host"
+            )));
+        };
+        let valid =
+            !content.is_empty() && content.chars().all(|c| c.is_ascii_hexdigit() || c == ':');
+        if !valid {
+            return Err(Error::new(format!(
+                "invalid store URL '{input}': invalid IPv6 host '[{content}]' \
+                 (allowed inside brackets: [0-9a-fA-F:]+)"
+            )));
+        }
+        let port = match tail {
+            "" => None,
+            _ => match tail.strip_prefix(':') {
+                Some(port) => Some(parse_port(input, port)?),
+                None => {
+                    return Err(Error::new(format!(
+                        "invalid store URL '{input}': unexpected text after ']' \
+                         (expected ':port' or the base path)"
+                    )));
+                }
+            },
+        };
+        return Ok((content.to_owned(), port));
+    }
+
+    let (host, port) = match host_port.split_once(':') {
+        Some((host, port)) => (host, Some(parse_port(input, port)?)),
+        None => (host_port, None),
+    };
+    let valid = !host.is_empty()
+        && !host.starts_with('-')
+        && host
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || matches!(c, '.' | '-'));
+    if !valid {
+        return Err(Error::new(format!(
+            "invalid store URL '{input}': invalid host '{host}' (allowed: \
+             [A-Za-z0-9.-]+ not starting with '-', or a bracketed IPv6 literal)"
+        )));
+    }
+    Ok((host.to_owned(), port))
+}
+
+fn parse_port(input: &str, port: &str) -> Result<u16, Error> {
+    match port.parse::<u16>() {
+        Ok(0) | Err(_) => Err(Error::new(format!(
+            "invalid store URL '{input}': invalid port '{port}' (expected 1-65535)"
+        ))),
+        Ok(port) => Ok(port),
+    }
+}

--- a/crates/snapdir-ssh-store/src/version.rs
+++ b/crates/snapdir-ssh-store/src/version.rs
@@ -1,0 +1,87 @@
+//! OpenSSH version-floor check (`ssh -V`, fail-closed, >= 8.5).
+//!
+//! 8.5 is the oldest release carrying every algorithm on the pinned security
+//! floor (notably `sntrup761x25519-sha512@openssh.com`), so emission fails
+//! closed on anything older — or anything unparsable (an unknown client
+//! cannot be assumed to honor the floor). There is deliberately **no
+//! override env**.
+
+use std::process::Command;
+
+use crate::Error;
+
+/// The minimum supported OpenSSH client version, as `(major, minor)`.
+pub const MIN_OPENSSH: (u32, u32) = (8, 5);
+
+/// Parses an `ssh -V` banner (`OpenSSH_9.6p1, LibreSSL …`, `OpenSSH_8.4p1
+/// Debian…`) into `(major, minor)`.
+///
+/// # Errors
+///
+/// Fails closed on any banner that does not contain `OpenSSH_<major>.<minor>`
+/// (including non-OpenSSH clients and `OpenSSH_for_Windows_…` spellings —
+/// unknown clients cannot be assumed to honor the floor).
+pub fn parse_openssh_version(banner: &str) -> Result<(u32, u32), Error> {
+    let unparsable = || {
+        Error::new(format!(
+            "cannot parse OpenSSH version from `ssh -V` output {banner:?}; \
+             refusing to proceed (the security floor requires OpenSSH >= \
+             {}.{})",
+            MIN_OPENSSH.0, MIN_OPENSSH.1
+        ))
+    };
+    let rest = banner
+        .find("OpenSSH_")
+        .map(|idx| &banner[idx + "OpenSSH_".len()..])
+        .ok_or_else(unparsable)?;
+    let (major, rest) = take_number(rest).ok_or_else(unparsable)?;
+    let rest = rest.strip_prefix('.').ok_or_else(unparsable)?;
+    let (minor, _) = take_number(rest).ok_or_else(unparsable)?;
+    Ok((major, minor))
+}
+
+/// Parses the banner and enforces the [`MIN_OPENSSH`] floor.
+///
+/// # Errors
+///
+/// Fails closed on an unparsable banner ([`parse_openssh_version`]) or a
+/// version below 8.5, naming the detected version and the floor.
+pub fn check_openssh_floor(banner: &str) -> Result<(u32, u32), Error> {
+    let (major, minor) = parse_openssh_version(banner)?;
+    if (major, minor) < MIN_OPENSSH {
+        return Err(Error::new(format!(
+            "OpenSSH {major}.{minor} is too old: the security floor requires \
+             OpenSSH >= {}.{} (it pins algorithms older clients do not \
+             ship); upgrade the local OpenSSH client",
+            MIN_OPENSSH.0, MIN_OPENSSH.1
+        )));
+    }
+    Ok((major, minor))
+}
+
+/// Runs the real `ssh -V` (version banner arrives on **stderr**) and enforces
+/// the floor. Thin untested wrapper over the table-tested
+/// [`check_openssh_floor`].
+///
+/// # Errors
+///
+/// Fails closed if `ssh` cannot be spawned, or per [`check_openssh_floor`].
+pub fn detect_openssh_floor() -> Result<(u32, u32), Error> {
+    let output = Command::new("ssh")
+        .arg("-V")
+        .output()
+        .map_err(|e| Error::new(format!("failed to run `ssh -V`: {e}")))?;
+    let banner = String::from_utf8_lossy(&output.stderr);
+    check_openssh_floor(&banner)
+}
+
+/// Splits a leading decimal number off `s`; `None` if it does not start with
+/// a digit.
+fn take_number(s: &str) -> Option<(u32, &str)> {
+    let end = s
+        .char_indices()
+        .find(|(_, c)| !c.is_ascii_digit())
+        .map_or(s.len(), |(idx, _)| idx);
+    let number = s.get(..end)?.parse().ok()?;
+    Some((number, &s[end..]))
+}

--- a/crates/snapdir-ssh-store/tests/accel.rs
+++ b/crates/snapdir-ssh-store/tests/accel.rs
@@ -1,0 +1,978 @@
+//! Gate `ssh-accel` (phase 24): the runtime-negotiated SNAPPACK acceleration
+//! in the emitted `ssh://` scripts, exercised hermetically through the real
+//! external-store contract (`ExternalStore::with_binary` →
+//! `snapdir-ssh-store` → emitted script → `tests/fixtures/fake-ssh`).
+//!
+//! The "remote host" is the fake-ssh fixture executing locally via `sh -c`
+//! with `FAKE_SSH_REMOTE_PATH` prepended to its PATH — tests point it at a
+//! per-test bin dir holding either the REAL `snapdir` binary (wrapped in a
+//! logging shim so accel engagement is asserted, never assumed), a hostile
+//! fake (`wire=99`), an "old snapdir" fake (errors on `version
+//! --capabilities`), or a sentinel fake that records any plumbing
+//! invocation. The local pipe ends are injected via the script-runtime
+//! `SNAPDIR_SSH_LOCAL_SNAPDIR` override (documented test/debug plumbing).
+//!
+//! **Locating the real `snapdir` binary**: `CARGO_BIN_EXE_snapdir` only
+//! resolves inside snapdir-cli, so the tests look for a sibling target-dir
+//! artifact (`current_exe()/../../snapdir`, i.e. `target/<profile>/snapdir`,
+//! with a `CARGO_MANIFEST_DIR/../../target/<profile>` fallback). Under
+//! `cargo test --workspace` (CI) snapdir-cli builds first, so the binary is
+//! present and the accel tests RUN; a bare `cargo test -p snapdir-ssh-store`
+//! on a clean tree skips them with an eprintln (run
+//! `cargo build -p snapdir-cli` first).
+//!
+//! Harness helpers mirror `tests/fake_ssh_roundtrip.rs` (duplicated
+//! deliberately — the suites stay independently readable and runnable);
+//! that suite pins `SNAPDIR_SSH_NO_ACCEL=1` and owns the dumb-path
+//! contract, THIS suite owns the dispatch + accel behavior.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
+use snapdir_core::merkle::{directory_checksum, Blake3Hasher, Hasher};
+use snapdir_core::snapshot_id;
+use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
+
+use snapdir_ssh_store::config::Config;
+use snapdir_ssh_store::script::sh_quote;
+use snapdir_ssh_store::ssh_engine;
+use snapdir_ssh_store::url::SshUrl;
+use snapdir_ssh_store::Engine;
+
+use snapdir_stores::ExternalStore;
+
+/// Serializes env-touching tests (`PATH` / `FAKE_*` / `SNAPDIR_SSH_*` env
+/// are process-global and flow into the spawned binary + eval shell +
+/// fixture + "remote" snapdir).
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// A unique temp dir removed on drop (no dev-dependency needed).
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "snapdir-ssh-accel-{}-{tag}-{n}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("create temp dir");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+/// Holds `ENV_LOCK` and restores every touched env var on drop (panic-safe).
+struct EnvGuard {
+    saved: Vec<(String, Option<String>)>,
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl EnvGuard {
+    fn new() -> Self {
+        Self {
+            saved: Vec::new(),
+            _lock: ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner),
+        }
+    }
+
+    fn set(&mut self, key: &str, value: &str) {
+        if !self.saved.iter().any(|(k, _)| k == key) {
+            self.saved.push((key.to_owned(), std::env::var(key).ok()));
+        }
+        std::env::set_var(key, value);
+    }
+
+    fn remove(&mut self, key: &str) {
+        if !self.saved.iter().any(|(k, _)| k == key) {
+            self.saved.push((key.to_owned(), std::env::var(key).ok()));
+        }
+        std::env::remove_var(key);
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.saved.drain(..) {
+            match value {
+                Some(v) => std::env::set_var(&key, v),
+                None => std::env::remove_var(&key),
+            }
+        }
+    }
+}
+
+/// Locates the REAL `snapdir` CLI binary as a sibling target-dir artifact
+/// (see the module docs). `None` = not built.
+fn snapdir_cli_binary() -> Option<PathBuf> {
+    if let Ok(exe) = std::env::current_exe() {
+        // target/<profile>/deps/accel-<hash> → target/<profile>/snapdir
+        if let Some(profile_dir) = exe.parent().and_then(Path::parent) {
+            let candidate = profile_dir.join("snapdir");
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    let workspace_target = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target");
+    ["debug", "release"]
+        .iter()
+        .map(|profile| workspace_target.join(profile).join("snapdir"))
+        .find(|candidate| candidate.is_file())
+}
+
+/// The real binary, or an eprintln skip marker (`None`). CI runs
+/// `cargo test --workspace`, where snapdir-cli builds first — the accel
+/// tests therefore always RUN there.
+fn require_snapdir(test: &str) -> Option<PathBuf> {
+    let bin = snapdir_cli_binary();
+    if bin.is_none() {
+        eprintln!(
+            "SKIP {test}: the real `snapdir` binary is not in the target dir \
+             (run `cargo build -p snapdir-cli` first, or `cargo test --workspace`)"
+        );
+    }
+    bin
+}
+
+/// Installs `tests/fixtures/fake-ssh` as `<bindir>/ssh` (mode 0755) and
+/// returns the env guard with `PATH` prepended, `FAKE_REMOTE_ROOT` set, the
+/// accel/runtime knobs scrubbed (this suite sets them per test), and
+/// `SNAPDIR_CACHE_DIR` pinned to a temp dir (the "remote" snapdir inherits
+/// this process's env through the fixture — its cache must never touch the
+/// developer's real one). Shadows `bash` with `/bin/bash` (3.2 on macOS)
+/// like the dumb suite, proving emitted-text bash-3.2-cleanliness.
+fn fake_remote_env(bindir: &Path, remote_root: &Path, cache_pin: &Path) -> EnvGuard {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("fake-ssh");
+    let ssh = bindir.join("ssh");
+    fs::copy(&fixture, &ssh).expect("install fake-ssh as ssh");
+    let mut perms = fs::metadata(&ssh).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&ssh, perms).unwrap();
+    if Path::new("/bin/bash").is_file() {
+        std::os::unix::fs::symlink("/bin/bash", bindir.join("bash")).expect("shadow bash");
+    }
+
+    let mut guard = EnvGuard::new();
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    guard.set("PATH", &format!("{}:{old_path}", bindir.display()));
+    guard.set("FAKE_REMOTE_ROOT", &remote_root.display().to_string());
+    guard.set("SNAPDIR_CACHE_DIR", &cache_pin.display().to_string());
+    guard.remove("SNAPDIR_STORE");
+    guard.remove("SNAPDIR_SSH_NO_ACCEL");
+    guard.remove("SNAPDIR_SSH_FORCE_ACCEL");
+    guard.remove("SNAPDIR_SSH_PULL_SENDALL");
+    guard.remove("SNAPDIR_SSH_LOCAL_SNAPDIR");
+    guard.remove("FAKE_SSH_REMOTE_PATH");
+    guard.remove("FAKE_SSH_FAIL_MATCH");
+    guard.remove("FAKE_SSH_TRUNCATE_TAR");
+    guard.remove("FAKE_SSH_EVIL_TAR");
+    guard
+}
+
+/// Writes `content` as an executable script at `path`.
+fn write_script(path: &Path, content: &str) {
+    fs::write(path, content).expect("write script");
+    let mut perms = fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).unwrap();
+}
+
+/// Installs a remote `snapdir` into `dir` that logs every invocation's argv
+/// to `log` and execs the REAL binary — accel engagement is asserted from
+/// the log, never assumed.
+fn install_logging_snapdir(dir: &Path, real: &Path, log: &Path) {
+    write_script(
+        &dir.join("snapdir"),
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >>{log}\nexec {real} \"$@\"\n",
+            log = sh_quote(&log.display().to_string()),
+            real = sh_quote(&real.display().to_string()),
+        ),
+    );
+}
+
+/// Installs a remote `snapdir` that answers `version --capabilities` with
+/// `caps_line` and records any OTHER invocation (the plumbing the dispatch
+/// must not call) by creating `sentinel` and failing.
+fn install_caps_only_snapdir(dir: &Path, caps_line: &str, sentinel: &Path) {
+    write_script(
+        &dir.join("snapdir"),
+        &format!(
+            "#!/bin/sh\nif [ \"$1\" = version ] && [ \"$2\" = --capabilities ]; then\n  \
+             printf '%s\\n' {caps}\n  exit 0\nfi\nprintf '%s\\n' \"$*\" >{sentinel}\nexit 1\n",
+            caps = sh_quote(caps_line),
+            sentinel = sh_quote(&sentinel.display().to_string()),
+        ),
+    );
+}
+
+/// Installs a remote `snapdir` that predates the wire plumbing: ANY
+/// invocation (including `version --capabilities`) errors, so the combined
+/// probe degrades to `caps none`.
+fn install_old_snapdir(dir: &Path) {
+    write_script(
+        &dir.join("snapdir"),
+        "#!/bin/sh\necho 'snapdir: unknown option' >&2\nexit 2\n",
+    );
+}
+
+fn store_url(base: &Path) -> String {
+    format!("ssh://fakehost{}", base.display())
+}
+
+fn external_store(base: &Path) -> ExternalStore {
+    ExternalStore::with_binary(&store_url(base), env!("CARGO_BIN_EXE_snapdir-ssh-store"))
+}
+
+/// Builds a manifest for `files` (name → content), writes the sharded
+/// staging layout (objects + manifest) under `staging`, and returns the
+/// manifest, its snapshot id, and the per-file checksums.
+fn stage_tree(staging: &Path, files: &[(&str, &[u8])]) -> (Manifest, String, Vec<String>) {
+    let hasher = Blake3Hasher::new();
+    let mut entries = Vec::new();
+    let mut sums = Vec::new();
+    let mut total = 0u64;
+    for (name, content) in files {
+        let sum = hasher.hash_hex(content);
+        entries.push(ManifestEntry::new(
+            PathType::File,
+            "600",
+            sum.clone(),
+            content.len() as u64,
+            format!("./{name}"),
+        ));
+        sums.push(sum);
+        total += content.len() as u64;
+    }
+    let root = directory_checksum(sums.iter().map(String::as_str), &hasher);
+    entries.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root,
+        total,
+        "./",
+    ));
+    let manifest = Manifest::from_entries(entries);
+    let id = snapshot_id(&manifest, &hasher);
+
+    for (sum, (_, content)) in sums.iter().zip(files) {
+        let obj = staging.join(object_path(sum));
+        fs::create_dir_all(obj.parent().unwrap()).unwrap();
+        fs::write(&obj, content).unwrap();
+    }
+    let man = staging.join(manifest_path(&id));
+    fs::create_dir_all(man.parent().unwrap()).unwrap();
+    // The CANONICAL stored byte form (`to_string()` + trailing `\n`,
+    // matching file_store.rs::write_manifest): the real orchestrator stages
+    // through the cache FileStore, and the pack stream re-serializes to the
+    // same form — the oracle compares manifest BYTES across both paths.
+    fs::write(&man, manifest_bytes(&manifest)).unwrap();
+    (manifest, id, sums)
+}
+
+/// The serialized (stored) byte form of a manifest: text + trailing `\n`.
+fn manifest_bytes(manifest: &Manifest) -> String {
+    format!("{manifest}\n")
+}
+
+/// Collects every regular file under `dir`, recursively.
+fn files_under(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                out.extend(files_under(&path));
+            } else if path.is_file() {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+/// The SORTED relative paths of every regular file under `root`.
+fn relative_file_set(root: &Path) -> Vec<String> {
+    let mut rels: Vec<String> = files_under(root)
+        .iter()
+        .map(|p| {
+            p.strip_prefix(root)
+                .expect("file under root")
+                .display()
+                .to_string()
+        })
+        .collect();
+    rels.sort();
+    rels
+}
+
+/// The default test files (several distinct objects).
+const FILES: &[(&str, &[u8])] = &[
+    ("a.txt", b"alpha payload\n"),
+    ("b.txt", b"bravo bravo payload\n"),
+    ("c.bin", b"charlie third object\n"),
+];
+
+fn log_lines(log: &Path) -> String {
+    fs::read_to_string(log).unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// accel-oracle (HEADLINE): forced-dumb and accel pushes are byte-identical
+// ---------------------------------------------------------------------------
+
+#[test]
+fn accel_oracle_dumb_and_accel_pushes_are_byte_identical() {
+    let Some(real) = require_snapdir("accel_oracle_dumb_and_accel_pushes_are_byte_identical")
+    else {
+        return;
+    };
+    let staging = TempDir::new("or-stage");
+    let remote_root = TempDir::new("or-remote");
+    let bindir = TempDir::new("or-bin");
+    let remote_bin = TempDir::new("or-remote-bin");
+    let cache_pin = TempDir::new("or-cachepin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path(), cache_pin.path());
+
+    let (manifest, id, _sums) = stage_tree(staging.path(), FILES);
+    let root_dumb = remote_root.path().join("dumb");
+    let root_accel = remote_root.path().join("accel");
+
+    // Push 1: forced dumb into root A.
+    env.set("SNAPDIR_SSH_NO_ACCEL", "1");
+    external_store(&root_dumb)
+        .push(&manifest, staging.path())
+        .expect("forced-dumb push");
+
+    // Push 2: accel into root B (real snapdir on the remote PATH behind a
+    // logging wrapper; the local pipe ends use the same real binary).
+    let log = remote_bin.path().join("invocations.log");
+    install_logging_snapdir(remote_bin.path(), &real, &log);
+    env.remove("SNAPDIR_SSH_NO_ACCEL");
+    env.set(
+        "FAKE_SSH_REMOTE_PATH",
+        &remote_bin.path().display().to_string(),
+    );
+    env.set("SNAPDIR_SSH_LOCAL_SNAPDIR", &real.display().to_string());
+    external_store(&root_accel)
+        .push(&manifest, staging.path())
+        .expect("accel push");
+
+    // The accel path actually ran (never assume): the remote saw the diff
+    // and the pack stream.
+    let log = log_lines(&log);
+    assert!(log.contains("objects-needed"), "accel diff ran: {log}");
+    assert!(log.contains("receive-pack"), "accel stream ran: {log}");
+
+    // IDENTICAL results: same snapshot id committed (same manifest path),
+    // identical recursive file SET, byte-equal contents (objects AND
+    // manifest) — mirroring sync.rs's mirrors-same-snapshot assertions.
+    let set_dumb = relative_file_set(&root_dumb);
+    let set_accel = relative_file_set(&root_accel);
+    assert_eq!(
+        set_dumb, set_accel,
+        "the .objects/** + manifest file sets must be identical"
+    );
+    assert!(
+        set_dumb.contains(&manifest_path(&id)),
+        "snapshot id committed on both"
+    );
+    for rel in &set_dumb {
+        assert_eq!(
+            fs::read(root_dumb.join(rel)).unwrap(),
+            fs::read(root_accel.join(rel)).unwrap(),
+            "byte-equal at {rel}"
+        );
+    }
+    assert_eq!(
+        fs::read_to_string(root_accel.join(manifest_path(&id))).unwrap(),
+        manifest_bytes(&manifest),
+        "manifest bytes are the staged manifest's bytes"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// accel push → get-manifest → accel fetch round trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn accel_push_get_manifest_accel_fetch_roundtrip() {
+    let Some(real) = require_snapdir("accel_push_get_manifest_accel_fetch_roundtrip") else {
+        return;
+    };
+    let staging = TempDir::new("rt-stage");
+    let remote_root = TempDir::new("rt-remote");
+    let bindir = TempDir::new("rt-bin");
+    let remote_bin = TempDir::new("rt-remote-bin");
+    let cache = TempDir::new("rt-cache");
+    let cache_pin = TempDir::new("rt-cachepin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path(), cache_pin.path());
+
+    let log = remote_bin.path().join("invocations.log");
+    install_logging_snapdir(remote_bin.path(), &real, &log);
+    env.set(
+        "FAKE_SSH_REMOTE_PATH",
+        &remote_bin.path().display().to_string(),
+    );
+    env.set("SNAPDIR_SSH_LOCAL_SNAPDIR", &real.display().to_string());
+
+    let (manifest, id, sums) = stage_tree(staging.path(), FILES);
+    let base = remote_root.path().join("snap");
+    let store = external_store(&base);
+
+    store.push(&manifest, staging.path()).expect("accel push");
+    assert!(log_lines(&log).contains("receive-pack"), "push used accel");
+
+    // get-manifest round-trips byte-identically (the shim also id-verifies).
+    let fetched = store.get_manifest(&id).expect("get_manifest");
+    assert_eq!(fetched.to_string(), manifest.to_string());
+
+    // Accel fetch into a cold cache lands every object, byte-equal, at the
+    // sharded cache paths (the LOCAL receive-pack verified each record).
+    store
+        .fetch_files(&manifest, cache.path())
+        .expect("accel fetch");
+    assert!(log_lines(&log).contains("send-pack"), "fetch used accel");
+    for (sum, (_, content)) in sums.iter().zip(FILES) {
+        let cached = cache.path().join(object_path(sum));
+        assert_eq!(
+            &fs::read(&cached).unwrap_or_else(|_| panic!("object {sum} in cache")),
+            content
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// interrupted-accel completion: manifest-only pack
+// ---------------------------------------------------------------------------
+
+#[test]
+fn accel_push_completes_interrupted_push_with_manifest_only_pack() {
+    let Some(real) =
+        require_snapdir("accel_push_completes_interrupted_push_with_manifest_only_pack")
+    else {
+        return;
+    };
+    let staging = TempDir::new("ip-stage");
+    let remote_root = TempDir::new("ip-remote");
+    let bindir = TempDir::new("ip-bin");
+    let remote_bin = TempDir::new("ip-remote-bin");
+    let cache_pin = TempDir::new("ip-cachepin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path(), cache_pin.path());
+
+    let log = remote_bin.path().join("invocations.log");
+    install_logging_snapdir(remote_bin.path(), &real, &log);
+    env.set(
+        "FAKE_SSH_REMOTE_PATH",
+        &remote_bin.path().display().to_string(),
+    );
+    env.set("SNAPDIR_SSH_LOCAL_SNAPDIR", &real.display().to_string());
+
+    let (manifest, id, sums) = stage_tree(staging.path(), FILES);
+    let base = remote_root.path().join("snap");
+
+    // Interrupted state: every OBJECT already on the remote, NO manifest
+    // (the want list is fully present → objects-needed answers empty → the
+    // stream is the manifest-only pack).
+    for (sum, (_, content)) in sums.iter().zip(FILES) {
+        let obj = base.join(object_path(sum));
+        fs::create_dir_all(obj.parent().unwrap()).unwrap();
+        fs::write(&obj, content).unwrap();
+    }
+    assert!(!base.join(manifest_path(&id)).exists());
+
+    external_store(&base)
+        .push(&manifest, staging.path())
+        .expect("completing accel push");
+
+    let log = log_lines(&log);
+    assert!(log.contains("objects-needed"), "diff ran: {log}");
+    assert!(
+        log.contains("receive-pack"),
+        "manifest-only pack streamed: {log}"
+    );
+    assert_eq!(
+        fs::read_to_string(base.join(manifest_path(&id))).unwrap(),
+        manifest_bytes(&manifest),
+        "the manifest landed (interrupted push completed)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// fallback (a): remote snapdir without the plumbing → dumb, byte-identical
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fallback_old_remote_snapdir_falls_back_to_dumb_byte_identically() {
+    let Some(real) =
+        require_snapdir("fallback_old_remote_snapdir_falls_back_to_dumb_byte_identically")
+    else {
+        return;
+    };
+    let staging = TempDir::new("fa-stage");
+    let remote_root = TempDir::new("fa-remote");
+    let bindir = TempDir::new("fa-bin");
+    let remote_bin = TempDir::new("fa-remote-bin");
+    let cache_pin = TempDir::new("fa-cachepin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path(), cache_pin.path());
+
+    let (manifest, _id, _sums) = stage_tree(staging.path(), FILES);
+    let root_dumb = remote_root.path().join("dumb");
+    let root_fallback = remote_root.path().join("fallback");
+
+    // Reference: forced dumb.
+    env.set("SNAPDIR_SSH_NO_ACCEL", "1");
+    external_store(&root_dumb)
+        .push(&manifest, staging.path())
+        .expect("forced-dumb push");
+    env.remove("SNAPDIR_SSH_NO_ACCEL");
+
+    // Remote `snapdir` predates `version --capabilities` (any invocation
+    // errors — also the hermetic stand-in for "no snapdir on the remote
+    // PATH": the probe degrades to `caps none` either way). Local snapdir IS
+    // available, so the dispatch genuinely reaches the caps check.
+    install_old_snapdir(remote_bin.path());
+    env.set(
+        "FAKE_SSH_REMOTE_PATH",
+        &remote_bin.path().display().to_string(),
+    );
+    env.set("SNAPDIR_SSH_LOCAL_SNAPDIR", &real.display().to_string());
+    external_store(&root_fallback)
+        .push(&manifest, staging.path())
+        .expect("push must fall back to dumb and succeed");
+
+    let set_dumb = relative_file_set(&root_dumb);
+    assert_eq!(
+        set_dumb,
+        relative_file_set(&root_fallback),
+        "fallback result must be byte-identical to the dumb root"
+    );
+    for rel in &set_dumb {
+        assert_eq!(
+            fs::read(root_dumb.join(rel)).unwrap(),
+            fs::read(root_fallback.join(rel)).unwrap(),
+            "byte-equal at {rel}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// fallback (b): wire mismatch → dumb, plumbing never invoked
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fallback_wire_mismatch_falls_back_to_dumb_without_invoking_plumbing() {
+    let Some(real) =
+        require_snapdir("fallback_wire_mismatch_falls_back_to_dumb_without_invoking_plumbing")
+    else {
+        return;
+    };
+    let staging = TempDir::new("fw-stage");
+    let remote_root = TempDir::new("fw-remote");
+    let bindir = TempDir::new("fw-bin");
+    let remote_bin = TempDir::new("fw-remote-bin");
+    let cache_pin = TempDir::new("fw-cachepin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path(), cache_pin.path());
+
+    // The remote advertises every cap — but on a FUTURE wire. Exact-integer
+    // negotiation must refuse and go dumb.
+    let sentinel = remote_bin.path().join("plumbing-invoked");
+    install_caps_only_snapdir(
+        remote_bin.path(),
+        "snapdir 9.9.9 wire=99 caps=objects-needed,send-pack,receive-pack",
+        &sentinel,
+    );
+    env.set(
+        "FAKE_SSH_REMOTE_PATH",
+        &remote_bin.path().display().to_string(),
+    );
+    env.set("SNAPDIR_SSH_LOCAL_SNAPDIR", &real.display().to_string());
+
+    let (manifest, id, sums) = stage_tree(staging.path(), FILES);
+    let base = remote_root.path().join("snap");
+    external_store(&base)
+        .push(&manifest, staging.path())
+        .expect("wire-mismatch push must fall back to dumb and succeed");
+
+    assert!(
+        !sentinel.exists(),
+        "the remote plumbing must never be invoked on a wire mismatch: {}",
+        log_lines(&sentinel)
+    );
+    for (sum, (_, content)) in sums.iter().zip(FILES) {
+        assert_eq!(&fs::read(base.join(object_path(sum))).unwrap(), content);
+    }
+    assert_eq!(
+        fs::read_to_string(base.join(manifest_path(&id))).unwrap(),
+        manifest_bytes(&manifest)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// fallback (c): FORCE_ACCEL without caps → designed error
+// ---------------------------------------------------------------------------
+
+#[test]
+fn force_accel_without_caps_fails_naming_host_wire_caps_and_remedies() {
+    let Some(real) =
+        require_snapdir("force_accel_without_caps_fails_naming_host_wire_caps_and_remedies")
+    else {
+        return;
+    };
+    let staging = TempDir::new("fc-stage");
+    let remote_root = TempDir::new("fc-remote");
+    let bindir = TempDir::new("fc-bin");
+    let remote_bin = TempDir::new("fc-remote-bin");
+    let cache_pin = TempDir::new("fc-cachepin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path(), cache_pin.path());
+
+    install_old_snapdir(remote_bin.path());
+    env.set(
+        "FAKE_SSH_REMOTE_PATH",
+        &remote_bin.path().display().to_string(),
+    );
+    env.set("SNAPDIR_SSH_LOCAL_SNAPDIR", &real.display().to_string());
+    env.set("SNAPDIR_SSH_FORCE_ACCEL", "1");
+
+    let (manifest, id, _sums) = stage_tree(staging.path(), FILES);
+    let base = remote_root.path().join("snap");
+    let err = external_store(&base)
+        .push(&manifest, staging.path())
+        .unwrap_err();
+    match &err {
+        StoreError::Backend { message, .. } => {
+            assert!(message.contains("fakehost"), "names the host: {message}");
+            assert!(
+                message.contains("wire=1"),
+                "names the required wire: {message}"
+            );
+            assert!(
+                message.contains("objects-needed,receive-pack"),
+                "names the required caps: {message}"
+            );
+            assert!(
+                message.contains("unset SNAPDIR_SSH_FORCE_ACCEL"),
+                "names the remedies: {message}"
+            );
+            assert!(
+                message.contains("install or upgrade snapdir"),
+                "names the remedies: {message}"
+            );
+        }
+        other => panic!("expected Backend error, got {other:?}"),
+    }
+    // Nothing was pushed (the error fires before any transfer).
+    assert!(
+        !base.join(manifest_path(&id)).exists(),
+        "FORCE_ACCEL error must abort before any transfer"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// NO_ACCEL forces dumb even when the remote has full caps
+// ---------------------------------------------------------------------------
+
+#[test]
+fn no_accel_forces_dumb_even_with_full_remote_caps() {
+    let Some(real) = require_snapdir("no_accel_forces_dumb_even_with_full_remote_caps") else {
+        return;
+    };
+    let staging = TempDir::new("na-stage");
+    let remote_root = TempDir::new("na-remote");
+    let bindir = TempDir::new("na-bin");
+    let remote_bin = TempDir::new("na-remote-bin");
+    let cache_pin = TempDir::new("na-cachepin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path(), cache_pin.path());
+
+    // The remote advertises full wire=1 caps, but any actual plumbing
+    // invocation (objects-needed / receive-pack) trips the sentinel.
+    let sentinel = remote_bin.path().join("plumbing-invoked");
+    install_caps_only_snapdir(
+        remote_bin.path(),
+        "snapdir 9.9.9 wire=1 caps=objects-needed,send-pack,receive-pack",
+        &sentinel,
+    );
+    env.set(
+        "FAKE_SSH_REMOTE_PATH",
+        &remote_bin.path().display().to_string(),
+    );
+    env.set("SNAPDIR_SSH_LOCAL_SNAPDIR", &real.display().to_string());
+    env.set("SNAPDIR_SSH_NO_ACCEL", "1");
+
+    let (manifest, id, sums) = stage_tree(staging.path(), FILES);
+    let base = remote_root.path().join("snap");
+    external_store(&base)
+        .push(&manifest, staging.path())
+        .expect("NO_ACCEL push must succeed via the dumb path");
+
+    assert!(
+        !sentinel.exists(),
+        "NO_ACCEL must keep the remote plumbing uninvoked: {}",
+        log_lines(&sentinel)
+    );
+    for (sum, (_, content)) in sums.iter().zip(FILES) {
+        assert_eq!(&fs::read(base.join(object_path(sum))).unwrap(), content);
+    }
+    assert!(base.join(manifest_path(&id)).is_file());
+}
+
+// ---------------------------------------------------------------------------
+// PULL_SENDALL: a warm cache still requests the FULL list
+// ---------------------------------------------------------------------------
+
+#[test]
+fn pull_sendall_streams_full_list_even_with_warm_cache() {
+    let Some(real) = require_snapdir("pull_sendall_streams_full_list_even_with_warm_cache") else {
+        return;
+    };
+    let staging = TempDir::new("sa-stage");
+    let remote_root = TempDir::new("sa-remote");
+    let bindir = TempDir::new("sa-bin");
+    let remote_bin = TempDir::new("sa-remote-bin");
+    let cache = TempDir::new("sa-cache");
+    let cache_pin = TempDir::new("sa-cachepin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path(), cache_pin.path());
+
+    let log = remote_bin.path().join("invocations.log");
+    install_logging_snapdir(remote_bin.path(), &real, &log);
+    env.set(
+        "FAKE_SSH_REMOTE_PATH",
+        &remote_bin.path().display().to_string(),
+    );
+    env.set("SNAPDIR_SSH_LOCAL_SNAPDIR", &real.display().to_string());
+
+    let (manifest, _id, sums) = stage_tree(staging.path(), FILES);
+    let base = remote_root.path().join("snap");
+    let store = external_store(&base);
+    store.push(&manifest, staging.path()).expect("accel push");
+
+    // Warm the cache completely.
+    for (sum, (_, content)) in sums.iter().zip(FILES) {
+        let obj = cache.path().join(object_path(sum));
+        fs::create_dir_all(obj.parent().unwrap()).unwrap();
+        fs::write(&obj, content).unwrap();
+    }
+
+    // Warm cache WITHOUT the knob: the emit-time diff is empty → the script
+    // skips the probe + transfer round trips entirely.
+    fs::write(&log, b"").unwrap();
+    store
+        .fetch_files(&manifest, cache.path())
+        .expect("warm-cache fetch (no-op)");
+    assert_eq!(
+        log_lines(&log),
+        "",
+        "an empty needed set must skip every remote snapdir round trip"
+    );
+
+    // Warm cache WITH the knob: the baked FULL list is streamed anyway.
+    env.set("SNAPDIR_SSH_PULL_SENDALL", "1");
+    store
+        .fetch_files(&manifest, cache.path())
+        .expect("SENDALL fetch");
+    let log = log_lines(&log);
+    assert!(
+        log.contains("send-pack"),
+        "SENDALL must still request the full list: {log}"
+    );
+    // The cache stays byte-correct (receive-pack re-verified every record).
+    for (sum, (_, content)) in sums.iter().zip(FILES) {
+        assert_eq!(
+            &fs::read(cache.path().join(object_path(sum))).unwrap(),
+            content
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// emitted-text invariants (pure library calls — no env, no fixture)
+// ---------------------------------------------------------------------------
+
+const TEXT_URL: &str = "ssh://fakehost/srv/snap";
+
+fn ssh_url() -> SshUrl {
+    SshUrl::parse(Engine::Ssh, TEXT_URL).unwrap()
+}
+
+fn default_cfg() -> Config {
+    Config::from_lookup(Engine::Ssh, |_| None).unwrap()
+}
+
+/// Every `ssh` process the script can spawn carries the security floor, and
+/// nothing traps `INT` (the orchestrator owns it).
+fn assert_skeleton_invariants(script: &str) {
+    for line in script.lines() {
+        if line.contains("command ssh") {
+            assert!(
+                line.contains("'StrictHostKeyChecking=yes'"),
+                "every ssh invocation must carry the floor: {line}"
+            );
+        }
+    }
+    assert!(!script.contains("INT"), "the script must never trap INT");
+}
+
+#[test]
+fn emitted_push_script_carries_combined_probe_and_both_paths() {
+    let staging = TempDir::new("tp-stage");
+    let (_, id, sums) = stage_tree(staging.path(), &[("foo", b"foo\n"), ("bar", b"bar\n")]);
+    let staging_dir = staging.path().display().to_string();
+    let script =
+        ssh_engine::get_push_script(&ssh_url(), &default_cfg(), &id, &staging_dir).unwrap();
+    assert_skeleton_invariants(&script);
+
+    // ONE combined probe round trip: the manifest test and the capability
+    // query travel in the SAME _snapdir_ssh invocation.
+    let probe_line = script
+        .lines()
+        .find(|l| l.contains("version --capabilities"))
+        .expect("capability probe present");
+    assert!(
+        probe_line.contains("manifest=1") && probe_line.contains("test -f"),
+        "manifest probe and caps probe must share one round trip: {probe_line}"
+    );
+    assert!(
+        probe_line.contains("caps none"),
+        "snapdir-less remotes must degrade inside the same probe: {probe_line}"
+    );
+    assert_eq!(
+        script.matches("version --capabilities").count(),
+        1,
+        "exactly one capability probe"
+    );
+
+    // The wire check is a baked literal (emit-time constant), not a runtime
+    // derivation from the remote semver.
+    assert!(
+        script.contains(" wire=1 "),
+        "baked literal wire token: {script}"
+    );
+
+    // BOTH paths embedded; dispatch covers the four runtime branches.
+    assert!(script.contains("_snapdir_dumb_push() {"));
+    assert!(script.contains("_snapdir_accel_push() {"));
+    assert!(script.contains("SNAPDIR_SSH_NO_ACCEL"));
+    assert!(script.contains("_snapdir_caps_ok objects-needed receive-pack"));
+    assert!(script.contains("SNAPDIR_SSH_FORCE_ACCEL"));
+
+    // Local pipe end: env override consulted at runtime, graceful dumb
+    // fallback when no local snapdir exists.
+    assert!(script.contains("\"${SNAPDIR_SSH_LOCAL_SNAPDIR:-snapdir}\""));
+    assert!(script.contains("snapdir_local_ok"));
+
+    // Accel body: want heredoc carries every deduped F-checksum; the
+    // manifest rides the pack last and is required remotely.
+    for sum in &sums {
+        assert!(script.contains(sum.as_str()), "want list carries {sum}");
+    }
+    // The remote commands travel as ONE sh_quoted argument to _snapdir_ssh
+    // (nested quoting), targeting the remote base as a file:// store.
+    assert!(script.contains(&format!(
+        "_snapdir_ssh {}",
+        sh_quote("snapdir objects-needed --store 'file:///srv/snap'")
+    )));
+    assert!(script.contains(&format!("--manifest-id '{id}'")));
+    assert!(
+        script.contains("--require-manifest"),
+        "the remote receive-pack must require the pushed manifest id"
+    );
+    // The send-pack side hands an ABSOLUTE staging store to file://.
+    assert!(
+        script.contains(&format!(
+            "--store {}",
+            sh_quote(&format!("file://{staging_dir}"))
+        )),
+        "absolute staging dir handed to file://"
+    );
+
+    // FORCE_ACCEL error text: host + remedies.
+    assert!(script.contains("'fakehost'"), "error names the host");
+    assert!(script.contains("unset SNAPDIR_SSH_FORCE_ACCEL"));
+    assert!(script.contains("install or upgrade snapdir"));
+
+    // Stream failures never silently retry dumb.
+    assert!(script.contains("retrying the push resumes incrementally"));
+}
+
+#[test]
+fn emitted_fetch_script_carries_caps_probe_and_both_id_lists() {
+    let staging = TempDir::new("tf-stage");
+    let cache = TempDir::new("tf-cache");
+    let (manifest, _id, sums) = stage_tree(staging.path(), &[("foo", b"foo\n"), ("bar", b"bar\n")]);
+
+    // Pre-seed one object so needed != all (the two lists must differ).
+    let cached = cache.path().join(object_path(&sums[0]));
+    fs::create_dir_all(cached.parent().unwrap()).unwrap();
+    fs::write(&cached, b"foo\n").unwrap();
+
+    let cache_dir = cache.path().display().to_string();
+    let script = ssh_engine::get_fetch_files_script(
+        &ssh_url(),
+        &default_cfg(),
+        &manifest.to_string(),
+        &cache_dir,
+    )
+    .unwrap();
+    assert_skeleton_invariants(&script);
+
+    // Caps-only probe (no manifest test on fetch), exactly one.
+    assert_eq!(script.matches("version --capabilities").count(), 1);
+    assert!(script.contains(" wire=1 "), "baked literal wire token");
+
+    // BOTH paths and BOTH baked id lists; the dispatch picks at runtime.
+    assert!(script.contains("_snapdir_dumb_fetch() {"));
+    assert!(script.contains("_snapdir_accel_fetch() {"));
+    assert!(script.contains("cat >\"$snapdir_tmp/ids\""));
+    assert!(script.contains("cat >\"$snapdir_tmp/ids_all\""));
+    assert!(script.contains("SNAPDIR_SSH_PULL_SENDALL"));
+    assert!(script.contains("_snapdir_caps_ok send-pack"));
+    assert!(script.contains("SNAPDIR_SSH_NO_ACCEL"));
+    assert!(script.contains("\"${SNAPDIR_SSH_LOCAL_SNAPDIR:-snapdir}\""));
+
+    // The remote streams via send-pack reading ids on ITS stdin; the LOCAL
+    // (trusted) receive-pack lands them in the ABSOLUTE cache store.
+    assert!(script.contains(&format!(
+        "_snapdir_ssh {} <\"$snapdir_ids\"",
+        sh_quote("snapdir send-pack --store 'file:///srv/snap' --ids -")
+    )));
+    assert!(
+        script.contains(&format!(
+            "receive-pack --store {}",
+            sh_quote(&format!("file://{cache_dir}"))
+        )),
+        "absolute cache dir handed to file://"
+    );
+
+    // The needed list excludes the cached sum; the SENDALL list carries it.
+    assert!(script.contains(&sums[1]), "needed sum baked");
+    assert_eq!(
+        script.matches(sums[0].as_str()).count(),
+        1,
+        "cached sum appears ONLY in the ids_all heredoc"
+    );
+
+    assert!(script.contains("retrying the fetch resumes incrementally"));
+    assert!(script.contains("unset SNAPDIR_SSH_FORCE_ACCEL"));
+}

--- a/crates/snapdir-ssh-store/tests/common/mod.rs
+++ b/crates/snapdir-ssh-store/tests/common/mod.rs
@@ -1,0 +1,254 @@
+//! Shared harness for the loopback-sshd integration suite
+//! (`tests/loopback_sshd.rs`): temp dirs, the env-serialization guard,
+//! manifest staging/assertion helpers, and the real-`snapdir` locator.
+//!
+//! The hermetic suites (`fake_ssh_roundtrip.rs`, `fake_sftp_roundtrip.rs`,
+//! `accel.rs`) deliberately keep their own private copies of these helpers so
+//! each stays independently readable and runnable; THIS module exists so the
+//! loopback suite and its sshd fixture share one copy without churning those
+//! green suites.
+
+pub mod sshd;
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
+use snapdir_core::merkle::{directory_checksum, Blake3Hasher, Hasher};
+use snapdir_core::snapshot_id;
+use snapdir_core::store::{manifest_path, object_path};
+use snapdir_ssh_store::script::sh_quote;
+
+/// Serializes env-touching tests (`SNAPDIR_*` / `TMPDIR` env are
+/// process-global and flow into the spawned store binary, the eval shell,
+/// and every ssh client it runs).
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+static TEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
+
+/// A unique temp dir removed on drop (no dev-dependency needed).
+///
+/// Rooted at a FIXED base (`/tmp`), deliberately NOT `std::env::temp_dir()`:
+/// the suite pins the process-global `TMPDIR` per test (under the env
+/// lock), but tests CREATE their dirs in parallel outside the lock —
+/// reading `TMPDIR` here would let one test's staging/cache land inside
+/// another test's pinned scratch and be wiped along with it (the exact
+/// parallel-scheduling race the PM re-run caught). The fixed short base
+/// also keeps the emitted scripts' `ControlPath` sockets
+/// (`$TMPDIR/snapdir-ssh-store.XXXXXX/cm`) under the ~104-byte `sun_path`
+/// limit. Names carry the pid + a process-wide counter, so nothing is
+/// shared across tests or test binaries.
+pub struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    pub fn new(tag: &str) -> Self {
+        let n = TEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = PathBuf::from("/tmp").join(format!("sd-lb-{}-{tag}-{n}", std::process::id()));
+        fs::create_dir_all(&path).expect("create temp dir");
+        Self { path }
+    }
+
+    pub fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+/// Holds `ENV_LOCK` and restores every touched env var on drop (panic-safe).
+pub struct EnvGuard {
+    saved: Vec<(String, Option<String>)>,
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl EnvGuard {
+    pub fn new() -> Self {
+        Self {
+            saved: Vec::new(),
+            _lock: ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner),
+        }
+    }
+
+    pub fn set(&mut self, key: &str, value: &str) {
+        if !self.saved.iter().any(|(k, _)| k == key) {
+            self.saved.push((key.to_owned(), std::env::var(key).ok()));
+        }
+        std::env::set_var(key, value);
+    }
+
+    pub fn remove(&mut self, key: &str) {
+        if !self.saved.iter().any(|(k, _)| k == key) {
+            self.saved.push((key.to_owned(), std::env::var(key).ok()));
+        }
+        std::env::remove_var(key);
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.saved.drain(..) {
+            match value {
+                Some(v) => std::env::set_var(&key, v),
+                None => std::env::remove_var(&key),
+            }
+        }
+    }
+}
+
+/// `SNAPDIR_SSH_TEST_REQUIRE=1` — set by CI so this suite can never silently
+/// rot into all-skips: any environmental skip becomes a hard failure.
+pub fn test_require() -> bool {
+    std::env::var("SNAPDIR_SSH_TEST_REQUIRE").ok().as_deref() == Some("1")
+}
+
+/// Builds a manifest for `files` (name → content), writes the sharded
+/// staging layout (objects + manifest in its CANONICAL stored byte form)
+/// under `staging`, and returns the manifest, its snapshot id, and the
+/// per-file checksums.
+pub fn stage_tree(staging: &Path, files: &[(&str, &[u8])]) -> (Manifest, String, Vec<String>) {
+    let hasher = Blake3Hasher::new();
+    let mut entries = Vec::new();
+    let mut sums = Vec::new();
+    let mut total = 0u64;
+    for (name, content) in files {
+        let sum = hasher.hash_hex(content);
+        entries.push(ManifestEntry::new(
+            PathType::File,
+            "600",
+            sum.clone(),
+            content.len() as u64,
+            format!("./{name}"),
+        ));
+        sums.push(sum);
+        total += content.len() as u64;
+    }
+    let root = directory_checksum(sums.iter().map(String::as_str), &hasher);
+    entries.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root,
+        total,
+        "./",
+    ));
+    let manifest = Manifest::from_entries(entries);
+    let id = snapshot_id(&manifest, &hasher);
+
+    for (sum, (_, content)) in sums.iter().zip(files) {
+        let obj = staging.join(object_path(sum));
+        fs::create_dir_all(obj.parent().unwrap()).unwrap();
+        fs::write(&obj, content).unwrap();
+    }
+    let man = staging.join(manifest_path(&id));
+    fs::create_dir_all(man.parent().unwrap()).unwrap();
+    fs::write(&man, manifest_bytes(&manifest)).unwrap();
+    (manifest, id, sums)
+}
+
+/// The serialized (stored) byte form of a manifest: text + trailing `\n`
+/// (matching `file_store.rs::write_manifest`, so the accel oracle can
+/// compare manifest BYTES across the dumb and pack paths).
+pub fn manifest_bytes(manifest: &Manifest) -> String {
+    format!("{manifest}\n")
+}
+
+/// Collects every regular file under `dir`, recursively.
+pub fn files_under(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                out.extend(files_under(&path));
+            } else if path.is_file() {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+/// The SORTED relative paths of every regular file under `root`.
+pub fn relative_file_set(root: &Path) -> Vec<String> {
+    let mut rels: Vec<String> = files_under(root)
+        .iter()
+        .map(|p| {
+            p.strip_prefix(root)
+                .expect("file under root")
+                .display()
+                .to_string()
+        })
+        .collect();
+    rels.sort();
+    rels
+}
+
+/// Writes `content` as an executable script at `path`.
+pub fn write_script(path: &Path, content: &str) {
+    fs::write(path, content).expect("write script");
+    let mut perms = fs::metadata(path).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(path, perms).unwrap();
+}
+
+/// Installs a `snapdir` into `dir` that logs every invocation's argv to
+/// `log` and execs the REAL binary — accel engagement is asserted from the
+/// log, never assumed.
+pub fn install_logging_snapdir(dir: &Path, real: &Path, log: &Path) {
+    write_script(
+        &dir.join("snapdir"),
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >>{log}\nexec {real} \"$@\"\n",
+            log = sh_quote(&log.display().to_string()),
+            real = sh_quote(&real.display().to_string()),
+        ),
+    );
+}
+
+/// Locates the REAL `snapdir` CLI binary as a sibling target-dir artifact
+/// (`CARGO_BIN_EXE_snapdir` only resolves inside snapdir-cli, so the suite
+/// looks for `target/<profile>/snapdir` next to its own test executable,
+/// with a workspace-target fallback). `None` = not built.
+pub fn snapdir_cli_binary() -> Option<PathBuf> {
+    if let Ok(exe) = std::env::current_exe() {
+        // target/<profile>/deps/loopback_sshd-<hash> → target/<profile>/snapdir
+        if let Some(profile_dir) = exe.parent().and_then(Path::parent) {
+            let candidate = profile_dir.join("snapdir");
+            if candidate.is_file() {
+                return Some(candidate);
+            }
+        }
+    }
+    let workspace_target = Path::new(env!("CARGO_MANIFEST_DIR")).join("../../target");
+    ["debug", "release"]
+        .iter()
+        .map(|profile| workspace_target.join(profile).join("snapdir"))
+        .find(|candidate| candidate.is_file())
+}
+
+/// The real `snapdir` binary, or a skip marker (`None`). Under
+/// `SNAPDIR_SSH_TEST_REQUIRE=1` a missing binary PANICS instead of
+/// skipping (CI runs the full workspace, where snapdir-cli builds first).
+pub fn require_snapdir(test: &str) -> Option<PathBuf> {
+    if let Some(bin) = snapdir_cli_binary() {
+        return Some(bin);
+    }
+    let msg = format!(
+        "{test}: the real `snapdir` binary is not in the target dir \
+         (run `cargo build -p snapdir-cli` first, or `cargo test --workspace`)"
+    );
+    assert!(
+        !test_require(),
+        "SNAPDIR_SSH_TEST_REQUIRE=1 forbids skipping — {msg}"
+    );
+    eprintln!("SKIP {msg}");
+    None
+}

--- a/crates/snapdir-ssh-store/tests/common/sshd.rs
+++ b/crates/snapdir-ssh-store/tests/common/sshd.rs
@@ -1,0 +1,347 @@
+//! Self-spawned **loopback sshd** fixture (no docker, no root): a temp dir
+//! holding ed25519 host + user keys, an `authorized_keys`, a per-instance
+//! `known_hosts`, and one `sshd -D -e -f <abs config>` child per requested
+//! flavor, listening on a probed high port of `127.0.0.1` and killed (and
+//! waited) on drop.
+//!
+//! # Flavors
+//!
+//! - [`Flavor::Shell`] — a normal account: shell allowed, `Subsystem sftp
+//!   internal-sftp`. `set_env_path` optionally pins the session `PATH` via
+//!   the server-side `SetEnv` directive (how the accel tests expose — or
+//!   deliberately hide — a `snapdir` binary to the "remote": the remote side
+//!   of `ssh 127.0.0.1` inherits sshd's session env, NOT the test env).
+//! - [`Flavor::SftpOnly`] — same + `ForceCommand internal-sftp`: every exec
+//!   request is replaced by the in-process SFTP server, so there is NO
+//!   usable shell (`ChrootDirectory` needs root, so no-shell IS the property
+//!   under test).
+//!
+//! # Skip policy (house pattern, cf. `snapdir-stores/src/s3_store.rs` live
+//! tests)
+//!
+//! If `sshd` / `ssh` / `ssh-keygen` are missing the suite `eprintln!`-skips —
+//! UNLESS `SNAPDIR_SSH_TEST_REQUIRE=1` (CI sets it so the suite can't rot
+//! into all-skips), in which case it panics with a clear message.
+//!
+//! `SNAPDIR_SSH_TEST_HOST` is reserved as a documented FUTURE override
+//! (point the suite at an externally-provisioned ssh server instead of the
+//! self-spawned loopback one); it is intentionally not implemented yet.
+
+use std::fmt::Write as _;
+use std::fs;
+use std::net::{Ipv4Addr, SocketAddr, TcpListener, TcpStream};
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Child, Command, Output, Stdio};
+use std::time::{Duration, Instant};
+
+use super::{test_require, TempDir};
+
+/// How long to wait for a spawned sshd to accept TCP connections.
+const READY_TIMEOUT: Duration = Duration::from_secs(10);
+
+/// Server flavor — see the module docs.
+pub enum Flavor {
+    /// Shell allowed + sftp subsystem; `set_env_path` pins the session
+    /// `PATH` via `SetEnv` when given.
+    Shell { set_env_path: Option<String> },
+    /// `ForceCommand internal-sftp`: pure-SFTP, no usable shell.
+    SftpOnly,
+}
+
+/// Locates the sshd server binary: the conventional sbin locations first
+/// (macOS ships `/usr/sbin/sshd`, which is rarely on `PATH`), then `PATH`.
+pub fn find_sshd() -> Option<PathBuf> {
+    for candidate in [
+        "/usr/sbin/sshd",
+        "/usr/local/sbin/sshd",
+        "/opt/homebrew/sbin/sshd",
+    ] {
+        let path = Path::new(candidate);
+        if path.is_file() {
+            return Some(path.to_owned());
+        }
+    }
+    std::env::var_os("PATH").and_then(|path| {
+        std::env::split_paths(&path)
+            .map(|dir| dir.join("sshd"))
+            .find(|candidate| candidate.is_file())
+    })
+}
+
+/// `true` when `tool` can be spawned (presence check only; the exit status
+/// is irrelevant — `ssh-keygen` exits nonzero without arguments).
+fn tool_spawns(tool: &str, arg: &str) -> bool {
+    Command::new(tool)
+        .arg(arg)
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status()
+        .is_ok()
+}
+
+/// The sshd binary, or a skip marker (`None`) when the OpenSSH tooling is
+/// missing. Under `SNAPDIR_SSH_TEST_REQUIRE=1` missing tooling PANICS.
+pub fn require_loopback_tooling(test: &str) -> Option<PathBuf> {
+    let sshd = find_sshd();
+    let missing = if sshd.is_none() {
+        Some("sshd (server)")
+    } else if !tool_spawns("ssh", "-V") {
+        Some("ssh (client)")
+    } else if !tool_spawns("ssh-keygen", "-?") {
+        Some("ssh-keygen")
+    } else {
+        None
+    };
+    if let Some(missing) = missing {
+        let msg = format!("{test}: OpenSSH tooling missing: {missing}");
+        assert!(
+            !test_require(),
+            "SNAPDIR_SSH_TEST_REQUIRE=1 forbids skipping — {msg}"
+        );
+        eprintln!("SKIP {msg}");
+        return None;
+    }
+    sshd
+}
+
+/// The key material + config dir shared by every server a test spawns:
+/// `0700` temp dir, ed25519 host + user keys, `authorized_keys` (0600), and
+/// a `known_hosts` that grows one `[127.0.0.1]:<port>` line per spawned
+/// server.
+pub struct SshKit {
+    root: TempDir,
+    sshd_bin: PathBuf,
+    host_key: PathBuf,
+    host_pub_line: String,
+    authorized_keys: PathBuf,
+    /// The client's private key (`*_STORE_IDENTITY_FILE`).
+    pub user_key: PathBuf,
+    /// The fixture `known_hosts` (`*_STORE_KNOWN_HOSTS`).
+    pub known_hosts: PathBuf,
+    spawned: u32,
+}
+
+impl SshKit {
+    /// Builds the kit, or `None` on an (allowed) environmental skip — see
+    /// [`require_loopback_tooling`].
+    pub fn new(test: &str) -> Option<Self> {
+        let sshd_bin = require_loopback_tooling(test)?;
+        let root = TempDir::new("sshd-kit");
+        fs::set_permissions(root.path(), fs::Permissions::from_mode(0o700))
+            .expect("chmod 700 kit dir");
+
+        let host_key = root.path().join("host_key");
+        let user_key = root.path().join("user_key");
+        keygen(&host_key);
+        keygen(&user_key);
+        let host_pub_line = fs::read_to_string(root.path().join("host_key.pub"))
+            .expect("read host pubkey")
+            .trim()
+            .to_owned();
+
+        let authorized_keys = root.path().join("authorized_keys");
+        fs::copy(root.path().join("user_key.pub"), &authorized_keys)
+            .expect("install authorized_keys");
+        fs::set_permissions(&authorized_keys, fs::Permissions::from_mode(0o600))
+            .expect("chmod 600 authorized_keys");
+
+        let known_hosts = root.path().join("known_hosts");
+        fs::write(&known_hosts, "").expect("create known_hosts");
+
+        Some(Self {
+            root,
+            sshd_bin,
+            host_key,
+            host_pub_line,
+            authorized_keys,
+            user_key,
+            known_hosts,
+            spawned: 0,
+        })
+    }
+
+    /// The kit's `0700` temp dir (also a convenient parent for per-test
+    /// remote store bases).
+    pub fn dir(&self) -> &Path {
+        self.root.path()
+    }
+
+    /// Spawns one sshd of the given `flavor` on a freshly probed loopback
+    /// port (retrying the bind race a few times), waits until it accepts
+    /// TCP connections, and appends its host-key line to [`Self::known_hosts`].
+    pub fn spawn(&mut self, flavor: &Flavor) -> Sshd {
+        for attempt in 1..=4 {
+            let port = probe_free_port();
+            self.spawned += 1;
+            let n = self.spawned;
+            let config = self.root.path().join(format!("sshd_config_{n}"));
+            fs::write(&config, self.config_text(port, flavor)).expect("write sshd_config");
+            let log_path = self.root.path().join(format!("sshd_{n}.log"));
+            let log = fs::File::create(&log_path).expect("create sshd log");
+
+            let mut child = Command::new(&self.sshd_bin)
+                .arg("-D")
+                .arg("-e")
+                .arg("-f")
+                .arg(&config) // absolute (macOS sshd requires it)
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(log)
+                .spawn()
+                .expect("spawn sshd");
+
+            if wait_ready(port, &mut child) {
+                let entry = format!("[127.0.0.1]:{port} {}\n", self.host_pub_line);
+                let mut known = fs::read_to_string(&self.known_hosts).unwrap_or_default();
+                known.push_str(&entry);
+                fs::write(&self.known_hosts, known).expect("append known_hosts");
+                return Sshd { port, child };
+            }
+
+            let _ = child.kill();
+            let _ = child.wait();
+            eprintln!(
+                "sshd attempt {attempt} on port {port} did not become ready \
+                 (log: {}); retrying",
+                log_path.display()
+            );
+        }
+        panic!(
+            "sshd failed to become ready after 4 attempts (see {}/sshd_*.log)",
+            self.root.path().display()
+        );
+    }
+
+    /// Writes a `known_hosts` carrying a WRONG (freshly generated decoy)
+    /// host key for `[127.0.0.1]:<port>` — the host-key-fail-closed test's
+    /// poisoned input.
+    pub fn wrong_known_hosts(&self, port: u16) -> PathBuf {
+        let decoy = self.root.path().join(format!("decoy_key_{port}"));
+        keygen(&decoy);
+        let decoy_pub = fs::read_to_string(self.root.path().join(format!("decoy_key_{port}.pub")))
+            .expect("read decoy pubkey")
+            .trim()
+            .to_owned();
+        let path = self.root.path().join(format!("known_hosts_wrong_{port}"));
+        fs::write(&path, format!("[127.0.0.1]:{port} {decoy_pub}\n")).expect("write wrong kh");
+        path
+    }
+
+    /// Runs one command over a DIRECT ssh client invocation (explicit flags,
+    /// no env) — used to probe server-side behavior (e.g. whether `SetEnv
+    /// PATH` is honored) independently of the engines under test.
+    pub fn ssh_exec(&self, port: u16, command: &str) -> Output {
+        Command::new("ssh")
+            .args([
+                "-o",
+                "BatchMode=yes",
+                "-o",
+                "StrictHostKeyChecking=yes",
+                "-o",
+                "IdentitiesOnly=yes",
+                "-o",
+                "ConnectTimeout=10",
+            ])
+            .arg("-o")
+            .arg(format!("IdentityFile={}", self.user_key.display()))
+            .arg("-o")
+            .arg(format!("UserKnownHostsFile={}", self.known_hosts.display()))
+            .arg("-o")
+            .arg(format!("Port={port}"))
+            .arg("--")
+            .arg("127.0.0.1")
+            .arg(command)
+            .stdin(Stdio::null())
+            .output()
+            .expect("run ssh")
+    }
+
+    /// The `sshd_config` for `port`/`flavor`. Absolute paths everywhere; the
+    /// kit dir is `0700` and the key files `0600` (`StrictModes no` keeps
+    /// sshd from second-guessing temp-dir lineage anyway); `UsePAM no` +
+    /// pubkey-only auth so the server runs as the current (non-root) user.
+    fn config_text(&self, port: u16, flavor: &Flavor) -> String {
+        let mut text = format!(
+            "ListenAddress 127.0.0.1\n\
+             Port {port}\n\
+             HostKey {host_key}\n\
+             AuthorizedKeysFile {authorized_keys}\n\
+             PubkeyAuthentication yes\n\
+             PasswordAuthentication no\n\
+             KbdInteractiveAuthentication no\n\
+             UsePAM no\n\
+             StrictModes no\n\
+             PidFile none\n\
+             LogLevel VERBOSE\n\
+             Subsystem sftp internal-sftp\n",
+            host_key = self.host_key.display(),
+            authorized_keys = self.authorized_keys.display(),
+        );
+        match flavor {
+            Flavor::Shell { set_env_path } => {
+                if let Some(path) = set_env_path {
+                    let _ = writeln!(text, "SetEnv PATH={path}");
+                }
+            }
+            Flavor::SftpOnly => text.push_str("ForceCommand internal-sftp\n"),
+        }
+        text
+    }
+}
+
+/// One running `sshd -D` child; killed and reaped on drop.
+pub struct Sshd {
+    /// The loopback port the server listens on.
+    pub port: u16,
+    child: Child,
+}
+
+impl Drop for Sshd {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+fn keygen(path: &Path) {
+    let output = Command::new("ssh-keygen")
+        .args(["-q", "-N", "", "-t", "ed25519", "-f"])
+        .arg(path)
+        .output()
+        .expect("run ssh-keygen");
+    assert!(
+        output.status.success(),
+        "ssh-keygen -f {} failed: {}",
+        path.display(),
+        String::from_utf8_lossy(&output.stderr)
+    );
+}
+
+/// Binds `127.0.0.1:0`, takes the kernel-assigned port, drops the listener
+/// (the small reuse race is covered by [`SshKit::spawn`]'s retry loop).
+fn probe_free_port() -> u16 {
+    TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .expect("bind 127.0.0.1:0")
+        .local_addr()
+        .expect("local_addr")
+        .port()
+}
+
+/// Polls `127.0.0.1:<port>` until sshd accepts (true) or it exits / the
+/// timeout lapses (false).
+fn wait_ready(port: u16, child: &mut Child) -> bool {
+    let addr = SocketAddr::from((Ipv4Addr::LOCALHOST, port));
+    let deadline = Instant::now() + READY_TIMEOUT;
+    while Instant::now() < deadline {
+        if matches!(child.try_wait(), Ok(Some(_)) | Err(_)) {
+            return false; // sshd died (config error / port race)
+        }
+        if TcpStream::connect_timeout(&addr, Duration::from_millis(250)).is_ok() {
+            return true;
+        }
+        std::thread::sleep(Duration::from_millis(100));
+    }
+    false
+}

--- a/crates/snapdir-ssh-store/tests/emitted_contract.rs
+++ b/crates/snapdir-ssh-store/tests/emitted_contract.rs
@@ -1,0 +1,850 @@
+//! T1 contract tests for the snapdir-ssh-store scaffold: argument grammar
+//! (mock-store parity, divergences documented in `src/args.rs`), URL parsing,
+//! env-family config + the un-weakenable security-floor flag ordering,
+//! `ssh -V` floor parsing, quoting/heredoc helpers, and the emitted script
+//! skeleton's textual invariants.
+
+use std::ffi::OsString;
+use std::sync::Mutex;
+
+use snapdir_ssh_store::args::{parse, Invocation, Subcommand};
+use snapdir_ssh_store::config::{
+    Config, DEFAULT_CONNECT_TIMEOUT, DEFAULT_CONTROL_PERSIST, DEFAULT_JOBS, DEFAULT_UMASK,
+    FLOOR_CIPHERS, FLOOR_HOST_KEY_ALGORITHMS, FLOOR_KEX_ALGORITHMS,
+};
+use snapdir_ssh_store::script::{
+    heredoc, remote_manifest_path, remote_object_path, sftp_quote, sh_quote, skeleton,
+};
+use snapdir_ssh_store::url::SshUrl;
+use snapdir_ssh_store::version::{check_openssh_floor, parse_openssh_version, MIN_OPENSSH};
+use snapdir_ssh_store::{run_with, Engine};
+
+/// Serializes every test that touches the process environment (`from_env`
+/// and the `run_with` dispatcher, which calls it): std env is process-global,
+/// same pattern as `RATELIMIT_ENV_LOCK` in snapdir-cli.
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+fn os_args(args: &[&str]) -> Vec<OsString> {
+    args.iter().map(OsString::from).collect()
+}
+
+/// An env lookup over a fixed table (the pure injection seam — no process
+/// env, no lock needed).
+fn lookup_from<'a>(pairs: &'a [(&'a str, &'a str)]) -> impl Fn(&str) -> Option<String> + 'a {
+    move |name| {
+        pairs
+            .iter()
+            .find(|(key, _)| *key == name)
+            .map(|(_, value)| (*value).to_owned())
+    }
+}
+
+fn no_env(_: &str) -> Option<String> {
+    None
+}
+
+fn default_config() -> Config {
+    Config::from_lookup(Engine::Ssh, no_env).unwrap()
+}
+
+fn parse_url(input: &str) -> SshUrl {
+    SshUrl::parse(Engine::Ssh, input).unwrap()
+}
+
+fn url_err(input: &str) -> String {
+    SshUrl::parse(Engine::Ssh, input).unwrap_err().to_string()
+}
+
+// ---------------------------------------------------------------------------
+// args: mock grammar parity (`--k v`, `--k=v`, `--version`) + rejections
+// ---------------------------------------------------------------------------
+
+#[test]
+fn args_space_separated_form_parses() {
+    let parsed = parse(os_args(&[
+        "get-push-command",
+        "--id",
+        "abc123",
+        "--store",
+        "ssh://host/srv/snap",
+        "--staging-dir",
+        "/tmp/staging",
+    ]))
+    .unwrap();
+    let Invocation::Command(cmd) = parsed else {
+        panic!("expected a command invocation");
+    };
+    assert_eq!(cmd.subcommand, Subcommand::GetPushCommand);
+    assert_eq!(cmd.id, "abc123");
+    assert_eq!(cmd.store, "ssh://host/srv/snap");
+    assert_eq!(cmd.staging_dir.as_deref(), Some("/tmp/staging"));
+    assert_eq!(cmd.cache_dir, None);
+}
+
+#[test]
+fn args_equals_form_parses() {
+    let parsed = parse(os_args(&[
+        "get-fetch-files-command",
+        "--id=abc123",
+        "--store=sftp://host/srv/snap",
+        "--cache-dir=/tmp/cache",
+    ]))
+    .unwrap();
+    let Invocation::Command(cmd) = parsed else {
+        panic!("expected a command invocation");
+    };
+    assert_eq!(cmd.subcommand, Subcommand::GetFetchFilesCommand);
+    assert_eq!(cmd.cache_dir.as_deref(), Some("/tmp/cache"));
+}
+
+#[test]
+fn args_mixed_forms_and_subcommand_position_independent() {
+    let parsed = parse(os_args(&[
+        "--id=abc",
+        "--store",
+        "ssh://h/base",
+        "get-manifest-command",
+    ]))
+    .unwrap();
+    let Invocation::Command(cmd) = parsed else {
+        panic!("expected a command invocation");
+    };
+    assert_eq!(cmd.subcommand, Subcommand::GetManifestCommand);
+    assert_eq!(cmd.id, "abc");
+}
+
+#[test]
+fn args_version_tokens_short_circuit() {
+    for version_arg in ["-v", "--version", "version"] {
+        let parsed = parse(os_args(&["get-push-command", "--id", "x", version_arg])).unwrap();
+        assert_eq!(parsed, Invocation::Version, "token {version_arg}");
+    }
+}
+
+#[test]
+fn args_rejections_are_clear() {
+    // (args, expected error fragment) — divergence from the mock's silent
+    // skip/last-wins is deliberate; see src/args.rs.
+    let cases: &[(&[&str], &str)] = &[
+        (
+            &[
+                "get-manifest-command",
+                "--id",
+                "x",
+                "--store",
+                "s",
+                "--bogus",
+                "v",
+            ],
+            "unknown option '--bogus'",
+        ),
+        (
+            &["get-manifest-command", "stray", "--id", "x", "--store", "s"],
+            "unexpected argument 'stray'",
+        ),
+        (
+            &["get-manifest-command", "--id"],
+            "missing value for '--id'",
+        ),
+        (
+            &[
+                "get-manifest-command",
+                "--id",
+                "a",
+                "--id",
+                "b",
+                "--store",
+                "s",
+            ],
+            "given more than once",
+        ),
+        (
+            &[
+                "get-manifest-command",
+                "get-push-command",
+                "--id",
+                "x",
+                "--store",
+                "s",
+            ],
+            "multiple subcommands",
+        ),
+        (&["--id", "x", "--store", "s"], "missing subcommand"),
+        (
+            &["get-manifest-command", "--store", "s"],
+            "missing required option --id",
+        ),
+        (
+            &["get-manifest-command", "--id", "x"],
+            "missing required option --store",
+        ),
+        (
+            &["get-push-command", "--id", "x", "--store", "s"],
+            "missing required option --staging-dir",
+        ),
+        (
+            &["get-fetch-files-command", "--id", "x", "--store", "s"],
+            "missing required option --cache-dir",
+        ),
+    ];
+    for (args, fragment) in cases {
+        let err = parse(os_args(args)).unwrap_err().to_string();
+        assert!(
+            err.contains(fragment),
+            "args {args:?}: expected {fragment:?} in {err:?}"
+        );
+    }
+}
+
+#[test]
+fn args_manifest_command_needs_no_dirs() {
+    let parsed = parse(os_args(&[
+        "get-manifest-command",
+        "--id",
+        "x",
+        "--store",
+        "s",
+    ]))
+    .unwrap();
+    assert!(matches!(parsed, Invocation::Command(_)));
+}
+
+// ---------------------------------------------------------------------------
+// url: grammar table (incl. IPv6, password rejection, hostile chars)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn url_minimal_parses() {
+    let url = parse_url("ssh://example.com/srv/snapdir");
+    assert_eq!(url.user, None);
+    assert_eq!(url.host, "example.com");
+    assert_eq!(url.port, None);
+    assert_eq!(url.base, "/srv/snapdir");
+    assert_eq!(url.host_arg(), "example.com");
+}
+
+#[test]
+fn url_user_and_port_parse() {
+    let url = parse_url("ssh://deploy_1.bot@snap-host.example.com:2222/srv/snap");
+    assert_eq!(url.user.as_deref(), Some("deploy_1.bot"));
+    assert_eq!(url.host, "snap-host.example.com");
+    assert_eq!(url.port, Some(2222));
+    assert_eq!(url.base, "/srv/snap");
+}
+
+#[test]
+fn url_sftp_scheme_is_distinct() {
+    let url = SshUrl::parse(Engine::Sftp, "sftp://example.com/srv/snap").unwrap();
+    assert_eq!(url.host, "example.com");
+
+    let err = SshUrl::parse(Engine::Sftp, "ssh://example.com/srv/snap")
+        .unwrap_err()
+        .to_string();
+    assert!(
+        err.contains("sftp://"),
+        "should name the expected scheme: {err}"
+    );
+    let err = url_err("sftp://example.com/srv/snap");
+    assert!(
+        err.contains("ssh://"),
+        "should name the expected scheme: {err}"
+    );
+}
+
+#[test]
+fn url_bracketed_ipv6_parses_with_and_without_port() {
+    let url = parse_url("ssh://backup@[2001:db8::1]:2200/srv/snap");
+    assert_eq!(url.user.as_deref(), Some("backup"));
+    assert_eq!(url.host, "2001:db8::1");
+    assert_eq!(url.port, Some(2200));
+    assert_eq!(
+        url.host_arg(),
+        "[2001:db8::1]",
+        "brackets restored for argv"
+    );
+
+    let url = parse_url("ssh://[::1]/srv/snap");
+    assert_eq!(url.host, "::1");
+    assert_eq!(url.port, None);
+}
+
+#[test]
+fn url_password_rejected_naming_keys_and_agent() {
+    let err = url_err("ssh://user:hunter2@example.com/srv/snap");
+    assert!(err.contains("password"), "should name the problem: {err}");
+    assert!(
+        err.contains("IdentityFile") && err.contains("agent"),
+        "should point at keys/agent: {err}"
+    );
+}
+
+#[test]
+fn url_base_path_rules() {
+    // Bare root and missing base are rejected.
+    assert!(url_err("ssh://example.com/").contains("base path"));
+    assert!(url_err("ssh://example.com").contains("missing absolute base path"));
+    // Trailing slashes trim; inner bytes stay literal (no percent-decoding).
+    assert_eq!(parse_url("ssh://h/srv/snap/").base, "/srv/snap");
+    assert_eq!(parse_url("ssh://h/a%20b/c d").base, "/a%20b/c d");
+    // Control characters (and NUL) are rejected.
+    assert!(url_err("ssh://h/srv/\tsnap").contains("control"));
+    assert!(url_err("ssh://h/srv/\u{0}snap").contains("control"));
+}
+
+#[test]
+fn url_hostile_users_and_hosts_rejected() {
+    for (input, what) in [
+        ("ssh:///srv/snap", "invalid host"),
+        ("ssh://@example.com/srv", "invalid user"),
+        ("ssh://-oProxyCommand=evil@example.com/srv", "invalid user"),
+        ("ssh://user@/srv", "invalid host"),
+        ("ssh://-evil.example.com/srv", "invalid host"),
+        ("ssh://host;rm -rf ~/srv", "invalid host"),
+        ("ssh://host$(x)/srv", "invalid host"),
+        ("ssh://[zz8::1]/srv", "invalid IPv6 host"),
+        ("ssh://[2001:db8::1/srv", "unterminated '['"),
+        ("ssh://[::1]junk/srv", "unexpected text after ']'"),
+    ] {
+        let err = url_err(input);
+        assert!(err.contains(what), "{input}: expected {what:?} in {err:?}");
+    }
+}
+
+#[test]
+fn url_port_bounds() {
+    assert!(url_err("ssh://h:0/srv").contains("invalid port"));
+    assert!(url_err("ssh://h:70000/srv").contains("invalid port"));
+    assert!(url_err("ssh://h:2a2/srv").contains("invalid port"));
+    assert_eq!(parse_url("ssh://h:65535/srv").port, Some(65535));
+    assert_eq!(parse_url("ssh://h:1/srv").port, Some(1));
+}
+
+// ---------------------------------------------------------------------------
+// config: env family, fallbacks, validation
+// ---------------------------------------------------------------------------
+
+#[test]
+fn config_defaults() {
+    let cfg = default_config();
+    assert_eq!(cfg.identity_file, None);
+    assert_eq!(cfg.port, None);
+    assert_eq!(cfg.known_hosts, None);
+    assert_eq!(cfg.connect_timeout, DEFAULT_CONNECT_TIMEOUT);
+    assert_eq!(cfg.connect_timeout, 10);
+    assert_eq!(cfg.jobs, DEFAULT_JOBS);
+    assert_eq!(cfg.jobs, 4);
+    assert_eq!(cfg.control_persist, DEFAULT_CONTROL_PERSIST);
+    assert_eq!(cfg.control_persist, 60);
+    assert_eq!(cfg.umask, DEFAULT_UMASK);
+    assert_eq!(cfg.umask, "077");
+    assert!(cfg.extra_opts.is_empty());
+}
+
+#[test]
+fn config_engine_prefixes_are_disjoint() {
+    let pairs = [
+        ("SNAPDIR_SFTP_STORE_CONNECT_TIMEOUT", "20"),
+        ("SNAPDIR_SFTP_STORE_IDENTITY_FILE", "/keys/sftp_ed25519"),
+    ];
+    let sftp = Config::from_lookup(Engine::Sftp, lookup_from(&pairs)).unwrap();
+    assert_eq!(sftp.connect_timeout, 20);
+    assert_eq!(sftp.identity_file.as_deref(), Some("/keys/sftp_ed25519"));
+
+    // The ssh engine must not see the sftp family.
+    let ssh = Config::from_lookup(Engine::Ssh, lookup_from(&pairs)).unwrap();
+    assert_eq!(ssh.connect_timeout, DEFAULT_CONNECT_TIMEOUT);
+    assert_eq!(ssh.identity_file, None);
+}
+
+#[test]
+fn config_jobs_fallback_chain() {
+    let all = [
+        ("SNAPDIR_SSH_STORE_JOBS", "9"),
+        ("SNAPDIR_JOBS", "7"),
+        ("SNAPDIR_MAX_JOBS", "5"),
+    ];
+    let cfg = Config::from_lookup(Engine::Ssh, lookup_from(&all)).unwrap();
+    assert_eq!(cfg.jobs, 9, "engine-family JOBS wins");
+
+    let global = [("SNAPDIR_JOBS", "7"), ("SNAPDIR_MAX_JOBS", "5")];
+    let cfg = Config::from_lookup(Engine::Ssh, lookup_from(&global)).unwrap();
+    assert_eq!(cfg.jobs, 7, "SNAPDIR_JOBS beats SNAPDIR_MAX_JOBS");
+
+    let max_only = [("SNAPDIR_MAX_JOBS", "5")];
+    let cfg = Config::from_lookup(Engine::Ssh, lookup_from(&max_only)).unwrap();
+    assert_eq!(cfg.jobs, 5, "SNAPDIR_MAX_JOBS is the last fallback");
+}
+
+#[test]
+fn config_validation_failures_name_the_variable() {
+    for (name, value, fragment) in [
+        ("SNAPDIR_SSH_STORE_PORT", "0", "invalid port"),
+        ("SNAPDIR_SSH_STORE_PORT", "junk", "invalid port"),
+        ("SNAPDIR_SSH_STORE_CONNECT_TIMEOUT", "0", "positive integer"),
+        (
+            "SNAPDIR_SSH_STORE_CONNECT_TIMEOUT",
+            "-2",
+            "positive integer",
+        ),
+        ("SNAPDIR_SSH_STORE_JOBS", "many", "positive integer"),
+        ("SNAPDIR_SSH_STORE_UMASK", "789", "octal"),
+        ("SNAPDIR_SSH_STORE_UMASK", "07777", "octal"),
+        ("SNAPDIR_SSH_STORE_UMASK", "rwx", "octal"),
+    ] {
+        let pairs = [(name, value)];
+        let err = Config::from_lookup(Engine::Ssh, lookup_from(&pairs))
+            .unwrap_err()
+            .to_string();
+        assert!(
+            err.contains(name),
+            "{name}={value}: missing var name in {err:?}"
+        );
+        assert!(
+            err.contains(fragment),
+            "{name}={value}: expected {fragment:?} in {err:?}"
+        );
+    }
+}
+
+#[test]
+fn config_extra_opts_split_and_validated() {
+    let pairs = [(
+        "SNAPDIR_SSH_STORE_EXTRA_OPTS",
+        "ServerAliveInterval=30  ProxyJump=bastion.example.com Ciphers=^aes256-gcm@openssh.com",
+    )];
+    let cfg = Config::from_lookup(Engine::Ssh, lookup_from(&pairs)).unwrap();
+    assert_eq!(
+        cfg.extra_opts,
+        vec![
+            "ServerAliveInterval=30",
+            "ProxyJump=bastion.example.com",
+            "Ciphers=^aes256-gcm@openssh.com",
+        ]
+    );
+
+    for bad in [
+        "NoEqualsSign",
+        "Key=",
+        "1Key=value",
+        "Key=va;lue",
+        "Key=$(evil)",
+        "Key=va`lue",
+        "Key='quoted'",
+        "Key=a|b",
+        "Key=a>b",
+        "Key=a*",
+    ] {
+        let pairs = [("SNAPDIR_SSH_STORE_EXTRA_OPTS", bad)];
+        let err = Config::from_lookup(Engine::Ssh, lookup_from(&pairs)).unwrap_err();
+        assert!(
+            err.to_string().contains("invalid token"),
+            "{bad:?} should be rejected: {err}"
+        );
+    }
+}
+
+#[test]
+fn config_from_env_reads_the_process_environment() {
+    let _guard = ENV_LOCK.lock().unwrap();
+    std::env::set_var("SNAPDIR_SSH_STORE_CONNECT_TIMEOUT", "33");
+    std::env::set_var("SNAPDIR_SSH_STORE_EXTRA_OPTS", "Compression=yes");
+    let cfg = Config::from_env(Engine::Ssh);
+    std::env::remove_var("SNAPDIR_SSH_STORE_CONNECT_TIMEOUT");
+    std::env::remove_var("SNAPDIR_SSH_STORE_EXTRA_OPTS");
+    let cfg = cfg.unwrap();
+    assert_eq!(cfg.connect_timeout, 33);
+    assert_eq!(cfg.extra_opts, vec!["Compression=yes"]);
+}
+
+// ---------------------------------------------------------------------------
+// security floor: ordered flag builder
+// ---------------------------------------------------------------------------
+
+/// The floor tokens, in their pinned order.
+fn floor_tokens(connect_timeout: u32) -> Vec<String> {
+    vec![
+        "BatchMode=yes".to_owned(),
+        "StrictHostKeyChecking=yes".to_owned(),
+        "PasswordAuthentication=no".to_owned(),
+        "KbdInteractiveAuthentication=no".to_owned(),
+        "ClearAllForwardings=yes".to_owned(),
+        format!("KexAlgorithms={FLOOR_KEX_ALGORITHMS}"),
+        format!("Ciphers={FLOOR_CIPHERS}"),
+        format!("HostKeyAlgorithms={FLOOR_HOST_KEY_ALGORITHMS}"),
+        format!("ConnectTimeout={connect_timeout}"),
+    ]
+}
+
+#[test]
+fn flag_args_floor_comes_first_in_order() {
+    let cfg = default_config();
+    let url = parse_url("ssh://example.com/srv/snap");
+    let flags = cfg.flag_args(&url);
+    let expected = floor_tokens(10);
+    assert!(flags.len() >= expected.len() * 2);
+    for (i, token) in expected.iter().enumerate() {
+        assert_eq!(flags[2 * i], "-o");
+        assert_eq!(&flags[2 * i + 1], token, "floor position {i}");
+    }
+    // Minimal config + URL: nothing after the floor.
+    assert_eq!(flags.len(), expected.len() * 2);
+}
+
+#[test]
+fn flag_args_url_port_beats_env_port() {
+    let pairs = [("SNAPDIR_SSH_STORE_PORT", "2200")];
+    let cfg = Config::from_lookup(Engine::Ssh, lookup_from(&pairs)).unwrap();
+
+    let url = parse_url("ssh://example.com:9022/srv/snap");
+    let flags = cfg.flag_args(&url);
+    assert!(
+        flags.contains(&"Port=9022".to_owned()),
+        "URL port wins: {flags:?}"
+    );
+    assert!(!flags.contains(&"Port=2200".to_owned()));
+
+    let url = parse_url("ssh://example.com/srv/snap");
+    let flags = cfg.flag_args(&url);
+    assert!(
+        flags.contains(&"Port=2200".to_owned()),
+        "env port is the fallback"
+    );
+}
+
+#[test]
+fn flag_args_config_derived_options() {
+    let pairs = [
+        ("SNAPDIR_SSH_STORE_IDENTITY_FILE", "/keys/id_ed25519"),
+        ("SNAPDIR_SSH_STORE_KNOWN_HOSTS", "/keys/known_hosts"),
+    ];
+    let cfg = Config::from_lookup(Engine::Ssh, lookup_from(&pairs)).unwrap();
+    let url = parse_url("ssh://deploy@example.com/srv/snap");
+    let flags = cfg.flag_args(&url);
+    assert!(flags.contains(&"User=deploy".to_owned()));
+    let identity = flags
+        .iter()
+        .position(|f| f == "IdentityFile=/keys/id_ed25519")
+        .expect("IdentityFile flag");
+    assert_eq!(
+        flags[identity + 2],
+        "IdentitiesOnly=yes",
+        "IdentitiesOnly rides with IdentityFile"
+    );
+    assert!(flags.contains(&"UserKnownHostsFile=/keys/known_hosts".to_owned()));
+
+    // Without an identity file, IdentitiesOnly must NOT be forced.
+    let cfg = default_config();
+    let flags = cfg.flag_args(&url);
+    assert!(!flags.iter().any(|f| f.starts_with("IdentitiesOnly")));
+    assert!(!flags.iter().any(|f| f.starts_with("IdentityFile")));
+}
+
+#[test]
+fn flag_args_extras_come_strictly_after_the_floor() {
+    // The headline un-weakenability proof: a hostile extra trying to disable
+    // host-key checking lands strictly AFTER the floor's `=yes` token, and
+    // OpenSSH is first-obtained-value-wins.
+    let pairs = [("SNAPDIR_SSH_STORE_EXTRA_OPTS", "StrictHostKeyChecking=no")];
+    let cfg = Config::from_lookup(Engine::Ssh, lookup_from(&pairs)).unwrap();
+    let url = parse_url("ssh://example.com/srv/snap");
+    let flags = cfg.flag_args(&url);
+    let floor_pos = flags
+        .iter()
+        .position(|f| f == "StrictHostKeyChecking=yes")
+        .expect("floor token");
+    let extra_pos = flags
+        .iter()
+        .position(|f| f == "StrictHostKeyChecking=no")
+        .expect("extra token");
+    assert!(
+        floor_pos < extra_pos,
+        "floor must precede the extra: {flags:?}"
+    );
+    assert_eq!(extra_pos, flags.len() - 1, "extras are last");
+}
+
+// ---------------------------------------------------------------------------
+// version floor: `ssh -V` banner table
+// ---------------------------------------------------------------------------
+
+#[test]
+fn openssh_version_parser_table() {
+    assert_eq!(
+        parse_openssh_version("OpenSSH_9.6p1, LibreSSL 3.3.6").unwrap(),
+        (9, 6)
+    );
+    assert_eq!(
+        parse_openssh_version("OpenSSH_8.4p1 Debian-5+deb11u3, OpenSSL 1.1.1n  15 Mar 2022")
+            .unwrap(),
+        (8, 4)
+    );
+    assert_eq!(parse_openssh_version("OpenSSH_8.5p1").unwrap(), (8, 5));
+    assert_eq!(
+        parse_openssh_version("OpenSSH_10.0p2, OpenSSL 3.5.0").unwrap(),
+        (10, 0)
+    );
+    for garbage in [
+        "",
+        "ssh: command not found",
+        "Dropbear v2022.83",
+        "OpenSSH_for_Windows_8.1p1",
+        "OpenSSH_x.y",
+    ] {
+        let err = parse_openssh_version(garbage).unwrap_err().to_string();
+        assert!(err.contains("cannot parse"), "{garbage:?}: {err}");
+    }
+}
+
+#[test]
+fn openssh_floor_fails_closed_below_8_5() {
+    assert_eq!(MIN_OPENSSH, (8, 5));
+    let err = check_openssh_floor("OpenSSH_8.4p1 Debian-5")
+        .unwrap_err()
+        .to_string();
+    assert!(err.contains("8.4") && err.contains("8.5"), "{err}");
+    check_openssh_floor("OpenSSH_8.5p1").unwrap();
+    check_openssh_floor("OpenSSH_9.9p2").unwrap();
+    check_openssh_floor("OpenSSH_10.1p1").unwrap();
+    // Unparsable banner fails closed too.
+    check_openssh_floor("Dropbear v2022.83").unwrap_err();
+}
+
+// ---------------------------------------------------------------------------
+// script: quoting, heredocs, sharded-path reuse, skeleton invariants
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sh_quote_edge_cases() {
+    assert_eq!(sh_quote("plain"), "'plain'");
+    assert_eq!(sh_quote("a b"), "'a b'");
+    assert_eq!(sh_quote(""), "''");
+    assert_eq!(sh_quote("don't"), r"'don'\''t'");
+    assert_eq!(sh_quote("*?[!~"), "'*?[!~'");
+    assert_eq!(sh_quote("$HOME `id`"), "'$HOME `id`'");
+}
+
+#[test]
+fn sftp_quote_edge_cases() {
+    assert_eq!(sftp_quote("plain"), "\"plain\"");
+    assert_eq!(sftp_quote("a b/c"), "\"a b/c\"");
+    assert_eq!(sftp_quote("a\"b"), "\"a\\\"b\"");
+    assert_eq!(sftp_quote("a\\b"), "\"a\\\\b\"");
+}
+
+#[test]
+fn heredoc_emits_quoted_delimiter_and_lines() {
+    let out = heredoc("cat >\"$snapdir_tmp/list\"", &["one".into(), "two".into()]);
+    assert_eq!(
+        out,
+        "cat >\"$snapdir_tmp/list\" <<'SNAPDIR_EOF'\none\ntwo\nSNAPDIR_EOF\n"
+    );
+}
+
+#[test]
+fn heredoc_delimiter_dodges_colliding_lines() {
+    let out = heredoc(
+        "cat",
+        &["SNAPDIR_EOF".into(), "SNAPDIR_EOF_".into(), "x".into()],
+    );
+    let delimiter = "SNAPDIR_EOF__";
+    assert!(out.starts_with(&format!("cat <<'{delimiter}'\n")), "{out}");
+    assert!(out.ends_with(&format!("\n{delimiter}\n")));
+}
+
+#[test]
+fn remote_paths_reuse_the_frozen_core_sharding() {
+    // Golden values from snapdir_core::store's doc examples — the helpers
+    // must delegate to the frozen layout, never reimplement it.
+    let hex = "49dc870df1de7fd60794cebce449f5ccdae575affaa67a24b62acb03e039db92";
+    assert_eq!(
+        remote_object_path("/srv/snap", hex),
+        "/srv/snap/.objects/49d/c87/0df/1de7fd60794cebce449f5ccdae575affaa67a24b62acb03e039db92"
+    );
+    assert_eq!(
+        remote_manifest_path("/srv/snap", hex),
+        "/srv/snap/.manifests/49d/c87/0df/1de7fd60794cebce449f5ccdae575affaa67a24b62acb03e039db92"
+    );
+    assert_eq!(remote_object_path("/srv/snap", hex), {
+        format!("/srv/snap/{}", snapdir_core::store::object_path(hex))
+    });
+}
+
+/// Extracts the single-line body of a `_snapdir_<name>()` wrapper.
+fn wrapper_body<'a>(script: &'a str, name: &str) -> &'a str {
+    let open = format!("_snapdir_{name}() {{");
+    let start = script
+        .find(&open)
+        .unwrap_or_else(|| panic!("{open} missing"));
+    let rest = &script[start + open.len()..];
+    let end = rest.find('}').expect("wrapper close");
+    rest[..end].trim()
+}
+
+fn assert_ordered_floor(text: &str, context: &str) {
+    let mut from = 0usize;
+    for token in floor_tokens(10) {
+        let quoted = format!("-o '{token}'");
+        let pos = text[from..]
+            .find(&quoted)
+            .unwrap_or_else(|| panic!("{context}: {quoted} missing/out of order in: {text}"));
+        from += pos + quoted.len();
+    }
+}
+
+#[test]
+fn skeleton_carries_cleanup_trap_mux_and_floor_in_every_wrapper() {
+    let cfg = default_config();
+    let url = parse_url("ssh://deploy@example.com/srv/snap");
+    let script = skeleton(&url, &cfg);
+
+    // Private 0700 temp dir + cleanup trap (EXIT TERM HUP — never INT).
+    assert!(script.contains("mktemp -d"), "{script}");
+    assert!(script.contains("chmod 700 \"$snapdir_tmp\""));
+    assert!(script.contains("trap _snapdir_cleanup EXIT TERM HUP"));
+    for line in script.lines() {
+        if line.contains("trap") {
+            assert!(
+                !line.contains("INT"),
+                "the orchestrator owns the INT trap: {line}"
+            );
+        }
+    }
+
+    // Cleanup closes the master and removes the temp dir.
+    let cleanup = wrapper_body(&script, "cleanup");
+    assert!(cleanup.contains("-O exit"), "{cleanup}");
+    assert!(cleanup.contains("rm -rf \"$snapdir_tmp\""));
+
+    // Both wrappers multiplex and carry the ordered floor + host separator.
+    for (name, command) in [("ssh", "command ssh "), ("sftp", "command sftp ")] {
+        let body = wrapper_body(&script, name);
+        assert!(body.contains(command), "{name}: {body}");
+        assert!(body.contains("-o ControlMaster=auto"), "{name}: {body}");
+        assert!(
+            body.contains("-o ControlPath=\"$snapdir_tmp/cm\""),
+            "{name}: {body}"
+        );
+        assert!(body.contains("-o ControlPersist=60"), "{name}: {body}");
+        assert_ordered_floor(body, name);
+        assert!(body.contains("-- 'example.com'"), "{name}: {body}");
+    }
+    assert!(wrapper_body(&script, "ssh").ends_with("\"$@\""));
+    assert!(wrapper_body(&script, "sftp").contains("-b \"$1\""));
+    assert_ordered_floor(wrapper_body(&script, "cleanup"), "cleanup");
+}
+
+#[test]
+fn skeleton_extras_render_after_the_floor_and_user_rides_along() {
+    let pairs = [
+        ("SNAPDIR_SSH_STORE_EXTRA_OPTS", "StrictHostKeyChecking=no"),
+        ("SNAPDIR_SSH_STORE_CONTROL_PERSIST", "120"),
+    ];
+    let cfg = Config::from_lookup(Engine::Ssh, lookup_from(&pairs)).unwrap();
+    let url = parse_url("ssh://deploy@[2001:db8::1]:2200/srv/snap");
+    let script = skeleton(&url, &cfg);
+
+    let body = wrapper_body(&script, "ssh");
+    let floor = body.find("-o 'StrictHostKeyChecking=yes'").expect("floor");
+    let extra = body.find("-o 'StrictHostKeyChecking=no'").expect("extra");
+    assert!(floor < extra, "floor first, extras last: {body}");
+    assert!(body.contains("-o 'Port=2200'"));
+    assert!(body.contains("-o 'User=deploy'"));
+    assert!(body.contains("-o ControlPersist=120"));
+    assert!(
+        body.contains("-- '[2001:db8::1]'"),
+        "IPv6 stays bracketed: {body}"
+    );
+}
+
+#[test]
+fn skeleton_is_bash_32_clean() {
+    let cfg = default_config();
+    let url = parse_url("ssh://example.com/srv/snap");
+    let script = skeleton(&url, &cfg);
+    assert!(!script.contains("declare -A"), "no associative arrays");
+    assert!(
+        !script.contains("^^") && !script.contains(",,"),
+        "no 4.x case ops"
+    );
+    assert!(!script.contains("readarray") && !script.contains("mapfile"));
+}
+
+// ---------------------------------------------------------------------------
+// run dispatcher: version line, fail-closed engines, error surfacing
+// ---------------------------------------------------------------------------
+
+fn run_capture(engine: Engine, args: &[&str]) -> (u8, String, String) {
+    // The dispatcher reads the process env (Config::from_env) — serialize
+    // with the env-mutating tests.
+    let _guard = ENV_LOCK.lock().unwrap();
+    let mut out = Vec::new();
+    let mut err = Vec::new();
+    let code = run_with(engine, os_args(args), std::io::empty(), &mut out, &mut err);
+    (
+        code,
+        String::from_utf8(out).unwrap(),
+        String::from_utf8(err).unwrap(),
+    )
+}
+
+#[test]
+fn run_version_prints_engine_binary_name_and_crate_version() {
+    let (code, out, err) = run_capture(Engine::Ssh, &["snapdir-ssh-store", "--version"]);
+    assert_eq!(code, 0);
+    assert_eq!(
+        out,
+        format!("snapdir-ssh-store {}\n", env!("CARGO_PKG_VERSION"))
+    );
+    assert!(err.is_empty());
+
+    let (code, out, _) = run_capture(Engine::Sftp, &["snapdir-sftp-store", "-v"]);
+    assert_eq!(code, 0);
+    assert_eq!(
+        out,
+        format!("snapdir-sftp-store {}\n", env!("CARGO_PKG_VERSION"))
+    );
+}
+
+#[test]
+fn run_engines_fail_closed_until_implemented() {
+    let (code, out, err) = run_capture(
+        Engine::Ssh,
+        &[
+            "snapdir-ssh-store",
+            "get-manifest-command",
+            "--id",
+            "abc",
+            "--store",
+            "ssh://example.com/srv/snap",
+        ],
+    );
+    assert_eq!(code, 1);
+    assert!(out.is_empty(), "stdout must stay script-pure: {out:?}");
+    assert!(err.contains("not implemented"), "{err}");
+    assert!(err.contains("get-manifest-command"), "{err}");
+}
+
+#[test]
+fn run_surfaces_arg_and_url_errors_on_stderr() {
+    let (code, _, err) = run_capture(Engine::Ssh, &["snapdir-ssh-store", "--bogus=1"]);
+    assert_eq!(code, 1);
+    assert!(err.contains("snapdir-ssh-store:"), "{err}");
+    assert!(
+        err.contains("missing subcommand") || err.contains("unknown option"),
+        "{err}"
+    );
+
+    let (code, _, err) = run_capture(
+        Engine::Sftp,
+        &[
+            "snapdir-sftp-store",
+            "get-manifest-command",
+            "--id",
+            "abc",
+            "--store",
+            "ssh://example.com/srv/snap",
+        ],
+    );
+    assert_eq!(code, 1);
+    assert!(err.contains("sftp://"), "scheme mismatch surfaced: {err}");
+}

--- a/crates/snapdir-ssh-store/tests/emitted_contract.rs
+++ b/crates/snapdir-ssh-store/tests/emitted_contract.rs
@@ -806,7 +806,7 @@ fn run_version_prints_engine_binary_name_and_crate_version() {
 }
 
 #[test]
-fn run_engines_fail_closed_until_implemented() {
+fn run_ssh_engine_validates_the_id_before_emitting_anything() {
     let (code, out, err) = run_capture(
         Engine::Ssh,
         &[
@@ -820,8 +820,7 @@ fn run_engines_fail_closed_until_implemented() {
     );
     assert_eq!(code, 1);
     assert!(out.is_empty(), "stdout must stay script-pure: {out:?}");
-    assert!(err.contains("not implemented"), "{err}");
-    assert!(err.contains("get-manifest-command"), "{err}");
+    assert!(err.contains("invalid snapshot id"), "{err}");
 }
 
 #[test]

--- a/crates/snapdir-ssh-store/tests/fake_sftp_roundtrip.rs
+++ b/crates/snapdir-ssh-store/tests/fake_sftp_roundtrip.rs
@@ -1,0 +1,592 @@
+//! T1 hermetic round-trip tests for the `sftp://` engine, driven through the
+//! real external-store contract: `snapdir_stores::ExternalStore::with_binary`
+//! spawns the actual `snapdir-sftp-store` binary, captures the scripts it
+//! emits, and `eval`s them exactly like the orchestrator
+//! (`set -eEuo pipefail; trap 'kill 0' INT; <script> wait`).
+//!
+//! Hermetic: a per-test bin dir containing `tests/fixtures/fake-sftp`
+//! installed as `sftp` is prepended to `PATH`, and `FAKE_REMOTE_ROOT` fences
+//! the "remote" filesystem into a temp dir. No network, no real ssh
+//! connection. The skeleton's cleanup does run the real `ssh -O exit`
+//! (system PATH stays appended); with no `ControlMaster` socket it fails
+//! instantly and the skeleton's `2>/dev/null || true` swallows it — which is
+//! why no `ssh` stub is needed (verified by every test here passing with the
+//! cleanup trap firing).
+//!
+//! Env vars are process-global, so every env-touching test serializes on
+//! `ENV_LOCK` and restores via the `EnvGuard` drop. The emitted-text tests
+//! at the bottom are pure (library calls, no env, no lock).
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
+use snapdir_core::merkle::{directory_checksum, Blake3Hasher, Hasher};
+use snapdir_core::snapshot_id;
+use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
+
+use snapdir_ssh_store::config::Config;
+use snapdir_ssh_store::script::{sftp_quote, sh_quote};
+use snapdir_ssh_store::sftp_engine;
+use snapdir_ssh_store::url::SshUrl;
+use snapdir_ssh_store::Engine;
+
+use snapdir_stores::ExternalStore;
+
+/// The store base path on the fake remote: maps to `<FAKE_REMOTE_ROOT>/snap`.
+const REMOTE_BASE: &str = "/snap";
+const STORE_URL: &str = "sftp://fakehost/snap";
+
+/// Serializes env-touching tests (`PATH` / `FAKE_*` / `SNAPDIR_SFTP_STORE_*`
+/// are process-global and flow into the spawned binary + eval shell +
+/// fixture).
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// A unique temp dir removed on drop (no dev-dependency needed).
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "snapdir-sftp-test-{}-{tag}-{n}",
+            std::process::id()
+        ));
+        fs::create_dir_all(&path).expect("create temp dir");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+/// Holds `ENV_LOCK` and restores every touched env var on drop (panic-safe).
+struct EnvGuard {
+    saved: Vec<(String, Option<String>)>,
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl EnvGuard {
+    fn new() -> Self {
+        Self {
+            saved: Vec::new(),
+            _lock: ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner),
+        }
+    }
+
+    fn set(&mut self, key: &str, value: &str) {
+        if !self.saved.iter().any(|(k, _)| k == key) {
+            self.saved.push((key.to_owned(), std::env::var(key).ok()));
+        }
+        std::env::set_var(key, value);
+    }
+
+    fn remove(&mut self, key: &str) {
+        if !self.saved.iter().any(|(k, _)| k == key) {
+            self.saved.push((key.to_owned(), std::env::var(key).ok()));
+        }
+        std::env::remove_var(key);
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.saved.drain(..) {
+            match value {
+                Some(v) => std::env::set_var(&key, v),
+                None => std::env::remove_var(&key),
+            }
+        }
+    }
+}
+
+/// Installs `tests/fixtures/fake-sftp` as `<bindir>/sftp` (mode 0755) and
+/// returns the env guard with `PATH` prepended and `FAKE_REMOTE_ROOT` set.
+///
+/// Also shadows `bash` with the system `/bin/bash` (3.2 on macOS): the
+/// shim's eval shell and the fixture's `env bash` shebang then run the
+/// emitted scripts under the OLDEST bash we support, proving the
+/// bash-3.2-cleanliness of the emitted text on every test run.
+fn fake_remote_env(bindir: &Path, remote_root: &Path) -> EnvGuard {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("fake-sftp");
+    let sftp = bindir.join("sftp");
+    fs::copy(&fixture, &sftp).expect("install fake-sftp as sftp");
+    let mut perms = fs::metadata(&sftp).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&sftp, perms).unwrap();
+    if Path::new("/bin/bash").is_file() {
+        std::os::unix::fs::symlink("/bin/bash", bindir.join("bash")).expect("shadow bash");
+    }
+
+    let mut guard = EnvGuard::new();
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    guard.set("PATH", &format!("{}:{old_path}", bindir.display()));
+    guard.set("FAKE_REMOTE_ROOT", &remote_root.display().to_string());
+    guard
+}
+
+fn external_store() -> ExternalStore {
+    ExternalStore::with_binary(STORE_URL, env!("CARGO_BIN_EXE_snapdir-sftp-store"))
+}
+
+/// Builds a manifest for `files` (name → content), writes the sharded
+/// staging layout (objects + manifest) under `staging`, and returns the
+/// manifest, its snapshot id, and the per-file checksums.
+fn stage_tree(staging: &Path, files: &[(&str, &[u8])]) -> (Manifest, String, Vec<String>) {
+    let hasher = Blake3Hasher::new();
+    let mut entries = Vec::new();
+    let mut sums = Vec::new();
+    let mut total = 0u64;
+    for (name, content) in files {
+        let sum = hasher.hash_hex(content);
+        entries.push(ManifestEntry::new(
+            PathType::File,
+            "600",
+            sum.clone(),
+            content.len() as u64,
+            format!("./{name}"),
+        ));
+        sums.push(sum);
+        total += content.len() as u64;
+    }
+    let root = directory_checksum(sums.iter().map(String::as_str), &hasher);
+    entries.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root,
+        total,
+        "./",
+    ));
+    let manifest = Manifest::from_entries(entries);
+    let id = snapshot_id(&manifest, &hasher);
+
+    for (sum, (_, content)) in sums.iter().zip(files) {
+        let obj = staging.join(object_path(sum));
+        fs::create_dir_all(obj.parent().unwrap()).unwrap();
+        fs::write(&obj, content).unwrap();
+    }
+    let man = staging.join(manifest_path(&id));
+    fs::create_dir_all(man.parent().unwrap()).unwrap();
+    fs::write(&man, manifest.to_string()).unwrap();
+    (manifest, id, sums)
+}
+
+/// The fake remote path of `rel` under the store base.
+fn remote(remote_root: &Path, rel: &str) -> PathBuf {
+    remote_root
+        .join(REMOTE_BASE.trim_start_matches('/'))
+        .join(rel)
+}
+
+/// Collects every regular file under `dir`, recursively.
+fn files_under(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                out.extend(files_under(&path));
+            } else if path.is_file() {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// parity round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sftp_push_get_manifest_fetch_roundtrip() {
+    let staging = TempDir::new("rt-stage");
+    let remote_root = TempDir::new("rt-remote");
+    let bindir = TempDir::new("rt-bin");
+    let cache = TempDir::new("rt-cache");
+    let _env = fake_remote_env(bindir.path(), remote_root.path());
+
+    let files: &[(&str, &[u8])] = &[("foo", b"foo\n"), ("bar", b"bar bar\n")];
+    let (manifest, id, sums) = stage_tree(staging.path(), files);
+    let store = external_store();
+
+    store.push(&manifest, staging.path()).expect("push");
+
+    // Objects and the manifest landed at their sharded remote paths.
+    for (sum, (_, content)) in sums.iter().zip(files) {
+        let obj = remote(remote_root.path(), &object_path(sum));
+        assert!(obj.is_file(), "object {sum} should be on the remote");
+        assert_eq!(&fs::read(&obj).unwrap(), content);
+        let mode = fs::metadata(&obj).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "chmod 600 discipline on {sum}");
+    }
+    let man = remote(remote_root.path(), &manifest_path(&id));
+    assert!(man.is_file(), "manifest should be on the remote");
+    assert_eq!(fs::read_to_string(&man).unwrap(), manifest.to_string());
+
+    // get-manifest round-trips byte-identically (the shim also id-verifies).
+    let fetched = store.get_manifest(&id).expect("get_manifest");
+    assert_eq!(fetched.to_string(), manifest.to_string());
+
+    // fetch_files lands objects in the sharded cache layout.
+    store
+        .fetch_files(&manifest, cache.path())
+        .expect("fetch_files");
+    for (sum, (_, content)) in sums.iter().zip(files) {
+        let cached = cache.path().join(object_path(sum));
+        assert!(cached.is_file(), "object {sum} should be in the cache");
+        assert_eq!(&fs::read(&cached).unwrap(), content);
+    }
+    // The incoming temp dir was cleaned up.
+    assert!(
+        !files_under(cache.path())
+            .iter()
+            .any(|p| p.to_string_lossy().contains(".snapdir-incoming.")),
+        "no incoming temp residue in the cache"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// not-found mapping
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sftp_get_manifest_missing_id_maps_to_manifest_not_found() {
+    let remote_root = TempDir::new("nf-remote");
+    let bindir = TempDir::new("nf-bin");
+    let _env = fake_remote_env(bindir.path(), remote_root.path());
+
+    let missing = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    match external_store().get_manifest(missing) {
+        Err(StoreError::ManifestNotFound { id }) => assert_eq!(id, missing),
+        other => panic!("expected ManifestNotFound, got {other:?}"),
+    }
+}
+
+#[test]
+fn sftp_unreachable_host_is_backend_error_not_not_found() {
+    // Connectivity failure must NEVER map to not-found: the probe's `pwd`
+    // liveness batch fails too, so the script exits with the real failure.
+    let remote_root = TempDir::new("ur-remote");
+    let bindir = TempDir::new("ur-bin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path());
+    env.set("FAKE_SFTP_UNREACHABLE", "1");
+
+    let id = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    match external_store().get_manifest(id) {
+        Err(StoreError::Backend { .. }) => {}
+        other => panic!("expected Backend error for unreachable store, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// idempotency
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sftp_push_is_noop_when_manifest_already_present() {
+    let staging = TempDir::new("id-stage");
+    let remote_root = TempDir::new("id-remote");
+    let bindir = TempDir::new("id-bin");
+    let _env = fake_remote_env(bindir.path(), remote_root.path());
+
+    let (manifest, id, sums) = stage_tree(staging.path(), &[("foo", b"foo\n")]);
+    let store = external_store();
+    store.push(&manifest, staging.path()).expect("first push");
+
+    // Remove the object but keep the manifest: a second push must short-
+    // circuit on the manifest probe and NOT touch the remote at all.
+    let obj = remote(remote_root.path(), &object_path(&sums[0]));
+    fs::remove_file(&obj).unwrap();
+
+    store
+        .push(&manifest, staging.path())
+        .expect("second push (no-op)");
+    assert!(
+        !obj.exists(),
+        "second push should have been a no-op (manifest already present)"
+    );
+    assert!(remote(remote_root.path(), &manifest_path(&id)).is_file());
+}
+
+// ---------------------------------------------------------------------------
+// atomicity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sftp_push_atomicity_failed_put_leaves_no_manifest_then_retry_completes() {
+    let staging = TempDir::new("at-stage");
+    let remote_root = TempDir::new("at-remote");
+    let bindir = TempDir::new("at-bin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path());
+    // One chunk so the per-process put counter is deterministic: the second
+    // object's put fails mid-batch.
+    env.set("SNAPDIR_SFTP_STORE_JOBS", "1");
+    env.set("FAKE_SFTP_FAIL_VERB", "put");
+    env.set("FAKE_SFTP_FAIL_AFTER", "2");
+
+    let files: &[(&str, &[u8])] = &[("a", b"alpha\n"), ("b", b"bravo\n"), ("c", b"charlie\n")];
+    let (manifest, id, sums) = stage_tree(staging.path(), files);
+    let store = external_store();
+
+    let err = store.push(&manifest, staging.path()).unwrap_err();
+    assert!(
+        matches!(err, StoreError::Backend { .. }),
+        "expected Backend error from failed push, got {err:?}"
+    );
+
+    // NO manifest committed.
+    assert!(
+        !remote(remote_root.path(), &manifest_path(&id)).exists(),
+        "a failed push must not commit the manifest"
+    );
+    // SOME objects landed; every file at a FINAL object path is complete
+    // (partials only ever exist at .tmp.<nonce> paths).
+    let expected: Vec<Vec<u8>> = files.iter().map(|(_, c)| c.to_vec()).collect();
+    let object_files = files_under(&remote(remote_root.path(), ".objects"));
+    let mut finals = 0;
+    for path in &object_files {
+        let name = path.file_name().unwrap().to_string_lossy();
+        if name.contains(".tmp.") {
+            continue; // orphaned partial from the killed transfer — allowed
+        }
+        finals += 1;
+        let content = fs::read(path).unwrap();
+        assert!(
+            expected.contains(&content),
+            "non-tmp partial at final path {path:?}: {content:?}"
+        );
+    }
+    assert!(finals >= 1, "the put before the injected failure landed");
+    assert!(
+        finals < files.len(),
+        "the injected failure stopped the transfer early"
+    );
+
+    // Clear the injection: the retry is idempotent and completes the push.
+    env.remove("FAKE_SFTP_FAIL_VERB");
+    env.remove("FAKE_SFTP_FAIL_AFTER");
+    store.push(&manifest, staging.path()).expect("retry push");
+    for (sum, (_, content)) in sums.iter().zip(files) {
+        let obj = remote(remote_root.path(), &object_path(sum));
+        assert_eq!(&fs::read(&obj).unwrap(), content, "object {sum} complete");
+    }
+    assert!(remote(remote_root.path(), &manifest_path(&id)).is_file());
+}
+
+// ---------------------------------------------------------------------------
+// fetch-missing-object
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sftp_fetch_missing_object_reports_exact_error() {
+    let staging = TempDir::new("fm-stage");
+    let remote_root = TempDir::new("fm-remote");
+    let bindir = TempDir::new("fm-bin");
+    let cache = TempDir::new("fm-cache");
+    let _env = fake_remote_env(bindir.path(), remote_root.path());
+
+    let (manifest, _id, sums) = stage_tree(staging.path(), &[("foo", b"foo\n"), ("bar", b"bar\n")]);
+    let store = external_store();
+    store.push(&manifest, staging.path()).expect("push");
+
+    // Delete one remote object: fetch must fail with the exact wording.
+    fs::remove_file(remote(remote_root.path(), &object_path(&sums[1]))).unwrap();
+
+    let err = store.fetch_files(&manifest, cache.path()).unwrap_err();
+    match &err {
+        StoreError::Backend { message, .. } => assert!(
+            message.contains(&format!("ERROR: missing object {}", sums[1])),
+            "exact missing-object wording expected in: {message}"
+        ),
+        other => panic!("expected Backend error, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// emitted-text invariants (pure library calls — no env, no fixture)
+// ---------------------------------------------------------------------------
+
+fn sftp_url() -> SshUrl {
+    SshUrl::parse(Engine::Sftp, STORE_URL).unwrap()
+}
+
+fn default_cfg() -> Config {
+    Config::from_lookup(Engine::Sftp, |_| None).unwrap()
+}
+
+#[test]
+fn emitted_push_script_orders_manifest_last_with_tmp_rename_discipline() {
+    let staging = TempDir::new("tx-stage");
+    let (_, id, sums) = stage_tree(staging.path(), &[("foo", b"foo\n"), ("bar", b"bar\n")]);
+    let staging_dir = staging.path().display().to_string();
+    let script =
+        sftp_engine::get_push_script(&sftp_url(), &default_cfg(), &id, &staging_dir).unwrap();
+
+    // Manifest commit comes AFTER the object-chunk machinery (objects-before-
+    // manifest): the manifest batch is the last _snapdir_sftp invocation.
+    let chunks_pos = script
+        .rfind("chunk.")
+        .expect("object chunk machinery present");
+    let manifest_pos = script
+        .find("$snapdir_tmp/manifest.batch")
+        .expect("manifest batch present");
+    assert!(
+        manifest_pos > chunks_pos,
+        "manifest batch must come after the object chunks"
+    );
+    let last_invocation = script.rfind("_snapdir_sftp ").unwrap();
+    assert!(
+        script[last_invocation..].contains("manifest.batch"),
+        "the final transfer is the manifest commit"
+    );
+
+    // put-to-tmp + rename + chmod discipline for every object and the manifest.
+    for sum in &sums {
+        let remote_obj = format!("{REMOTE_BASE}/{}", object_path(sum));
+        let staged_obj = format!("{staging_dir}/{}", object_path(sum));
+        assert!(
+            script.contains(&format!("put \"{staged_obj}\" \"{remote_obj}.tmp.")),
+            "put-to-tmp for {sum}"
+        );
+        assert!(
+            script.contains(&format!("\" \"{remote_obj}\"\nchmod 600 \"{remote_obj}\"")),
+            "rename-into-place + chmod 600 for {sum}"
+        );
+        assert!(
+            script.contains(&format!("-rm \"{remote_obj}\"")),
+            "-rm before rename"
+        );
+    }
+    let remote_man = format!("{REMOTE_BASE}/{}", manifest_path(&id));
+    let staged_man = format!("{staging_dir}/{}", manifest_path(&id));
+    assert!(script.contains(&format!("put \"{staged_man}\" \"{remote_man}.tmp.")));
+    assert!(script.contains(&format!("chmod 600 \"{remote_man}\"")));
+
+    // Exact no-op wording on the short-circuit path.
+    assert!(script.contains("echo 'Manifest already exists on store.'"));
+
+    // Existence probing of OBJECT paths is only ever tolerated (-ls): no
+    // unprefixed `ls` of an object path (the manifest probe alone is
+    // unprefixed, and intentionally so).
+    for line in script.lines() {
+        if line.starts_with("ls ") {
+            assert!(
+                !line.contains(".objects/"),
+                "unprefixed ls of an object path: {line}"
+            );
+        }
+        if line.contains(".objects/") && line.starts_with("-ls ") {
+            assert!(line.starts_with("-ls \""), "tolerated quoted -ls: {line}");
+        }
+    }
+    assert!(
+        script.contains(&format!("-ls \"{REMOTE_BASE}/.objects/")),
+        "tolerated object existence probe present"
+    );
+
+    // Explicit per-pid wait with status collection.
+    assert!(script.contains("wait \"$snapdir_pid\" || snapdir_failed=1"));
+}
+
+#[test]
+fn emitted_get_manifest_script_keeps_stdout_pure_with_exact_not_found_wording() {
+    let id = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    let script =
+        sftp_engine::get_manifest_script(&sftp_url(), &default_cfg(), id, STORE_URL).unwrap();
+
+    // Exact not-found wording, on stderr, exit 1.
+    let wording = sh_quote(&format!("ID '{id}' not found on --store '{STORE_URL}'."));
+    assert!(
+        script.contains(&format!("printf '%s\\n' {wording} >&2")),
+        "exact not-found wording: {script}"
+    );
+
+    // Every sftp invocation's stdout is redirected away; only the final cat
+    // emits manifest bytes on stdout.
+    for line in script.lines() {
+        if line.trim_start().starts_with("_snapdir_sftp ") {
+            assert!(
+                line.contains(">/dev/null") || line.contains(">\"$snapdir_tmp/"),
+                "sftp chatter must not reach stdout: {line}"
+            );
+        }
+    }
+    assert!(script.trim_end().ends_with("cat \"$snapdir_tmp/manifest\""));
+
+    // The probe disambiguates missing vs unreachable over the live master.
+    assert!(script.contains("pwd"));
+    assert!(script.contains("cat \"$snapdir_tmp/probe.err\" >&2"));
+}
+
+#[test]
+fn emitted_fetch_script_has_exact_error_wording_tolerated_gets_and_ignored_chunk_exits() {
+    let staging = TempDir::new("fx-stage");
+    let cache = TempDir::new("fx-cache");
+    let (manifest, _id, sums) = stage_tree(staging.path(), &[("foo", b"foo\n"), ("bar", b"bar\n")]);
+    let script = sftp_engine::get_fetch_files_script(
+        &sftp_url(),
+        &default_cfg(),
+        &manifest.to_string(),
+        &cache.path().display().to_string(),
+    )
+    .unwrap();
+
+    // Incoming temp dir under the cache; exact missing-object wording.
+    assert!(script.contains("mktemp -d \"$snapdir_cache/.snapdir-incoming.XXXXXX\""));
+    assert!(script.contains("printf 'ERROR: missing object %s\\n' \"$snapdir_sum\" >&2"));
+
+    // Transfers are tolerated -get lines (the post-check decides), chunk
+    // exits are explicitly waited and IGNORED.
+    assert!(script.contains("printf -- '-get %s \"%s/%s\"\\n'"));
+    assert!(script.contains("wait \"$snapdir_pid\" || true"));
+
+    // Every needed checksum's remote path is baked, sftp-quoted, at emit time.
+    for sum in &sums {
+        let remote_obj = format!("{REMOTE_BASE}/{}", object_path(sum));
+        assert!(script.contains(&format!("{sum} {}", sftp_quote(&remote_obj))));
+    }
+}
+
+#[test]
+fn emitted_fetch_script_skips_objects_already_cached() {
+    let staging = TempDir::new("fc-stage");
+    let cache = TempDir::new("fc-cache");
+    let (manifest, _id, sums) = stage_tree(staging.path(), &[("foo", b"foo\n"), ("bar", b"bar\n")]);
+
+    // Pre-seed one object in the cache: it must not be re-fetched.
+    let cached = cache.path().join(object_path(&sums[0]));
+    fs::create_dir_all(cached.parent().unwrap()).unwrap();
+    fs::write(&cached, b"foo\n").unwrap();
+
+    let script = sftp_engine::get_fetch_files_script(
+        &sftp_url(),
+        &default_cfg(),
+        &manifest.to_string(),
+        &cache.path().display().to_string(),
+    )
+    .unwrap();
+    assert!(
+        !script.contains(&sums[0]),
+        "cached object must be dropped at emit time"
+    );
+    assert!(script.contains(&sums[1]), "uncached object must be fetched");
+}

--- a/crates/snapdir-ssh-store/tests/fake_ssh_roundtrip.rs
+++ b/crates/snapdir-ssh-store/tests/fake_ssh_roundtrip.rs
@@ -135,6 +135,16 @@ fn fake_remote_env(bindir: &Path, remote_root: &Path) -> EnvGuard {
     let old_path = std::env::var("PATH").unwrap_or_default();
     guard.set("PATH", &format!("{}:{old_path}", bindir.display()));
     guard.set("FAKE_REMOTE_ROOT", &remote_root.display().to_string());
+    // This suite is the DUMB-path contract: pin the runtime dispatch to the
+    // dumb bodies so a `snapdir` with wire plumbing on the host machine's
+    // PATH can never flip these tests onto the accel path (tests/accel.rs
+    // owns the dispatch + accel behavior), and scrub the other accel knobs
+    // a developer shell might leak.
+    guard.set("SNAPDIR_SSH_NO_ACCEL", "1");
+    guard.remove("SNAPDIR_SSH_FORCE_ACCEL");
+    guard.remove("SNAPDIR_SSH_PULL_SENDALL");
+    guard.remove("SNAPDIR_SSH_LOCAL_SNAPDIR");
+    guard.remove("FAKE_SSH_REMOTE_PATH");
     guard
 }
 
@@ -526,9 +536,14 @@ fn emitted_push_script_probes_then_transfers_then_commits_inside_dumb_function()
         "the object transfer must precede the manifest commit"
     );
 
-    // The dumb body is a function the accel gate can branch around.
+    // The dumb body is a function the runtime dispatch branches around
+    // (both paths embedded; tests/accel.rs owns the dispatch behavior).
     assert!(script.contains("_snapdir_dumb_push() {"));
-    assert!(script.trim_end().ends_with("_snapdir_dumb_push"));
+    assert!(script.contains("_snapdir_accel_push() {"));
+    assert!(
+        script.contains("  _snapdir_dumb_push\n"),
+        "the dispatch must still invoke the dumb body"
+    );
 
     // Exact no-op wording on the short-circuit path, BEFORE the dumb body.
     let noop = script
@@ -594,9 +609,14 @@ fn emitted_fetch_script_gates_extraction_on_the_exact_match_allowlist() {
     .unwrap();
     assert_skeleton_invariants(&script);
 
-    // The dumb body is a function the accel gate can branch around.
+    // The dumb body is a function the runtime dispatch branches around
+    // (both paths embedded; tests/accel.rs owns the dispatch behavior).
     assert!(script.contains("_snapdir_dumb_fetch() {"));
-    assert!(script.trim_end().ends_with("_snapdir_dumb_fetch"));
+    assert!(script.contains("_snapdir_accel_fetch() {"));
+    assert!(
+        script.contains("  _snapdir_dumb_fetch\n"),
+        "the dispatch must still invoke the dumb body"
+    );
 
     // Ordering: pre-transfer remote existence check → tar saved to a local
     // file → allowlist gate → extraction into the incoming temp dir.
@@ -645,9 +665,18 @@ fn emitted_fetch_script_skips_objects_already_cached() {
         &cache.path().display().to_string(),
     )
     .unwrap();
+    // The cached object is dropped from the transfer set at emit time: its
+    // sharded relpath never appears (no dumb pair, no expected-list entry),
+    // and the only place the bare checksum survives is the full-list
+    // `ids_all` heredoc baked for the runtime SNAPDIR_SSH_PULL_SENDALL knob.
     assert!(
-        !script.contains(&sums[0]),
-        "cached object must be dropped at emit time"
+        !script.contains(&object_path(&sums[0])),
+        "cached object must be dropped from the transfer set at emit time"
+    );
+    assert_eq!(
+        script.matches(&sums[0]).count(),
+        1,
+        "the cached checksum may only survive in the baked SENDALL list"
     );
     assert!(script.contains(&sums[1]), "uncached object must be fetched");
 }

--- a/crates/snapdir-ssh-store/tests/fake_ssh_roundtrip.rs
+++ b/crates/snapdir-ssh-store/tests/fake_ssh_roundtrip.rs
@@ -1,0 +1,653 @@
+//! T1 hermetic round-trip tests for the `ssh://` dumb engine, driven through
+//! the real external-store contract: `snapdir_stores::ExternalStore::
+//! with_binary` spawns the actual `snapdir-ssh-store` binary, captures the
+//! scripts it emits, and `eval`s them exactly like the orchestrator
+//! (`set -eEuo pipefail; trap 'kill 0' INT; <script> wait`).
+//!
+//! Hermetic: a per-test bin dir containing `tests/fixtures/fake-ssh`
+//! installed as `ssh` is prepended to `PATH`, and the "remote" filesystem is
+//! fenced into a temp dir by constructing the store URL as
+//! `ssh://fakehost<abs-fake-root-base>` — the emitted base path IS an
+//! absolute path under `FAKE_REMOTE_ROOT`, so the fixture needs no path
+//! remapping (remote commands run locally via `sh -c` with stdin/stdout
+//! passed through, so the tar pipelines are honestly exercised). The
+//! skeleton's `-O exit` cleanup also hits the fixture (a no-op success).
+//!
+//! Env vars are process-global, so every env-touching test serializes on
+//! `ENV_LOCK` and restores via the `EnvGuard` drop. The emitted-text tests
+//! at the bottom are pure (library calls, no env, no lock). The harness
+//! helpers mirror `tests/fake_sftp_roundtrip.rs` (duplicated deliberately:
+//! the two suites stay independently readable and runnable).
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard, PoisonError};
+
+use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
+use snapdir_core::merkle::{directory_checksum, Blake3Hasher, Hasher};
+use snapdir_core::snapshot_id;
+use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
+
+use snapdir_ssh_store::config::Config;
+use snapdir_ssh_store::script::{remote_manifest_path, sh_quote};
+use snapdir_ssh_store::ssh_engine;
+use snapdir_ssh_store::url::SshUrl;
+use snapdir_ssh_store::Engine;
+
+use snapdir_stores::ExternalStore;
+
+/// Serializes env-touching tests (`PATH` / `FAKE_*` env are process-global
+/// and flow into the spawned binary + eval shell + fixture).
+static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// A unique temp dir removed on drop (no dev-dependency needed).
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path =
+            std::env::temp_dir().join(format!("snapdir-ssh-test-{}-{tag}-{n}", std::process::id()));
+        fs::create_dir_all(&path).expect("create temp dir");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+/// Holds `ENV_LOCK` and restores every touched env var on drop (panic-safe).
+struct EnvGuard {
+    saved: Vec<(String, Option<String>)>,
+    _lock: MutexGuard<'static, ()>,
+}
+
+impl EnvGuard {
+    fn new() -> Self {
+        Self {
+            saved: Vec::new(),
+            _lock: ENV_LOCK.lock().unwrap_or_else(PoisonError::into_inner),
+        }
+    }
+
+    fn set(&mut self, key: &str, value: &str) {
+        if !self.saved.iter().any(|(k, _)| k == key) {
+            self.saved.push((key.to_owned(), std::env::var(key).ok()));
+        }
+        std::env::set_var(key, value);
+    }
+
+    fn remove(&mut self, key: &str) {
+        if !self.saved.iter().any(|(k, _)| k == key) {
+            self.saved.push((key.to_owned(), std::env::var(key).ok()));
+        }
+        std::env::remove_var(key);
+    }
+}
+
+impl Drop for EnvGuard {
+    fn drop(&mut self) {
+        for (key, value) in self.saved.drain(..) {
+            match value {
+                Some(v) => std::env::set_var(&key, v),
+                None => std::env::remove_var(&key),
+            }
+        }
+    }
+}
+
+/// Installs `tests/fixtures/fake-ssh` as `<bindir>/ssh` (mode 0755) and
+/// returns the env guard with `PATH` prepended and `FAKE_REMOTE_ROOT` set.
+///
+/// Also shadows `bash` with the system `/bin/bash` (3.2 on macOS): the
+/// shim's eval shell then runs the emitted scripts under the OLDEST bash we
+/// support, proving the bash-3.2-cleanliness of the emitted text on every
+/// test run (the remote half runs under plain `sh` inside the fixture).
+fn fake_remote_env(bindir: &Path, remote_root: &Path) -> EnvGuard {
+    let fixture = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("tests")
+        .join("fixtures")
+        .join("fake-ssh");
+    let ssh = bindir.join("ssh");
+    fs::copy(&fixture, &ssh).expect("install fake-ssh as ssh");
+    let mut perms = fs::metadata(&ssh).unwrap().permissions();
+    perms.set_mode(0o755);
+    fs::set_permissions(&ssh, perms).unwrap();
+    if Path::new("/bin/bash").is_file() {
+        std::os::unix::fs::symlink("/bin/bash", bindir.join("bash")).expect("shadow bash");
+    }
+
+    let mut guard = EnvGuard::new();
+    let old_path = std::env::var("PATH").unwrap_or_default();
+    guard.set("PATH", &format!("{}:{old_path}", bindir.display()));
+    guard.set("FAKE_REMOTE_ROOT", &remote_root.display().to_string());
+    guard
+}
+
+/// The store base on the fake remote: an absolute path under the fenced
+/// remote root (see the module docs — the URL embeds it, so the fixture
+/// needs no remapping).
+fn remote_base(remote_root: &Path) -> PathBuf {
+    remote_root.join("snap")
+}
+
+fn store_url(remote_root: &Path) -> String {
+    format!("ssh://fakehost{}", remote_base(remote_root).display())
+}
+
+fn external_store(remote_root: &Path) -> ExternalStore {
+    ExternalStore::with_binary(
+        &store_url(remote_root),
+        env!("CARGO_BIN_EXE_snapdir-ssh-store"),
+    )
+}
+
+/// Builds a manifest for `files` (name → content), writes the sharded
+/// staging layout (objects + manifest) under `staging`, and returns the
+/// manifest, its snapshot id, and the per-file checksums.
+fn stage_tree(staging: &Path, files: &[(&str, &[u8])]) -> (Manifest, String, Vec<String>) {
+    let hasher = Blake3Hasher::new();
+    let mut entries = Vec::new();
+    let mut sums = Vec::new();
+    let mut total = 0u64;
+    for (name, content) in files {
+        let sum = hasher.hash_hex(content);
+        entries.push(ManifestEntry::new(
+            PathType::File,
+            "600",
+            sum.clone(),
+            content.len() as u64,
+            format!("./{name}"),
+        ));
+        sums.push(sum);
+        total += content.len() as u64;
+    }
+    let root = directory_checksum(sums.iter().map(String::as_str), &hasher);
+    entries.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root,
+        total,
+        "./",
+    ));
+    let manifest = Manifest::from_entries(entries);
+    let id = snapshot_id(&manifest, &hasher);
+
+    for (sum, (_, content)) in sums.iter().zip(files) {
+        let obj = staging.join(object_path(sum));
+        fs::create_dir_all(obj.parent().unwrap()).unwrap();
+        fs::write(&obj, content).unwrap();
+    }
+    let man = staging.join(manifest_path(&id));
+    fs::create_dir_all(man.parent().unwrap()).unwrap();
+    fs::write(&man, manifest.to_string()).unwrap();
+    (manifest, id, sums)
+}
+
+/// The fake remote path of `rel` under the store base.
+fn remote(remote_root: &Path, rel: &str) -> PathBuf {
+    remote_base(remote_root).join(rel)
+}
+
+/// Collects every regular file under `dir`, recursively.
+fn files_under(dir: &Path) -> Vec<PathBuf> {
+    let mut out = Vec::new();
+    if let Ok(entries) = fs::read_dir(dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                out.extend(files_under(&path));
+            } else if path.is_file() {
+                out.push(path);
+            }
+        }
+    }
+    out
+}
+
+// ---------------------------------------------------------------------------
+// parity round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ssh_push_get_manifest_fetch_roundtrip() {
+    let staging = TempDir::new("rt-stage");
+    let remote_root = TempDir::new("rt-remote");
+    let bindir = TempDir::new("rt-bin");
+    let cache = TempDir::new("rt-cache");
+    let _env = fake_remote_env(bindir.path(), remote_root.path());
+
+    let files: &[(&str, &[u8])] = &[("foo", b"foo\n"), ("bar", b"bar bar\n")];
+    let (manifest, id, sums) = stage_tree(staging.path(), files);
+    let store = external_store(remote_root.path());
+
+    store.push(&manifest, staging.path()).expect("push");
+
+    // Objects and the manifest landed at their sharded remote paths, with
+    // the umask discipline (no group/other bits).
+    for (sum, (_, content)) in sums.iter().zip(files) {
+        let obj = remote(remote_root.path(), &object_path(sum));
+        assert!(obj.is_file(), "object {sum} should be on the remote");
+        assert_eq!(&fs::read(&obj).unwrap(), content);
+        let mode = fs::metadata(&obj).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode & 0o077, 0, "umask 077 discipline on {sum}: {mode:o}");
+    }
+    let man = remote(remote_root.path(), &manifest_path(&id));
+    assert!(man.is_file(), "manifest should be on the remote");
+    assert_eq!(fs::read_to_string(&man).unwrap(), manifest.to_string());
+    let man_mode = fs::metadata(&man).unwrap().permissions().mode() & 0o777;
+    assert_eq!(man_mode & 0o077, 0, "umask 077 discipline on the manifest");
+
+    // No leftover remote temp dirs (the extract removed its incoming dir).
+    assert!(
+        !files_under(&remote_base(remote_root.path()))
+            .iter()
+            .any(|p| p.to_string_lossy().contains(".snapdir-incoming.")),
+        "no incoming temp residue on the remote"
+    );
+
+    // get-manifest round-trips byte-identically (the shim also id-verifies).
+    let fetched = store.get_manifest(&id).expect("get_manifest");
+    assert_eq!(fetched.to_string(), manifest.to_string());
+
+    // fetch_files lands objects in the sharded cache layout.
+    store
+        .fetch_files(&manifest, cache.path())
+        .expect("fetch_files");
+    for (sum, (_, content)) in sums.iter().zip(files) {
+        let cached = cache.path().join(object_path(sum));
+        assert!(cached.is_file(), "object {sum} should be in the cache");
+        assert_eq!(&fs::read(&cached).unwrap(), content);
+    }
+    // The incoming temp dir was cleaned up.
+    assert!(
+        !files_under(cache.path())
+            .iter()
+            .any(|p| p.to_string_lossy().contains(".snapdir-incoming.")),
+        "no incoming temp residue in the cache"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// not-found mapping
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ssh_get_manifest_missing_id_maps_to_manifest_not_found() {
+    let remote_root = TempDir::new("nf-remote");
+    let bindir = TempDir::new("nf-bin");
+    let _env = fake_remote_env(bindir.path(), remote_root.path());
+
+    let missing = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    match external_store(remote_root.path()).get_manifest(missing) {
+        Err(StoreError::ManifestNotFound { id }) => assert_eq!(id, missing),
+        other => panic!("expected ManifestNotFound, got {other:?}"),
+    }
+}
+
+#[test]
+fn ssh_connectivity_failure_is_backend_error_not_not_found() {
+    // The probe's exit-code discipline: a non-0/1 ssh exit (here 255 from
+    // the injected connection failure) must surface as a Backend error and
+    // NEVER masquerade as "not found" (which would trigger silent re-push).
+    let remote_root = TempDir::new("cn-remote");
+    let bindir = TempDir::new("cn-bin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path());
+    env.set("FAKE_SSH_FAIL_MATCH", "test -f");
+
+    let id = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    match external_store(remote_root.path()).get_manifest(id) {
+        Err(StoreError::Backend { .. }) => {}
+        other => panic!("expected Backend error for unreachable store, got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// idempotency
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ssh_push_is_noop_when_manifest_already_present() {
+    let staging = TempDir::new("id-stage");
+    let remote_root = TempDir::new("id-remote");
+    let bindir = TempDir::new("id-bin");
+    let _env = fake_remote_env(bindir.path(), remote_root.path());
+
+    let (manifest, id, sums) = stage_tree(staging.path(), &[("foo", b"foo\n")]);
+    let store = external_store(remote_root.path());
+    store.push(&manifest, staging.path()).expect("first push");
+
+    // Remove the object but keep the manifest: a second push must short-
+    // circuit on the manifest probe and NOT touch the remote at all.
+    let obj = remote(remote_root.path(), &object_path(&sums[0]));
+    fs::remove_file(&obj).unwrap();
+
+    store
+        .push(&manifest, staging.path())
+        .expect("second push (no-op)");
+    assert!(
+        !obj.exists(),
+        "second push should have been a no-op (manifest already present)"
+    );
+    assert!(remote(remote_root.path(), &manifest_path(&id)).is_file());
+}
+
+// ---------------------------------------------------------------------------
+// atomicity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ssh_push_atomicity_truncated_transfer_leaves_no_manifest_then_retry_completes() {
+    let staging = TempDir::new("at-stage");
+    let remote_root = TempDir::new("at-remote");
+    let bindir = TempDir::new("at-bin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path());
+    // The remote tar-extract sees only the first 1536 bytes of the stream
+    // (first object complete, second cut mid-header) and then the
+    // "connection" dies.
+    env.set("FAKE_SSH_TRUNCATE_TAR", "1536");
+
+    let files: &[(&str, &[u8])] = &[("a", b"alpha\n"), ("b", b"bravo\n"), ("c", b"charlie\n")];
+    let (manifest, id, sums) = stage_tree(staging.path(), files);
+    let store = external_store(remote_root.path());
+
+    let err = store.push(&manifest, staging.path()).unwrap_err();
+    assert!(
+        matches!(err, StoreError::Backend { .. }),
+        "expected Backend error from failed push, got {err:?}"
+    );
+
+    // NO manifest committed.
+    assert!(
+        !remote(remote_root.path(), &manifest_path(&id)).exists(),
+        "a failed push must not commit the manifest"
+    );
+    // Nothing incomplete at FINAL paths: every file on the remote is either
+    // inside a .snapdir-incoming temp dir (debris of the killed transfer —
+    // allowed, a retry ignores it) or a complete expected object.
+    let expected: Vec<Vec<u8>> = files.iter().map(|(_, c)| c.to_vec()).collect();
+    for path in files_under(&remote_base(remote_root.path())) {
+        if path.to_string_lossy().contains(".snapdir-incoming.") {
+            continue;
+        }
+        let content = fs::read(&path).unwrap();
+        assert!(
+            expected.contains(&content),
+            "incomplete file at final path {path:?}: {content:?}"
+        );
+    }
+
+    // Clear the injection: the retry is idempotent and completes the push.
+    env.remove("FAKE_SSH_TRUNCATE_TAR");
+    store.push(&manifest, staging.path()).expect("retry push");
+    for (sum, (_, content)) in sums.iter().zip(files) {
+        let obj = remote(remote_root.path(), &object_path(sum));
+        assert_eq!(&fs::read(&obj).unwrap(), content, "object {sum} complete");
+    }
+    assert!(remote(remote_root.path(), &manifest_path(&id)).is_file());
+}
+
+// ---------------------------------------------------------------------------
+// fetch-missing-object
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ssh_fetch_missing_object_fails_before_any_transfer_with_exact_error() {
+    let staging = TempDir::new("fm-stage");
+    let remote_root = TempDir::new("fm-remote");
+    let bindir = TempDir::new("fm-bin");
+    let cache = TempDir::new("fm-cache");
+    let _env = fake_remote_env(bindir.path(), remote_root.path());
+
+    let (manifest, _id, sums) = stage_tree(staging.path(), &[("foo", b"foo\n"), ("bar", b"bar\n")]);
+    let store = external_store(remote_root.path());
+    store.push(&manifest, staging.path()).expect("push");
+
+    // Delete one remote object: fetch must fail with the exact wording.
+    fs::remove_file(remote(remote_root.path(), &object_path(&sums[1]))).unwrap();
+
+    let err = store.fetch_files(&manifest, cache.path()).unwrap_err();
+    match &err {
+        StoreError::Backend { message, .. } => assert!(
+            message.contains(&format!("ERROR: missing object {}", sums[1])),
+            "exact missing-object wording expected in: {message}"
+        ),
+        other => panic!("expected Backend error, got {other:?}"),
+    }
+    // The pre-transfer check fired BEFORE any object moved: the cache got
+    // nothing (not even the object that does exist on the remote).
+    assert!(
+        files_under(cache.path()).is_empty(),
+        "the missing-object check must abort before any transfer"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// tar-allowlist (malicious remote)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ssh_fetch_rejects_unexpected_tar_entries_without_extracting() {
+    let staging = TempDir::new("ev-stage");
+    let remote_root = TempDir::new("ev-remote");
+    let bindir = TempDir::new("ev-bin");
+    let cache = TempDir::new("ev-cache");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path());
+
+    let (manifest, _id, _sums) = stage_tree(staging.path(), &[("foo", b"foo\n")]);
+    let store = external_store(remote_root.path());
+    store.push(&manifest, staging.path()).expect("push");
+
+    // Hostile remote: the tar stream carries a foreign `payload/evil`
+    // entry. The exact-match allowlist must name it and refuse to extract
+    // — `../`/absolute/symlink entry names are covered by the same
+    // exact-match property (anything not literally expected is rejected).
+    env.set("FAKE_SSH_EVIL_TAR", "1");
+    let err = store.fetch_files(&manifest, cache.path()).unwrap_err();
+    match &err {
+        StoreError::Backend { message, .. } => assert!(
+            message.contains("payload/evil"),
+            "the unexpected entry must be named: {message}"
+        ),
+        other => panic!("expected Backend error, got {other:?}"),
+    }
+    // NOTHING was extracted: no foreign files, no objects, no temp dirs.
+    assert!(
+        files_under(cache.path()).is_empty(),
+        "a rejected tar must never reach the cache: {:?}",
+        files_under(cache.path())
+    );
+}
+
+// ---------------------------------------------------------------------------
+// emitted-text invariants (pure library calls — no env, no fixture)
+// ---------------------------------------------------------------------------
+
+const TEXT_URL: &str = "ssh://fakehost/srv/snap";
+
+fn ssh_url() -> SshUrl {
+    SshUrl::parse(Engine::Ssh, TEXT_URL).unwrap()
+}
+
+fn default_cfg() -> Config {
+    Config::from_lookup(Engine::Ssh, |_| None).unwrap()
+}
+
+/// Every `ssh` process the script can spawn goes through a line carrying
+/// the security floor, and nothing traps `INT` (the orchestrator owns it).
+fn assert_skeleton_invariants(script: &str) {
+    for line in script.lines() {
+        if line.contains("command ssh") {
+            assert!(
+                line.contains("'StrictHostKeyChecking=yes'"),
+                "every ssh invocation must carry the floor: {line}"
+            );
+        }
+    }
+    assert!(
+        script.contains("command ssh"),
+        "the _snapdir_ssh wrapper must be defined"
+    );
+    assert!(!script.contains("INT"), "the script must never trap INT");
+}
+
+#[test]
+fn emitted_push_script_probes_then_transfers_then_commits_inside_dumb_function() {
+    let staging = TempDir::new("tx-stage");
+    let (_, id, sums) = stage_tree(staging.path(), &[("foo", b"foo\n"), ("bar", b"bar\n")]);
+    let staging_dir = staging.path().display().to_string();
+    let script =
+        ssh_engine::get_push_script(&ssh_url(), &default_cfg(), &id, &staging_dir).unwrap();
+    assert_skeleton_invariants(&script);
+
+    // Ordering: manifest probe → object transfer → manifest commit.
+    let probe = script.find("test -f").expect("manifest probe present");
+    let transfer = script.find("tar -C").expect("tar transfer present");
+    let commit = script
+        .find(".snapdir-manifest.")
+        .expect("manifest commit present");
+    assert!(probe < transfer, "probe must precede the object transfer");
+    assert!(
+        transfer < commit,
+        "the object transfer must precede the manifest commit"
+    );
+
+    // The dumb body is a function the accel gate can branch around.
+    assert!(script.contains("_snapdir_dumb_push() {"));
+    assert!(script.trim_end().ends_with("_snapdir_dumb_push"));
+
+    // Exact no-op wording on the short-circuit path, BEFORE the dumb body.
+    let noop = script
+        .find("echo 'Manifest already exists on store.'")
+        .expect("exact no-op wording");
+    assert!(noop < script.find("_snapdir_dumb_push() {").unwrap());
+
+    // Every candidate sharded relpath is baked into the heredoc; the
+    // staging dir is quoted at the local tar.
+    for sum in &sums {
+        assert!(script.contains(&object_path(sum)), "relpath for {sum}");
+    }
+    assert!(script.contains(&format!("tar -C {} -cf -", sh_quote(&staging_dir))));
+
+    // Remote commands stay POSIX (no bashisms): atomic same-fs rename via
+    // mktemp temp dir + mv -f, under the configured umask.
+    assert!(script.contains("mktemp -d .snapdir-incoming.XXXXXX"));
+    assert!(script.contains("umask 077"));
+    assert!(script.contains("mv -f"));
+}
+
+#[test]
+fn emitted_get_manifest_script_has_exact_not_found_wording_and_exit_code_discipline() {
+    let id = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    let script = ssh_engine::get_manifest_script(&ssh_url(), &default_cfg(), id, TEXT_URL).unwrap();
+    assert_skeleton_invariants(&script);
+
+    // Exact not-found wording, on stderr, exit 1 — only on probe exit 1.
+    let wording = sh_quote(&format!("ID '{id}' not found on --store '{TEXT_URL}'."));
+    assert!(
+        script.contains(&format!("printf '%s\\n' {wording} >&2")),
+        "exact not-found wording: {script}"
+    );
+    // Any other nonzero probe exit is connectivity, surfaced with the real
+    // code — NEVER the not-found wording.
+    assert!(script.contains("elif [ \"$snapdir_probe_status\" -ne 1 ]; then"));
+    assert!(script.contains("exit \"$snapdir_probe_status\""));
+    assert!(script.contains("failed to reach the store"));
+
+    // stdout purity: the only stdout producer is the final `cat <manifest>`.
+    let remote_man = remote_manifest_path("/srv/snap", id);
+    let cat_invocation = format!(
+        "_snapdir_ssh {}",
+        sh_quote(&format!("cat {}", sh_quote(&remote_man)))
+    );
+    assert!(
+        script.trim_end().ends_with(&cat_invocation),
+        "the final command must be the manifest cat: {script}"
+    );
+}
+
+#[test]
+fn emitted_fetch_script_gates_extraction_on_the_exact_match_allowlist() {
+    let staging = TempDir::new("fx-stage");
+    let cache = TempDir::new("fx-cache");
+    let (manifest, _id, sums) = stage_tree(staging.path(), &[("foo", b"foo\n"), ("bar", b"bar\n")]);
+    let script = ssh_engine::get_fetch_files_script(
+        &ssh_url(),
+        &default_cfg(),
+        &manifest.to_string(),
+        &cache.path().display().to_string(),
+    )
+    .unwrap();
+    assert_skeleton_invariants(&script);
+
+    // The dumb body is a function the accel gate can branch around.
+    assert!(script.contains("_snapdir_dumb_fetch() {"));
+    assert!(script.trim_end().ends_with("_snapdir_dumb_fetch"));
+
+    // Ordering: pre-transfer remote existence check → tar saved to a local
+    // file → allowlist gate → extraction into the incoming temp dir.
+    let preflight = script
+        .find("ERROR: missing object")
+        .expect("pre-transfer check present");
+    let saved = script.find("objects.tar").expect("tar saved locally");
+    let allowlist = script
+        .find("LC_ALL=C grep -vxF -f")
+        .expect("exact-match allowlist present");
+    let extract = script
+        .find("tar -C \"$snapdir_ltmp\" -xf")
+        .expect("extraction present");
+    assert!(preflight < saved, "existence check precedes the transfer");
+    assert!(
+        saved < allowlist && allowlist < extract,
+        "no extraction before the allowlist"
+    );
+
+    // Exact ERROR wording in BOTH the remote pre-check and the epilogue.
+    assert!(script.matches("ERROR: missing object").count() >= 2);
+    assert!(script.contains("printf 'ERROR: missing object %s\\n' \"$snapdir_sum\" >&2"));
+
+    // Incoming temp dir under the cache; every needed pair baked.
+    assert!(script.contains("mktemp -d \"$snapdir_cache/.snapdir-incoming.XXXXXX\""));
+    for sum in &sums {
+        assert!(script.contains(&format!("{sum} {}", object_path(sum))));
+    }
+}
+
+#[test]
+fn emitted_fetch_script_skips_objects_already_cached() {
+    let staging = TempDir::new("fc-stage");
+    let cache = TempDir::new("fc-cache");
+    let (manifest, _id, sums) = stage_tree(staging.path(), &[("foo", b"foo\n"), ("bar", b"bar\n")]);
+
+    // Pre-seed one object in the cache: it must not be re-fetched.
+    let cached = cache.path().join(object_path(&sums[0]));
+    fs::create_dir_all(cached.parent().unwrap()).unwrap();
+    fs::write(&cached, b"foo\n").unwrap();
+
+    let script = ssh_engine::get_fetch_files_script(
+        &ssh_url(),
+        &default_cfg(),
+        &manifest.to_string(),
+        &cache.path().display().to_string(),
+    )
+    .unwrap();
+    assert!(
+        !script.contains(&sums[0]),
+        "cached object must be dropped at emit time"
+    );
+    assert!(script.contains(&sums[1]), "uncached object must be fetched");
+}

--- a/crates/snapdir-ssh-store/tests/fixtures/fake-sftp
+++ b/crates/snapdir-ssh-store/tests/fixtures/fake-sftp
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+#
+# fake-sftp: hermetic stand-in for OpenSSH's `sftp` used by
+# tests/fake_sftp_roundtrip.rs. NOT shipped, NOT the oracle — it interprets
+# exactly the batch verbs the sftp engine emits (ls, get, put, rm, rename,
+# mkdir, chmod, pwd, each with optional `-` failure tolerance) against
+# $FAKE_REMOTE_ROOT: the absolute remote paths in batch commands map to
+# ${FAKE_REMOTE_ROOT}<path>, so the destination-host argument is irrelevant
+# (a real server's filesystem root, fenced into a temp dir).
+#
+# CLI shape parsed: the one `_snapdir_sftp` produces —
+#     sftp <-o flags...> -b <batchfile> -- <host>
+# All `-o` options are accepted and ignored (no ControlMaster emulation; the
+# emitted scripts must not depend on a live master beyond what sftp itself
+# provides).
+#
+# Like real sftp, each batch command is echoed to STDOUT as `sftp> <cmd>`
+# (so the engine's listing parser is honestly exercised: it must drop these
+# lines), a successful `ls <path>` prints the path, errors go to stderr, an
+# unprefixed failing command aborts the batch with exit 1, and a `-` prefix
+# tolerates the failure.
+#
+# Fault injection (counted PER PROCESS, i.e. within a single sftp
+# invocation — each emitted chunk/batch runs in its own process):
+#   FAKE_SFTP_FAIL_VERB=<verb>   fail this verb...
+#   FAKE_SFTP_FAIL_AFTER=<n>     ...from its Nth occurrence on (default 1).
+#                                A failing `put` leaves a PARTIAL file at the
+#                                destination, simulating a killed transfer.
+#   FAKE_SFTP_UNREACHABLE=1      exit 255 before reading the batch, like a
+#                                connection-level failure.
+#
+# bash-3.2-clean: no associative arrays, no ${var^^}, no readarray.
+set -euo pipefail
+
+batch=""
+host=""
+while [ $# -gt 0 ]; do
+	case "$1" in
+	-o)
+		shift 2
+		;;
+	-b)
+		batch="$2"
+		shift 2
+		;;
+	--)
+		shift
+		host="$1"
+		shift
+		;;
+	*)
+		echo "fake-sftp: unexpected argument '$1'" >&2
+		exit 2
+		;;
+	esac
+done
+if [ -z "$batch" ] || [ -z "$host" ]; then
+	echo "fake-sftp: expected 'sftp <-o flags...> -b <file> -- <host>'" >&2
+	exit 2
+fi
+root="${FAKE_REMOTE_ROOT:?FAKE_REMOTE_ROOT must be set}"
+
+if [ "${FAKE_SFTP_UNREACHABLE:-0}" = "1" ]; then
+	echo "fake-sftp: Connection closed by remote host" >&2
+	exit 255
+fi
+
+fail_verb="${FAKE_SFTP_FAIL_VERB:-}"
+fail_after="${FAKE_SFTP_FAIL_AFTER:-1}"
+fail_count=0
+
+# map <remote-abs-path>: the fake remote filesystem lives under $root.
+map() {
+	printf '%s%s' "$root" "$1"
+}
+
+while IFS= read -r line || [ -n "$line" ]; do
+	[ -n "$line" ] || continue
+	printf 'sftp> %s\n' "$line"
+	tolerate=0
+	cmd="$line"
+	case "$cmd" in
+	-*)
+		tolerate=1
+		cmd="${cmd#-}"
+		;;
+	esac
+	# Unquote arguments the way sftp's batch parser would (double quotes with
+	# backslash escapes). `eval set --` is acceptable in a test fixture: the
+	# inputs are emit-time-quoted checksums and test-controlled paths.
+	eval "set -- $cmd"
+	verb="$1"
+	shift
+	injected=0
+	if [ -n "$fail_verb" ] && [ "$verb" = "$fail_verb" ]; then
+		fail_count=$((fail_count + 1))
+		if [ "$fail_count" -ge "$fail_after" ]; then
+			injected=1
+		fi
+	fi
+	status=0
+	case "$verb" in
+	pwd)
+		if [ "$injected" -eq 1 ]; then
+			status=1
+		else
+			echo "Remote working directory: /"
+		fi
+		;;
+	ls)
+		p="$(map "$1")"
+		if [ "$injected" -eq 1 ] || [ ! -e "$p" ]; then
+			echo "Can't ls: \"$1\" not found" >&2
+			status=1
+		else
+			printf '%s\n' "$1"
+		fi
+		;;
+	get)
+		src="$(map "$1")"
+		dst="$2"
+		if [ "$injected" -eq 1 ] || [ ! -f "$src" ]; then
+			echo "File \"$1\" not found." >&2
+			status=1
+		else
+			cp "$src" "$dst" || status=1
+		fi
+		;;
+	put)
+		src="$1"
+		dst="$(map "$2")"
+		if [ "$injected" -eq 1 ]; then
+			# A killed transfer leaves a partial file at the destination.
+			printf 'PARTIAL' >"$dst" 2>/dev/null || true
+			echo "fake-sftp: injected put failure for \"$2\"" >&2
+			status=1
+		elif [ ! -f "$src" ]; then
+			echo "stat $1: No such file or directory" >&2
+			status=1
+		else
+			cp "$src" "$dst" || status=1
+		fi
+		;;
+	rm)
+		p="$(map "$1")"
+		if [ "$injected" -eq 1 ] || [ ! -f "$p" ]; then
+			echo "Couldn't delete file: \"$1\"" >&2
+			status=1
+		else
+			rm -f "$p"
+		fi
+		;;
+	rename)
+		# Strict SSH_FXP_RENAME semantics: fails if the target exists (the
+		# engine must `-rm` first; stricter than posix-rename@openssh.com).
+		src="$(map "$1")"
+		dst="$(map "$2")"
+		if [ "$injected" -eq 1 ] || [ ! -e "$src" ] || [ -e "$dst" ]; then
+			echo "Couldn't rename file \"$1\" to \"$2\"" >&2
+			status=1
+		else
+			mv "$src" "$dst"
+		fi
+		;;
+	mkdir)
+		# Single-level, fails if it exists — like the real verb; the engine
+		# must tolerate with `-mkdir`.
+		p="$(map "$1")"
+		if [ "$injected" -eq 1 ] || [ -e "$p" ]; then
+			echo "Couldn't create directory: \"$1\"" >&2
+			status=1
+		else
+			mkdir "$p" || status=1
+		fi
+		;;
+	chmod)
+		mode="$1"
+		p="$(map "$2")"
+		if [ "$injected" -eq 1 ] || [ ! -e "$p" ]; then
+			echo "Couldn't stat remote file: \"$2\"" >&2
+			status=1
+		else
+			chmod "$mode" "$p"
+		fi
+		;;
+	*)
+		echo "fake-sftp: unknown verb '$verb'" >&2
+		status=1
+		;;
+	esac
+	if [ "$status" -ne 0 ] && [ "$tolerate" -ne 1 ]; then
+		exit 1
+	fi
+done <"$batch"
+exit 0

--- a/crates/snapdir-ssh-store/tests/fixtures/fake-ssh
+++ b/crates/snapdir-ssh-store/tests/fixtures/fake-ssh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# fake-ssh: hermetic stand-in for OpenSSH's `ssh` used by
+# tests/fake_ssh_roundtrip.rs. NOT shipped, NOT the oracle — it emulates the
+# one CLI shape `_snapdir_ssh` (and the skeleton's `-O exit` cleanup)
+# produces:
+#
+#     ssh <-o flags...> [-O <ctl>] -- <host> [command words...]
+#
+# All `-o` options are accepted and ignored (no ControlMaster emulation),
+# `-O exit` is a no-op success (the cleanup trap fires it on every run).
+# The remaining words after the host are joined with spaces — exactly like
+# real ssh — and executed locally via `sh -c` (a POSIX shell, like a dash
+# remote). There is no path remapping: the tests fence the "remote"
+# filesystem by constructing the store URL as ssh://fakehost<abs-path>, so
+# every emitted base path is an absolute path under $FAKE_REMOTE_ROOT (which
+# must be set — the fence is the contract). stdin/stdout pass straight
+# through, so tar pipelines work.
+#
+# Fault injection:
+#   FAKE_SSH_FAIL_MATCH=<substr>   a remote command containing <substr>
+#                                  exits 255 before executing anything,
+#                                  like a connection-level failure.
+#   FAKE_SSH_TRUNCATE_TAR=<bytes>  a remote tar-extract command (`tar -C
+#                                  ... -xf -`) sees only the first <bytes>
+#                                  bytes of its stdin and the "connection"
+#                                  then fails (exit 1) — a killed
+#                                  mid-transfer push.
+#   FAKE_SSH_EVIL_TAR=1            a remote tar-create command (`tar -cf`)
+#                                  is hijacked: it drains stdin and emits a
+#                                  tar with a foreign `payload/evil` entry
+#                                  instead. The engine's exact-match
+#                                  allowlist must reject ANY unexpected
+#                                  entry name — `../`/absolute/symlink
+#                                  attacks are covered by the same property.
+#
+# bash-3.2-clean: no associative arrays, no ${var^^}, no readarray.
+set -euo pipefail
+
+ctl=""
+host=""
+have_host=0
+while [ $# -gt 0 ]; do
+	case "$1" in
+	-o)
+		shift 2
+		;;
+	-O)
+		ctl="$2"
+		shift 2
+		;;
+	--)
+		shift
+		host="$1"
+		have_host=1
+		shift
+		break
+		;;
+	*)
+		echo "fake-ssh: unexpected argument '$1'" >&2
+		exit 2
+		;;
+	esac
+done
+
+: "${FAKE_REMOTE_ROOT:?FAKE_REMOTE_ROOT must be set}"
+
+if [ "$ctl" = "exit" ]; then
+	# ControlMaster teardown: nothing to tear down here.
+	exit 0
+fi
+if [ "$have_host" -ne 1 ] || [ -z "$host" ]; then
+	echo "fake-ssh: expected 'ssh <-o flags...> -- <host> [command]'" >&2
+	exit 2
+fi
+if [ $# -eq 0 ]; then
+	echo "fake-ssh: interactive sessions are not supported" >&2
+	exit 2
+fi
+cmd="$*"
+
+if [ -n "${FAKE_SSH_FAIL_MATCH:-}" ]; then
+	case "$cmd" in
+	*"$FAKE_SSH_FAIL_MATCH"*)
+		echo "fake-ssh: Connection closed by remote host" >&2
+		exit 255
+		;;
+	esac
+fi
+
+if [ "${FAKE_SSH_EVIL_TAR:-0}" = "1" ]; then
+	case "$cmd" in
+	*"tar -cf"*)
+		# Hostile remote: ignore the requested path list and ship a tar
+		# whose entry name matches nothing the client expects.
+		cat >/dev/null
+		evil="$(mktemp -d "${TMPDIR:-/tmp}/fake-ssh-evil.XXXXXX")"
+		mkdir -p "$evil/payload"
+		echo "owned" >"$evil/payload/evil"
+		tar -cf - -C "$evil" payload/evil
+		rm -rf "$evil"
+		exit 0
+		;;
+	esac
+fi
+
+if [ -n "${FAKE_SSH_TRUNCATE_TAR:-}" ]; then
+	case "$cmd" in
+	*"tar -C"*"-xf -"*)
+		# Feed the extract only a truncated prefix of the stream, run it
+		# for realism (it fails on the unexpected EOF, possibly leaving
+		# remote .snapdir-incoming debris), then fail the "connection".
+		head -c "$FAKE_SSH_TRUNCATE_TAR" | sh -c "$cmd" >/dev/null 2>&1 || true
+		echo "fake-ssh: injected mid-transfer failure" >&2
+		exit 1
+		;;
+	esac
+fi
+
+exec sh -c "$cmd"

--- a/crates/snapdir-ssh-store/tests/fixtures/fake-ssh
+++ b/crates/snapdir-ssh-store/tests/fixtures/fake-ssh
@@ -17,6 +17,14 @@
 # must be set — the fence is the contract). stdin/stdout pass straight
 # through, so tar pipelines work.
 #
+# Remote environment:
+#   FAKE_SSH_REMOTE_PATH=<dir>     prepended to PATH before the remote
+#                                  command runs — tests point it at a dir
+#                                  holding the binaries the "remote host"
+#                                  should offer (the real `snapdir`, a fake
+#                                  printing a hostile capability line, a
+#                                  logging wrapper, ...).
+#
 # Fault injection:
 #   FAKE_SSH_FAIL_MATCH=<substr>   a remote command containing <substr>
 #                                  exits 255 before executing anything,
@@ -78,6 +86,11 @@ if [ $# -eq 0 ]; then
 	exit 2
 fi
 cmd="$*"
+
+if [ -n "${FAKE_SSH_REMOTE_PATH:-}" ]; then
+	PATH="$FAKE_SSH_REMOTE_PATH:$PATH"
+	export PATH
+fi
 
 if [ -n "${FAKE_SSH_FAIL_MATCH:-}" ]; then
 	case "$cmd" in

--- a/crates/snapdir-ssh-store/tests/loopback_sshd.rs
+++ b/crates/snapdir-ssh-store/tests/loopback_sshd.rs
@@ -1,0 +1,578 @@
+//! Gate `loopback-sshd-suite` (phase 24, T2): REAL OpenSSH end-to-end — the
+//! actual `ssh`/`sftp` clients (with the full security floor) against a
+//! self-spawned loopback `sshd` (no docker, no root; see
+//! `tests/common/sshd.rs`), driven through the real external-store contract
+//! (`ExternalStore::with_binary` → store binary → emitted script → `eval`).
+//!
+//! Coverage: dumb `ssh://` + `sftp://` push→get-manifest→fetch round trips;
+//! the restricted `ForceCommand internal-sftp` server (sftp:// works, ssh://
+//! fails — no shell IS the property); host-key fail-closed INCLUDING the
+//! behavioral un-weakenable-floor proof (`EXTRA_OPTS=StrictHostKeyChecking=no`
+//! still fails); the accel round trip + byte-identical dumb-vs-accel oracle
+//! over real sshd (remote `snapdir` exposed via the server-side `SetEnv
+//! PATH`, wrapped in a logging shim so engagement is asserted, never
+//! assumed); graceful fallback + the `SNAPDIR_SSH_FORCE_ACCEL` designed
+//! error; idempotent re-push; and no leaked `ControlMaster` sockets / temp
+//! dirs.
+//!
+//! **Isolation under parallel scheduling**: every mutable directory is
+//! per-test — staging/cache/`TMPDIR` scratch are distinct
+//! [`common::TempDir`]s on a FIXED `/tmp` base (never
+//! `std::env::temp_dir()`, which would re-read the mutated `TMPDIR`), each
+//! sshd kit is per-test, and [`loopback_env`] pins `TMPDIR` to the test's
+//! OWN scratch inside the env-lock guard. No test ever reads or writes
+//! another test's directories, so the suite is deterministic at any
+//! `--test-threads` level; the leak assertion scans only its own scratch
+//! and only for script-created `snapdir-ssh-store.*` artifacts.
+//!
+//! **Skip policy** (house pattern): missing OpenSSH tooling or a missing
+//! real `snapdir` binary `eprintln!`-skips — unless `SNAPDIR_SSH_TEST_REQUIRE=1`
+//! (CI sets it), which turns those skips into panics. The ONE allowed skip
+//! under REQUIRE is an sshd whose `SetEnv` directive doesn't pin `PATH`
+//! (pre-8.7 servers): only the two PATH-dependent accel/fallback tests skip,
+//! with the decision printed (macOS and CI both ship OpenSSH ≥ 8.7, so in
+//! practice everything runs).
+//!
+//! **probe-count decision**: the plan's "accel push = exactly 3 ssh round
+//! trips" gate is asserted hermetically in `tests/accel.rs` (emitted-text:
+//! exactly one capability probe, one diff, one stream). Over real sshd the
+//! client is the REAL `ssh`, so counting its invocations would mean wrapping
+//! the system client — re-proving what the emitted-text tests already pin.
+//! This suite instead asserts accel ENGAGEMENT (logging `snapdir` wrapper)
+//! and an empty-log no-op on the idempotent re-push.
+//!
+//! `SNAPDIR_SSH_TEST_HOST` (external server override) is documented in
+//! `tests/common/sshd.rs` as a future knob; not implemented this gate.
+
+#![cfg(unix)]
+
+mod common;
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+
+use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
+use snapdir_stores::ExternalStore;
+
+use common::sshd::{Flavor, SshKit};
+use common::{
+    files_under, install_logging_snapdir, manifest_bytes, relative_file_set, require_snapdir,
+    stage_tree, EnvGuard, TempDir,
+};
+
+/// The default test files (several distinct objects).
+const FILES: &[(&str, &[u8])] = &[
+    ("a.txt", b"alpha payload\n"),
+    ("b.txt", b"bravo bravo payload\n"),
+    ("c.bin", b"charlie third object\n"),
+];
+
+fn ssh_store(base: &Path) -> ExternalStore {
+    ExternalStore::with_binary(
+        &format!("ssh://127.0.0.1{}", base.display()),
+        env!("CARGO_BIN_EXE_snapdir-ssh-store"),
+    )
+}
+
+fn sftp_store(base: &Path) -> ExternalStore {
+    ExternalStore::with_binary(
+        &format!("sftp://127.0.0.1{}", base.display()),
+        env!("CARGO_BIN_EXE_snapdir-sftp-store"),
+    )
+}
+
+/// Takes the env lock and points BOTH engine families (`SNAPDIR_SSH_STORE_*`
+/// and `SNAPDIR_SFTP_STORE_*`) at the kit's identity / `known_hosts` / port,
+/// scrubbing every other knob a developer shell might leak (env is
+/// process-global and flows into the spawned store binary + eval shell +
+/// every ssh client it runs — hence the serialization).
+///
+/// `tmp` is the test's OWN `TMPDIR` scratch: every emitted script this test
+/// runs places its `mktemp -d` work dir (`ControlPath` socket included)
+/// there.
+/// The pin lives inside the guard (set under the lock, restored on drop) and
+/// store operations only happen while the guard is held, so no other test's
+/// scripts ever see — or write into — this test's scratch.
+fn loopback_env(kit: &SshKit, port: u16, tmp: &Path) -> EnvGuard {
+    let mut guard = EnvGuard::new();
+    guard.set("TMPDIR", &tmp.display().to_string());
+    let identity = kit.user_key.display().to_string();
+    let known_hosts = kit.known_hosts.display().to_string();
+    for prefix in ["SNAPDIR_SSH_STORE_", "SNAPDIR_SFTP_STORE_"] {
+        guard.set(&format!("{prefix}IDENTITY_FILE"), &identity);
+        guard.set(&format!("{prefix}KNOWN_HOSTS"), &known_hosts);
+        guard.set(&format!("{prefix}PORT"), &port.to_string());
+        guard.set(&format!("{prefix}CONNECT_TIMEOUT"), "10");
+        guard.remove(&format!("{prefix}EXTRA_OPTS"));
+        guard.remove(&format!("{prefix}JOBS"));
+        guard.remove(&format!("{prefix}UMASK"));
+        guard.remove(&format!("{prefix}CONTROL_PERSIST"));
+    }
+    guard.remove("SNAPDIR_STORE");
+    guard.remove("SNAPDIR_JOBS");
+    guard.remove("SNAPDIR_MAX_JOBS");
+    guard.remove("SNAPDIR_SSH_NO_ACCEL");
+    guard.remove("SNAPDIR_SSH_FORCE_ACCEL");
+    guard.remove("SNAPDIR_SSH_PULL_SENDALL");
+    guard.remove("SNAPDIR_SSH_LOCAL_SNAPDIR");
+    guard
+}
+
+/// Asserts a full push → get-manifest → fetch round trip for `store` against
+/// a real server, mirroring the hermetic suites' assertions: sharded remote
+/// paths, no group/other permission bits, byte-equal objects + manifest, no
+/// temp residue (`.snapdir-incoming.` / `.tmp.`) on either side.
+fn assert_roundtrip(store: &ExternalStore, staging: &Path, base: &Path, cache: &Path) {
+    let (manifest, id, sums) = stage_tree(staging, FILES);
+
+    store.push(&manifest, staging).expect("push");
+    for (sum, (_, content)) in sums.iter().zip(FILES) {
+        let obj = base.join(object_path(sum));
+        assert!(obj.is_file(), "object {sum} should be on the remote");
+        assert_eq!(&fs::read(&obj).unwrap(), content);
+        let mode = fs::metadata(&obj).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode & 0o077, 0, "0600-class discipline on {sum}: {mode:o}");
+    }
+    let man = base.join(manifest_path(&id));
+    assert!(man.is_file(), "manifest should be on the remote");
+    assert_eq!(fs::read_to_string(&man).unwrap(), manifest_bytes(&manifest));
+    let man_mode = fs::metadata(&man).unwrap().permissions().mode() & 0o777;
+    assert_eq!(man_mode & 0o077, 0, "0600-class discipline on the manifest");
+    assert_no_temp_residue(base, "remote");
+
+    let fetched = store.get_manifest(&id).expect("get_manifest");
+    assert_eq!(fetched.to_string(), manifest.to_string());
+
+    store.fetch_files(&manifest, cache).expect("fetch_files");
+    for (sum, (_, content)) in sums.iter().zip(FILES) {
+        let cached = cache.join(object_path(sum));
+        assert!(cached.is_file(), "object {sum} should be in the cache");
+        assert_eq!(&fs::read(&cached).unwrap(), content);
+    }
+    assert_no_temp_residue(cache, "cache");
+}
+
+fn assert_no_temp_residue(root: &Path, side: &str) {
+    let residue: Vec<PathBuf> = files_under(root)
+        .into_iter()
+        .filter(|p| {
+            let s = p.to_string_lossy();
+            s.contains(".snapdir-incoming.") || s.contains(".tmp.") || s.contains(".snapdir-")
+        })
+        .collect();
+    assert!(
+        residue.is_empty(),
+        "no temp residue on the {side}: {residue:?}"
+    );
+}
+
+/// Asserts the test's OWN `TMPDIR` scratch holds no script-created
+/// artifacts: the emitted scripts `mktemp -d` their 0700 work dirs
+/// (`ControlPath` `cm` socket included) as `snapdir-ssh-store.*` under
+/// `$TMPDIR`, and every EXIT trap must have run `ssh -O exit` + `rm -rf`.
+/// Scoped to that name pattern and to this test's private scratch only, so
+/// it is deterministic regardless of what other tests are doing.
+fn assert_no_script_leaks(tmp: &Path) {
+    let leaked: Vec<String> = fs::read_dir(tmp)
+        .expect("read TMPDIR scratch")
+        .filter_map(Result::ok)
+        .map(|e| e.file_name().to_string_lossy().into_owned())
+        .filter(|name| name.starts_with("snapdir-ssh-store."))
+        .collect();
+    assert!(
+        leaked.is_empty(),
+        "leaked ControlMaster sockets / script temp dirs under the test's TMPDIR: {leaked:?}"
+    );
+}
+
+fn log_lines(log: &Path) -> String {
+    fs::read_to_string(log).unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// 1. ssh:// dumb round trip over real sshd (port A)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn ssh_dumb_push_get_manifest_fetch_roundtrip_over_sshd() {
+    let Some(mut kit) = SshKit::new("ssh_dumb_push_get_manifest_fetch_roundtrip_over_sshd") else {
+        return;
+    };
+    let server = kit.spawn(&Flavor::Shell { set_env_path: None });
+    let staging = TempDir::new("sd-stage");
+    let cache = TempDir::new("sd-cache");
+    let tmp = TempDir::new("sd-tmp");
+    let base = kit.dir().join("remote-ssh-dumb");
+
+    let mut env = loopback_env(&kit, server.port, tmp.path());
+    env.set("SNAPDIR_SSH_NO_ACCEL", "1");
+    assert_roundtrip(&ssh_store(&base), staging.path(), &base, cache.path());
+}
+
+// ---------------------------------------------------------------------------
+// 2. sftp:// round trip over real sshd (port A)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sftp_push_get_manifest_fetch_roundtrip_over_sshd() {
+    let Some(mut kit) = SshKit::new("sftp_push_get_manifest_fetch_roundtrip_over_sshd") else {
+        return;
+    };
+    let server = kit.spawn(&Flavor::Shell { set_env_path: None });
+    let staging = TempDir::new("sf-stage");
+    let cache = TempDir::new("sf-cache");
+    let tmp = TempDir::new("sf-tmp");
+    let base = kit.dir().join("remote-sftp");
+
+    let _env = loopback_env(&kit, server.port, tmp.path());
+    assert_roundtrip(&sftp_store(&base), staging.path(), &base, cache.path());
+}
+
+// ---------------------------------------------------------------------------
+// 3. restricted-sftp-only (port B): sftp:// succeeds, ssh:// fails
+// ---------------------------------------------------------------------------
+
+#[test]
+fn restricted_sftp_only_server_allows_sftp_and_rejects_ssh() {
+    let Some(mut kit) = SshKit::new("restricted_sftp_only_server_allows_sftp_and_rejects_ssh")
+    else {
+        return;
+    };
+    let server = kit.spawn(&Flavor::SftpOnly);
+    let staging = TempDir::new("rs-stage");
+    let cache = TempDir::new("rs-cache");
+    let tmp = TempDir::new("rs-tmp");
+    let sftp_base = kit.dir().join("remote-restricted-sftp");
+    let ssh_base = kit.dir().join("remote-restricted-ssh");
+
+    let mut env = loopback_env(&kit, server.port, tmp.path());
+
+    // The sftp:// engine speaks pure SFTP — a ForceCommand internal-sftp
+    // account (the restricted-hosting story) round-trips fully.
+    assert_roundtrip(
+        &sftp_store(&sftp_base),
+        staging.path(),
+        &sftp_base,
+        cache.path(),
+    );
+
+    // The ssh:// engine needs a remote POSIX shell — the same server must
+    // reject it (pinned to the dumb path so the dispatch is deterministic),
+    // and nothing may land.
+    env.set("SNAPDIR_SSH_NO_ACCEL", "1");
+    let (manifest, id, _sums) = stage_tree(staging.path(), FILES);
+    ssh_store(&ssh_base)
+        .push(&manifest, staging.path())
+        .expect_err("ssh:// push must fail against a ForceCommand internal-sftp server");
+    assert!(
+        !ssh_base.join(manifest_path(&id)).exists(),
+        "no manifest may land via ssh:// on the sftp-only server"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 4. host-key fail-closed + the behavioral un-weakenable-floor proof
+// ---------------------------------------------------------------------------
+
+#[test]
+fn host_key_mismatch_fails_closed_and_extra_opts_cannot_weaken_the_floor() {
+    let Some(mut kit) =
+        SshKit::new("host_key_mismatch_fails_closed_and_extra_opts_cannot_weaken_the_floor")
+    else {
+        return;
+    };
+    let server = kit.spawn(&Flavor::Shell { set_env_path: None });
+    let staging = TempDir::new("hk-stage");
+    let tmp = TempDir::new("hk-tmp");
+    let base = kit.dir().join("remote-hostkey");
+    let wrong = kit.wrong_known_hosts(server.port);
+
+    let mut env = loopback_env(&kit, server.port, tmp.path());
+    env.set("SNAPDIR_SSH_NO_ACCEL", "1");
+    env.set(
+        "SNAPDIR_SSH_STORE_KNOWN_HOSTS",
+        &wrong.display().to_string(),
+    );
+
+    let (manifest, id, _sums) = stage_tree(staging.path(), FILES);
+
+    // A known_hosts carrying the WRONG key for the server: fail closed.
+    let err = ssh_store(&base)
+        .push(&manifest, staging.path())
+        .expect_err("push must fail on a host-key mismatch");
+    assert!(
+        matches!(err, StoreError::Backend { .. }),
+        "host-key mismatch is a Backend (connectivity) error, got {err:?}"
+    );
+
+    // The BEHAVIORAL un-weakenable-floor proof: user extras trying to turn
+    // host-key checking OFF are structurally inert (the floor's
+    // StrictHostKeyChecking=yes was already first-obtained), so it STILL
+    // fails — against a live server, with the real ssh client.
+    env.set("SNAPDIR_SSH_STORE_EXTRA_OPTS", "StrictHostKeyChecking=no");
+    ssh_store(&base)
+        .push(&manifest, staging.path())
+        .expect_err("EXTRA_OPTS=StrictHostKeyChecking=no must NOT weaken the floor");
+
+    assert!(
+        !base.join(manifest_path(&id)).exists(),
+        "nothing may land on a server whose host key never verified"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. accel round trip + byte-identical dumb-vs-accel oracle over real sshd
+// ---------------------------------------------------------------------------
+
+#[test]
+fn accel_oracle_roundtrip_and_idempotent_repush_over_sshd() {
+    let test = "accel_oracle_roundtrip_and_idempotent_repush_over_sshd";
+    let Some(real) = require_snapdir(test) else {
+        return;
+    };
+    let Some(mut kit) = SshKit::new(test) else {
+        return;
+    };
+
+    // Expose the real snapdir to the REMOTE side (sshd sessions inherit
+    // sshd's env, not the test env) through SetEnv PATH, behind a logging
+    // wrapper so accel engagement is asserted, never assumed.
+    let bin = kit.dir().join("bin");
+    fs::create_dir_all(&bin).expect("create remote bin dir");
+    let log = kit.dir().join("invocations.log");
+    install_logging_snapdir(&bin, &real, &log);
+    let server = kit.spawn(&Flavor::Shell {
+        set_env_path: Some(format!("{}:/usr/bin:/bin:/usr/sbin:/sbin", bin.display())),
+    });
+
+    // The DOCUMENTED environmental skip: sshd honors SetEnv PATH only from
+    // OpenSSH 8.7 on (macOS + CI both ship newer). Allowed even under
+    // SNAPDIR_SSH_TEST_REQUIRE=1.
+    let probe = kit.ssh_exec(server.port, "command -v snapdir");
+    if !probe.status.success() {
+        eprintln!(
+            "SKIP {test}: this sshd does not honor `SetEnv PATH` \
+             (need OpenSSH >= 8.7 server): {}",
+            String::from_utf8_lossy(&probe.stderr).trim()
+        );
+        return;
+    }
+
+    let staging = TempDir::new("ao-stage");
+    let cache = TempDir::new("ao-cache");
+    let tmp = TempDir::new("ao-tmp");
+    let base_dumb = kit.dir().join("remote-oracle-dumb");
+    let base_accel = kit.dir().join("remote-oracle-accel");
+    let (manifest, id, sums) = stage_tree(staging.path(), FILES);
+
+    let mut env = loopback_env(&kit, server.port, tmp.path());
+    env.set("SNAPDIR_SSH_LOCAL_SNAPDIR", &real.display().to_string());
+
+    // Reference: forced-dumb push into root A.
+    env.set("SNAPDIR_SSH_NO_ACCEL", "1");
+    ssh_store(&base_dumb)
+        .push(&manifest, staging.path())
+        .expect("forced-dumb push");
+
+    // Accel push into root B; prove engagement from the remote-side log.
+    env.remove("SNAPDIR_SSH_NO_ACCEL");
+    let accel = ssh_store(&base_accel);
+    accel.push(&manifest, staging.path()).expect("accel push");
+    let pushed = log_lines(&log);
+    assert!(
+        pushed.contains("objects-needed"),
+        "accel diff ran: {pushed}"
+    );
+    assert!(
+        pushed.contains("receive-pack"),
+        "accel stream ran: {pushed}"
+    );
+
+    // THE ORACLE: identical file SET, byte-equal contents, same committed
+    // snapshot id — dumb vs accel over a real server.
+    let set_dumb = relative_file_set(&base_dumb);
+    assert_eq!(
+        set_dumb,
+        relative_file_set(&base_accel),
+        "the .objects/** + manifest file sets must be identical"
+    );
+    assert!(
+        set_dumb.contains(&manifest_path(&id)),
+        "snapshot id committed on both"
+    );
+    for rel in &set_dumb {
+        assert_eq!(
+            fs::read(base_dumb.join(rel)).unwrap(),
+            fs::read(base_accel.join(rel)).unwrap(),
+            "byte-equal at {rel}"
+        );
+    }
+    assert_eq!(
+        fs::read_to_string(base_accel.join(manifest_path(&id))).unwrap(),
+        manifest_bytes(&manifest),
+        "manifest bytes are the staged manifest's bytes"
+    );
+
+    // Idempotent re-push: the combined probe sees manifest=1 and exits
+    // before any transfer — no plumbing invocation reaches the remote.
+    fs::write(&log, b"").unwrap();
+    accel
+        .push(&manifest, staging.path())
+        .expect("idempotent re-push");
+    let repushed = log_lines(&log);
+    assert!(
+        !repushed.contains("receive-pack") && !repushed.contains("objects-needed"),
+        "a re-push of a present manifest must not stream anything: {repushed}"
+    );
+    assert_eq!(
+        set_dumb,
+        relative_file_set(&base_accel),
+        "re-push must not change the remote"
+    );
+
+    // Accel fetch into a cold cache: the remote send-pack streamed, every
+    // object landed byte-equal at its sharded cache path (the LOCAL
+    // receive-pack verified each record).
+    accel
+        .fetch_files(&manifest, cache.path())
+        .expect("accel fetch");
+    assert!(log_lines(&log).contains("send-pack"), "fetch used accel");
+    for (sum, (_, content)) in sums.iter().zip(FILES) {
+        assert_eq!(
+            &fs::read(cache.path().join(object_path(sum)))
+                .unwrap_or_else(|_| panic!("object {sum} in cache")),
+            content
+        );
+    }
+
+    // get-manifest round-trips byte-identically over the real server too.
+    let fetched = accel.get_manifest(&id).expect("get_manifest");
+    assert_eq!(fetched.to_string(), manifest.to_string());
+}
+
+// ---------------------------------------------------------------------------
+// 6. fallback over real sshd: no remote snapdir → dumb; FORCE_ACCEL → error
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fallback_without_remote_snapdir_and_force_accel_designed_error() {
+    let test = "fallback_without_remote_snapdir_and_force_accel_designed_error";
+    let Some(real) = require_snapdir(test) else {
+        return;
+    };
+    let Some(mut kit) = SshKit::new(test) else {
+        return;
+    };
+
+    // A shell server whose session PATH deliberately carries NO snapdir.
+    let server = kit.spawn(&Flavor::Shell {
+        set_env_path: Some("/usr/bin:/bin".to_owned()),
+    });
+    let probe = kit.ssh_exec(server.port, "command -v snapdir");
+    if probe.status.success() {
+        // Either SetEnv is unsupported (pre-8.7) and the default session
+        // PATH carries a system-installed snapdir, or one lives in
+        // /usr/bin:/bin — the "no remote snapdir" premise doesn't hold here.
+        eprintln!(
+            "SKIP {test}: a `snapdir` is visible on the remote session PATH ({})",
+            String::from_utf8_lossy(&probe.stdout).trim()
+        );
+        return;
+    }
+
+    let staging = TempDir::new("fb-stage");
+    let tmp = TempDir::new("fb-tmp");
+    let base = kit.dir().join("remote-fallback");
+    let base_forced = kit.dir().join("remote-forced");
+    let (manifest, id, sums) = stage_tree(staging.path(), FILES);
+
+    let mut env = loopback_env(&kit, server.port, tmp.path());
+    // A local snapdir IS available, so the dispatch genuinely reaches the
+    // capability check before degrading.
+    env.set("SNAPDIR_SSH_LOCAL_SNAPDIR", &real.display().to_string());
+
+    // Graceful fallback: the dumb path completes the push end-to-end.
+    ssh_store(&base)
+        .push(&manifest, staging.path())
+        .expect("push must fall back to the dumb path and succeed");
+    for (sum, (_, content)) in sums.iter().zip(FILES) {
+        assert_eq!(&fs::read(base.join(object_path(sum))).unwrap(), content);
+    }
+    assert_eq!(
+        fs::read_to_string(base.join(manifest_path(&id))).unwrap(),
+        manifest_bytes(&manifest)
+    );
+
+    // FORCE_ACCEL without remote caps: the designed error, before any
+    // transfer.
+    env.set("SNAPDIR_SSH_FORCE_ACCEL", "1");
+    let err = ssh_store(&base_forced)
+        .push(&manifest, staging.path())
+        .expect_err("FORCE_ACCEL without remote caps must fail");
+    match &err {
+        StoreError::Backend { message, .. } => {
+            assert!(message.contains("127.0.0.1"), "names the host: {message}");
+            assert!(message.contains("wire=1"), "names the wire: {message}");
+            assert!(
+                message.contains("unset SNAPDIR_SSH_FORCE_ACCEL"),
+                "names the remedies: {message}"
+            );
+            assert!(
+                message.contains("install or upgrade snapdir"),
+                "names the remedies: {message}"
+            );
+        }
+        other => panic!("expected Backend error, got {other:?}"),
+    }
+    assert!(
+        !base_forced.join(manifest_path(&id)).exists(),
+        "the FORCE_ACCEL error must abort before any transfer"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 7. idempotent re-push + no leaked ControlMaster sockets / temp dirs
+// ---------------------------------------------------------------------------
+
+#[test]
+fn repush_is_idempotent_and_no_control_sockets_or_temp_dirs_leak() {
+    let Some(mut kit) =
+        SshKit::new("repush_is_idempotent_and_no_control_sockets_or_temp_dirs_leak")
+    else {
+        return;
+    };
+    let server = kit.spawn(&Flavor::Shell { set_env_path: None });
+    let staging = TempDir::new("lk-stage");
+    let cache = TempDir::new("lk-cache");
+    // This test's OWN TMPDIR scratch (pinned by loopback_env, like every
+    // test): all 4 emitted scripts below mktemp their work dirs here.
+    let tmp = TempDir::new("lk-tmp");
+    let base = kit.dir().join("remote-leak");
+    let (manifest, id, _sums) = stage_tree(staging.path(), FILES);
+
+    let mut env = loopback_env(&kit, server.port, tmp.path());
+    env.set("SNAPDIR_SSH_NO_ACCEL", "1");
+
+    let store = ssh_store(&base);
+    store.push(&manifest, staging.path()).expect("push");
+    let after_first = relative_file_set(&base);
+    assert!(after_first.contains(&manifest_path(&id)), "manifest landed");
+
+    // Idempotent re-push: present manifest → no-op success, remote unchanged.
+    store.push(&manifest, staging.path()).expect("re-push");
+    assert_eq!(
+        after_first,
+        relative_file_set(&base),
+        "a re-push must not change the remote"
+    );
+
+    store.get_manifest(&id).expect("get_manifest");
+    store.fetch_files(&manifest, cache.path()).expect("fetch");
+
+    // Every emitted script placed its 0700 work dir (ControlPath socket
+    // included) under this test's private TMPDIR, and each EXIT trap ran
+    // `ssh -O exit` + `rm -rf`: no live `cm` master socket and no
+    // `snapdir-ssh-store.*` dir may remain.
+    assert_no_script_leaks(tmp.path());
+}

--- a/crates/snapdir-stores/Cargo.toml
+++ b/crates/snapdir-stores/Cargo.toml
@@ -23,6 +23,15 @@ integration-mock = []
 snapdir-core.workspace = true
 thiserror.workspace = true
 
+# --- SNAPPACK wire format (pack.rs) ------------------------------------------
+# `blake3` powers the INCREMENTAL payload hashing in `pack.rs`: obj payloads
+# stream through the hasher in O(1) memory, which the buffer-only
+# `snapdir_core::merkle::Hasher` trait (`hash_hex(&[u8])`) cannot do. This is
+# NOT a new supply-chain edge: it is the exact version requirement
+# `snapdir-core` already declares, so the lock graph gains no crate and the
+# deny.toml posture is unchanged.
+blake3 = "1.8.5"
+
 # --- S3 store (s3:// + S3-compatible) ---------------------------------------
 # CRITICAL TLS constraint: the shipped binary statically links on musl, so the
 # whole workspace standardizes on the `ring` rustls provider. `aws-lc-rs` is

--- a/crates/snapdir-stores/src/lib.rs
+++ b/crates/snapdir-stores/src/lib.rs
@@ -35,6 +35,12 @@
 //! - [`stream`] ([`StreamStore`]) — object/manifest-level, content-addressed,
 //!   verified read/write primitives (the foundation for store-to-store sync),
 //!   implemented for [`FileStore`], [`S3Store`], [`GcsStore`], and [`B2Store`].
+//! - [`pack`] ([`write_pack`], [`read_pack`], [`PackSink`]) — the SNAPPACK 1
+//!   wire stream behind the `ssh://` acceleration plumbing
+//!   (`snapdir send-pack | ssh … 'snapdir receive-pack'`): `obj` records
+//!   stream through incremental BLAKE3 verification (O(1) memory into a
+//!   [`FileSink`]), the manifest rides last and commits only after the `end`
+//!   trailer, so truncation can never publish a snapshot.
 //! - [`sync`] ([`sync_snapshot`], [`SyncReport`]) — streaming store-to-store
 //!   snapshot copy: walks a source manifest and copies its raw objects
 //!   source → dest through memory only (no local filesystem staging),
@@ -48,6 +54,7 @@ pub(crate) mod fetch;
 pub mod file_store;
 pub mod gcs_store;
 pub mod limits;
+pub mod pack;
 pub(crate) mod push;
 pub mod retry;
 pub mod router;
@@ -66,6 +73,10 @@ pub use b2_store::B2Store;
 pub use file_store::FileStore;
 pub use gcs_store::{GcsLocation, GcsStore};
 pub use limits::{for_scheme, BackendLimits};
+pub use pack::{
+    is_hex64, read_pack, write_pack, FileSink, PackReadReport, PackSink, PackWriteReport,
+    StreamSink, MAX_HEADER_BYTES, MAX_MANIFEST_BYTES, WIRE_CAPS, WIRE_MAGIC, WIRE_VERSION,
+};
 pub use retry::{
     parse_retry_after, retry_async, retry_blocking, retry_network, AsyncSleeper, Attempt,
     BlockingSleeper, DefaultJitter, FixedJitter, Jitter, RetryPolicy, ThreadSleeper, TokioSleeper,

--- a/crates/snapdir-stores/src/pack.rs
+++ b/crates/snapdir-stores/src/pack.rs
@@ -1,0 +1,1512 @@
+//! SNAPPACK 1 — the snapdir pack wire format.
+//!
+//! A pack is a single self-verifying byte stream that carries raw
+//! content-addressed objects (and at most one manifest) between two snapdir
+//! processes, e.g. `snapdir send-pack | ssh host 'snapdir receive-pack'` — the
+//! acceleration path of the upcoming `ssh://` store. Both ends of the pipe are
+//! snapdir itself, so the format is deliberately minimal (no tar semantics, no
+//! entry names, no padding).
+//!
+//! # Grammar (normative)
+//!
+//! ```text
+//! stream   := "SNAPPACK 1\n" record* "end\n"
+//! record   := "obj " hex64 " " len "\n" payload(len)
+//!           | "manifest " hex64 " " len "\n" payload(len)   ; at most one; must be the LAST record
+//! hex64    := 64 lowercase hex chars, regex ^[0-9a-f]{64}$ (validated on read AND write)
+//! len      := decimal u64
+//! payload  := exactly len raw bytes, no padding/terminator
+//! ```
+//!
+//! # Invariants
+//!
+//! - **Header memory bound:** every header line (including its terminating
+//!   `\n`) is at most [`MAX_HEADER_BYTES`] bytes. The reader rejects a longer
+//!   line as soon as the cap is hit, without buffering more.
+//! - **Verify-before-file:** an `obj` payload streams through an INCREMENTAL
+//!   BLAKE3 hasher while it is staged; it is committed at its claimed
+//!   content-address only if the computed hash equals the claimed `hex64`. A
+//!   mismatch removes the staged bytes (temp file) and aborts the WHOLE stream
+//!   with [`StoreError::Integrity`] — a corrupt stream taints everything after
+//!   it, so nothing past the bad record is trusted.
+//! - **Manifest-last / commit-at-`end`:** the optional `manifest` record must
+//!   be the last record (any record after it is rejected), its payload is
+//!   buffered (capped at [`MAX_MANIFEST_BYTES`]), and it is committed to the
+//!   sink only after the `end` trailer has been read. EOF before `end` is a
+//!   hard error and the manifest is NEVER committed — so a truncated stream or
+//!   dropped connection can file (verified) objects but can never make the
+//!   snapshot observable, preserving the store-wide manifest-last invariant.
+//! - **Idempotent duplicates:** a duplicate `obj` record is skipped
+//!   (write-once), but its bytes are still read and hash-verified — the stream
+//!   cannot seek, and a hash mismatch on ANY record (present or not) aborts.
+//! - **No path input:** the on-disk location of every payload is derived
+//!   exclusively from the validated claimed checksum
+//!   ([`snapdir_core::store::object_path`] /
+//!   [`snapdir_core::store::manifest_path`]); there is no entry-name concept,
+//!   so the path-traversal class is structurally absent.
+//!
+//! # Memory profile
+//!
+//! [`read_pack`] into a [`FileSink`] is O(1) memory per record regardless of
+//! object size: payload bytes stream through a fixed-size buffer into a temp
+//! sibling of the final object path (the same temp+atomic-rename discipline as
+//! `file_store.rs`) while the incremental hasher runs. The generic
+//! [`StreamSink`] buffers ONE object record at a time (its
+//! [`StreamStore::put_object`] primitive takes whole buffers); the manifest
+//! record is always buffered, capped at [`MAX_MANIFEST_BYTES`].
+//!
+//! [`write_pack`] reads one object at a time via
+//! [`StreamStore::get_object`] (one whole object buffered at a time; the
+//! send-pack CLI layers any further streaming on top in a later gate).
+
+use std::fs;
+use std::io::{self, BufRead, BufReader, Read, Write};
+use std::path::{Path, PathBuf};
+
+use snapdir_core::manifest::Manifest;
+use snapdir_core::merkle::{snapshot_id, Blake3Hasher, Hasher};
+use snapdir_core::store::{manifest_path, object_path, StoreError};
+
+use crate::file_store::FileStore;
+use crate::stream::StreamStore;
+
+/// The pack wire-format version this build speaks. Single source of truth for
+/// the wire: the capability line (`snapdir version --capabilities`) bakes this
+/// value, and [`read_pack`] negotiates on an exact integer match only.
+pub const WIRE_VERSION: u32 = 1;
+
+/// The plumbing capabilities this build advertises alongside [`WIRE_VERSION`].
+pub const WIRE_CAPS: &[&str] = &["objects-needed", "send-pack", "receive-pack"];
+
+/// The exact magic line that opens every pack stream (version baked in; a
+/// unit test pins it to [`WIRE_VERSION`]).
+pub const WIRE_MAGIC: &str = "SNAPPACK 1\n";
+
+/// Hard cap on a header line, INCLUDING its terminating `\n`. The reader
+/// rejects a longer line the moment the cap is reached — this bounds reader
+/// memory before any validation happens. (The longest valid header —
+/// `manifest <hex64> <u64::MAX>\n` — is 95 bytes, so the cap is comfortable.)
+pub const MAX_HEADER_BYTES: usize = 128;
+
+/// Hard cap on a `manifest` record's payload, which (unlike `obj` payloads)
+/// is buffered in memory until the `end` trailer commits it.
+pub const MAX_MANIFEST_BYTES: u64 = 64 * 1024 * 1024;
+
+/// Cap on the up-front `Vec` preallocation for a buffered payload, so a
+/// header that LIES about a huge `len` (while sending few bytes) cannot force
+/// a giant allocation before a single payload byte arrives. The buffer still
+/// grows organically with the bytes actually received.
+const STAGE_PREALLOC_CAP: u64 = 8 * 1024 * 1024;
+
+/// Returns `true` when `s` is a syntactically valid snapdir content address:
+/// exactly 64 lowercase hex characters (`^[0-9a-f]{64}$`).
+///
+/// This is the wire's single checksum validator — used by [`write_pack`]
+/// (before emitting a record), [`read_pack`] (on every record header), and
+/// [`StreamStore::objects_needed`] (fail-closed input validation).
+#[must_use]
+pub fn is_hex64(s: &str) -> bool {
+    s.len() == 64 && s.bytes().all(|b| matches!(b, b'0'..=b'9' | b'a'..=b'f'))
+}
+
+/// What [`write_pack`] emitted.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PackWriteReport {
+    /// Number of `obj` records emitted (duplicates in `ids` emit duplicate
+    /// records — deduplication is the caller's job).
+    pub objects_written: u64,
+    /// Whether a `manifest` record was emitted (i.e. `manifest_id` was given).
+    pub manifest_written: bool,
+}
+
+/// What [`read_pack`] filed into its sink.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct PackReadReport {
+    /// Objects verified and newly committed to the sink.
+    pub objects_written: u64,
+    /// Objects whose bytes were read and hash-verified but NOT rewritten
+    /// because the sink already had them (idempotent duplicates).
+    pub objects_skipped: u64,
+    /// Whether a manifest was committed (only ever `true` after a verified
+    /// `manifest` record AND the `end` trailer).
+    pub manifest_committed: bool,
+}
+
+/// Where [`read_pack`] files verified records.
+///
+/// The reader owns the framing, the incremental hashing, and the
+/// verify-before-commit decision; a sink only stages bytes and
+/// commits/aborts on the reader's instruction:
+///
+/// 1. [`has_object`](Self::has_object) — skip-but-verify gate for duplicates.
+/// 2. [`stage_object`](Self::stage_object) — pull the (length-limited) payload
+///    into staging (temp file / memory buffer). Called only for absent
+///    objects; the reader hashes every byte the sink pulls.
+/// 3. [`commit_object`](Self::commit_object) on hash match, or
+///    [`abort_object`](Self::abort_object) on mismatch/truncation/error —
+///    abort must leave NOTHING behind (no temp files, no partial objects).
+/// 4. [`put_manifest`](Self::put_manifest) — called only after the `end`
+///    trailer, with an id the reader has already verified.
+pub trait PackSink {
+    /// Returns `true` when the sink already holds `checksum` (the record's
+    /// bytes will then be verified-and-discarded rather than re-written).
+    fn has_object(&mut self, checksum: &str) -> Result<bool, StoreError>;
+
+    /// Stages the payload for `checksum` by reading `payload` to EOF (the
+    /// reader has already limited it to exactly `len` bytes). Must not make
+    /// the object observable at its final address yet. On error the sink must
+    /// clean up after itself or tolerate the follow-up
+    /// [`abort_object`](Self::abort_object) call.
+    fn stage_object(
+        &mut self,
+        checksum: &str,
+        len: u64,
+        payload: &mut dyn Read,
+    ) -> Result<(), StoreError>;
+
+    /// Commits the staged payload at its (reader-verified) content-address.
+    fn commit_object(&mut self, checksum: &str) -> Result<(), StoreError>;
+
+    /// Discards any staged payload for `checksum`, leaving no trace (best
+    /// effort; must tolerate nothing being staged).
+    fn abort_object(&mut self, checksum: &str);
+
+    /// Commits the manifest under `id`. Called only after the `end` trailer of
+    /// a fully verified stream (manifest-last survives truncation).
+    fn put_manifest(&mut self, id: &str, manifest: &Manifest) -> Result<(), StoreError>;
+}
+
+/// Generic [`PackSink`] over any [`StreamStore`]: buffers one `obj` payload at
+/// a time in memory, then files it via the store's verify-before-write
+/// [`put_object`](StreamStore::put_object) (so the store's own integrity
+/// discipline re-checks the commit). Use [`FileSink`] for `file://`-rooted
+/// sinks to get O(1) memory per record.
+pub struct StreamSink<'a> {
+    store: &'a dyn StreamStore,
+    staged: Option<(String, Vec<u8>)>,
+}
+
+impl<'a> StreamSink<'a> {
+    /// Wraps `store` as a pack sink.
+    #[must_use]
+    pub fn new(store: &'a dyn StreamStore) -> Self {
+        Self {
+            store,
+            staged: None,
+        }
+    }
+}
+
+impl PackSink for StreamSink<'_> {
+    fn has_object(&mut self, checksum: &str) -> Result<bool, StoreError> {
+        self.store.has_object(checksum)
+    }
+
+    fn stage_object(
+        &mut self,
+        checksum: &str,
+        len: u64,
+        payload: &mut dyn Read,
+    ) -> Result<(), StoreError> {
+        // Defensive: a stage while something else is staged means the reader
+        // sequencing was violated; drop the stale staging rather than leak it.
+        self.staged = None;
+        // Preallocate at most STAGE_PRELLOC_CAP so a lying `len` cannot force a
+        // huge allocation; the buffer grows with the bytes actually received
+        // (which the reader caps at the true `len`).
+        let prealloc = usize::try_from(len.min(STAGE_PREALLOC_CAP)).unwrap_or(0);
+        let mut buf = Vec::with_capacity(prealloc);
+        payload.read_to_end(&mut buf)?;
+        self.staged = Some((checksum.to_owned(), buf));
+        Ok(())
+    }
+
+    fn commit_object(&mut self, checksum: &str) -> Result<(), StoreError> {
+        match self.staged.take() {
+            Some((staged_checksum, bytes)) if staged_checksum == checksum => {
+                // `put_object` re-verifies bytes-hash-to-address before writing
+                // (the store's own verify-before-write discipline).
+                self.store.put_object(checksum, bytes)
+            }
+            _ => Err(protocol(format!(
+                "internal pack sink error: commit of {checksum} without a matching staged payload"
+            ))),
+        }
+    }
+
+    fn abort_object(&mut self, _checksum: &str) {
+        self.staged = None;
+    }
+
+    fn put_manifest(&mut self, id: &str, manifest: &Manifest) -> Result<(), StoreError> {
+        self.store.put_manifest(id, manifest)
+    }
+}
+
+/// File-backed [`PackSink`] over a [`FileStore`]: `obj` payloads stream
+/// through a fixed-size buffer straight into a unique temp sibling of the
+/// final object path, then an atomic rename commits on hash match — O(1)
+/// memory per record regardless of object size.
+///
+/// This mirrors `file_store.rs`'s private `temp_sibling`/persist discipline
+/// (temp file in the SAME directory so the rename is an atomic,
+/// same-filesystem move; a partially-written object is never visible at its
+/// content-address; a failed record removes its temp file).
+pub struct FileSink<'a> {
+    store: &'a FileStore,
+    staged: Option<StagedFile>,
+}
+
+/// A staged-but-uncommitted object payload on disk.
+struct StagedFile {
+    checksum: String,
+    tmp: PathBuf,
+    target: PathBuf,
+}
+
+impl<'a> FileSink<'a> {
+    /// Wraps `store` as a streaming, file-backed pack sink.
+    #[must_use]
+    pub fn new(store: &'a FileStore) -> Self {
+        Self {
+            store,
+            staged: None,
+        }
+    }
+}
+
+impl Drop for FileSink<'_> {
+    /// Last-resort cleanup: never leave a stray temp file in `.objects/` even
+    /// if the reader bails between stage and commit/abort.
+    fn drop(&mut self) {
+        if let Some(staged) = self.staged.take() {
+            let _ = fs::remove_file(&staged.tmp);
+        }
+    }
+}
+
+impl PackSink for FileSink<'_> {
+    fn has_object(&mut self, checksum: &str) -> Result<bool, StoreError> {
+        StreamStore::has_object(self.store, checksum)
+    }
+
+    fn stage_object(
+        &mut self,
+        checksum: &str,
+        _len: u64,
+        payload: &mut dyn Read,
+    ) -> Result<(), StoreError> {
+        // Defensive: drop (and remove) any stale staging first.
+        self.abort_object(checksum);
+
+        // The on-disk location derives EXCLUSIVELY from the validated claimed
+        // checksum — never from any stream-supplied name.
+        let target = self.store.root().join(object_path(checksum));
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent)?;
+        }
+        let tmp = temp_sibling(&target);
+        let mut file = fs::File::create(&tmp)?;
+        // `io::copy` streams through a fixed-size buffer (O(1) memory); the
+        // reader-side incremental hasher sees every byte we pull here.
+        let copied = io::copy(payload, &mut file);
+        drop(file);
+        if let Err(err) = copied {
+            // Failed mid-write: remove the temp file, leave nothing behind.
+            let _ = fs::remove_file(&tmp);
+            return Err(err.into());
+        }
+        self.staged = Some(StagedFile {
+            checksum: checksum.to_owned(),
+            tmp,
+            target,
+        });
+        Ok(())
+    }
+
+    fn commit_object(&mut self, checksum: &str) -> Result<(), StoreError> {
+        match self.staged.take() {
+            Some(staged) if staged.checksum == checksum => {
+                // Atomic rename into the final content-addressed location; the
+                // reader has already verified the streamed bytes hash to
+                // `checksum`, so this is the rename-on-match step.
+                fs::rename(&staged.tmp, &staged.target)?;
+                Ok(())
+            }
+            other => {
+                if let Some(staged) = other {
+                    let _ = fs::remove_file(&staged.tmp);
+                }
+                Err(protocol(format!(
+                    "internal pack sink error: commit of {checksum} without a matching staged payload"
+                )))
+            }
+        }
+    }
+
+    fn abort_object(&mut self, _checksum: &str) {
+        if let Some(staged) = self.staged.take() {
+            let _ = fs::remove_file(&staged.tmp);
+        }
+    }
+
+    fn put_manifest(&mut self, id: &str, manifest: &Manifest) -> Result<(), StoreError> {
+        // FileStore::put_manifest re-verifies snapshot_id(manifest) == id and
+        // writes via its own temp+atomic-rename path.
+        self.store.put_manifest(id, manifest)
+    }
+}
+
+/// Emits a SNAPPACK 1 stream: magic, one `obj` record per entry of `ids` IN
+/// INPUT ORDER, then (if `manifest_id` is given) the `manifest` record LAST,
+/// then the `end` trailer.
+///
+/// Fail-closed discipline:
+///
+/// - Every id (and `manifest_id`) is validated against `^[0-9a-f]{64}$` BEFORE
+///   any byte is written.
+/// - The manifest is fetched and serialized up front (fail fast) but emitted
+///   last; its serialized bytes (`Manifest` text + trailing `\n`, exactly the
+///   stored byte form `file_store.rs` writes) must hash back to `manifest_id`.
+/// - Each object's bytes are re-verified to hash to its id after
+///   [`get_object`](StreamStore::get_object) (belt and braces over the store's
+///   own read verification) before its record is written.
+/// - Any failure — including a missing object — aborts BEFORE the `end`
+///   trailer is emitted, so a consumer of the partial stream also fails
+///   (no silent partial transfer).
+///
+/// Duplicates in `ids` emit duplicate records (the reader handles them
+/// idempotently); deduplication is the caller's job.
+pub fn write_pack(
+    source: &dyn StreamStore,
+    ids: &[String],
+    manifest_id: Option<&str>,
+    mut out: impl Write,
+) -> Result<PackWriteReport, StoreError> {
+    // Validate EVERY checksum before emitting anything (fail closed).
+    for id in ids {
+        if !is_hex64(id) {
+            return Err(protocol(format!(
+                "invalid object checksum {id:?}: expected 64 lowercase hex characters"
+            )));
+        }
+    }
+    if let Some(id) = manifest_id {
+        if !is_hex64(id) {
+            return Err(protocol(format!(
+                "invalid manifest id {id:?}: expected 64 lowercase hex characters"
+            )));
+        }
+    }
+
+    let hasher = Blake3Hasher::new();
+
+    // Fetch + serialize the manifest UP FRONT (fail fast before streaming
+    // megabytes of objects), but emit it LAST. Serialization matches
+    // `file_store.rs::write_manifest` exactly — `to_string()` + trailing `\n`,
+    // the byte form `snapshot_id` hashes — so ids round-trip.
+    let manifest_payload: Option<(&str, Vec<u8>)> = match manifest_id {
+        Some(id) => {
+            let manifest = source.get_manifest(id)?;
+            let mut text = manifest.to_string();
+            text.push('\n');
+            let bytes = text.into_bytes();
+            let actual = hasher.hash_hex(&bytes);
+            if actual != id {
+                return Err(StoreError::Integrity {
+                    address: manifest_path(id),
+                    expected: id.to_owned(),
+                    actual,
+                });
+            }
+            Some((id, bytes))
+        }
+        None => None,
+    };
+
+    out.write_all(WIRE_MAGIC.as_bytes())?;
+    let mut report = PackWriteReport::default();
+
+    for id in ids {
+        // `get_object` already verifies the read; re-verify here anyway so a
+        // non-verifying StreamStore impl can never push corrupt bytes onto the
+        // wire under a clean address (fail closed).
+        let bytes = source.get_object(id)?;
+        let actual = hasher.hash_hex(&bytes);
+        if actual != *id {
+            return Err(StoreError::Integrity {
+                address: object_path(id),
+                expected: id.clone(),
+                actual,
+            });
+        }
+        writeln!(out, "obj {id} {}", bytes.len())?;
+        out.write_all(&bytes)?;
+        report.objects_written += 1;
+    }
+
+    if let Some((id, bytes)) = manifest_payload {
+        writeln!(out, "manifest {id} {}", bytes.len())?;
+        out.write_all(&bytes)?;
+        report.manifest_written = true;
+    }
+
+    out.write_all(b"end\n")?;
+    out.flush()?;
+    Ok(report)
+}
+
+/// Consumes a SNAPPACK 1 stream from `input`, filing verified records into
+/// `sink`. See the [module docs](crate::pack) for the full invariant list;
+/// in short:
+///
+/// - every record header is validated (magic, version, `hex64`, decimal len,
+///   [`MAX_HEADER_BYTES`] cap);
+/// - every payload is incrementally BLAKE3-hashed and must match its claimed
+///   checksum (mismatch ⇒ staged bytes discarded, whole stream aborted);
+/// - duplicate objects are verified-but-skipped (write-once);
+/// - the manifest (if any) must be the last record and is committed ONLY
+///   after the `end` trailer; EOF before `end` is a hard error and never
+///   commits the manifest.
+pub fn read_pack(input: impl Read, sink: &mut dyn PackSink) -> Result<PackReadReport, StoreError> {
+    let mut input = BufReader::new(input);
+
+    check_magic(&read_header_line(&mut input)?)?;
+
+    let mut report = PackReadReport::default();
+    let mut pending_manifest: Option<(String, Manifest)> = None;
+
+    loop {
+        let line = read_header_line(&mut input)?;
+        if line == "end" {
+            // The `end` trailer is the ONLY place a manifest commits:
+            // truncation anywhere above has already errored out, so a
+            // committed manifest proves the whole stream verified.
+            if let Some((id, manifest)) = pending_manifest.take() {
+                sink.put_manifest(&id, &manifest)?;
+                report.manifest_committed = true;
+            }
+            return Ok(report);
+        }
+        if pending_manifest.is_some() {
+            return Err(protocol(format!(
+                "record after the manifest record (only the `end` trailer may follow it): {line:?}"
+            )));
+        }
+        let (kind, checksum, len) = parse_record_header(&line)?;
+        match kind {
+            RecordKind::Obj => read_obj_record(&mut input, sink, &checksum, len, &mut report)?,
+            RecordKind::Manifest => {
+                pending_manifest = Some(read_manifest_record(&mut input, &checksum, len)?);
+            }
+        }
+    }
+}
+
+/// A record header's type tag.
+enum RecordKind {
+    Obj,
+    Manifest,
+}
+
+/// Reads, verifies, and files (or verified-skips) one `obj` payload.
+fn read_obj_record(
+    input: &mut dyn Read,
+    sink: &mut dyn PackSink,
+    checksum: &str,
+    len: u64,
+    report: &mut PackReadReport,
+) -> Result<(), StoreError> {
+    let present = sink.has_object(checksum)?;
+    let mut payload = HashingTake::new(input, len);
+
+    if present {
+        // Idempotent duplicate / pre-seeded object: the stream cannot seek, so
+        // the bytes are still consumed AND hash-verified, but not re-written.
+        payload.drain()?;
+    } else if let Err(err) = sink.stage_object(checksum, len, &mut payload) {
+        sink.abort_object(checksum);
+        return Err(err);
+    }
+
+    if payload.remaining() > 0 {
+        if !present {
+            sink.abort_object(checksum);
+        }
+        return Err(if payload.hit_eof() {
+            protocol(format!(
+                "truncated pack stream: EOF inside the payload of object {checksum} \
+                 ({} of {len} bytes missing)",
+                payload.remaining()
+            ))
+        } else {
+            protocol(format!(
+                "internal pack sink error: sink consumed only {} of {len} payload bytes \
+                 for object {checksum}",
+                len - payload.remaining()
+            ))
+        });
+    }
+
+    // Verify the streamed bytes hash to the CLAIMED address. A mismatch files
+    // nothing under the claimed checksum (the staged temp is removed) and
+    // aborts the whole stream — everything after a corrupt record is tainted.
+    let actual = payload.finalize_hex();
+    if actual != checksum {
+        if !present {
+            sink.abort_object(checksum);
+        }
+        return Err(StoreError::Integrity {
+            address: object_path(checksum),
+            expected: checksum.to_owned(),
+            actual,
+        });
+    }
+
+    if present {
+        report.objects_skipped += 1;
+    } else {
+        sink.commit_object(checksum)?;
+        report.objects_written += 1;
+    }
+    Ok(())
+}
+
+/// Reads and verifies one `manifest` payload, returning it for the
+/// commit-at-`end` step (it is NEVER committed here).
+fn read_manifest_record(
+    input: &mut dyn Read,
+    id: &str,
+    len: u64,
+) -> Result<(String, Manifest), StoreError> {
+    if len > MAX_MANIFEST_BYTES {
+        return Err(protocol(format!(
+            "manifest record of {len} bytes exceeds the {MAX_MANIFEST_BYTES}-byte cap"
+        )));
+    }
+    let mut payload = HashingTake::new(input, len);
+    // Bounded by the cap check above (and the prealloc guard for lying
+    // headers), so buffering the manifest is safe.
+    let mut buf = Vec::with_capacity(usize::try_from(len.min(STAGE_PREALLOC_CAP)).unwrap_or(0));
+    payload.read_to_end(&mut buf)?;
+    if payload.remaining() > 0 {
+        return Err(protocol(format!(
+            "truncated pack stream: EOF inside the payload of manifest {id} \
+             ({} of {len} bytes missing)",
+            payload.remaining()
+        )));
+    }
+
+    // 1) The raw payload bytes must hash to the claimed snapshot id (the
+    //    stored manifest byte form is exactly what `snapshot_id` hashes).
+    let actual = payload.finalize_hex();
+    if actual != id {
+        return Err(StoreError::Integrity {
+            address: manifest_path(id),
+            expected: id.to_owned(),
+            actual,
+        });
+    }
+
+    // 2) The payload must PARSE, and the parsed manifest must re-render to the
+    //    same snapshot id — rejecting a payload that raw-hashes correctly but
+    //    is not the canonical serialization (it would not round-trip).
+    let text = String::from_utf8(buf).map_err(|err| StoreError::Backend {
+        message: format!("manifest {id} payload is not valid UTF-8"),
+        source: Some(Box::new(err)),
+    })?;
+    let manifest = Manifest::parse(&text)?;
+    let rendered_id = snapshot_id(&manifest, &Blake3Hasher::new());
+    if rendered_id != id {
+        return Err(StoreError::Integrity {
+            address: manifest_path(id),
+            expected: id.to_owned(),
+            actual: rendered_id,
+        });
+    }
+
+    Ok((id.to_owned(), manifest))
+}
+
+/// Builds a protocol-violation error (malformed/truncated stream, bad header,
+/// cap exceeded, …). Hash mismatches use [`StoreError::Integrity`] instead.
+fn protocol(message: impl Into<String>) -> StoreError {
+    StoreError::Backend {
+        message: message.into(),
+        source: None,
+    }
+}
+
+/// Reads one `\n`-terminated header line (returned WITHOUT the `\n`),
+/// enforcing the [`MAX_HEADER_BYTES`] cap while reading — an over-long line is
+/// rejected the moment the cap is hit, without buffering more. EOF at any
+/// point inside a header position is a hard truncation error (`end` is the
+/// only legitimate way to finish a stream).
+fn read_header_line(input: &mut impl BufRead) -> Result<String, StoreError> {
+    let mut line: Vec<u8> = Vec::with_capacity(32);
+    loop {
+        let mut byte = [0u8; 1];
+        let n = input.read(&mut byte)?;
+        if n == 0 {
+            return Err(protocol(if line.is_empty() {
+                "truncated pack stream: unexpected EOF before the `end` trailer".to_owned()
+            } else {
+                format!(
+                    "truncated pack stream: EOF inside a header line (read {:?} so far)",
+                    String::from_utf8_lossy(&line)
+                )
+            }));
+        }
+        if byte[0] == b'\n' {
+            break;
+        }
+        line.push(byte[0]);
+        if line.len() >= MAX_HEADER_BYTES {
+            return Err(protocol(format!(
+                "header line exceeds the {MAX_HEADER_BYTES}-byte cap"
+            )));
+        }
+    }
+    String::from_utf8(line).map_err(|err| StoreError::Backend {
+        message: "header line is not valid UTF-8".to_owned(),
+        source: Some(Box::new(err)),
+    })
+}
+
+/// Validates the magic line (already stripped of its `\n`). Negotiation is on
+/// the exact `wire` integer only: a different version — newer OR older — is
+/// rejected, and the caller falls back to the dumb path.
+fn check_magic(line: &str) -> Result<(), StoreError> {
+    let Some(version) = line.strip_prefix("SNAPPACK ") else {
+        return Err(protocol(format!(
+            "bad pack magic {line:?} (expected {:?})",
+            WIRE_MAGIC.trim_end()
+        )));
+    };
+    if version != WIRE_VERSION.to_string() {
+        return Err(protocol(format!(
+            "unsupported pack wire version {version:?}: this build speaks wire={WIRE_VERSION}"
+        )));
+    }
+    Ok(())
+}
+
+/// Parses a record header line into `(kind, hex64, len)`, enforcing the exact
+/// single-space token grammar, the `^[0-9a-f]{64}$` checksum shape, and a
+/// strictly-decimal `u64` length.
+fn parse_record_header(line: &str) -> Result<(RecordKind, String, u64), StoreError> {
+    let mut parts = line.split(' ');
+    let kind = match parts.next() {
+        Some("obj") => RecordKind::Obj,
+        Some("manifest") => RecordKind::Manifest,
+        _ => {
+            return Err(protocol(format!(
+                "unknown record header {line:?} (expected `obj`, `manifest`, or `end`)"
+            )));
+        }
+    };
+    let (Some(checksum), Some(len_token), None) = (parts.next(), parts.next(), parts.next()) else {
+        return Err(protocol(format!(
+            "malformed record header {line:?} (expected `<kind> <hex64> <len>`)"
+        )));
+    };
+    if !is_hex64(checksum) {
+        return Err(protocol(format!(
+            "invalid checksum {checksum:?} in record header: expected 64 lowercase hex characters"
+        )));
+    }
+    if len_token.is_empty() || !len_token.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(protocol(format!(
+            "invalid payload length {len_token:?} in record header: expected a decimal u64"
+        )));
+    }
+    let len: u64 = len_token.parse().map_err(|_| {
+        protocol(format!(
+            "payload length {len_token:?} does not fit in a u64"
+        ))
+    })?;
+    Ok((kind, checksum.to_owned(), len))
+}
+
+/// A length-limited reader that incrementally BLAKE3-hashes everything read
+/// through it. This is how the reader keeps verification O(1)-memory while a
+/// sink streams the payload to disk: the sink pulls bytes, the hasher sees
+/// every one of them, and [`finalize_hex`](Self::finalize_hex) yields the
+/// digest once the payload is exhausted.
+struct HashingTake<'a> {
+    inner: &'a mut dyn Read,
+    remaining: u64,
+    hit_eof: bool,
+    hasher: blake3::Hasher,
+}
+
+impl<'a> HashingTake<'a> {
+    fn new(inner: &'a mut dyn Read, len: u64) -> Self {
+        Self {
+            inner,
+            remaining: len,
+            hit_eof: false,
+            hasher: blake3::Hasher::new(),
+        }
+    }
+
+    /// Payload bytes not yet read. Non-zero after EOF means truncation.
+    fn remaining(&self) -> u64 {
+        self.remaining
+    }
+
+    /// Whether the underlying stream hit EOF while payload bytes were still
+    /// owed (distinguishes a truncated stream from a sink that under-read).
+    fn hit_eof(&self) -> bool {
+        self.hit_eof
+    }
+
+    /// Lowercase hex BLAKE3 digest of every byte read through this reader.
+    fn finalize_hex(&self) -> String {
+        self.hasher.finalize().to_hex().to_string()
+    }
+
+    /// Reads (and hashes) the rest of the payload through a fixed-size buffer,
+    /// discarding the bytes — the verified-skip path for duplicate objects.
+    fn drain(&mut self) -> io::Result<()> {
+        let mut buf = [0u8; 8 * 1024];
+        loop {
+            if self.read(&mut buf)? == 0 {
+                return Ok(());
+            }
+        }
+    }
+}
+
+impl Read for HashingTake<'_> {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        if self.remaining == 0 || buf.is_empty() {
+            return Ok(0);
+        }
+        let cap = usize::try_from(self.remaining)
+            .unwrap_or(usize::MAX)
+            .min(buf.len());
+        let n = self.inner.read(&mut buf[..cap])?;
+        if n == 0 {
+            self.hit_eof = true;
+            return Ok(0);
+        }
+        self.hasher.update(&buf[..n]);
+        self.remaining -= n as u64;
+        Ok(n)
+    }
+}
+
+/// Builds a unique temp sibling path for `target` (same directory, so the
+/// final rename stays on one filesystem). Mirrors the private
+/// `file_store.rs::temp_sibling` discipline — pid + a process-monotonic
+/// counter so concurrent stages never collide.
+fn temp_sibling(target: &Path) -> PathBuf {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
+    let file_name = target
+        .file_name()
+        .map(|s| s.to_string_lossy().into_owned())
+        .unwrap_or_default();
+    let tmp_name = format!("{file_name}.{pid}.{n}.tmp");
+    match target.parent() {
+        Some(parent) => parent.join(tmp_name),
+        None => PathBuf::from(tmp_name),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use snapdir_core::manifest::{ManifestEntry, PathType};
+    use snapdir_core::store::Store;
+    use std::fs;
+
+    // A tiny temp-dir helper so tests don't pull in a dev-dependency (same
+    // pattern as file_store.rs tests).
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static COUNTER: AtomicU64 = AtomicU64::new(0);
+            let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "snapdir-pack-test-{}-{tag}-{n}",
+                std::process::id()
+            ));
+            fs::create_dir_all(&path).expect("create temp dir");
+            Self { path }
+        }
+
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = fs::remove_dir_all(&self.path);
+        }
+    }
+
+    /// Deterministic multi-MB payload (exercises the streaming path).
+    fn big_payload(len: usize) -> Vec<u8> {
+        (0..len).map(|i| u8::try_from(i % 251).unwrap()).collect()
+    }
+
+    /// Files `payloads` as objects in a fresh `FileStore`, returning the store
+    /// (+ its tempdir guard) and the content-addresses in payload order.
+    fn seed_store(tag: &str, payloads: &[Vec<u8>]) -> (TempDir, FileStore, Vec<String>) {
+        let dir = TempDir::new(tag);
+        let store = FileStore::from_root(dir.path());
+        let hasher = Blake3Hasher::new();
+        let ids = payloads
+            .iter()
+            .map(|p| {
+                let checksum = hasher.hash_hex(p);
+                store.put_object(&checksum, p.clone()).expect("seed object");
+                checksum
+            })
+            .collect();
+        (dir, store, ids)
+    }
+
+    /// Builds a manifest whose file entries reference `payloads` (real BLAKE3
+    /// checksums) and returns it with its snapshot id.
+    fn manifest_for(payloads: &[Vec<u8>]) -> (Manifest, String) {
+        let hasher = Blake3Hasher::new();
+        let mut manifest = Manifest::new();
+        manifest.push(ManifestEntry::new(PathType::Directory, "700", "x", 0, "./"));
+        for (i, payload) in payloads.iter().enumerate() {
+            manifest.push(ManifestEntry::new(
+                PathType::File,
+                "600",
+                hasher.hash_hex(payload),
+                u64::try_from(payload.len()).unwrap(),
+                format!("./obj-{i:02}"),
+            ));
+        }
+        let manifest = Manifest::from_entries(manifest.entries().to_vec());
+        let id = snapshot_id(&manifest, &hasher);
+        (manifest, id)
+    }
+
+    /// The serialized (stored) byte form of a manifest: text + trailing `\n`.
+    fn manifest_bytes(manifest: &Manifest) -> Vec<u8> {
+        let mut text = manifest.to_string();
+        text.push('\n');
+        text.into_bytes()
+    }
+
+    /// Recursively collects every regular FILE under `dir` (used to prove
+    /// no stray temp files survive a failed stream).
+    fn files_under(dir: &Path) -> Vec<PathBuf> {
+        let mut files = Vec::new();
+        let Ok(entries) = fs::read_dir(dir) else {
+            return files;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.is_dir() {
+                files.extend(files_under(&path));
+            } else {
+                files.push(path);
+            }
+        }
+        files
+    }
+
+    /// Hand-builds a raw record (`<kind> <hex> <len>\n<payload>`).
+    fn raw_record(kind: &str, hex: &str, payload: &[u8]) -> Vec<u8> {
+        let mut out = format!("{kind} {hex} {}\n", payload.len()).into_bytes();
+        out.extend_from_slice(payload);
+        out
+    }
+
+    /// Hand-builds a full stream: magic + records + `end\n`.
+    fn raw_stream(records: &[Vec<u8>]) -> Vec<u8> {
+        let mut out = WIRE_MAGIC.as_bytes().to_vec();
+        for record in records {
+            out.extend_from_slice(record);
+        }
+        out.extend_from_slice(b"end\n");
+        out
+    }
+
+    fn hex_of(bytes: &[u8]) -> String {
+        Blake3Hasher::new().hash_hex(bytes)
+    }
+
+    // --- wire constants ----------------------------------------------------
+
+    #[test]
+    fn pack_wire_constants_are_consistent() {
+        assert_eq!(WIRE_MAGIC, format!("SNAPPACK {WIRE_VERSION}\n"));
+        assert_eq!(WIRE_VERSION, 1);
+        assert_eq!(WIRE_CAPS, &["objects-needed", "send-pack", "receive-pack"]);
+    }
+
+    #[test]
+    fn pack_is_hex64_validates_shape() {
+        let valid = "0123456789abcdef".repeat(4);
+        assert!(is_hex64(&valid));
+        assert!(!is_hex64(&valid[..63])); // 63 chars
+        assert!(!is_hex64(&format!("{valid}0"))); // 65 chars
+        assert!(!is_hex64(&valid.to_uppercase())); // uppercase
+        assert!(!is_hex64(&format!("g{}", &valid[1..]))); // non-hex
+        assert!(!is_hex64("")); // empty
+    }
+
+    // --- roundtrips ----------------------------------------------------------
+
+    #[test]
+    fn pack_roundtrip_file_sink_streams_objects_and_manifest() {
+        // Includes a 0-byte object and a multi-MB object (streaming path).
+        let payloads = vec![
+            Vec::new(),
+            b"hello pack\n".to_vec(),
+            big_payload(3 * 1024 * 1024 + 7),
+        ];
+        let (a_dir, a, ids) = seed_store("rt-a", &payloads);
+        let (manifest, man_id) = manifest_for(&payloads);
+        a.put_manifest(&man_id, &manifest).expect("seed manifest");
+
+        let mut pack = Vec::new();
+        let wrote = write_pack(&a, &ids, Some(&man_id), &mut pack).expect("write_pack");
+        assert_eq!(wrote.objects_written, 3);
+        assert!(wrote.manifest_written);
+
+        let b_dir = TempDir::new("rt-b");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        let read = read_pack(pack.as_slice(), &mut sink).expect("read_pack");
+        assert_eq!(read.objects_written, 3);
+        assert_eq!(read.objects_skipped, 0);
+        assert!(read.manifest_committed);
+
+        // B's objects are byte-equal to A's at the identical sharded keys.
+        for (id, payload) in ids.iter().zip(&payloads) {
+            let key = object_path(id);
+            assert_eq!(
+                fs::read(b_dir.path().join(&key)).expect("b object"),
+                *payload,
+                "object {key} byte-equal"
+            );
+            assert_eq!(
+                fs::read(a_dir.path().join(&key)).expect("a object"),
+                fs::read(b_dir.path().join(&key)).expect("b object"),
+            );
+        }
+        // Manifest present in B and round-trips to the same id + entries.
+        let back = b.get_manifest(&man_id).expect("manifest in B");
+        assert_eq!(back, manifest);
+        assert_eq!(snapshot_id(&back, &Blake3Hasher::new()), man_id);
+        // No temp litter anywhere.
+        assert!(
+            !files_under(b_dir.path())
+                .iter()
+                .any(|p| p.to_string_lossy().ends_with(".tmp")),
+            "no stray temp files after a clean stream"
+        );
+    }
+
+    #[test]
+    fn pack_roundtrip_stream_sink_generic() {
+        let payloads = vec![b"alpha\n".to_vec(), b"beta\n".to_vec()];
+        let (_a_dir, a, ids) = seed_store("ss-a", &payloads);
+        let (manifest, man_id) = manifest_for(&payloads);
+        a.put_manifest(&man_id, &manifest).expect("seed manifest");
+
+        let mut pack = Vec::new();
+        write_pack(&a, &ids, Some(&man_id), &mut pack).expect("write_pack");
+
+        let b_dir = TempDir::new("ss-b");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = StreamSink::new(&b);
+        let read = read_pack(pack.as_slice(), &mut sink).expect("read_pack");
+        assert_eq!(read.objects_written, 2);
+        assert!(read.manifest_committed);
+
+        for (id, payload) in ids.iter().zip(&payloads) {
+            assert_eq!(b.get_object(id).expect("object"), *payload);
+        }
+        assert_eq!(b.get_manifest(&man_id).expect("manifest"), manifest);
+    }
+
+    #[test]
+    fn pack_empty_stream_roundtrips() {
+        // "SNAPPACK 1\nend\n" is a valid, empty pack.
+        let payloads: Vec<Vec<u8>> = Vec::new();
+        let (_a_dir, a, ids) = seed_store("empty-a", &payloads);
+        let mut pack = Vec::new();
+        let wrote = write_pack(&a, &ids, None, &mut pack).expect("write_pack");
+        assert_eq!(wrote, PackWriteReport::default());
+        assert_eq!(pack, b"SNAPPACK 1\nend\n");
+
+        let b_dir = TempDir::new("empty-b");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        let read = read_pack(pack.as_slice(), &mut sink).expect("read_pack");
+        assert_eq!(read, PackReadReport::default());
+    }
+
+    #[test]
+    fn pack_manifest_only_stream_completes_interrupted_push() {
+        // Empty object set + manifest: the manifest-only pack that finishes an
+        // interrupted push whose objects all landed earlier.
+        let payloads = vec![b"already there\n".to_vec()];
+        let (_a_dir, a, _ids) = seed_store("mo-a", &payloads);
+        let (manifest, man_id) = manifest_for(&payloads);
+        a.put_manifest(&man_id, &manifest).expect("seed manifest");
+
+        let mut pack = Vec::new();
+        let wrote = write_pack(&a, &[], Some(&man_id), &mut pack).expect("write_pack");
+        assert_eq!(wrote.objects_written, 0);
+        assert!(wrote.manifest_written);
+
+        let b_dir = TempDir::new("mo-b");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        let read = read_pack(pack.as_slice(), &mut sink).expect("read_pack");
+        assert!(read.manifest_committed);
+        assert_eq!(b.get_manifest(&man_id).expect("manifest"), manifest);
+    }
+
+    // --- header edge cases ---------------------------------------------------
+
+    #[test]
+    fn pack_rejects_oversized_header_line() {
+        let mut stream = WIRE_MAGIC.as_bytes().to_vec();
+        stream.extend_from_slice("o".repeat(200).as_bytes());
+        stream.extend_from_slice(b"\nend\n");
+        let b_dir = TempDir::new("hdr-cap");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        let err = read_pack(stream.as_slice(), &mut sink).expect_err("must reject");
+        assert!(err.to_string().contains("128-byte cap"), "got: {err}");
+    }
+
+    #[test]
+    fn pack_rejects_bad_magic_and_bad_version() {
+        let b_dir = TempDir::new("magic");
+        let b = FileStore::from_root(b_dir.path());
+        for stream in [
+            &b"SNAPHACK 1\nend\n"[..],
+            &b"GARBAGE\nend\n"[..],
+            &b"SNAPPACK 2\nend\n"[..],
+            &b"SNAPPACK 01\nend\n"[..], // non-canonical version token
+            &b"SNAPPACK \nend\n"[..],
+            &b""[..], // empty input: truncated before the magic
+        ] {
+            let mut sink = FileSink::new(&b);
+            assert!(
+                read_pack(stream, &mut sink).is_err(),
+                "stream {:?} must be rejected",
+                String::from_utf8_lossy(stream)
+            );
+        }
+    }
+
+    #[test]
+    fn pack_rejects_malformed_checksums_and_lengths() {
+        let valid = "0123456789abcdef".repeat(4);
+        let headers = [
+            format!("obj {} 0", valid.to_uppercase()),   // uppercase
+            format!("obj {} 0", &valid[..63]),           // 63 chars
+            format!("obj {valid}0 0"),                   // 65 chars
+            format!("obj g{} 0", &valid[1..]),           // non-hex
+            format!("obj {valid} 12x"),                  // garbage len
+            format!("obj {valid} +5"),                   // sign is not decimal
+            format!("obj {valid} 99999999999999999999"), // > u64::MAX
+            format!("obj {valid}"),                      // missing len
+            format!("obj {valid} 0 extra"),              // trailing token
+            format!("blob {valid} 0"),                   // unknown kind
+            format!("obj  {valid} 0"),                   // double space
+        ];
+        let b_dir = TempDir::new("hdr-bad");
+        let b = FileStore::from_root(b_dir.path());
+        for header in headers {
+            let mut stream = WIRE_MAGIC.as_bytes().to_vec();
+            stream.extend_from_slice(header.as_bytes());
+            stream.extend_from_slice(b"\nend\n");
+            let mut sink = FileSink::new(&b);
+            assert!(
+                read_pack(stream.as_slice(), &mut sink).is_err(),
+                "header {header:?} must be rejected"
+            );
+        }
+    }
+
+    // --- security: hash-mismatch fails closed --------------------------------
+
+    #[test]
+    fn pack_mismatched_object_files_nothing_and_leaves_no_temp() {
+        // A record CLAIMS checksum X but its bytes hash to Y: hard error,
+        // nothing filed at X's path, no manifest committed, no temp litter.
+        let claimed = hex_of(b"good bytes");
+        let evil = b"evil bytes"; // same length as "good bytes"
+        let (manifest, man_id) = manifest_for(&[b"good bytes".to_vec()]);
+        let stream = raw_stream(&[
+            raw_record("obj", &claimed, evil),
+            raw_record("manifest", &man_id, &manifest_bytes(&manifest)),
+        ]);
+
+        let b_dir = TempDir::new("sec");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        let err = read_pack(stream.as_slice(), &mut sink).expect_err("must abort");
+        match err {
+            StoreError::Integrity {
+                expected, actual, ..
+            } => {
+                assert_eq!(expected, claimed);
+                assert_eq!(actual, hex_of(evil));
+            }
+            other => panic!("expected Integrity, got {other:?}"),
+        }
+        drop(sink);
+
+        // NOTHING filed under the claimed checksum; no manifest; no temp files
+        // (or any other file) anywhere in the sink store.
+        assert!(!StreamStore::has_object(&b, &claimed).unwrap());
+        assert!(!b_dir.path().join(object_path(&claimed)).exists());
+        assert!(matches!(
+            b.get_manifest(&man_id),
+            Err(StoreError::ManifestNotFound { .. })
+        ));
+        assert_eq!(
+            files_under(b_dir.path()),
+            Vec::<PathBuf>::new(),
+            "no file (object, manifest, or stray temp) may survive"
+        );
+    }
+
+    #[test]
+    fn pack_mismatch_aborts_even_when_object_already_present() {
+        // Skip-but-verify: a record for an ALREADY-PRESENT object whose stream
+        // bytes are corrupt still aborts the whole stream (and everything
+        // after the bad record is dropped).
+        let good = b"present object\n".to_vec();
+        let payloads = vec![good.clone()];
+        let (b_dir, b, ids) = seed_store("dup-bad", &payloads);
+
+        let corrupt = b"PRESENT OBJECT\n"; // same length, different bytes
+        let later = b"later payload\n";
+        let stream = raw_stream(&[
+            raw_record("obj", &ids[0], corrupt),
+            raw_record("obj", &hex_of(later), later),
+        ]);
+
+        let mut sink = FileSink::new(&b);
+        let err = read_pack(stream.as_slice(), &mut sink).expect_err("must abort");
+        assert!(matches!(err, StoreError::Integrity { .. }));
+        drop(sink);
+
+        // The pre-existing object is untouched; the record AFTER the corrupt
+        // one was never processed.
+        assert_eq!(b.get_object(&ids[0]).unwrap(), good);
+        assert!(!StreamStore::has_object(&b, &hex_of(later)).unwrap());
+        assert!(
+            !files_under(b_dir.path())
+                .iter()
+                .any(|p| p.to_string_lossy().ends_with(".tmp")),
+            "no stray temp files"
+        );
+    }
+
+    // --- truncation ----------------------------------------------------------
+
+    #[test]
+    fn pack_truncated_before_end_files_objects_but_never_manifest() {
+        // Cut the stream after all records but WITHOUT the `end` trailer: the
+        // verified objects ARE filed, the manifest is NOT committed even
+        // though its record was fully read before the cut.
+        let payloads = vec![b"one\n".to_vec(), b"two\n".to_vec()];
+        let (_a_dir, a, ids) = seed_store("trunc-a", &payloads);
+        let (manifest, man_id) = manifest_for(&payloads);
+        a.put_manifest(&man_id, &manifest).expect("seed manifest");
+
+        let mut pack = Vec::new();
+        write_pack(&a, &ids, Some(&man_id), &mut pack).expect("write_pack");
+        assert!(pack.ends_with(b"end\n"));
+        let cut = &pack[..pack.len() - b"end\n".len()];
+
+        let b_dir = TempDir::new("trunc-b");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        let err = read_pack(cut, &mut sink).expect_err("truncation is a hard error");
+        assert!(err.to_string().contains("truncated"), "got: {err}");
+        drop(sink);
+
+        // The N verified objects ARE filed (a retry resumes incrementally)...
+        for (id, payload) in ids.iter().zip(&payloads) {
+            assert_eq!(b.get_object(id).unwrap(), *payload);
+        }
+        // ...but the manifest must NEVER be committed (manifest-last).
+        assert!(matches!(
+            b.get_manifest(&man_id),
+            Err(StoreError::ManifestNotFound { .. })
+        ));
+        assert!(
+            !files_under(b_dir.path())
+                .iter()
+                .any(|p| p.to_string_lossy().ends_with(".tmp")),
+            "no stray temp files"
+        );
+    }
+
+    #[test]
+    fn pack_truncated_mid_payload_keeps_earlier_objects_drops_partial() {
+        let payloads = vec![b"first object\n".to_vec(), big_payload(256 * 1024)];
+        let (_a_dir, a, ids) = seed_store("midcut-a", &payloads);
+
+        let mut pack = Vec::new();
+        write_pack(&a, &ids, None, &mut pack).expect("write_pack");
+        // Cut inside the SECOND object's payload.
+        let cut = &pack[..pack.len() - 100_000];
+
+        let b_dir = TempDir::new("midcut-b");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        let err = read_pack(cut, &mut sink).expect_err("mid-payload truncation");
+        assert!(err.to_string().contains("truncated"), "got: {err}");
+        drop(sink);
+
+        // Object 1 (fully verified before the cut) is filed; the partial
+        // object 2 is NOT, and its temp file was removed.
+        assert_eq!(b.get_object(&ids[0]).unwrap(), payloads[0]);
+        assert!(!StreamStore::has_object(&b, &ids[1]).unwrap());
+        assert!(
+            !files_under(b_dir.path())
+                .iter()
+                .any(|p| p.to_string_lossy().ends_with(".tmp")),
+            "partial payload temp must be removed"
+        );
+    }
+
+    // --- duplicates ------------------------------------------------------------
+
+    #[test]
+    fn pack_duplicate_object_records_are_idempotent_write_once() {
+        let payload = b"duplicated payload\n".to_vec();
+        let checksum = hex_of(&payload);
+        let stream = raw_stream(&[
+            raw_record("obj", &checksum, &payload),
+            raw_record("obj", &checksum, &payload),
+        ]);
+
+        let b_dir = TempDir::new("dup");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        let read = read_pack(stream.as_slice(), &mut sink).expect("duplicates are fine");
+        assert_eq!(read.objects_written, 1, "write-once");
+        assert_eq!(
+            read.objects_skipped, 1,
+            "second record verified-but-skipped"
+        );
+        assert_eq!(b.get_object(&checksum).unwrap(), payload);
+    }
+
+    #[test]
+    fn pack_preseeded_object_is_skipped_but_verified() {
+        // The sink already holds the object: the record's bytes are consumed
+        // (the stream cannot seek) and verified, but not rewritten.
+        let payload = b"already in the store\n".to_vec();
+        let (_b_dir, b, ids) = seed_store("preseed", std::slice::from_ref(&payload));
+
+        let stream = raw_stream(&[raw_record("obj", &ids[0], &payload)]);
+        let mut sink = FileSink::new(&b);
+        let read = read_pack(stream.as_slice(), &mut sink).expect("read_pack");
+        assert_eq!(read.objects_written, 0);
+        assert_eq!(read.objects_skipped, 1);
+        assert_eq!(b.get_object(&ids[0]).unwrap(), payload);
+    }
+
+    // --- manifest rules ----------------------------------------------------------
+
+    #[test]
+    fn pack_rejects_record_after_manifest() {
+        let payload = b"object after manifest\n".to_vec();
+        let (manifest, man_id) = manifest_for(std::slice::from_ref(&payload));
+        let stream = raw_stream(&[
+            raw_record("manifest", &man_id, &manifest_bytes(&manifest)),
+            raw_record("obj", &hex_of(&payload), &payload),
+        ]);
+
+        let b_dir = TempDir::new("after-man");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        let err = read_pack(stream.as_slice(), &mut sink).expect_err("must reject");
+        assert!(err.to_string().contains("after the manifest"), "got: {err}");
+        // The pending manifest must NOT have been committed.
+        assert!(matches!(
+            b.get_manifest(&man_id),
+            Err(StoreError::ManifestNotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn pack_manifest_payload_must_hash_to_claimed_id() {
+        // (a) claimed id != raw hash of the payload -> Integrity.
+        let (manifest, _real_id) = manifest_for(&[b"whatever\n".to_vec()]);
+        let wrong_id = hex_of(b"some other bytes");
+        let stream = raw_stream(&[raw_record(
+            "manifest",
+            &wrong_id,
+            &manifest_bytes(&manifest),
+        )]);
+        let b_dir = TempDir::new("man-bad-id");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        let err = read_pack(stream.as_slice(), &mut sink).expect_err("must reject");
+        assert!(matches!(err, StoreError::Integrity { .. }));
+        assert!(matches!(
+            b.get_manifest(&wrong_id),
+            Err(StoreError::ManifestNotFound { .. })
+        ));
+
+        // (b) raw hash matches the claimed id but the payload is not a
+        // parseable manifest -> rejected, nothing committed.
+        let garbage = b"not a manifest at all\n".to_vec();
+        let garbage_id = hex_of(&garbage);
+        let stream = raw_stream(&[raw_record("manifest", &garbage_id, &garbage)]);
+        let mut sink = FileSink::new(&b);
+        assert!(read_pack(stream.as_slice(), &mut sink).is_err());
+        assert!(matches!(
+            b.get_manifest(&garbage_id),
+            Err(StoreError::ManifestNotFound { .. })
+        ));
+    }
+
+    #[test]
+    fn pack_rejects_manifest_over_64mib_cap() {
+        let big_len: u64 = MAX_MANIFEST_BYTES + 1;
+        let claimed = hex_of(b"irrelevant");
+        let mut stream = WIRE_MAGIC.as_bytes().to_vec();
+        stream.extend_from_slice(format!("manifest {claimed} {big_len}\n").as_bytes());
+        // No payload needed: the cap check fires on the header alone.
+        let b_dir = TempDir::new("man-cap");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        let err = read_pack(stream.as_slice(), &mut sink).expect_err("must reject");
+        assert!(err.to_string().contains("cap"), "got: {err}");
+    }
+
+    // --- write_pack fail-closed ---------------------------------------------------
+
+    #[test]
+    fn pack_write_missing_object_aborts_before_end() {
+        let payloads = vec![b"present\n".to_vec()];
+        let (_a_dir, a, mut ids) = seed_store("wmiss-a", &payloads);
+        // A syntactically valid but ABSENT object id.
+        let absent = hex_of(b"never stored");
+        ids.push(absent.clone());
+
+        let mut pack = Vec::new();
+        let err = write_pack(&a, &ids, None, &mut pack).expect_err("missing object");
+        assert!(matches!(err, StoreError::ObjectNotFound { .. }));
+        // The partial stream has NO `end` trailer, so a consumer fails too.
+        assert!(!pack.ends_with(b"end\n"));
+        let b_dir = TempDir::new("wmiss-b");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        assert!(read_pack(pack.as_slice(), &mut sink).is_err());
+    }
+
+    #[test]
+    fn pack_write_invalid_id_emits_nothing() {
+        let (_a_dir, a, _ids) = seed_store("winv-a", &[b"x\n".to_vec()]);
+        let mut pack = Vec::new();
+        let err = write_pack(&a, &["NOT-HEX".to_owned()], None, &mut pack).expect_err("invalid id");
+        assert!(
+            err.to_string().contains("invalid object checksum"),
+            "got: {err}"
+        );
+        assert!(pack.is_empty(), "fail closed: not a single byte written");
+
+        // Same for an invalid manifest id.
+        let mut pack = Vec::new();
+        let err = write_pack(&a, &[], Some("zz"), &mut pack).expect_err("invalid manifest id");
+        assert!(
+            err.to_string().contains("invalid manifest id"),
+            "got: {err}"
+        );
+        assert!(pack.is_empty());
+    }
+
+    #[test]
+    fn pack_write_emits_records_in_input_order() {
+        let payloads = vec![b"bbb\n".to_vec(), b"aaa\n".to_vec(), b"ccc\n".to_vec()];
+        let (_a_dir, a, ids) = seed_store("order-a", &payloads);
+        let mut pack = Vec::new();
+        write_pack(&a, &ids, None, &mut pack).expect("write_pack");
+        let text = String::from_utf8_lossy(&pack);
+        let positions: Vec<usize> = ids
+            .iter()
+            .map(|id| text.find(id.as_str()).expect("record present"))
+            .collect();
+        let mut sorted = positions.clone();
+        sorted.sort_unstable();
+        assert_eq!(positions, sorted, "obj records keep input order");
+    }
+
+    // --- StreamStore::objects_needed -------------------------------------------
+
+    #[test]
+    fn pack_objects_needed_returns_absent_subset_in_input_order() {
+        let p1 = b"seeded one\n".to_vec();
+        let p3 = b"seeded three\n".to_vec();
+        let (_dir, store, seeded) = seed_store("needed", &[p1, p3]);
+        let absent_a = hex_of(b"absent a");
+        let absent_b = hex_of(b"absent b");
+
+        // Full ordered list interleaving present + absent.
+        let list = vec![
+            seeded[0].clone(),
+            absent_a.clone(),
+            seeded[1].clone(),
+            absent_b.clone(),
+        ];
+        let needed = store.objects_needed(&list).expect("objects_needed");
+        assert_eq!(needed, vec![absent_a.clone(), absent_b.clone()]);
+
+        // Dedup is the caller's job: an absent checksum supplied twice is
+        // reported twice, still in input order.
+        let list = vec![absent_b.clone(), absent_a.clone(), absent_b.clone()];
+        let needed = store.objects_needed(&list).expect("objects_needed");
+        assert_eq!(needed, vec![absent_b.clone(), absent_a, absent_b]);
+
+        // Everything present -> empty complement.
+        assert_eq!(
+            store.objects_needed(&seeded).expect("ok"),
+            Vec::<String>::new()
+        );
+    }
+
+    #[test]
+    fn pack_objects_needed_invalid_checksum_fails_closed() {
+        let (_dir, store, seeded) = seed_store("needed-bad", &[b"x\n".to_vec()]);
+        let valid_absent = hex_of(b"absent");
+        for bad in [
+            "UPPERCASE0000000000000000000000000000000000000000000000000000AA".to_owned(),
+            "0123456789abcdef".repeat(4)[..63].to_owned(),
+            format!("{}0", "0123456789abcdef".repeat(4)),
+            "not hex at all".to_owned(),
+            String::new(),
+        ] {
+            // The invalid entry errors the WHOLE call even when valid entries
+            // precede it — nothing is returned (fail closed).
+            let list = vec![seeded[0].clone(), valid_absent.clone(), bad.clone()];
+            let err = store.objects_needed(&list).expect_err("must fail closed");
+            assert!(
+                err.to_string().contains("invalid object checksum"),
+                "checksum {bad:?}: got {err}"
+            );
+        }
+    }
+}

--- a/crates/snapdir-stores/src/stream.rs
+++ b/crates/snapdir-stores/src/stream.rs
@@ -92,4 +92,55 @@ pub trait StreamStore: Store {
     /// - [`StoreError::Integrity`] if the manifest does not hash to `id`.
     /// - [`StoreError::Io`] / [`StoreError::Backend`] on transport failure.
     fn put_manifest(&self, id: &str, manifest: &Manifest) -> Result<(), StoreError>;
+
+    /// Returns the subset of `checksums` NOT present in the store, PRESERVING
+    /// INPUT ORDER.
+    ///
+    /// This is the diff primitive behind the `snapdir objects-needed` wire
+    /// plumbing (SNAPPACK acceleration, see [`crate::pack`]): a sender offers
+    /// a snapshot's full object list and the receiver answers with exactly the
+    /// objects it still needs, so only those ride the pack stream.
+    ///
+    /// Semantics:
+    ///
+    /// - **Fail closed:** every checksum is validated against
+    ///   `^[0-9a-f]{64}$` ([`crate::pack::is_hex64`]) BEFORE the first
+    ///   existence probe; any invalid entry is a hard error and nothing is
+    ///   returned (a malformed request must never be partially answered).
+    /// - **Order-preserving, no dedup:** the returned complement keeps the
+    ///   input order, and deduplication is the CALLER's job — an absent
+    ///   checksum supplied twice is reported twice.
+    /// - The default implementation loops [`has_object`](Self::has_object)
+    ///   (one existence probe per checksum). Follow-up (not this gate): the
+    ///   S3/GCS backends should override this with their batched listing APIs
+    ///   to cut round trips — any override must preserve the exact contract
+    ///   above.
+    ///
+    /// # Errors
+    ///
+    /// - [`StoreError::Backend`] if any checksum is not 64 lowercase hex
+    ///   characters (fail closed, before any probe).
+    /// - Whatever [`has_object`](Self::has_object) surfaces on transport
+    ///   failure.
+    fn objects_needed(&self, checksums: &[String]) -> Result<Vec<String>, StoreError> {
+        // Validate EVERYTHING up front so an invalid entry can never be
+        // answered partially (fail closed).
+        for checksum in checksums {
+            if !crate::pack::is_hex64(checksum) {
+                return Err(StoreError::Backend {
+                    message: format!(
+                        "invalid object checksum {checksum:?}: expected 64 lowercase hex characters"
+                    ),
+                    source: None,
+                });
+            }
+        }
+        let mut needed = Vec::new();
+        for checksum in checksums {
+            if !self.has_object(checksum)? {
+                needed.push(checksum.clone());
+            }
+        }
+        Ok(needed)
+    }
 }

--- a/docs/adr/0000-index.md
+++ b/docs/adr/0000-index.md
@@ -35,3 +35,4 @@ earlier one.
 | [0024](0024-retire-the-bash-oracle.md) | Retire the Bash oracle (full cut) | Accepted |
 | [0025](0025-keep-native-certs.md) | Keep native-certs in the scratch image | Accepted |
 | [0026](0026-latest-deps-with-release-age-cooldown.md) | Adopt latest deps with a 3-day minimum-release-age | Accepted |
+| [0027](0027-ssh-sftp-stores-system-openssh-wire-plumbing.md) | SSH/SFTP stores via system OpenSSH + wire-versioned plumbing | Accepted |

--- a/docs/adr/0027-ssh-sftp-stores-system-openssh-wire-plumbing.md
+++ b/docs/adr/0027-ssh-sftp-stores-system-openssh-wire-plumbing.md
@@ -1,0 +1,76 @@
+# 0027 — SSH/SFTP stores via system OpenSSH + wire-versioned plumbing
+
+Status: Accepted, 2026-06
+
+## Context
+
+Users want to push/pull snapshots to plain SSH hosts, including restricted
+accounts that only offer SFTP (`ForceCommand internal-sftp` chroots). snapdir
+already routes any unknown `--store` scheme to an external `snapdir-<scheme>-store`
+binary via the emit-command contract, so new schemes need no router change.
+The decision drivers:
+
+- **No new crypto dependencies.** The deny.toml posture is deliberately pinned
+  to the ring-backed rustls stack (ADR-0004); a native SSH implementation
+  (russh) would import a large independent crypto tree.
+- **Performance.** Per-object round trips over SSH are prohibitive; OpenSSH's
+  `ControlMaster` multiplexing amortizes one TCP+auth handshake per operation,
+  and a remote manifest-diff turns O(N) existence probes into O(1) round trips
+  when snapdir is installed remotely.
+- **Restricted accounts.** A meaningful share of SSH endpoints are
+  sftp-only chroots with no shell, so a pure-SFTP engine must exist alongside
+  the shell engine.
+- **Integrity.** Remote writes must keep the verify-then-rename and
+  manifest-last disciplines the native stores guarantee.
+
+## Decision
+
+Ship a new workspace crate `crates/snapdir-ssh-store` (sole dependency
+`snapdir-core`) with two binaries implementing the emit-command contract over
+the **system OpenSSH client**:
+
+- `snapdir-sftp-store` (`sftp://`) — pure SFTP batchfiles; works with no
+  remote shell.
+- `snapdir-ssh-store` (`ssh://`) — remote POSIX shell + a batched-probe /
+  single-`tar | ssh`-pipeline dumb path, plus a runtime-negotiated
+  acceleration: hidden CLI plumbing (`snapdir version --capabilities`,
+  `objects-needed`, `send-pack`, `receive-pack`) speaking the custom
+  **SNAPPACK 1** pack format (`docs/rust-port/ssh-wire-protocol.md`), with
+  the remote end BLAKE3-verifying every record and committing the manifest
+  only after the verified `end` trailer.
+
+Both engines emit an **ordered, un-weakenable security floor** ahead of every
+ssh/sftp invocation (modern-only kex/AEAD ciphers/host keys,
+`StrictHostKeyChecking=yes`, `BatchMode=yes`; user `EXTRA_OPTS` are appended
+last, so OpenSSH's first-obtained-value-wins rule makes them unable to weaken
+the floor), and fail closed below OpenSSH 8.5. Compatibility negotiation keys
+on an exact `wire=<u32>` integer match — never on semver.
+
+## Alternatives considered
+
+- **Native russh `StreamStore` (in-process SSH).** Deferred, not rejected: it
+  is the only way to support `sync` over ssh, but it imports a large crypto
+  tree into the deny.toml ring posture for a use case nobody has asked for
+  yet. Revisit when a sync-to-ssh need exists.
+- **Raw `tar | ssh` without remote verification.** Rejected: a dumb remote
+  `tar -x` cannot hash payloads or commit the manifest last, breaking the
+  verify-then-rename discipline every other store guarantees (and exposing
+  the tar entry-name attack surface).
+- **The `tar` crate for the pack format.** Rejected: both ends of the pack
+  pipe are snapdir itself, so a ~40-line custom format (SNAPPACK) avoids tar
+  semantics — entry names, padding, permission metadata — entirely, with zero
+  new dependencies and no path-traversal class.
+
+## Consequences
+
+- `snapdir sync` does not support `ssh://`/`sftp://` (external stores have no
+  in-process streaming surface); `push`/`fetch`/`pull`/`checkout` all work.
+  Documented limitation.
+- Wire compatibility is governed by the `wire` integer, independent of
+  release versions; older/newer remotes degrade gracefully to the dumb path,
+  which stays byte-identical to the accelerated path (oracle-gated).
+- The local OpenSSH client must be ≥ 8.5 (fail-closed, no override); stock
+  clients on e.g. RHEL 8 / Ubuntu 20.04 / Debian 11 are excluded by policy.
+- The transport inherits the user's SSH ecosystem (agent, `~/.ssh/config`,
+  `ProxyJump`, known_hosts) instead of reimplementing it; host-key trust is
+  fail-closed and cannot be disabled through snapdir.

--- a/docs/rust-port/CHANGELOG.md
+++ b/docs/rust-port/CHANGELOG.md
@@ -7,6 +7,55 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`ssh://` and `sftp://` stores over the system OpenSSH client.** A new
+  `snapdir-ssh-store` crate ships two external-store binaries —
+  `snapdir-ssh-store` (`ssh://`, needs a remote POSIX shell) and
+  `snapdir-sftp-store` (`sftp://`, pure SFTP; works against restricted
+  `ForceCommand internal-sftp` chroot accounts) — with no SSH
+  reimplementation and zero new crypto dependencies. Store URLs take
+  `ssh://[user@]host[:port]/abs/base`; each scheme reads its own
+  `SNAPDIR_{SSH,SFTP}_STORE_*` env family (`IDENTITY_FILE`, `KNOWN_HOSTS`,
+  `PORT`, `CONNECT_TIMEOUT`, `JOBS`, `CONTROL_PERSIST`, `UMASK`,
+  `EXTRA_OPTS`). Every invocation multiplexes over one `ControlMaster`
+  connection and starts with an un-weakenable modern-only security floor
+  (pinned kex/AEAD-cipher/host-key lists, `StrictHostKeyChecking=yes`,
+  `BatchMode=yes`; `EXTRA_OPTS` are appended last and structurally cannot
+  weaken it); OpenSSH ≥ 8.5 is required locally, fail-closed. `snapdir sync`
+  does not support these stores.
+- **Automatic `ssh://` acceleration via SNAPPACK.** When the remote host has
+  a wire-compatible `snapdir` on its `PATH`, pushes and fetches negotiate at
+  runtime (exact `wire=1` integer match, never semver) and switch to a
+  self-verifying pack stream: the object list is diffed remotely and only
+  missing objects ride one `send-pack | receive-pack` pipe, with the manifest
+  as the last record, committed only after the verified `end` trailer —
+  manifest-last preserved end-to-end, byte-identical to the plain path.
+  Graceful fallback when the remote lacks the plumbing;
+  `SNAPDIR_SSH_NO_ACCEL=1`, `SNAPDIR_SSH_FORCE_ACCEL=1`, and
+  `SNAPDIR_SSH_PULL_SENDALL=1` control it. Spec:
+  `docs/rust-port/ssh-wire-protocol.md`.
+- **Hidden wire plumbing in the CLI.** `snapdir version --capabilities`
+  prints the negotiation line (`snapdir <semver> wire=<u32> caps=<csv>`), and
+  three hidden subcommands — `objects-needed`, `send-pack`, `receive-pack` —
+  implement the pack protocol over any built-in store with fail-closed input
+  validation and incremental BLAKE3 verification. The documented CLI surface
+  and plain `snapdir version` output are unchanged.
+- **`StreamStore::objects_needed`.** A defaulted trait method answering which
+  of the offered checksums a store does not hold (order-preserving,
+  fail-closed validation), available across the `file://`, `s3://`, `gs://`,
+  and `b2://` stores.
+
+### Fixed
+
+- **External-store CLI wiring.** `snapdir push`/`fetch --store` against an
+  external `snapdir-<scheme>-store` binary passed directory *trees* where the
+  emit-command contract expects *sharded store roots*, breaking every
+  external store end-to-end. Push now stages the snapshot into the local
+  cache and pushes from the cache root, and fetch lands objects directly in
+  the cache root, committing the manifest last. Affects all
+  `snapdir-*-store` binaries; the built-in stores were never affected.
+
 ## [1.4.0] — 2026-06-09
 
 ### Added

--- a/docs/rust-port/CHANGELOG.md
+++ b/docs/rust-port/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] — 2026-06-10
+
 ### Added
 
 - **`ssh://` and `sftp://` stores over the system OpenSSH client.** A new
@@ -329,7 +331,8 @@ Bash-written caches and remote buckets stay mutually readable.
   `gcloud`) in the shipped binary. External tools are used only by the test
   suite.
 
-[Unreleased]: https://github.com/snapdir/snapdir/compare/v1.4.0...HEAD
+[Unreleased]: https://github.com/snapdir/snapdir/compare/v1.5.0...HEAD
+[1.5.0]: https://github.com/snapdir/snapdir/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/snapdir/snapdir/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/snapdir/snapdir/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/snapdir/snapdir/compare/v1.1.0...v1.2.0

--- a/docs/rust-port/ssh-wire-protocol.md
+++ b/docs/rust-port/ssh-wire-protocol.md
@@ -1,0 +1,210 @@
+# snapdir SSH wire protocol — SNAPPACK 1 and the plumbing subcommands
+
+> This document is the normative description of the wire protocol behind the
+> `ssh://` store's acceleration path: the **SNAPPACK 1** pack stream, the
+> capability/negotiation line, and the three hidden plumbing subcommands
+> (`objects-needed`, `send-pack`, `receive-pack`). The implementation of
+> record is `crates/snapdir-stores/src/pack.rs` (format + reader/writer) and
+> `crates/snapdir-cli/src/cli.rs` (the plumbing CLI). If this prose and the
+> code disagree, the code and its tests win — report the discrepancy.
+
+The pack stream carries raw content-addressed objects (and at most one
+manifest) between two snapdir processes, e.g.
+`snapdir send-pack | ssh host 'snapdir receive-pack'`. Both ends of the pipe
+are snapdir itself, so the format is deliberately minimal: no tar semantics,
+no entry names, no padding.
+
+---
+
+## 1. SNAPPACK 1 grammar
+
+```text
+stream   := "SNAPPACK 1\n" record* "end\n"
+record   := "obj " hex64 " " len "\n" payload(len)
+          | "manifest " hex64 " " len "\n" payload(len)   ; at most one; must be the LAST record
+hex64    := 64 lowercase hex chars, regex ^[0-9a-f]{64}$ (validated on read AND write)
+len      := decimal u64
+payload  := exactly len raw bytes, no padding/terminator
+```
+
+The magic line is exactly `SNAPPACK 1\n` — the version is baked into the
+magic (`pack::WIRE_MAGIC`, pinned by test to `pack::WIRE_VERSION = 1`).
+
+### 1.1 Limits
+
+- **Header cap — 128 bytes.** Every header line, *including* its terminating
+  `\n`, is at most `MAX_HEADER_BYTES = 128` bytes. The reader rejects a longer
+  line the moment the cap is hit, without buffering more — this bounds reader
+  memory before any validation happens. (The longest valid header,
+  `manifest <hex64> <u64::MAX>\n`, is 95 bytes.)
+- **Manifest cap — 64 MiB.** A `manifest` record's payload (which, unlike
+  `obj` payloads, is buffered in memory until the `end` trailer commits it) is
+  capped at `MAX_MANIFEST_BYTES = 64 MiB`.
+
+### 1.2 Reader invariants
+
+- **Streaming + incremental BLAKE3.** Every payload streams through an
+  incremental BLAKE3 hasher while it is staged. On `file://` sinks, `obj`
+  payload bytes stream through a fixed-size buffer into a temp sibling of the
+  final object path (the same temp + atomic-rename discipline as the file
+  store) — O(1) memory per record regardless of object size.
+- **Verify-before-file.** An object is committed at its claimed
+  content-address only if the computed hash equals the claimed `hex64`. A
+  mismatch removes the staged bytes and aborts the WHOLE stream — everything
+  after a corrupt record is tainted. The on-disk location is derived
+  exclusively from the validated claimed checksum (the sharded
+  `object_path`/`manifest_path` layout); there is no entry-name concept, so
+  the path-traversal class is structurally absent.
+- **Truncation never commits.** The optional `manifest` record must be the
+  last record (any record after it is rejected); its payload is buffered and
+  committed to the sink **only after the `end` trailer has been read**. EOF
+  before `end` is a hard error and the manifest is NEVER committed — a
+  truncated stream or dropped connection can file (verified) objects but can
+  never make the snapshot observable, preserving the store-wide manifest-last
+  invariant on the receiving side.
+- **Manifest double-check.** The manifest payload must hash to the claimed
+  snapshot id, must parse, and the parsed manifest must re-render to the same
+  id — a payload that raw-hashes correctly but is not the canonical
+  serialization is rejected.
+- **Idempotent duplicates.** A duplicate `obj` record (or one whose object the
+  sink already holds) is skipped (write-once), but its bytes are still
+  consumed and hash-verified — the stream cannot seek, and a hash mismatch on
+  ANY record aborts.
+
+### 1.3 Writer invariants
+
+- Every id (and the optional manifest id) is validated against
+  `^[0-9a-f]{64}$` **before any byte is written**.
+- The manifest is fetched and re-verified up front (fail fast) but emitted
+  **last**; object records are emitted in input order, each re-verified to
+  hash to its id before its record is written.
+- Any failure — including a missing requested object — aborts **before** the
+  `end` trailer is emitted, so a consumer of the partial stream fails too: no
+  silent partial transfer.
+- Duplicates in the input emit duplicate records; deduplication is the
+  caller's job (the CLI plumbing dedupes, preserving first-occurrence order).
+
+---
+
+## 2. Capability line and negotiation
+
+`snapdir version --capabilities` (a hidden flag on the `version` subcommand)
+prints one line:
+
+```text
+snapdir <semver> wire=<u32> caps=<csv>
+```
+
+e.g. `snapdir 1.4.0 wire=1 caps=objects-needed,send-pack,receive-pack`.
+
+- The grammar is space-separated `key=value` fields after the program name and
+  semver; **unknown fields are ignored** by consumers (forward-compatible).
+- **Negotiation keys on the exact `wire` integer match — NEVER on the
+  semver.** A probe accepts a remote only when its line carries the exact
+  ` wire=1 ` token and every required capability as a member of the `caps=`
+  comma list (push requires `objects-needed,receive-pack`; fetch requires
+  `send-pack`).
+- Older snapdir versions error on the unknown `--capabilities` flag; the probe
+  treats any output without a parsable capability line as "no acceleration" —
+  clean degradation with no special code on that path. Plain `snapdir version`
+  output is unchanged.
+
+---
+
+## 3. The plumbing subcommands
+
+All three are hidden from the documented CLI surface and fail closed: every
+checksum input is validated against `^[0-9a-f]{64}$` before any store access
+or any output.
+
+### 3.1 `snapdir objects-needed --store <url>`
+
+- **stdin:** candidate object checksums, one per line.
+- **stdout:** exactly the subset the store does NOT hold, one per line, in
+  first-occurrence input order (input is deduped, order preserved).
+- **Fail-closed:** ANY malformed line errors (nonzero exit) before the store
+  is even resolved, with NOTHING on stdout — a malformed request is never
+  partially answered. Empty input is valid and prints nothing.
+- Routes through the same stream-store resolver as `sync`, so it works for
+  `file://`, `s3://`, `gs://`, and `b2://`; external `snapdir-*-store` URLs
+  are rejected.
+
+### 3.2 `snapdir send-pack --store <url> --ids <FILE|-> [--manifest-id <id>]`
+
+- **input:** `--ids` names a file listing one checksum per line (`-` reads
+  stdin). The list is validated and deduped (first-occurrence order) before
+  any store work; a malformed list emits not a single pack byte.
+- **stdout:** the raw SNAPPACK stream — the byte stream is the entire stdout
+  contract; the `sent pack: …` summary goes to stderr (suppressed by
+  `--quiet`).
+- With `--manifest-id`, that snapshot's manifest rides the pack as the LAST
+  record.
+- **exit:** nonzero on any failure, per the writer invariants above (abort
+  before `end`, so the piped consumer fails too).
+
+### 3.3 `snapdir receive-pack --store <url> [--require-manifest <id>]`
+
+- **stdin:** a SNAPPACK stream, consumed per the reader invariants above.
+  `file://` stores stream each payload through the O(1)-memory temp-sibling
+  sink; every other stream store buffers one record at a time.
+- `--require-manifest <id>` (validated up front) fails the command — after
+  the read — unless the stream committed a manifest with EXACTLY that id;
+  without the flag an objects-only stream is success.
+- **stdout:** silent. The `received pack: …` summary goes to stderr
+  (suppressed by `--quiet`).
+- **exit:** nonzero on any protocol violation, hash mismatch, truncation, or
+  an unmet `--require-manifest`.
+
+---
+
+## 4. Accelerated dataflows (`ssh://` store)
+
+The emitted `ssh://` scripts embed BOTH the dumb tar pipeline and the
+accelerated path and dispatch at script runtime (emit time has no
+connection). `SNAPDIR_SSH_NO_ACCEL=1` — or no usable local `snapdir` binary —
+forces the dumb path; `SNAPDIR_SSH_FORCE_ACCEL=1` turns a failed negotiation
+into a designed error instead of a fallback. Both paths produce byte-identical
+stores (the dumb-vs-accel oracle gate).
+
+### 4.1 Push — 3 round trips
+
+1. **Combined probe** (one round trip): `test -f <manifest path>` (`manifest=0|1`)
+   plus `command -v snapdir && snapdir version --capabilities || echo 'caps
+   none'`. A present manifest short-circuits (`Manifest already exists on
+   store.`, exit 0). A probe *transport* failure surfaces the real ssh exit
+   code — connectivity never masquerades as absence or as "no capabilities".
+2. **Diff**: the manifest's deduped object checksums go to the remote
+   `snapdir objects-needed --store file://<base>`, which answers with exactly
+   the absent subset.
+3. **Stream**: one local
+   `snapdir send-pack --store file://<staging> --ids <missing> --manifest-id <id>`
+   piped into the remote
+   `snapdir receive-pack --store file://<base> --require-manifest <id>`.
+   The manifest rides the pack as the last record and the remote commits it
+   only after the verified `end` trailer — the manifest-last invariant is
+   preserved end-to-end with no fourth round trip. An EMPTY missing set still
+   streams the manifest-only pack (this is what completes a previously
+   interrupted push).
+
+### 4.2 Fetch — 2 round trips
+
+1. **Caps-only probe** (skipped entirely when the emit-time cache diff leaves
+   nothing to fetch).
+2. **Stream**: the runtime-chosen id list (the emit-time cache diff, or the
+   full list under `SNAPDIR_SSH_PULL_SENDALL=1`) feeds
+   `ssh 'snapdir send-pack --store file://<base> --ids -'` piped into a LOCAL
+   `snapdir receive-pack --store file://<cache>` (no `--require-manifest` —
+   the manifest already arrived via `get-manifest-command`). The remote
+   stream is fully untrusted: the local receive-pack incrementally
+   BLAKE3-verifies every record in O(1) memory.
+
+### 4.3 Fallback policy
+
+- A probe or diff failure (ssh reachable, plumbing absent/broken) falls back
+  to the dumb path: nothing has been written yet, and the dumb path is
+  idempotent.
+- A failure of the send|receive **stream itself** exits nonzero with a retry
+  hint and NEVER silently retries on the dumb path — a mid-stream failure is
+  likely environmental and would hit the dumb path too, and a user retry
+  resumes incrementally for free (objects already filed are verified-then-
+  skipped; the manifest was never committed).

--- a/packaging/dist-workspace.toml
+++ b/packaging/dist-workspace.toml
@@ -6,9 +6,13 @@
 # (`.github/workflows/release.yml`) drives it on `v*` tags.
 #
 # Lane note (packaging): this file is the load-bearing artifact for the
-# `release-config` gate. The actual binary lives in `crates/snapdir-cli`
-# (bin name `snapdir`). Library crates (core/catalog/stores) are published to
-# crates.io by the workflow, NOT shipped as binaries here.
+# `release-config` gate. The primary binary lives in `crates/snapdir-cli`
+# (bin name `snapdir`); the external-store helper bins `snapdir-ssh-store` and
+# `snapdir-sftp-store` live in `crates/snapdir-ssh-store` and ship in the SAME
+# per-target archive (all targets, incl. the static musl legs — the crate is
+# std + snapdir-core only, so musl stays trivially clean). Library crates
+# (core/catalog/stores) are published to crates.io by the workflow, NOT
+# shipped as standalone archives here.
 #
 # NB: `dist` reads `[workspace]` from this file so the tool can run with
 # `--workspace packaging/dist-workspace.toml` while the real Cargo workspace
@@ -20,8 +24,15 @@ members = ["cargo:../"]
 # Pin the dist version the CI installer fetches so releases are reproducible.
 cargo-dist-version = "0.28.0"
 
-# Publish/announce only the `snapdir` binary from snapdir-cli. The library
-# crates are released to crates.io separately (see release.yml `crates-io`).
+# Package selection: `dist` auto-detects every workspace package with [[bin]]
+# targets (snapdir-cli -> `snapdir`; snapdir-ssh-store -> `snapdir-ssh-store`
+# + `snapdir-sftp-store`); the workspace-level `dist = false` keeps dist's own
+# publish/announce machinery off because release.yml's hand-rolled matrix is
+# the implementation of record — it builds all three bins per target
+# (`-p snapdir-cli -p snapdir-ssh-store --bins`) and stages them into one
+# archive per target. The library crates are released to crates.io separately
+# (see release.yml `crates-io`, order core -> catalog -> stores -> ssh-store
+# -> cli).
 dist = false
 
 # Hosting + release driver.

--- a/utils/ci/pre-push.sh
+++ b/utils/ci/pre-push.sh
@@ -55,6 +55,11 @@ MSRV="1.91.1"
 COVERAGE_FLOOR=75
 BUILDER_IMAGE="rust:1.96-slim-bookworm"
 
+# Mirror ci.yaml: the snapdir-ssh-store loopback sshd suite must RUN, never
+# eprintln-skip (macOS ships /usr/sbin/sshd; Linux: apt-get install
+# openssh-server). Applies to the test group AND coverage (llvm-cov runs tests).
+export SNAPDIR_SSH_TEST_REQUIRE=1
+
 # Accumulated failures: each entry is "CHECK NAME|||reproduce command".
 FAILURES=()
 


### PR DESCRIPTION
## snapdir 1.5.0 — sftp:// and ssh:// stores

### Added
- **`sftp://` store** (`snapdir-sftp-store`): pure-SFTP engine over the system OpenSSH client; works against restricted `ForceCommand internal-sftp` (chroot) servers. Parallel batched transfers over a single ControlMaster connection; atomic put-tmp/rename per object; manifest committed last.
- **`ssh://` store** (`snapdir-ssh-store`): shell-based engine with batched existence probing and a single atomic `tar | ssh` pipeline — plus **runtime-negotiated acceleration** when a compatible `snapdir` is on the remote: one probe round trip, remote manifest diff via `objects-needed`, and a single verified `send-pack | receive-pack` SNAPPACK stream with the manifest as the trailing commit. O(1) round trips instead of O(N) per-object probes; graceful fallback to the plain path (`SNAPDIR_SSH_NO_ACCEL` / `SNAPDIR_SSH_FORCE_ACCEL` / `SNAPDIR_SSH_PULL_SENDALL`).
- Un-weakenable modern-only OpenSSH security floor (≥ 8.5): `StrictHostKeyChecking=yes`, AEAD-only ciphers, modern kex/host-key algorithms, `BatchMode`, no password auth; user `EXTRA_OPTS` and `~/.ssh/config` cannot weaken it.
- SNAPPACK 1 wire format + hidden plumbing subcommands (`objects-needed`, `send-pack`, `receive-pack`, `version --capabilities`); BLAKE3 verify-then-rename on every record at both ends; a truncated stream can never publish a manifest. `StreamStore::objects_needed` (defaulted) for all native stores.
- Loopback-sshd integration suite (no docker) required in CI test+coverage on both OSes.
- Docs: README store rows + SSH/SFTP section, normative wire-protocol spec, ADR-0027.

### Fixed
- External-store CLI wiring: `push`/`fetch`/`pull` against any `snapdir-<scheme>-store` binary passed source/scratch *trees* where the emit-command contract expects *sharded store roots* — broken end-to-end for all external stores; now routed through the local cache with manifest-last preserved, covered by a `mock://` e2e test.

### Notes
- 12 commits, all gates green on the gatesmith ledger (165/165 at sign-off); workspace 554 tests / 0 failures with the sshd suite forced on.
- New crate `snapdir-ssh-store` (bins `snapdir-ssh-store` + `snapdir-sftp-store`), snapdir-core-only deps; publish loop + release archives updated. First crates.io publish of the new name needs Trusted-Publishing registration (operator step before tagging).
- Frozen manifest format and sharding untouched. `sync` intentionally does not support ssh/sftp stores (ADR-0027).