### PR TITLE
release: 1.7.0

### DIFF
--- a/.github/workflows/bench-verify.yml
+++ b/.github/workflows/bench-verify.yml
@@ -92,6 +92,20 @@ jobs:
             -- --warm-up-time 1 --measurement-time 3 --sample-size 10 \
             | tee -a bench-output.log || true
 
+      # snappack RECEIVE perf (informational): the load-bearing batch-vs-off
+      # number for the Phase-27 release gate. Filter `pack/receive/a` matches the
+      # 5k×4KiB text-like receive benches `pack/receive/a/{v1,zstd}/{off,batch}`
+      # only (scenario b — 256×1MiB incompressible — is skipped to keep CI cheap).
+      # The operator reads the batch-vs-off delta from these lines in the artifact.
+      - name: snappack receive perf
+        shell: bash
+        run: |
+          set -uo pipefail
+          mkdir -p target
+          cargo bench -p snapdir-benches --bench snappack 2>&1 \
+            -- 'pack/receive/a' --warm-up-time 1 --measurement-time 3 --sample-size 10 \
+            | tee -a bench-output.log || true
+
       - name: Upload bench results
         if: always()
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -165,6 +165,62 @@ jobs:
         run: cargo bench --workspace --no-run --locked
 
   # --------------------------------------------------------------------------
+  # Reflink (Linux FICLONE / copy-on-write): exercise the REAL clone fast-path.
+  # The standard ubuntu-latest runner is ext4, where FICLONE never fires (only
+  # the fs::copy fallback), so the `test` matrix above covers only the Linux
+  # FALLBACK path; APFS clonefile is covered by the macos-latest matrix leg.
+  # This job mounts a loopback Btrfs image (a reflink-capable FS) on the
+  # standard runner — no special/self-hosted runner — so the FICLONE ioctl
+  # genuinely fires and the reflink/clone-skip suites assert clonefile_hits()
+  # actually advanced. Mirrors the loopback-sshd sudo-env precedent in `test`.
+  #
+  # REQUIRED job (no continue-on-error): if the loopback mount ever proves
+  # flaky on the hosted runner, the documented fallback is to add
+  # `continue-on-error: true` here (a 1.7.x hardening step) — but ship it
+  # required so a broken FICLONE path can't merge silently.
+  # --------------------------------------------------------------------------
+  reflink:
+    name: Reflink (Btrfs FICLONE)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+
+      - name: Cache cargo artifacts
+        uses: Swatinem/rust-cache@v2
+        with:
+          key: reflink
+
+      # A loopback Btrfs image gives us a real reflink-capable filesystem on the
+      # stock ubuntu-latest runner (its root FS is ext4 → FICLONE never fires).
+      # chmod 1777 lets the unprivileged runner user create the src+store dirs
+      # the tests place under SNAPDIR_REFLINK_TEST_DIR / TMPDIR.
+      - name: Set up Btrfs loopback for reflink tests
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends btrfs-progs
+          truncate -s 2G /tmp/reflink.img
+          mkfs.btrfs -q /tmp/reflink.img
+          sudo mkdir -p /mnt/reflink
+          sudo mount -o loop /tmp/reflink.img /mnt/reflink
+          sudo chmod 1777 /mnt/reflink        # unprivileged runner user must create dirs
+
+      # reflink.rs is env-gated on SNAPDIR_REFLINK_TEST_DIR (+ _REQUIRE=1 makes a
+      # missing dir a hard panic, so this required leg can't rot into a silent
+      # skip). clone_skip / clone_skip_race use std::env::temp_dir(), so pointing
+      # TMPDIR at the Btrfs mount runs the StatGuarded skip + TOCTOU/race suites
+      # against REAL reflink for free.
+      - name: Reflink tests on Btrfs
+        run: cargo test -p snapdir-stores --test reflink --test clone_skip --test clone_skip_race --locked
+        env:
+          SNAPDIR_REFLINK_TEST_DIR: /mnt/reflink
+          TMPDIR: /mnt/reflink
+          SNAPDIR_REFLINK_TEST_REQUIRE: "1"
+
+  # --------------------------------------------------------------------------
   # Bench (iai-callgrind): deterministic CPU instruction-count perf gate.
   # Runs the real valgrind/callgrind measurement on a native Linux runner using
   # the SAME toolchain + iai-callgrind-runner pins as benches/run-iai-docker.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,9 @@ name: Release
 # crates.io. The publish jobs (release/crates-io) are hard-gated on a real
 # `v*` TAG PUSH (`github.event_name == 'push'`), so a manual run can never publish
 # regardless of the `dry_run` input value.
-#   - GitHub UI: Actions -> Release -> Run workflow -> branch `main`,
+#   - GitHub UI: Actions -> Release -> Run workflow -> branch `dev`,
 #     leave `dry_run: true`.
-#   - CLI:       gh workflow run release.yml --ref main -f dry_run=true
+#   - CLI:       gh workflow run release.yml --ref dev -f dry_run=true
 # A real publish still happens ONLY by pushing a semver tag (e.g. `git tag v0.5.0
 # && git push origin v0.5.0`).
 

--- a/.gitignore
+++ b/.gitignore
@@ -10,5 +10,9 @@ utils/qa-fixtures/latest-guide-commands.txt
 **/*.rs.bk
 # Cargo.lock is intentionally committed (binary workspace).
 
+# --- Gatesmith run artifacts ---
+.gatesmith/evidence/
+.gatesmith/handoff/
+
 # Coverage output (cargo llvm-cov / pre-push suite)
 lcov.info

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ and beta.
 | `crates/snapdir`         | The `snapdir` binary — a thin shim over `snapdir-cli`      |
 | `crates/snapdir-ssh-store` | `ssh://` + `sftp://` external-store binaries (system OpenSSH) |
 | `benches/`               | Criterion micro-benchmarks (`snapdir-benches`)             |
-| `tests/`                 | Integration + interop tests                                |
+| `tests/`                 | Integration + interop harnesses                            |
 
 ## Before you open a PR
 
@@ -40,7 +40,7 @@ cargo clippy --workspace --all-targets -- -D warnings
 
 `cargo fmt --all` applies formatting in place. All three must be clean.
 
-## Local CI check (pre-push hook)
+## Local CI gate (pre-push hook)
 
 `ci.yaml` runs on every push and burns paid GitHub Actions minutes — including
 on red commits. To catch failures *before* they reach CI, `utils/ci/pre-push.sh`
@@ -92,18 +92,22 @@ the script print the exact install command instead.
 
 ## The byte-format contract
 
-The port is **complete**: the legacy Bash implementation was removed, and the
-manifest byte-format contract is now guarded entirely in Rust by
-**`crates/snapdir-core/tests/compat_golden.rs`** — Rust golden-constant tests
-that assert the exact bytes of manifest lines, directory merkle checksums, and
-snapshot IDs against pinned golden values. Any accidental change to the line
-format, ordering, checksum algorithm, sharded layout, or exclude sets fails the
-golden tests.
+The port is **complete**: the legacy Bash implementation was removed in
+Phase 11, and the manifest byte-format contract is now guarded entirely in Rust.
+Two mechanisms keep the on-disk format frozen:
+
+- **`crates/snapdir-core/tests/compat_golden.rs`** — Rust golden-constant tests
+  that assert the exact bytes of manifest lines, directory merkle checksums, and
+  snapshot IDs against pinned golden values.
+- **`manifest-format.sha.lock`** — a tripwire over the format-defining source so
+  any accidental change to the line format, ordering, checksum algorithm,
+  sharded layout, or exclude sets trips CI and demands an explicit, reviewed
+  bump.
 
 Changing the manifest line format, ordering, the checksum algorithm, sharding,
 or the exclude sets is a breaking change to the storage format: it requires
-maintainer approval and a deliberate update to the golden tests.
-See [`docs/rust-port/manifest-spec.md`](docs/rust-port/manifest-spec.md)
+maintainer approval and a deliberate update to the golden tests and the
+SHA-lock. See [`docs/rust-port/manifest-spec.md`](docs/rust-port/manifest-spec.md)
 for the frozen format and the architecture decision records in
 [`docs/adr/`](docs/adr/) for the rationale.
 
@@ -111,7 +115,7 @@ for the frozen format and the architecture decision records in
 
 The shipped binary does everything in-process. Never shell out to `b3sum`,
 `sqlite3`, `aws`, `b2`, or `gcloud` from `crates/` — external binaries are
-allowed only in the test suite.
+allowed only in the test/oracle harness.
 
 ## Commits and PRs
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -692,6 +692,8 @@ dependencies = [
  "cfg-if",
  "constant_time_eq",
  "cpufeatures 0.3.0",
+ "memmap2",
+ "rayon-core",
 ]
 
 [[package]]
@@ -770,6 +772,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "556e016178bb5662a08681bbe0f00f8e17631781a4dfc8c45e466e4b185ec27f"
 dependencies = [
  "find-msvc-tools",
+ "jobserver",
+ "libc",
  "shlex 2.0.1",
 ]
 
@@ -2304,6 +2308,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jobserver"
+version = "0.1.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+dependencies = [
+ "getrandom 0.3.4",
+ "libc",
+]
+
+[[package]]
 name = "js-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2381,6 +2395,15 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "memmap2"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "714098028fe011992e1c3962653c96b2d578c4b4bce9036e15ff220319b1e0e3"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "mime"
@@ -2592,6 +2615,12 @@ dependencies = [
  "der",
  "spki",
 ]
+
+[[package]]
+name = "pkg-config"
+version = "0.3.33"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "potential_utf"
@@ -3450,14 +3479,14 @@ dependencies = [
 
 [[package]]
 name = "snapdir"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "snapdir-cli",
 ]
 
 [[package]]
 name = "snapdir-benches"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "criterion",
  "iai-callgrind",
@@ -3468,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-catalog"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "redb",
  "serde",
@@ -3478,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-cli"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3496,12 +3525,13 @@ dependencies = [
 
 [[package]]
 name = "snapdir-core"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "blake3",
  "libc",
  "md-5",
  "proptest",
+ "rayon",
  "regex",
  "sha2 0.11.0",
  "thiserror",
@@ -3509,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-ssh-store"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "snapdir-core",
  "snapdir-stores",
@@ -3517,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-stores"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",
@@ -3529,11 +3559,13 @@ dependencies = [
  "google-cloud-gax",
  "google-cloud-storage",
  "http 1.4.1",
+ "libc",
  "rayon",
  "rustls",
  "snapdir-core",
  "thiserror",
  "tokio",
+ "zstd",
 ]
 
 [[package]]
@@ -4666,3 +4698,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.6.0"
+version = "1.7.0"
 edition = "2021"
 rust-version = "1.91.1"
 authors = ["Bermi Ferrer <bermi@bermilabs.com>"]
@@ -24,9 +24,9 @@ categories = ["command-line-utilities", "filesystem"]
 
 [workspace.dependencies]
 # Internal crates
-snapdir-core = { path = "crates/snapdir-core", version = "1.6.0" }
-snapdir-catalog = { path = "crates/snapdir-catalog", version = "1.6.0" }
-snapdir-stores = { path = "crates/snapdir-stores", version = "1.6.0" }
+snapdir-core = { path = "crates/snapdir-core", version = "1.7.0" }
+snapdir-catalog = { path = "crates/snapdir-catalog", version = "1.7.0" }
+snapdir-stores = { path = "crates/snapdir-stores", version = "1.7.0" }
 
 # Errors: thiserror in libs, anyhow (+ context) in the bin.
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -137,7 +137,53 @@ Both engines enforce an **un-weakenable, modern-only security floor** on every `
 
 When the remote host has a wire-compatible `snapdir` on its `PATH`, `ssh://` transfers automatically switch to a pack-stream protocol that diffs objects remotely and streams only what's missing in O(1) round trips (falling back gracefully otherwise). Runtime toggles: `SNAPDIR_SSH_NO_ACCEL=1` forces the plain path, `SNAPDIR_SSH_FORCE_ACCEL=1` errors instead of falling back, and `SNAPDIR_SSH_PULL_SENDALL=1` makes an accelerated fetch request the full object list. Protocol details: [docs/rust-port/ssh-wire-protocol.md](docs/rust-port/ssh-wire-protocol.md).
 
+The accelerated pack stream **auto-negotiates zstd compression** (SNAPPACK 1Z): compression engages only when *both* ends are this release or newer, so a mixed-version pair simply stays uncompressed — no flag, no version mismatch. The level defaults to zstd's level 3 and is tunable with `SNAPDIR_SSH_ZSTD_LEVEL` (accepted range `1`–`19`; out-of-range values are clamped). Because SNAPPACK now compresses *above* the transport, on a WAN — or with HPN-SSH — disable the SSH client's own compression to avoid double-compressing already-compressed bytes: `EXTRA_OPTS="Compression=no"` (or `-o Compression=no` in your `~/.ssh/config`).
+
 Limitation: `snapdir sync` does not support `ssh://`/`sftp://` stores (they have no in-process streaming surface) — `push`, `fetch`, `pull`, and `checkout` all work.
+
+Crash durability on the receive side is controlled by `SNAPDIR_FSYNC`: `batch` (the default) fsyncs all received objects before committing the manifest last, so a manifest that survives a crash is backed by durable objects; `off` skips the barrier and relies on the OS to flush. On a journaling filesystem this gives the same crash-consistency story git provides — and no more. The `batch` default costs ~20% on a small-files receive (measured v1 +19.5% / zstd +29.9% on 5,000 × 4 KiB on Linux) — a fixed per-object fsync cost on the receive-pack path only (the ordinary `file://`/S3/GCS push path is unaffected); `SNAPDIR_FSYNC=off` opts out for speed at the cost of crash-safety.
+
+## Scheduled inventories — one object pool, many manifest locations
+
+A snapshot is a manifest plus the content objects it references, and those two halves don't have to live together. The global `--objects-store` / `$SNAPDIR_OBJECTS_STORE` flag routes **objects** to one shared pool's `.objects/` while **manifests** route to wherever `--store` points (`.manifests/`). One pool, many manifest locations — and **you** own the manifest layout (by date, host, or environment).
+
+```sh
+# Cron: a fresh manifest path per run, all sharing ONE object pool.
+snapdir push \
+  --objects-store s3://inventory/objects \
+  --store "s3://inventory/manifests/$(date +%Y/%m/%d)" \
+  /var/lib/app/data
+```
+
+Because objects are content-addressed, re-pushing to the same pool only costs the **changed bytes** — unchanged objects are already present and are skipped. So a daily inventory of mostly-static data is cheap: each run writes a new manifest and uploads only what actually changed. The catalog records the `--store` (manifest-side) URI. `--objects-store` is global, so it applies to `fetch`/`pull`/`verify` the same way; leave it unset and behavior is byte-for-byte unchanged. An external `custom://` store is rejected on either side (both halves are resolved in-process).
+
+### Bucket-to-bucket sync with split pools
+
+`snapdir sync` copies a snapshot directly between stores. The per-side `--from-objects` / `--to-objects` flags name an explicit object pool for each side, so source and destination can be **different buckets** with their own object pools — and cross-pool dedup still applies: objects already present in the destination pool are skipped.
+
+```sh
+snapdir sync --id "$id" \
+  --from        s3://src/manifests --from-objects s3://src/objects \
+  --to          gs://dst/manifests --to-objects   gs://dst/objects
+```
+
+These flags are distinct from the global `--objects-store`; when a side omits its `--*-objects` flag, that side is a plain colocated store. (`sync` does not support `ssh://`/`sftp://` stores.)
+
+### `snapdir diff` — compare inventories, manifests only
+
+`snapdir diff` compares two sides, each a **set of manifest locations**, and reports file-level changes — `A` (added), `D` (deleted), `M` (modified). It **reads manifests only**: it never downloads an object, so diffing across scheduled inventories is cheap even when the object pool is huge or unreachable.
+
+```sh
+# What changed between yesterday's and today's inventory?
+snapdir diff \
+  --from s3://inventory/manifests/2026/06/10 \
+  --to   s3://inventory/manifests/2026/06/11
+```
+
+- `--from` / `--to` are **repeatable** and the refs on each side are **unioned** — point a side at several manifest stores (or, with the global `--id`, pin one side to a single manifest) and they merge into one logical set.
+- `--all` also emits unchanged (`=`) paths; `--json` emits a `{status, path}` array instead of porcelain `X\t./path` lines.
+- `--exit-code` adopts git's `diff --exit-code` semantics: exit `1` when any difference is found (after writing the report), `0` otherwise.
+- `--on-conflict <error|last-wins>` controls an intra-side collision (the same path with differing content unioned across two refs on one side): `error` (the default) fails hard naming the path; `last-wins` lets the last ref win.
 
 ## Rate limiting & retries
 

--- a/_typos.toml
+++ b/_typos.toml
@@ -34,6 +34,13 @@ anc = "anc"
 # AIMD = Additive Increase Multiplicative Decrease (TCP-style congestion control);
 # the Phase-18 adaptive tuner's algorithm — intentional, not "aimed".
 aimd = "aimd"
+# `fo` = from-objects, a temp-dir-name abbreviation in the sync-split CLI tests
+# (e.g. `temp_dir("fo-src")`); these are deliberate string literals, not "of"/"for".
+fo = "fo"
+# `mis` = the English prefix in "mis-addressed" — the clone-skip safety invariant
+# ("never a silently mis-addressed object") spelled with a hyphen across the
+# copy-guard / clone-skip test prose. Intentional prefix, not "miss"/"mist".
+mis = "mis"
 
 [default.extend-identifiers]
 # crate / API identifiers that look like typos but are intentional.

--- a/benches/Cargo.toml
+++ b/benches/Cargo.toml
@@ -62,6 +62,14 @@ harness = false
 name = "pipeline"
 harness = false
 
+# SNAPPACK send/receive wall-clock benches over text-like (compressible) and
+# incompressible corpora, comparing v1 vs zstd on the wire and fsync off vs
+# batch on receive. A `#[test]` pins bytes-on-wire (zstd < v1 for the text
+# scenario). See benches/benches/snappack.rs.
+[[bench]]
+name = "snappack"
+harness = false
+
 # Deterministic INSTRUCTION-COUNT perf gate (iai-callgrind, harness = false).
 # Measures CPU instruction counts over FIXED TINY deterministic inputs so the
 # counts are stable; FAILS on a >5% Ir / EstimatedCycles regression. Compiles on

--- a/benches/benches/hot_paths.rs
+++ b/benches/benches/hot_paths.rs
@@ -76,11 +76,16 @@ fn build_few_large(count: usize, bytes_each: usize) -> TempDir {
     tmp
 }
 
-/// Runs a default-options BLAKE3 walk over `root`, black-boxing the result.
-fn run_walk(root: &Path) {
+/// Runs a BLAKE3 walk over `root` with the given `walk_jobs` setting,
+/// black-boxing the result.
+fn run_walk(root: &Path, walk_jobs: Option<usize>) {
+    let options = WalkOptions {
+        walk_jobs,
+        ..WalkOptions::default()
+    };
     let manifest = walk(
         black_box(root),
-        black_box(&WalkOptions::default()),
+        black_box(&options),
         black_box(&Blake3Hasher::new()),
     )
     .expect("walk corpus");
@@ -88,7 +93,12 @@ fn run_walk(root: &Path) {
 }
 
 /// 2. Walk hot path: build the two corpora ONCE (outside the timed loop), then
-///    bench `walk()` over each.
+///    bench `walk()` over each, contrasting the **sequential baseline**
+///    (`walk_jobs = Some(1)`, honest single-threaded) against the **parallel
+///    default** (`walk_jobs = None`, `available_parallelism` clamped) and an
+///    explicit `Some(8)`. The fast-walk feature's win is exactly this
+///    seq-vs-parallel delta; the corpora behave very differently (per-file
+///    syscall overhead vs raw hashing throughput) so they keep separate IDs.
 fn bench_walk(c: &mut Criterion) {
     // many-small: a few thousand tiny files across nested dirs — dominated by
     // per-file syscall/metadata overhead.
@@ -97,13 +107,22 @@ fn bench_walk(c: &mut Criterion) {
     // throughput.
     let large = build_few_large(8, 4 * 1024 * 1024);
 
+    // (id suffix, walk_jobs): baseline first, then the parallel variants.
+    let variants: &[(&str, Option<usize>)] = &[
+        ("seq_baseline", Some(1)),
+        ("parallel_default", None),
+        ("parallel_8", Some(8)),
+    ];
+
     let mut group = c.benchmark_group("walk");
-    group.bench_function("many_small", |b| {
-        b.iter(|| run_walk(many.path()));
-    });
-    group.bench_function("few_large", |b| {
-        b.iter(|| run_walk(large.path()));
-    });
+    for &(label, jobs) in variants {
+        group.bench_function(format!("many_small/{label}"), |b| {
+            b.iter(|| run_walk(many.path(), jobs));
+        });
+        group.bench_function(format!("few_large/{label}"), |b| {
+            b.iter(|| run_walk(large.path(), jobs));
+        });
+    }
     group.finish();
     // `many` / `large` drop here, removing the scratch trees.
 }

--- a/benches/benches/iai_hot.rs
+++ b/benches/benches/iai_hot.rs
@@ -33,6 +33,9 @@ use iai_callgrind::{
 use snapdir_benches::{deterministic_bytes, gate_scenarios, Scenario};
 use snapdir_core::merkle::snapshot_id;
 use snapdir_core::{walk, Blake3Hasher, Hasher, Manifest, WalkOptions};
+use snapdir_stores::{
+    read_pack, write_pack, Durability, FileSink, FileStore, PackReadReport, StreamStore,
+};
 use std::hint::black_box;
 use std::path::PathBuf;
 use tempfile::TempDir;
@@ -142,6 +145,61 @@ fn bench_snapshot_id(manifest: Manifest) -> String {
 }
 
 // ---------------------------------------------------------------------------
+// 4. SNAPPACK receive hot path (read_pack into a FileSink).
+// ---------------------------------------------------------------------------
+
+/// Fixed receive workload: 64 objects × 1KiB each (v1 wire). Small + constant
+/// so callgrind's instruction counts stay byte-stable.
+const PACK_OBJECTS: usize = 64;
+const PACK_OBJECT_BYTES: usize = 1024;
+
+/// A pre-encoded v1 pack + the fresh dest store dir it will be read into (NOT
+/// counted — runs in `setup`). The source objects are distinct (`deterministic_bytes`
+/// over a per-object length) so each has a unique content-address. The returned
+/// `TempDir` owns the dest dir (kept alive so the filed objects aren't dropped
+/// before the read completes); only `read_pack` is counted.
+fn setup_read_pack() -> (TempDir, Vec<u8>) {
+    let hasher = Blake3Hasher::new();
+
+    // Source store (its own tempdir) seeded with PACK_OBJECTS distinct objects.
+    let src_dir = TempDir::new().expect("create source store dir");
+    let src = FileStore::from_root(src_dir.path());
+    let mut ids = Vec::with_capacity(PACK_OBJECTS);
+    for i in 0..PACK_OBJECTS {
+        // Vary the length by a few bytes per object so addresses differ.
+        let bytes = deterministic_bytes(PACK_OBJECT_BYTES + i);
+        let checksum = hasher.hash_hex(&bytes);
+        src.put_object(&checksum, bytes)
+            .expect("seed source object");
+        ids.push(checksum);
+    }
+
+    // Encode the whole set into one in-memory v1 pack (no manifest).
+    let mut pack = Vec::new();
+    write_pack(&src, &ids, None, &mut pack).expect("write_pack into Vec");
+
+    // Fresh, empty dest dir for the read. `src_dir` can drop — the pack bytes
+    // are already in memory.
+    let dest_dir = TempDir::new().expect("create dest store dir");
+    (dest_dir, pack)
+}
+
+// `read_pack` of a fixed 64×1KiB v1 pack into a fresh FileSink (durability Off).
+// Only the receive (parse + verify + file) is counted; encoding + seeding ran
+// in `setup`. The first run sets the baseline.
+#[library_benchmark]
+#[bench::fixed(setup = setup_read_pack)]
+fn bench_read_pack(input: (TempDir, Vec<u8>)) -> PackReadReport {
+    let (dest_dir, pack) = input;
+    let store = FileStore::from_root(dest_dir.path());
+    let mut sink = FileSink::new(&store).with_durability(Durability::Off);
+    let report = read_pack(black_box(pack.as_slice()), black_box(&mut sink)).expect("read_pack");
+    // Keep the dest dir alive until the read (and any filing) completes.
+    drop(dest_dir);
+    black_box(report)
+}
+
+// ---------------------------------------------------------------------------
 // Groups + harness. The 5% Ir / EstimatedCycles soft limit is wired in via the
 // group `config` so every benched fn inherits the regression gate.
 // ---------------------------------------------------------------------------
@@ -149,7 +207,7 @@ fn bench_snapshot_id(manifest: Manifest) -> String {
 library_benchmark_group!(
     name = hot;
     config = callgrind_5pct();
-    benchmarks = bench_blake3, bench_walk, bench_snapshot_id
+    benchmarks = bench_blake3, bench_walk, bench_snapshot_id, bench_read_pack
 );
 
 main!(library_benchmark_groups = hot);

--- a/benches/benches/snappack.rs
+++ b/benches/benches/snappack.rs
@@ -1,0 +1,144 @@
+//! SNAPPACK send/receive wall-clock benchmarks (v1 vs zstd, fsync off vs batch).
+//!
+//! These criterion benches drive the just-landed SNAPPACK pack wire
+//! (`snapdir-stores`) end to end over two deterministic corpora:
+//!
+//! - **(a)** 5k × 4KiB *text-like* objects — compressible, the realistic
+//!   "small-text snapshot" the zstd transport targets.
+//! - **(b)** 256 × 1MiB *incompressible* objects — the worst case for
+//!   compression (proves zstd never materially expands an unhelpable payload).
+//!
+//! Two families, mirroring `pipeline.rs`'s `BatchSize::PerIteration` pattern:
+//!
+//! 1. `pack/send/{a,b}/{v1,zstd}` — [`write_pack_with_format`] into a `Vec`
+//!    (in-memory sink), `Throughput::Bytes` over the source object bytes.
+//! 2. `pack/receive/{a,b}/{v1,zstd} × {off,batch}` — [`read_pack`] a
+//!    pre-encoded pack into a FRESH `FileStore` dir per iteration via a
+//!    [`FileSink`] with [`Durability::Off`] / [`Durability::Batch`].
+//!
+//! Bytes-on-wire is pinned by a `#[test]` (`zstd < v1` for scenario (a), prints
+//! the ratio). These benches **measure only** — they never touch `crates/**`
+//! and change no output bytes; they exercise the shipped `snapdir-stores`
+//! public pack API exactly as `send-pack` / `receive-pack` will.
+
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion, Throughput};
+use snapdir_benches::{incompressible_bytes, text_like_bytes};
+use snapdir_core::merkle::{Blake3Hasher, Hasher};
+use snapdir_stores::{
+    read_pack, write_pack_with_format, Durability, FileSink, FileStore, PackFormat, StreamStore,
+};
+use std::hint::black_box;
+use tempfile::TempDir;
+
+/// Stable per-scenario seed (any fixed value; the corpora must be
+/// deterministic, not random).
+const SEED: u64 = 0x5311_AC3D_0BAD_F00D;
+
+/// Scenario (a): 5k × 4KiB text-like (compressible) objects.
+const A_OBJECTS: usize = 5_000;
+const A_BYTES: usize = 4 * 1024;
+
+/// Scenario (b): 256 × 1MiB incompressible objects.
+const B_OBJECTS: usize = 256;
+const B_BYTES: usize = 1024 * 1024;
+
+/// A built corpus: distinct object payloads + their content-addresses, plus a
+/// seeded `FileStore` (in its own long-lived `TempDir`) holding them. The store
+/// is the send source; the ids drive both send and receive.
+struct Corpus {
+    _src_dir: TempDir,
+    store: FileStore,
+    ids: Vec<String>,
+    total_bytes: u64,
+}
+
+/// Distinct deterministic payloads via `gen(len, seed + i)` so every object has
+/// a unique content-address (a content-addressed store would otherwise dedup
+/// identical bodies down to one).
+fn build_corpus(count: usize, len: usize, gen: fn(usize, u64) -> Vec<u8>) -> Corpus {
+    let hasher = Blake3Hasher::new();
+    let src_dir = TempDir::new().expect("create source store dir");
+    let store = FileStore::from_root(src_dir.path());
+    let mut ids = Vec::with_capacity(count);
+    let mut total_bytes = 0u64;
+    for i in 0..count {
+        let bytes = gen(len, SEED.wrapping_add(i as u64));
+        let checksum = hasher.hash_hex(&bytes);
+        total_bytes += bytes.len() as u64;
+        store
+            .put_object(&checksum, bytes)
+            .expect("seed source object");
+        ids.push(checksum);
+    }
+    Corpus {
+        _src_dir: src_dir,
+        store,
+        ids,
+        total_bytes,
+    }
+}
+
+/// Encodes the whole corpus into one in-memory pack in `format` (no manifest —
+/// the bench measures raw object transport).
+fn encode_pack(corpus: &Corpus, format: PackFormat) -> Vec<u8> {
+    let mut out = Vec::new();
+    write_pack_with_format(&corpus.store, &corpus.ids, None, format, &mut out)
+        .expect("write_pack into Vec");
+    out
+}
+
+/// A fresh, empty scratch directory (its own `TempDir`).
+fn fresh_dir() -> TempDir {
+    TempDir::new().expect("create scratch dir")
+}
+
+/// 1. `pack/send/{a,b}/{v1,zstd}`: write the whole corpus to an in-memory pack.
+fn bench_send(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pack/send");
+    for (name, corpus) in [
+        ("a", build_corpus(A_OBJECTS, A_BYTES, text_like_bytes)),
+        ("b", build_corpus(B_OBJECTS, B_BYTES, incompressible_bytes)),
+    ] {
+        group.throughput(Throughput::Bytes(corpus.total_bytes));
+        for (fmt_name, format) in [("v1", PackFormat::V1), ("zstd", PackFormat::zstd_default())] {
+            group.bench_function(format!("{name}/{fmt_name}"), |b| {
+                b.iter(|| black_box(encode_pack(black_box(&corpus), format)));
+            });
+        }
+    }
+    group.finish();
+}
+
+/// 2. `pack/receive/{a,b}/{v1,zstd} × {off,batch}`: pre-encode the pack ONCE,
+///    then each iteration reads it into a FRESH `FileStore` dir so real filing
+///    (and, under `batch`, fsync) work is timed.
+fn bench_receive(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pack/receive");
+    for (name, corpus) in [
+        ("a", build_corpus(A_OBJECTS, A_BYTES, text_like_bytes)),
+        ("b", build_corpus(B_OBJECTS, B_BYTES, incompressible_bytes)),
+    ] {
+        group.throughput(Throughput::Bytes(corpus.total_bytes));
+        for (fmt_name, format) in [("v1", PackFormat::V1), ("zstd", PackFormat::zstd_default())] {
+            let pack = encode_pack(&corpus, format);
+            for (dur_name, durability) in [("off", Durability::Off), ("batch", Durability::Batch)] {
+                group.bench_function(format!("{name}/{fmt_name}/{dur_name}"), |b| {
+                    b.iter_batched(
+                        fresh_dir,
+                        |dest_dir| {
+                            let store = FileStore::from_root(dest_dir.path());
+                            let mut sink = FileSink::new(&store).with_durability(durability);
+                            read_pack(black_box(pack.as_slice()), &mut sink).expect("read_pack");
+                            dest_dir
+                        },
+                        BatchSize::PerIteration,
+                    );
+                });
+            }
+        }
+    }
+    group.finish();
+}
+
+criterion_group!(snappack, bench_send, bench_receive);
+criterion_main!(snappack);

--- a/benches/clone-skip-compare.sh
+++ b/benches/clone-skip-compare.sh
@@ -1,0 +1,167 @@
+#!/usr/bin/env bash
+# clone-skip end-to-end before/after measurement (phase 29 clone-skip-bench gate).
+#
+# Measures the wall-clock effect of the clone-skip optimization: on a CoW clone,
+# `persist` skips its redundant post-copy re-hash.
+#
+#   AFTER    (clone-skip ON):  default invocation (clone fires + skip).
+#   BASELINE (clone-skip OFF): SNAPDIR_VERIFY_COPIES=1 (clone still fires but
+#                              `persist` re-hashes the temp = pre-feature behavior).
+#
+# Clone is ON in BOTH arms, so the delta isolates the skipped re-hash, NOT the
+# clonefile-vs-fs::copy difference (already measured in apfs-clone-bench).
+#
+# Generates a synthetic corpus from /dev/urandom. Source dir and cache dir both
+# live under $TMPDIR (same APFS volume) so the clone path is eligible.
+#
+# NOT committed-output: this is a measurement harness, bench-only.
+set -euo pipefail
+
+BIN="${SNAPDIR_BIN:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/target/release/snapdir}"
+WALK_JOBS="${WALK_JOBS:-8}"
+NFILES="${NFILES:-300}"
+FILE_MIB="${FILE_MIB:-30}"
+SUBDIRS="${SUBDIRS:-10}"
+REPS="${REPS:-2}"
+
+WORK="$(mktemp -d "${TMPDIR:-/tmp}/clone-skip-bench.XXXXXX")"
+SRC="$WORK/src"
+trap 'rm -rf "$WORK"' EXIT
+
+log() { printf '%s\n' "$*"; }
+
+# -- generate synthetic corpus: a large directory of sizable files -------------
+log "Generating synthetic corpus: $NFILES files x ${FILE_MIB} MiB across $SUBDIRS subdirs ..."
+mkdir -p "$SRC"
+for d in $(seq 1 "$SUBDIRS"); do mkdir -p "$SRC/d$d"; done
+i=0
+while [ "$i" -lt "$NFILES" ]; do
+  d=$(( (i % SUBDIRS) + 1 ))
+  dd if=/dev/urandom of="$SRC/d$d/f$i.bin" bs=1m count="$FILE_MIB" status=none
+  i=$((i + 1))
+done
+TOTAL_MIB=$(( NFILES * FILE_MIB ))
+log "Corpus generated: ~${TOTAL_MIB} MiB total."
+
+# warm the page cache (read every file once)
+warm() { find "$1" -type f -exec cat {} + >/dev/null 2>&1 || true; }
+
+# best-of-REPS wall clock (seconds) for a command; fresh empty cache each rep.
+# $1 = label, $2 = cache-dir-prefix, $3.. = extra env assignments before binary
+# Returns best time via global BEST; captures snapshot id via global LAST_ID.
+run_stage() {
+  local label="$1"; shift
+  local cprefix="$1"; shift
+  local extra_env="$1"; shift
+  local best="" id="" pooldir=""
+  warm "$SRC"
+  local rep
+  for rep in $(seq 1 "$REPS"); do
+    local C="$WORK/${cprefix}-rep${rep}"
+    rm -rf "$C"; mkdir -p "$C"
+    local t start end
+    start=$EPOCHREALTIME
+    env $extra_env "$BIN" --cache-dir "$C" --walk-jobs "$WALK_JOBS" stage "$SRC" >"$WORK/${cprefix}.id" 2>/dev/null
+    end=$EPOCHREALTIME
+    t=$(awk "BEGIN{printf \"%.3f\", $end-$start}")
+    log "  $label rep$rep: ${t}s"
+    if [ -z "$best" ] || awk "BEGIN{exit !($t < $best)}"; then best="$t"; fi
+    id="$(tr -d '[:space:]' < "$WORK/${cprefix}.id")"
+    pooldir="$C"
+  done
+  BEST="$best"; LAST_ID="$id"; LAST_CACHE="$pooldir"
+}
+
+# fingerprint of the object pool: sorted (sha, relpath) of every file under .objects
+pool_fingerprint() {
+  local cache="$1"
+  ( cd "$cache" && find .objects -type f 2>/dev/null | sort | while read -r f; do
+      printf '%s  %s\n' "$(shasum -a 256 "$f" | awk '{print $1}')" "$f"
+    done )
+}
+pool_count() { find "$1/.objects" -type f 2>/dev/null | wc -l | tr -d ' '; }
+
+log ""
+log "================ STAGE ================"
+run_stage "AFTER    (clone-skip ON )" "stage-after"    ""                        ; A_TIME="$BEST"; A_ID="$LAST_ID"; A_CACHE="$LAST_CACHE"
+run_stage "BASELINE (VERIFY_COPIES=1)" "stage-base"    "SNAPDIR_VERIFY_COPIES=1" ; B_TIME="$BEST"; B_ID="$LAST_ID"; B_CACHE="$LAST_CACHE"
+
+STAGE_SPEEDUP=$(awk "BEGIN{printf \"%.2f\", $B_TIME/$A_TIME}")
+A_POOL="$(pool_count "$A_CACHE")"; B_POOL="$(pool_count "$B_CACHE")"
+
+log ""
+log "  stage AFTER    best: ${A_TIME}s   id=$A_ID   objects=$A_POOL"
+log "  stage BASELINE best: ${B_TIME}s   id=$B_ID   objects=$B_POOL"
+log "  stage speedup (baseline/after) = ${STAGE_SPEEDUP}x"
+
+# identical pool + id assertion
+pool_fingerprint "$A_CACHE" > "$WORK/fp-after.txt"
+pool_fingerprint "$B_CACHE" > "$WORK/fp-base.txt"
+if diff -q "$WORK/fp-after.txt" "$WORK/fp-base.txt" >/dev/null; then POOL_MATCH="IDENTICAL"; else POOL_MATCH="DIFFER"; fi
+if [ "$A_ID" = "$B_ID" ]; then ID_MATCH="IDENTICAL"; else ID_MATCH="DIFFER"; fi
+log "  id match: $ID_MATCH ; object-pool fingerprint: $POOL_MATCH"
+
+# ---- CHECKOUT: stage once, then checkout AFTER vs BASELINE -------------------
+log ""
+log "================ CHECKOUT ================"
+CKC="$WORK/checkout-cache"
+rm -rf "$CKC"; mkdir -p "$CKC"
+warm "$SRC"
+"$BIN" --cache-dir "$CKC" --walk-jobs "$WALK_JOBS" stage "$SRC" >"$WORK/ck.id" 2>/dev/null
+CK_ID="$(tr -d '[:space:]' < "$WORK/ck.id")"
+log "  staged checkout source id=$CK_ID"
+
+run_checkout() {
+  local label="$1"; shift
+  local extra_env="$1"; shift
+  local best=""
+  local rep
+  for rep in $(seq 1 "$REPS"); do
+    local DEST="$WORK/co-${label// /_}-rep${rep}"
+    rm -rf "$DEST"
+    # warm objects in cache
+    find "$CKC/.objects" -type f -exec cat {} + >/dev/null 2>&1 || true
+    local t start end
+    start=$EPOCHREALTIME
+    env $extra_env "$BIN" --cache-dir "$CKC" --walk-jobs "$WALK_JOBS" checkout --id "$CK_ID" "$DEST" >/dev/null 2>/dev/null
+    end=$EPOCHREALTIME
+    t=$(awk "BEGIN{printf \"%.3f\", $end-$start}")
+    log "  $label rep$rep: ${t}s"
+    if [ -z "$best" ] || awk "BEGIN{exit !($t < $best)}"; then best="$t"; fi
+  done
+  CK_BEST="$best"
+}
+
+run_checkout "AFTER"    ""                        ; CK_A="$CK_BEST"
+run_checkout "BASELINE" "SNAPDIR_VERIFY_COPIES=1" ; CK_B="$CK_BEST"
+CK_SPEEDUP=$(awk "BEGIN{printf \"%.2f\", $CK_B/$CK_A}")
+log ""
+log "  checkout AFTER    best: ${CK_A}s"
+log "  checkout BASELINE best: ${CK_B}s"
+log "  checkout speedup (baseline/after) = ${CK_SPEEDUP}x"
+
+# export results for the log writer
+cat > "$WORK/results.env" <<EOF
+A_TIME=$A_TIME
+B_TIME=$B_TIME
+STAGE_SPEEDUP=$STAGE_SPEEDUP
+A_ID=$A_ID
+B_ID=$B_ID
+A_POOL=$A_POOL
+B_POOL=$B_POOL
+ID_MATCH=$ID_MATCH
+POOL_MATCH=$POOL_MATCH
+CK_ID=$CK_ID
+CK_A=$CK_A
+CK_B=$CK_B
+CK_SPEEDUP=$CK_SPEEDUP
+NFILES=$NFILES
+FILE_MIB=$FILE_MIB
+TOTAL_MIB=$TOTAL_MIB
+SUBDIRS=$SUBDIRS
+WALK_JOBS=$WALK_JOBS
+REPS=$REPS
+EOF
+cp "$WORK/results.env" "${RESULTS_OUT:-/tmp/clone-skip-results.env}"
+log ""
+log "results written to ${RESULTS_OUT:-/tmp/clone-skip-results.env}"

--- a/benches/reflink-compare.sh
+++ b/benches/reflink-compare.sh
@@ -1,0 +1,256 @@
+#!/usr/bin/env bash
+# Linux reflink (FICLONE) before/after measurement (phase 29 reflink-bench gate).
+#
+# The Linux sibling of benches/clone-skip-compare.sh. Measures the wall-clock
+# effect of the Linux FICLONE copy-on-write fast-path on `snapdir stage` +
+# `checkout`. The reflink path returns CopyMethod::Cloned and therefore inherits
+# the clone-skip stage/checkout re-hash elision for free:
+#
+#   AFTER    (reflink ON):  default invocation (FICLONE fires + clone-skip).
+#   BASELINE (reflink OFF): SNAPDIR_CLONEFILE=0 (forces plain fs::copy, no clone,
+#                           no skip = pre-feature behavior).
+#
+# This is the LINUX analogue of the macOS clone-skip bench
+# (.gatesmith/evidence/clone-skip-bench.log, which measured stage ~2.4x /
+# checkout ~1.5x on APFS). FICLONE requires a reflink-capable filesystem
+# (Btrfs / XFS reflink=1 / OpenZFS 2.2+ / bcachefs) AND src + cache co-located on
+# the SAME such filesystem (a reflink clones extents within one FS only).
+#
+# Where to run: the `Reflink (Btrfs FICLONE)` CI job (loopback Btrfs at
+# /mnt/reflink) or a local Linux VM with a reflink mount. On macOS / ext4 (no
+# reflink FS), this script prints a clear skip notice and exits 0 (graceful skip,
+# NOT a failure) so that bench-build verification on a non-reflink host passes.
+#
+# A reflink-capable directory is supplied via $SNAPDIR_REFLINK_TEST_DIR (env) or
+# as the first positional arg. Auto-detecting/creating one (loopback mkfs.btrfs)
+# is OUT of scope here — see utils/ci/reflink-vm-check.sh for that.
+#
+# Usage:
+#   SNAPDIR_REFLINK_TEST_DIR=/mnt/reflink benches/reflink-compare.sh
+#   benches/reflink-compare.sh /mnt/reflink
+#   benches/reflink-compare.sh --help
+#
+# NOT committed-output: this is a measurement harness, bench-only.
+set -euo pipefail
+
+usage() {
+  sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed '$d' | sed 's/^# \{0,1\}//'
+}
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+esac
+
+log() { printf '%s\n' "$*"; }
+
+# -- resolve a reflink-capable directory ---------------------------------------
+REFLINK_DIR="${SNAPDIR_REFLINK_TEST_DIR:-${1:-}}"
+
+skip() {
+  log "no reflink FS available — skipping (run on the Btrfs CI leg or a Linux VM)"
+  log "  reason: $1"
+  log "  supply a reflink-capable dir via \$SNAPDIR_REFLINK_TEST_DIR or arg 1"
+  log "  (Btrfs / XFS reflink=1 / OpenZFS 2.2+ / bcachefs); FICLONE is Linux-only."
+  exit 0
+}
+
+# Graceful skip on non-Linux (macOS clonefile is a different path; this bench
+# targets the Linux FICLONE branch specifically).
+case "$(uname -s)" in
+  Linux) ;;
+  *) skip "host is $(uname -s), not Linux (FICLONE is a Linux-only ioctl)" ;;
+esac
+
+[ -n "$REFLINK_DIR" ] || skip "\$SNAPDIR_REFLINK_TEST_DIR unset and no dir arg given"
+[ -d "$REFLINK_DIR" ] || skip "reflink dir '$REFLINK_DIR' does not exist"
+[ -w "$REFLINK_DIR" ] || skip "reflink dir '$REFLINK_DIR' is not writable"
+
+# Probe that the FS under $REFLINK_DIR actually supports reflinks: cp --reflink.
+PROBE="$(mktemp -d "$REFLINK_DIR/reflink-probe.XXXXXX")"
+probe_cleanup() { rm -rf "$PROBE"; }
+trap probe_cleanup EXIT
+printf 'reflink-probe\n' > "$PROBE/a"
+if ! cp --reflink=always "$PROBE/a" "$PROBE/b" 2>/dev/null; then
+  skip "'$REFLINK_DIR' does not support reflinks (cp --reflink=always failed)"
+fi
+trap - EXIT
+probe_cleanup
+
+# -- config (mirrors clone-skip-compare.sh) ------------------------------------
+BIN="${SNAPDIR_BIN:-$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/target/release/snapdir}"
+WALK_JOBS="${WALK_JOBS:-8}"
+NFILES="${NFILES:-300}"
+FILE_MIB="${FILE_MIB:-30}"
+SUBDIRS="${SUBDIRS:-10}"
+REPS="${REPS:-2}"
+
+# -- build the release binary (package `snapdir`, NOT snapdir-cli) -------------
+if [ ! -x "$BIN" ]; then
+  log "Building release binary: cargo build --release -p snapdir ..."
+  ( cd "$(dirname "${BASH_SOURCE[0]}")/.." && cargo build --release -p snapdir )
+fi
+
+# Work dir lives ON the reflink FS so src + cache are co-located (FICLONE needs
+# same-FS) — this is the key difference from the macOS sibling, which uses
+# $TMPDIR (APFS).
+WORK="$(mktemp -d "$REFLINK_DIR/reflink-bench.XXXXXX")"
+SRC="$WORK/src"
+trap 'rm -rf "$WORK"' EXIT
+
+# -- generate a GENERIC synthetic corpus: a large dir of sizable files ---------
+log "Generating synthetic corpus: $NFILES files x ${FILE_MIB} MiB across $SUBDIRS subdirs ..."
+mkdir -p "$SRC"
+for d in $(seq 1 "$SUBDIRS"); do mkdir -p "$SRC/d$d"; done
+i=0
+while [ "$i" -lt "$NFILES" ]; do
+  d=$(( (i % SUBDIRS) + 1 ))
+  dd if=/dev/urandom of="$SRC/d$d/f$i.bin" bs=1M count="$FILE_MIB" status=none
+  i=$((i + 1))
+done
+TOTAL_MIB=$(( NFILES * FILE_MIB ))
+log "Corpus generated: ~${TOTAL_MIB} MiB total (on reflink FS at $REFLINK_DIR)."
+
+# warm the page cache (read every file once)
+warm() { find "$1" -type f -exec cat {} + >/dev/null 2>&1 || true; }
+
+# best-of-REPS wall clock (seconds) for `stage`; fresh empty cache each rep.
+# $1 = label, $2 = cache-dir-prefix, $3 = extra env assignments before binary.
+run_stage() {
+  local label="$1"; shift
+  local cprefix="$1"; shift
+  local extra_env="$1"; shift
+  local best="" id="" pooldir=""
+  warm "$SRC"
+  local rep
+  for rep in $(seq 1 "$REPS"); do
+    local C="$WORK/${cprefix}-rep${rep}"
+    rm -rf "$C"; mkdir -p "$C"
+    local t start end
+    start=$EPOCHREALTIME
+    # extra_env must word-split: "" => no env arg, "FOO=1" => one assignment.
+    # shellcheck disable=SC2086
+    env $extra_env "$BIN" --cache-dir "$C" --walk-jobs "$WALK_JOBS" stage "$SRC" >"$WORK/${cprefix}.id" 2>/dev/null
+    end=$EPOCHREALTIME
+    t=$(awk "BEGIN{printf \"%.3f\", $end-$start}")
+    log "  $label rep$rep: ${t}s"
+    if [ -z "$best" ] || awk "BEGIN{exit !($t < $best)}"; then best="$t"; fi
+    id="$(tr -d '[:space:]' < "$WORK/${cprefix}.id")"
+    pooldir="$C"
+  done
+  BEST="$best"; LAST_ID="$id"; LAST_CACHE="$pooldir"
+}
+
+# fingerprint of the object pool: sorted (sha, relpath) of every file under .objects
+pool_fingerprint() {
+  local cache="$1"
+  ( cd "$cache" && find .objects -type f 2>/dev/null | sort | while read -r f; do
+      printf '%s  %s\n' "$(sha256sum "$f" | awk '{print $1}')" "$f"
+    done )
+}
+pool_count() { find "$1/.objects" -type f 2>/dev/null | wc -l | tr -d ' '; }
+
+log ""
+log "================ STAGE ================"
+run_stage "AFTER    (reflink ON )"  "stage-after" ""                  ; A_TIME="$BEST"; A_ID="$LAST_ID"; A_CACHE="$LAST_CACHE"
+run_stage "BASELINE (CLONEFILE=0)"  "stage-base"  "SNAPDIR_CLONEFILE=0"; B_TIME="$BEST"; B_ID="$LAST_ID"; B_CACHE="$LAST_CACHE"
+
+STAGE_SPEEDUP=$(awk "BEGIN{printf \"%.2f\", $B_TIME/$A_TIME}")
+A_POOL="$(pool_count "$A_CACHE")"; B_POOL="$(pool_count "$B_CACHE")"
+
+log ""
+log "  stage AFTER    best: ${A_TIME}s   id=$A_ID   objects=$A_POOL"
+log "  stage BASELINE best: ${B_TIME}s   id=$B_ID   objects=$B_POOL"
+log "  stage speedup (baseline/after) = ${STAGE_SPEEDUP}x"
+
+# identical pool + id assertion
+pool_fingerprint "$A_CACHE" > "$WORK/fp-after.txt"
+pool_fingerprint "$B_CACHE" > "$WORK/fp-base.txt"
+if diff -q "$WORK/fp-after.txt" "$WORK/fp-base.txt" >/dev/null; then POOL_MATCH="IDENTICAL"; else POOL_MATCH="DIFFER"; fi
+if [ "$A_ID" = "$B_ID" ]; then ID_MATCH="IDENTICAL"; else ID_MATCH="DIFFER"; fi
+log "  id match: $ID_MATCH ; object-pool fingerprint: $POOL_MATCH"
+
+# ---- CHECKOUT: stage once, then checkout AFTER vs BASELINE -------------------
+log ""
+log "================ CHECKOUT ================"
+CKC="$WORK/checkout-cache"
+rm -rf "$CKC"; mkdir -p "$CKC"
+warm "$SRC"
+"$BIN" --cache-dir "$CKC" --walk-jobs "$WALK_JOBS" stage "$SRC" >"$WORK/ck.id" 2>/dev/null
+CK_ID="$(tr -d '[:space:]' < "$WORK/ck.id")"
+log "  staged checkout source id=$CK_ID"
+
+run_checkout() {
+  local label="$1"; shift
+  local extra_env="$1"; shift
+  local best=""
+  local rep
+  for rep in $(seq 1 "$REPS"); do
+    local DEST="$WORK/co-${label// /_}-rep${rep}"
+    rm -rf "$DEST"
+    # warm objects in cache
+    find "$CKC/.objects" -type f -exec cat {} + >/dev/null 2>&1 || true
+    local t start end
+    start=$EPOCHREALTIME
+    # extra_env must word-split: "" => no env arg, "FOO=1" => one assignment.
+    # shellcheck disable=SC2086
+    env $extra_env "$BIN" --cache-dir "$CKC" --walk-jobs "$WALK_JOBS" checkout --id "$CK_ID" "$DEST" >/dev/null 2>/dev/null
+    end=$EPOCHREALTIME
+    t=$(awk "BEGIN{printf \"%.3f\", $end-$start}")
+    log "  $label rep$rep: ${t}s"
+    if [ -z "$best" ] || awk "BEGIN{exit !($t < $best)}"; then best="$t"; fi
+  done
+  CK_BEST="$best"
+}
+
+run_checkout "AFTER"    ""                   ; CK_A="$CK_BEST"
+run_checkout "BASELINE" "SNAPDIR_CLONEFILE=0"; CK_B="$CK_BEST"
+CK_SPEEDUP=$(awk "BEGIN{printf \"%.2f\", $CK_B/$CK_A}")
+log ""
+log "  checkout AFTER    best: ${CK_A}s"
+log "  checkout BASELINE best: ${CK_B}s"
+log "  checkout speedup (baseline/after) = ${CK_SPEEDUP}x"
+
+# -- write the evidence log ----------------------------------------------------
+EVIDENCE="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/.gatesmith/evidence/reflink-bench.log"
+mkdir -p "$(dirname "$EVIDENCE")"
+{
+  printf '================================================================================\n'
+  printf 'reflink-bench (phase 29) — Linux FICLONE CoW stage/checkout before/after\n'
+  printf '================================================================================\n\n'
+  printf 'Linux analogue of clone-skip-bench. The FICLONE reflink fast-path returns\n'
+  printf 'CopyMethod::Cloned and inherits the clone-skip re-hash elision, so on a\n'
+  printf 'reflink-capable FS (Btrfs / XFS reflink=1) it is expected to mirror the macOS\n'
+  printf 'clone-skip stage/checkout win.\n\n'
+  printf '  AFTER    (reflink ON ): default invocation (FICLONE fires + clone-skip).\n'
+  printf '  BASELINE (reflink OFF): SNAPDIR_CLONEFILE=0 (plain fs::copy, no clone/skip).\n\n'
+  printf 'Corpus (generic): a large directory of sizable random files generated from\n'
+  printf '/dev/urandom INTO the reflink FS (src + cache co-located, same FS — FICLONE\n'
+  printf 'clones extents within one filesystem only). No dataset / host / path named.\n'
+  printf '  %s files x ~%s MiB across %s subdirs = ~%s MiB total.\n\n' \
+    "$NFILES" "$FILE_MIB" "$SUBDIRS" "$TOTAL_MIB"
+  printf 'Method: fresh empty cache per stage run; page cache warmed; --walk-jobs held\n'
+  printf 'constant (%s); best-of-%s wall clock via bash EPOCHREALTIME.\n\n' "$WALK_JOBS" "$REPS"
+  printf -- '--------------------------------------------------------------------------------\n'
+  printf '1) STAGE — AFTER (reflink ON) vs BASELINE (SNAPDIR_CLONEFILE=0)\n'
+  printf -- '--------------------------------------------------------------------------------\n'
+  printf '  stage AFTER    best: %ss   objects=%s\n' "$A_TIME" "$A_POOL"
+  printf '  stage BASELINE best: %ss   objects=%s\n' "$B_TIME" "$B_POOL"
+  printf '  stage speedup (baseline/after) = %sx\n' "$STAGE_SPEEDUP"
+  printf '  snapshot id (after)    = %s\n' "$A_ID"
+  printf '  snapshot id (baseline) = %s\n' "$B_ID"
+  printf '  id match: %s ; object-pool fingerprint: %s\n\n' "$ID_MATCH" "$POOL_MATCH"
+  printf -- '--------------------------------------------------------------------------------\n'
+  printf '2) CHECKOUT — AFTER (reflink ON) vs BASELINE (SNAPDIR_CLONEFILE=0)\n'
+  printf -- '--------------------------------------------------------------------------------\n'
+  printf '  staged source id=%s\n' "$CK_ID"
+  printf '  checkout AFTER    best: %ss\n' "$CK_A"
+  printf '  checkout BASELINE best: %ss\n' "$CK_B"
+  printf '  checkout speedup (baseline/after) = %sx\n\n' "$CK_SPEEDUP"
+  printf 'VERDICT: object pool + snapshot id BYTE-IDENTICAL on/off (id %s, pool %s) —\n' "$ID_MATCH" "$POOL_MATCH"
+  printf 'the reflink CoW path is output-preserving. Stage speedup %sx, checkout %sx.\n' \
+    "$STAGE_SPEEDUP" "$CK_SPEEDUP"
+} > "$EVIDENCE"
+
+log ""
+log "evidence written to $EVIDENCE"
+log "baseline=${B_TIME}s after=${A_TIME}s stage-speedup=${STAGE_SPEEDUP}x checkout-speedup=${CK_SPEEDUP}x"

--- a/benches/src/lib.rs
+++ b/benches/src/lib.rs
@@ -49,6 +49,112 @@ pub fn deterministic_bytes(len: usize) -> Vec<u8> {
         .collect()
 }
 
+/// Avalanches `seed` into a well-mixed nonzero `xorshift64*` start state.
+///
+/// This is the splitmix64 finalizer. It matters because callers seed objects by
+/// `base + i` for consecutive `i`: feeding those *adjacent* seeds straight into
+/// `xorshift64*` would leave the per-object streams correlated (zstd's window
+/// then finds cross-object redundancy and an "incompressible" corpus compresses
+/// anyway). The finalizer's full avalanche makes `seed` and `seed + 1` produce
+/// statistically independent streams. The `| 1` guarantees the nonzero state
+/// `xorshift64*` requires.
+const fn mix_seed(seed: u64) -> u64 {
+    let mut z = seed.wrapping_add(0x9E37_79B9_7F4A_7C15);
+    z = (z ^ (z >> 30)).wrapping_mul(0xBF58_476D_1CE4_E5B9);
+    z = (z ^ (z >> 27)).wrapping_mul(0x94D0_49BB_1331_11EB);
+    (z ^ (z >> 31)) | 1
+}
+
+/// A small, fixed word table used by [`text_like_bytes`] to synthesize
+/// compressible, text-shaped corpora. Common English-ish tokens so the byte
+/// stream has the redundancy a real text snapshot would (and zstd can shrink
+/// it well below v1), with NO RNG, clock, or external data.
+const WORD_TABLE: &[&str] = &[
+    "the",
+    "snapshot",
+    "store",
+    "object",
+    "manifest",
+    "content",
+    "address",
+    "hash",
+    "blake3",
+    "stream",
+    "pack",
+    "verify",
+    "commit",
+    "durable",
+    "file",
+    "directory",
+    "checksum",
+    "snapdir",
+    "transfer",
+    "compress",
+    "and",
+    "of",
+    "into",
+    "a",
+    "with",
+    "every",
+    "record",
+    "bytes",
+    "wire",
+    "format",
+];
+
+/// Builds `len` bytes of **deterministic, compressible, text-like** content by
+/// concatenating space-separated words from [`WORD_TABLE`], chosen by a seeded
+/// xorshift index, then truncated/zero-padded to exactly `len`.
+///
+/// The high token redundancy means zstd compresses this materially better than
+/// the plain v1 wire — the realistic "small-text snapshot" workload the pack
+/// path targets. Fully deterministic (no RNG/clock); two calls with the same
+/// `(len, seed)` are byte-identical. Std-only, no new deps.
+///
+/// Note: [`deterministic_bytes`]' 256-byte ramp is *trivially* compressible and
+/// only suitable as a best-case third data point, not a realistic corpus — use
+/// this for the text scenario.
+#[must_use]
+pub fn text_like_bytes(len: usize, seed: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(len);
+    let mut state = mix_seed(seed); // avalanched: adjacent seeds → independent streams
+    while out.len() < len {
+        // xorshift64* step → pick a word.
+        state ^= state >> 12;
+        state ^= state << 25;
+        state ^= state >> 27;
+        let idx = (state.wrapping_mul(0x2545_F491_4F6C_DD1D) >> 33) as usize % WORD_TABLE.len();
+        out.extend_from_slice(WORD_TABLE[idx].as_bytes());
+        out.push(b' ');
+    }
+    out.truncate(len);
+    out
+}
+
+/// Builds `len` bytes of **deterministic, effectively incompressible** content
+/// using a seeded `xorshift64*` PRNG.
+///
+/// `xorshift64*` (seeded through the [`mix_seed`] splitmix64 finalizer so
+/// adjacent object seeds yield INDEPENDENT, non-cross-correlated streams) has
+/// output close to uniform, so zstd cannot shrink it — the worst case for the
+/// wire, proving the compressed path never materially *expands* a payload it
+/// can't help. Fully deterministic: same `(len, seed)` ⇒ same bytes. No RNG
+/// crate, no clock, no new deps.
+#[must_use]
+pub fn incompressible_bytes(len: usize, seed: u64) -> Vec<u8> {
+    let mut out = Vec::with_capacity(len);
+    let mut state = mix_seed(seed); // avalanched: adjacent seeds → independent streams
+    while out.len() < len {
+        state ^= state >> 12;
+        state ^= state << 25;
+        state ^= state >> 27;
+        let word = state.wrapping_mul(0x2545_F491_4F6C_DD1D);
+        let take = (len - out.len()).min(8);
+        out.extend_from_slice(&word.to_le_bytes()[..take]);
+    }
+    out
+}
+
 /// Which tier a [`Scenario`] belongs to.
 ///
 /// `Gate` scenarios are tiny/fast — they run inside `cargo test` (the

--- a/benches/tests/snappack_wire.rs
+++ b/benches/tests/snappack_wire.rs
@@ -1,0 +1,113 @@
+//! SNAPPACK bytes-on-wire contract test.
+//!
+//! Pins the property the `snappack` criterion bench's zstd path exists to
+//! exploit: for the **text-like (compressible)** corpus — scenario (a) of
+//! `benches/benches/snappack.rs` — a `PackFormat::Zstd` pack is strictly
+//! SMALLER on the wire than the plain `PackFormat::V1` pack, and the ratio is
+//! printed for the evidence record. A companion check pins that the
+//! **incompressible** corpus (scenario (b)) does not materially expand under
+//! zstd (the worst case stays bounded).
+//!
+//! This lives in `benches/tests/` (not inside the `harness = false` bench
+//! target, whose `criterion_main!` would shadow any `#[test]`), so the libtest
+//! harness actually runs it under `cargo test -p snapdir-benches`. It drives
+//! the shipped `snapdir-stores` pack API exactly as the bench does and changes
+//! no output bytes.
+
+use snapdir_benches::{incompressible_bytes, text_like_bytes};
+use snapdir_core::merkle::{Blake3Hasher, Hasher};
+use snapdir_stores::{write_pack_with_format, FileStore, PackFormat, StreamStore};
+use tempfile::TempDir;
+
+/// Stable per-object seed base — matches `snappack.rs` so the test exercises the
+/// same corpora the bench measures.
+const SEED: u64 = 0x5311_AC3D_0BAD_F00D;
+
+/// Scenario (a) object size (text-like, compressible).
+const A_BYTES: usize = 4 * 1024;
+/// Scenario (b) object size (incompressible).
+const B_BYTES: usize = 1024 * 1024;
+
+/// Seeds `count` distinct deterministic objects (via `gen(len, SEED+i)`) into a
+/// fresh `FileStore`, returning the store (+ its tempdir guard) and the ids in
+/// order.
+fn seed_corpus(
+    count: usize,
+    len: usize,
+    gen: fn(usize, u64) -> Vec<u8>,
+) -> (TempDir, FileStore, Vec<String>) {
+    let hasher = Blake3Hasher::new();
+    let dir = TempDir::new().expect("create source store dir");
+    let store = FileStore::from_root(dir.path());
+    let ids = (0..count)
+        .map(|i| {
+            let bytes = gen(len, SEED.wrapping_add(i as u64));
+            let checksum = hasher.hash_hex(&bytes);
+            store
+                .put_object(&checksum, bytes)
+                .expect("seed source object");
+            checksum
+        })
+        .collect();
+    (dir, store, ids)
+}
+
+/// Encodes the whole id set into one in-memory pack in `format` (no manifest).
+fn encode(store: &FileStore, ids: &[String], format: PackFormat) -> Vec<u8> {
+    let mut out = Vec::new();
+    write_pack_with_format(store, ids, None, format, &mut out).expect("write_pack into Vec");
+    out
+}
+
+/// Bytes-on-wire contract: for text-like scenario (a), zstd < v1. Uses a small
+/// slice (the ratio is content-driven, not count-driven) so the test is fast.
+#[test]
+fn zstd_pack_is_smaller_than_v1_for_text_scenario_a() {
+    let (_dir, store, ids) = seed_corpus(256, A_BYTES, text_like_bytes);
+    let v1 = encode(&store, &ids, PackFormat::V1);
+    let zstd = encode(&store, &ids, PackFormat::zstd_default());
+    // Integer permille ratio (zstd/v1 × 1000) — no float cast (clippy pedantic).
+    let permille = zstd.len() as u128 * 1000 / v1.len() as u128;
+    println!(
+        "snappack bytes-on-wire (scenario a, text-like, {} obj × {A_BYTES} B): \
+         v1 = {} B, zstd = {} B, ratio (zstd/v1) = {}.{:03}",
+        ids.len(),
+        v1.len(),
+        zstd.len(),
+        permille / 1000,
+        permille % 1000,
+    );
+    assert!(
+        zstd.len() < v1.len(),
+        "zstd pack ({} B) must be smaller than v1 ({} B) for text-like scenario (a)",
+        zstd.len(),
+        v1.len(),
+    );
+}
+
+/// Sanity: incompressible scenario (b) does NOT materially expand under zstd
+/// (the worst case stays bounded — never a runaway blow-up).
+#[test]
+fn zstd_does_not_blow_up_incompressible_scenario_b() {
+    let (_dir, store, ids) = seed_corpus(8, B_BYTES, incompressible_bytes);
+    let v1 = encode(&store, &ids, PackFormat::V1);
+    let zstd = encode(&store, &ids, PackFormat::zstd_default());
+    let permille = zstd.len() as u128 * 1000 / v1.len() as u128;
+    println!(
+        "snappack bytes-on-wire (scenario b, incompressible, {} obj × {B_BYTES} B): \
+         v1 = {} B, zstd = {} B, ratio (zstd/v1) = {}.{:03}",
+        ids.len(),
+        v1.len(),
+        zstd.len(),
+        permille / 1000,
+        permille % 1000,
+    );
+    // zstd stores an incompressible frame nearly verbatim (+small framing): the
+    // pack must not grow by more than 1% (integer ×100 comparison, no float).
+    assert!(
+        zstd.len() as u128 * 100 < v1.len() as u128 * 101,
+        "zstd pack ({} B) blew up vs v1 ({} B) on incompressible data",
+        zstd.len(),
+        v1.len(),
+    );
+}

--- a/crates/snapdir-cli/src/cli.rs
+++ b/crates/snapdir-cli/src/cli.rs
@@ -20,21 +20,24 @@ use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
 use anyhow::{Context, Result};
-use clap::{Args, CommandFactory, Parser, Subcommand};
+use clap::{Args, CommandFactory, Parser, Subcommand, ValueEnum};
 
 use crate::progress::{should_render, use_color, ColorChoice, ProgressReporter};
 use snapdir_catalog::{
     ancestors_json_line, locations_json_line, revisions_json_line, Catalog, SystemClock,
 };
+use snapdir_core::hash_file::HashFile;
 use snapdir_core::{
-    cache, expand_excludes, snapshot_id, walk_with_meter, Blake3Hasher, Blake3KeyedHasher,
-    ExcludeMatcher, ExpandedExclude, FollowMode, Hasher, Manifest, ManifestEntry, Md5Hasher, Meter,
-    PathMode, PathType, Phase, Sha256Hasher, Store, StoreError, WalkOptions,
+    cache, expand_excludes, snapshot_id, walk_with_guards, walk_with_meter, Blake3Hasher,
+    Blake3KeyedHasher, CopyGuard, ExcludeMatcher, ExpandedExclude, FollowMode, Hasher, Manifest,
+    ManifestEntry, Md5Hasher, Meter, PathMode, PathType, Phase, Sha256Hasher, Store, StoreError,
+    WalkOptions,
 };
 use snapdir_stores::{
-    is_hex64, limits, read_pack, resolve_adapter, write_pack, Adapter, B2Store, ExternalStore,
-    FileSink, FileStore, GcsStore, PackReadReport, PackSink, RetryPolicy, S3Store, StreamSink,
-    StreamStore, TransferAdaptivePolicy, TransferConfig, WIRE_CAPS, WIRE_VERSION,
+    is_hex64, limits, read_pack, resolve_adapter, write_pack_with_format, Adapter, B2Store,
+    Durability, ExternalStore, FileSink, FileStore, GcsStore, PackFormat, PackReadReport, PackSink,
+    RetryPolicy, S3Store, SplitStore, StreamSink, StreamStore, TransferAdaptivePolicy,
+    TransferConfig, DEFAULT_ZSTD_LEVEL, WIRE_CAPS, WIRE_VERSION,
 };
 
 /// Upper bound for the adaptive concurrency ceiling (`--max-jobs` / `--jobs`
@@ -83,6 +86,11 @@ pub struct GlobalArgs {
     /// Store URI: `protocol://location/path`.
     #[arg(long, global = true, value_name = "URI", env = "SNAPDIR_STORE")]
     pub store: Option<String>,
+
+    /// Shared object-pool store URI: when set, content OBJECTS route to this
+    /// pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`.
+    #[arg(long, global = true, value_name = "URI", env = "SNAPDIR_OBJECTS_STORE")]
+    pub objects_store: Option<String>,
 
     /// Snapshot ID to operate on.
     #[arg(long, global = true, value_name = "ID")]
@@ -170,6 +178,11 @@ pub struct GlobalArgs {
     )]
     pub jobs: Option<usize>,
 
+    /// Max parallel file-hashing jobs during the directory walk (0/auto =
+    /// number of CPUs, capped). Distinct from --jobs (transfer concurrency).
+    #[arg(long, global = true, value_name = "N", env = "SNAPDIR_WALK_JOBS")]
+    pub walk_jobs: Option<usize>,
+
     /// Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers).
     #[arg(long, global = true, value_name = "RATE", env = "SNAPDIR_LIMIT_RATE")]
     pub limit_rate: Option<String>,
@@ -212,6 +225,68 @@ pub struct GlobalArgs {
     /// Cap request rate (req/s); 0/unset uses the per-backend default.
     #[arg(long, global = true, value_name = "N")]
     pub max_requests: Option<u64>,
+}
+
+/// CLI selector for the SNAPPACK transport encoding `send-pack` emits.
+///
+/// Mirrors [`PackFormat`] one-for-one but stays a CLI-layer type: clap derives
+/// `--pack-format <v1|zstd>` from it (the value-enum tokens are the lowercase
+/// variant names), and [`PackFormatArg::resolve`] maps it to the library
+/// [`PackFormat`], reading the zstd level from the environment at this seam (the
+/// library itself is env-free). The default is [`PackFormatArg::V1`], so an
+/// invocation that omits the hidden flag emits the historical byte-identical v1
+/// stream.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum PackFormatArg {
+    /// Plain `SNAPPACK 1` — the historical byte-for-byte form (default).
+    V1,
+    /// `SNAPPACK 1Z` — the additive zstd-framed form.
+    Zstd,
+}
+
+impl PackFormatArg {
+    /// Maps the CLI selector to the library [`PackFormat`], reading the zstd
+    /// level from `SNAPDIR_SSH_ZSTD_LEVEL` (defaulting to [`DEFAULT_ZSTD_LEVEL`])
+    /// for the `zstd` form. The level is passed through to
+    /// [`PackFormat::Zstd`], which clamps it into the valid range; a malformed
+    /// env value falls back to the default rather than erroring, mirroring the
+    /// oracle's permissive numeric-env handling.
+    fn resolve(self) -> PackFormat {
+        match self {
+            Self::V1 => PackFormat::V1,
+            Self::Zstd => {
+                let level = std::env::var("SNAPDIR_SSH_ZSTD_LEVEL")
+                    .ok()
+                    .and_then(|v| v.trim().parse::<i32>().ok())
+                    .unwrap_or(DEFAULT_ZSTD_LEVEL);
+                PackFormat::Zstd(level)
+            }
+        }
+    }
+}
+
+/// CLI selector for the intra-side collision policy of `snapdir diff`.
+///
+/// Mirrors [`crate::diff::OnConflict`]; clap derives `--on-conflict
+/// <error|last-wins>` from it. The default is [`OnConflictArg::Error`], so an
+/// omitted flag fails hard on a differing-content path collision within one
+/// side (the SPEC default).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, ValueEnum)]
+pub enum OnConflictArg {
+    /// A differing-content collision is a hard error (default).
+    Error,
+    /// The last ref contributing the path wins.
+    LastWins,
+}
+
+impl OnConflictArg {
+    /// Maps the CLI selector to the library [`crate::diff::OnConflict`].
+    fn resolve(self) -> crate::diff::OnConflict {
+        match self {
+            Self::Error => crate::diff::OnConflict::Error,
+            Self::LastWins => crate::diff::OnConflict::LastWins,
+        }
+    }
 }
 
 /// The `snapdir` subcommands, matching the Bash orchestrator one-for-one.
@@ -310,6 +385,49 @@ pub enum Command {
         /// Destination store URI: `protocol://location/path`.
         #[arg(long, value_name = "STORE")]
         to: String,
+        /// Explicit SOURCE object pool URI (split source): objects are read from
+        /// here while manifests come from `--from`. Absent => `--from` is a plain
+        /// colocated store. Distinct from the global `--objects-store`.
+        #[arg(long, value_name = "URI")]
+        from_objects: Option<String>,
+        /// Explicit DESTINATION object pool URI (split dest): objects are written
+        /// here while manifests go to `--to`. Absent => `--to` is a plain
+        /// colocated store. Distinct from the global `--objects-store`.
+        #[arg(long, value_name = "URI")]
+        to_objects: Option<String>,
+    },
+
+    /// Compare two sides, each a set of manifests, reporting file-level
+    /// differences — reading MANIFESTS ONLY.
+    Diff {
+        /// FROM-side ref: a manifest-store URI (enumerated) and/or, with the
+        /// global `--id`, a single pinned manifest. Repeatable; refs are
+        /// UNIONED into the FROM side.
+        #[arg(long, value_name = "REF", action = clap::ArgAction::Append)]
+        from: Vec<String>,
+
+        /// TO-side ref: a manifest-store URI (enumerated) and/or a pinned
+        /// manifest. Repeatable; refs are UNIONED into the TO side.
+        #[arg(long, value_name = "REF", action = clap::ArgAction::Append)]
+        to: Vec<String>,
+
+        /// Also emit unchanged (equal) paths.
+        #[arg(long)]
+        all: bool,
+
+        /// Emit a JSON array of `{status, path}` objects instead of porcelain.
+        #[arg(long)]
+        json: bool,
+
+        /// Exit 1 when any difference is found (git `diff --exit-code`
+        /// semantics); the default exits 0 regardless.
+        #[arg(long)]
+        exit_code: bool,
+
+        /// Policy for an intra-side path collision (same path, differing
+        /// content unioned on one side).
+        #[arg(long, value_name = "POLICY", value_enum, default_value_t = OnConflictArg::Error)]
+        on_conflict: OnConflictArg,
     },
 
     /// Print the version.
@@ -365,7 +483,8 @@ pub enum Command {
     /// Hidden wire plumbing: the sending half of
     /// `snapdir send-pack | ssh host 'snapdir receive-pack'`. Any failure —
     /// including a missing object — aborts BEFORE the `end` trailer
-    /// ([`write_pack`]), so a consumer of the partial stream fails too.
+    /// ([`write_pack_with_format`]), so a consumer of the partial stream fails
+    /// too.
     #[command(hide = true)]
     SendPack {
         /// File listing one object checksum per line (`-` reads stdin).
@@ -375,6 +494,19 @@ pub enum Command {
         /// Snapshot id whose manifest rides the pack as the LAST record.
         #[arg(long, value_name = "ID")]
         manifest_id: Option<String>,
+
+        /// On-wire SNAPPACK transport encoding to emit.
+        ///
+        /// HIDDEN + defaults to `v1`, so an old `send-pack` invocation stays
+        /// BYTE-IDENTICAL (same magic, same body, same `--help` surface). `zstd`
+        /// opts into the additive `SNAPPACK 1Z` form (same record grammar, whole
+        /// body in one zstd frame); the receiver sniffs the magic and accepts
+        /// either form, so there is no negotiation flag on `receive-pack`. The
+        /// compression level is the library default ([`DEFAULT_ZSTD_LEVEL`]),
+        /// overridable via `SNAPDIR_SSH_ZSTD_LEVEL` (the library is env-free, so
+        /// the level env is read HERE in the CLI seam).
+        #[arg(long, value_name = "FORMAT", value_enum, default_value_t = PackFormatArg::V1, hide = true)]
+        pack_format: PackFormatArg,
     },
 
     /// Consume a SNAPPACK stream from stdin into the store.
@@ -492,7 +624,20 @@ impl Cli {
                 Ok(())
             }
             Command::Defaults => run_defaults(),
-            Command::Sync { from, to } => self.run_sync(from, to),
+            Command::Sync {
+                from,
+                to,
+                from_objects,
+                to_objects,
+            } => self.run_sync(from, to, from_objects.as_deref(), to_objects.as_deref()),
+            Command::Diff {
+                from,
+                to,
+                all,
+                json,
+                exit_code,
+                on_conflict,
+            } => self.run_diff(from, to, *all, *json, *exit_code, on_conflict.resolve()),
             Command::Completions { shell } => {
                 // Build-time hook: emit the requested shell's completion script
                 // to stdout for the release pipeline to bundle. The bin name is
@@ -509,9 +654,11 @@ impl Cli {
                 Ok(())
             }
             Command::ObjectsNeeded => self.run_objects_needed(),
-            Command::SendPack { ids, manifest_id } => {
-                self.run_send_pack(ids, manifest_id.as_deref())
-            }
+            Command::SendPack {
+                ids,
+                manifest_id,
+                pack_format,
+            } => self.run_send_pack(ids, manifest_id.as_deref(), pack_format.resolve()),
             Command::ReceivePack { require_manifest } => {
                 self.run_receive_pack(require_manifest.as_deref())
             }
@@ -949,8 +1096,12 @@ impl Cli {
             m.set_phase(Phase::Hashing);
         }
         // Stage uses the same default checksum surface as `push`/`id`: b3sum
-        // (or keyed-b3sum), relative paths, follow symlinks.
-        let manifest = self.build_manifest(
+        // (or keyed-b3sum), relative paths, follow symlinks. We take the walk's
+        // CopyGuard side channel too: setting it on the cache FileStore lets
+        // `persist` stat-validate each unchanged source and SKIP the redundant
+        // post-copy re-hash (the stage clone-skip win). The guard map never
+        // changes the manifest, the object bytes, or the snapshot id.
+        let (manifest, copy_guards) = self.build_manifest_with_guards(
             path,
             false,
             false,
@@ -974,7 +1125,14 @@ impl Cli {
             m.set_total(total_object_bytes(&manifest));
             m.set_phase(Phase::Transfer);
         }
-        let cache = self.cache_store_with_meter(meter.clone())?;
+        // The walk's guard map is keyed by each plain regular file's absolute
+        // working-tree path (`root.join(rel)`); `push` looks up
+        // `source.join(rel)` with `source == root`, so the keys align exactly
+        // and the StatGuarded clone-skip engages. An empty/missing guard for a
+        // source ⇒ `Untrusted` ⇒ today's re-hash behavior.
+        let cache = self
+            .cache_store_with_meter(meter.clone())?
+            .with_copy_guards(copy_guards);
         cache
             .push(&manifest, &root)
             .with_context(|| format!("staging snapshot {id} into the local cache"))?;
@@ -1177,6 +1335,13 @@ impl Cli {
     /// the concrete store cannot be constructed (e.g. credentials/region cannot
     /// be resolved for a remote backend).
     fn resolve_store(&self, meter: Option<Arc<Meter>>) -> Result<Box<dyn Store>> {
+        // When `--objects-store` is set, objects route to the shared pool and
+        // manifests to `--store` via an in-process `SplitStore`. When absent the
+        // store is the colocated `--store` exactly as before — byte-for-byte
+        // unchanged.
+        if self.globals.objects_store.is_some() {
+            return Ok(Box::new(self.resolve_split_store(meter)?));
+        }
         let store_url = self
             .globals
             .store
@@ -1185,6 +1350,38 @@ impl Cli {
         let adapter = resolve_adapter(store_url).context("resolving --store protocol")?;
         let config = self.transfer_config_for(Some(adapter.name()))?;
         store_for_adapter(&adapter, store_url, config, meter)
+    }
+
+    /// Builds the `SplitStore` for a split push/fetch/pull: objects go to the
+    /// `--objects-store` pool, manifests to `--store`. BOTH sides are built via
+    /// [`stream_store_for_adapter`], so an external `custom://` on EITHER side is
+    /// rejected with the same actionable error class `sync` uses. `--store`
+    /// missing → a clear error (not a panic).
+    ///
+    /// Only called when `--objects-store` is set.
+    fn resolve_split_store(&self, meter: Option<Arc<Meter>>) -> Result<SplitStore> {
+        let objects_url = self
+            .globals
+            .objects_store
+            .as_deref()
+            .context("missing --objects-store option")?;
+        let store_url = self.globals.store.as_deref().context(
+            "missing --store option: --objects-store sets the object pool, but the manifest \
+             location (--store / $SNAPDIR_STORE) is still required",
+        )?;
+
+        let objects_adapter =
+            resolve_adapter(objects_url).context("resolving --objects-store protocol")?;
+        let objects_config = self.transfer_config_for(Some(objects_adapter.name()))?;
+        let objects =
+            stream_store_for_adapter(&objects_adapter, objects_url, objects_config, meter.clone())?;
+
+        let manifests_adapter = resolve_adapter(store_url).context("resolving --store protocol")?;
+        let manifests_config = self.transfer_config_for(Some(manifests_adapter.name()))?;
+        let manifests =
+            stream_store_for_adapter(&manifests_adapter, store_url, manifests_config, meter)?;
+
+        Ok(SplitStore::from_boxed(objects, manifests))
     }
 
     /// `true` when the resolved `--store` URL routes to a third-party
@@ -1205,6 +1402,12 @@ impl Cli {
     /// the identical errors `resolve_store` surfaces, so calling this after a
     /// successful `resolve_store` introduces no new failure mode.
     fn store_is_external(&self) -> Result<bool> {
+        // A split store (`--objects-store` set) is always in-process: both sides
+        // are built via `stream_store_for_adapter`, which rejects external URLs.
+        // So a split store never takes the external emit-command push/fetch path.
+        if self.globals.objects_store.is_some() {
+            return Ok(false);
+        }
         let store_url = self
             .globals
             .store
@@ -1455,7 +1658,51 @@ impl Cli {
     ///
     /// Output convention (consistent with `push`/`stage`): on a real sync the id
     /// is printed to STDOUT; a human summary always goes to STDERR.
-    fn run_sync(&self, from_url: &str, to_url: &str) -> Result<()> {
+    /// Builds the `StreamStore` for ONE side of a `sync`. When `objects_url` is
+    /// present, that side is a split store: objects route to `objects_url`,
+    /// manifests to `manifest_url` — wrapped in an in-process [`SplitStore`]
+    /// exactly as [`Self::resolve_split_store`] does for `--objects-store`. When
+    /// absent, the side is the plain colocated store at `manifest_url`,
+    /// byte-for-byte as before. BOTH sides of a split are built via
+    /// [`stream_store_for_adapter`], so an external `custom://` on either is
+    /// rejected — identical to non-split sync.
+    ///
+    /// `side` names the side (`--from`/`--to`) for error context only.
+    fn sync_side_store(
+        &self,
+        manifest_url: &str,
+        objects_url: Option<&str>,
+        side: &str,
+    ) -> Result<Box<dyn StreamStore + Sync>> {
+        let Some(objects_url) = objects_url else {
+            let adapter = resolve_adapter(manifest_url)
+                .with_context(|| format!("resolving {side} store protocol"))?;
+            let config = self.transfer_config_for(Some(adapter.name()))?;
+            return stream_store_for_adapter(&adapter, manifest_url, config, None);
+        };
+
+        let objects_adapter = resolve_adapter(objects_url)
+            .with_context(|| format!("resolving {side}-objects protocol"))?;
+        let objects_config = self.transfer_config_for(Some(objects_adapter.name()))?;
+        let objects =
+            stream_store_for_adapter(&objects_adapter, objects_url, objects_config, None)?;
+
+        let manifests_adapter = resolve_adapter(manifest_url)
+            .with_context(|| format!("resolving {side} store protocol"))?;
+        let manifests_config = self.transfer_config_for(Some(manifests_adapter.name()))?;
+        let manifests =
+            stream_store_for_adapter(&manifests_adapter, manifest_url, manifests_config, None)?;
+
+        Ok(Box::new(SplitStore::from_boxed(objects, manifests)))
+    }
+
+    fn run_sync(
+        &self,
+        from_url: &str,
+        to_url: &str,
+        from_objects: Option<&str>,
+        to_objects: Option<&str>,
+    ) -> Result<()> {
         let id = self.require_id()?;
         anyhow::ensure!(
             from_url != to_url,
@@ -1463,14 +1710,16 @@ impl Cli {
         );
 
         let from_adapter = resolve_adapter(from_url).context("resolving --from store protocol")?;
-        let to_adapter = resolve_adapter(to_url).context("resolving --to store protocol")?;
         // Each endpoint gets its own per-backend rate-limit defaults; the shared
         // sync pipe (concurrency, retry, byte budget accounting) is driven by the
         // source-side config below.
-        let from_config = self.transfer_config_for(Some(from_adapter.name()))?;
-        let to_config = self.transfer_config_for(Some(to_adapter.name()))?;
-        let from_store = stream_store_for_adapter(&from_adapter, from_url, from_config, None)?;
-        let to_store = stream_store_for_adapter(&to_adapter, to_url, to_config, None)?;
+        // Per-side stores: when `--from-objects`/`--to-objects` is present, THAT
+        // side is a split store (objects = the flag's pool, manifests = the
+        // `--from`/`--to` URI), built exactly like `resolve_split_store`. Absent =>
+        // a plain colocated store as before. A `SplitStore` IS a `StreamStore`, so
+        // the `sync_snapshot` engine is unchanged.
+        let from_store = self.sync_side_store(from_url, from_objects, "--from")?;
+        let to_store = self.sync_side_store(to_url, to_objects, "--to")?;
         let config = self.transfer_config_for(Some(from_adapter.name()))?;
 
         self.log_transfer_config();
@@ -1518,6 +1767,124 @@ impl Cli {
         Ok(())
     }
 
+    /// `snapdir diff --from <ref>… --to <ref>… [--all] [--json] [--exit-code]
+    /// [--on-conflict <error|last-wins>]`: compare two SIDES, each a UNION of
+    /// one-or-more manifests, and report file-level differences.
+    ///
+    /// MANIFESTS ONLY: every ref is resolved via [`Self::resolve_side`], which
+    /// calls EXCLUSIVELY [`StreamStore::list_manifest_ids`] (to enumerate a
+    /// store) and [`Store::get_manifest`] (BLAKE3-verified) — it NEVER
+    /// constructs an object store, calls `get_object`, or fetches a blob. So a
+    /// store whose `.objects/` pool is absent/garbage still diffs correctly.
+    ///
+    /// The comparison itself is the pure map-diff in [`crate::diff`]: each side
+    /// unions to a `path -> ManifestEntry` map (collisions handled per
+    /// `on_conflict`), then [`crate::diff::classify`] yields the A/D/M(/=) rows.
+    fn run_diff(
+        &self,
+        from: &[String],
+        to: &[String],
+        all: bool,
+        json: bool,
+        exit_code: bool,
+        on_conflict: crate::diff::OnConflict,
+    ) -> Result<()> {
+        use crate::diff::{classify, render_json, render_porcelain, union_side};
+
+        // Resolve each side to its set of manifests (manifests-only reads), then
+        // union into a path map. A differing-content intra-side collision under
+        // OnConflict::Error surfaces as an actionable error naming the path.
+        let from_manifests = self.resolve_side(from).context("resolving --from side")?;
+        let to_manifests = self.resolve_side(to).context("resolving --to side")?;
+
+        let from_map = union_side(&from_manifests, on_conflict).map_err(|c| {
+            anyhow::anyhow!(
+                "intra-side conflict on --from: the path {:?} has differing content across \
+                 two refs (collision); pass --on-conflict last-wins to let the last ref win",
+                c.path
+            )
+        })?;
+        let to_map = union_side(&to_manifests, on_conflict).map_err(|c| {
+            anyhow::anyhow!(
+                "intra-side conflict on --to: the path {:?} has differing content across \
+                 two refs (collision); pass --on-conflict last-wins to let the last ref win",
+                c.path
+            )
+        })?;
+
+        let rows = classify(&from_map, &to_map, all);
+
+        // A "difference" for --exit-code is any A/D/M row (never an unchanged
+        // row that only --all surfaces).
+        let has_difference = rows
+            .iter()
+            .any(|r| r.status != crate::diff::Status::Unchanged);
+
+        let out = std::io::stdout();
+        let mut out = out.lock();
+        if json {
+            writeln!(out, "{}", render_json(&rows))?;
+        } else {
+            // render_porcelain already terminates each line with `\n`.
+            write!(out, "{}", render_porcelain(&rows))?;
+        }
+        out.flush()?;
+
+        // git `diff --exit-code` semantics: exit 1 on any difference, AFTER the
+        // porcelain has been written. Without the flag, always exit 0.
+        if exit_code && has_difference {
+            drop(out);
+            std::process::exit(1);
+        }
+        Ok(())
+    }
+
+    /// Resolves one diff SIDE (a list of refs) to its set of manifests, reading
+    /// MANIFESTS ONLY.
+    ///
+    /// For each ref: build the store via the same [`stream_store_for_adapter`]
+    /// resolver the plumbing commands use, then enumerate it with
+    /// [`StreamStore::list_manifest_ids`] and read each manifest with
+    /// [`Store::get_manifest`] (which BLAKE3-verifies the bytes hash back to the
+    /// id). When the global `--id` is set AND that id is present in this ref's
+    /// store, the side is PINNED to exactly that one manifest (otherwise the
+    /// whole store is unioned). An empty/missing manifest store contributes
+    /// nothing (its `list_manifest_ids` yields zero ids).
+    ///
+    /// NO object store is ever constructed and no blob is ever fetched — the
+    /// only store methods called are `list_manifest_ids` and `get_manifest`.
+    fn resolve_side(&self, refs: &[String]) -> Result<Vec<Manifest>> {
+        let pinned_id = self.globals.id.as_deref();
+        let mut manifests = Vec::new();
+        for store_url in refs {
+            let adapter =
+                resolve_adapter(store_url).context("resolving a --from/--to ref protocol")?;
+            let config = self.transfer_config_for(Some(adapter.name()))?;
+            // MANIFESTS-ONLY: a StreamStore exposes both list_manifest_ids and
+            // get_manifest; we never touch its object surface.
+            let store = stream_store_for_adapter(&adapter, store_url, config, None)?;
+
+            let all_ids = store
+                .list_manifest_ids()
+                .with_context(|| format!("listing manifests in {store_url}"))?;
+
+            // If --id is set and this store holds it, pin to that single
+            // manifest; else union the whole store's manifests.
+            let ids: Vec<String> = match pinned_id {
+                Some(id) if all_ids.iter().any(|x| x == id) => vec![id.to_owned()],
+                _ => all_ids,
+            };
+
+            for id in &ids {
+                let manifest = store
+                    .get_manifest(id)
+                    .with_context(|| format!("reading manifest {id} from {store_url}"))?;
+                manifests.push(manifest);
+            }
+        }
+        Ok(manifests)
+    }
+
     /// `snapdir objects-needed --store <url>` (hidden plumbing): read candidate
     /// checksums from stdin (one per line) and print the subset the store does
     /// NOT hold, one per line, preserving first-occurrence order.
@@ -1552,11 +1919,21 @@ impl Cli {
     /// only, the byte stream is the entire stdout contract.
     ///
     /// The id list gets the same fail-closed validation as `objects-needed`
-    /// (and is deduped — [`write_pack`] documents dedup as the caller's job).
-    /// Any failure, including a missing object, makes [`write_pack`] abort
-    /// BEFORE the `end` trailer, so the piped `receive-pack` fails too: no
-    /// silent partial transfer.
-    fn run_send_pack(&self, ids: &Path, manifest_id: Option<&str>) -> Result<()> {
+    /// (and is deduped — [`write_pack_with_format`] documents dedup as the
+    /// caller's job). Any failure, including a missing object, makes
+    /// [`write_pack_with_format`] abort BEFORE the `end` trailer, so the piped
+    /// `receive-pack` fails too: no silent partial transfer.
+    ///
+    /// `format` is the resolved on-wire encoding ([`PackFormat::V1`] by default
+    /// — byte-identical to the historical stream — or [`PackFormat::Zstd`] when
+    /// the hidden `--pack-format zstd` flag opts in). `receive-pack` needs no
+    /// matching flag: it sniffs the magic and accepts either form.
+    fn run_send_pack(
+        &self,
+        ids: &Path,
+        manifest_id: Option<&str>,
+        format: PackFormat,
+    ) -> Result<()> {
         // Read + validate the id list (file path or `-` = stdin) before any
         // store work; a malformed list emits not a single pack byte.
         let ids = if ids == Path::new("-") {
@@ -1577,7 +1954,7 @@ impl Cli {
         }
         let store = self.resolve_stream_store()?;
         let stdout = std::io::stdout();
-        let report = write_pack(&*store, &ids, manifest_id, stdout.lock())
+        let report = write_pack_with_format(&*store, &ids, manifest_id, format, stdout.lock())
             .context("writing pack stream to stdout")?;
         if !self.globals.quiet {
             eprintln!(
@@ -1625,8 +2002,12 @@ impl Cli {
 
         let (report, committed) = if matches!(adapter, Adapter::File) {
             // file:// — the hot ssh path: stream payloads straight to disk.
+            // `SNAPDIR_FSYNC` selects crash-durability (default `batch`); the
+            // barrier fires through `RecordingSink::flush_barrier` before the
+            // manifest commits, so a durable manifest implies durable objects.
+            let durability = fsync_durability_from_env()?;
             let store = FileStore::new_with_config(store_url, config);
-            let mut sink = FileSink::new(&store);
+            let mut sink = FileSink::new(&store).with_durability(durability);
             read_pack_recording(stdin.lock(), &mut sink)?
         } else {
             // Any other StreamStore: one buffered record at a time. External
@@ -1667,6 +2048,13 @@ impl Cli {
     /// `sync` uses (external `snapdir-*-store` URLs are rejected there — they
     /// have no in-process streaming surface).
     fn resolve_stream_store(&self) -> Result<Box<dyn StreamStore + Sync>> {
+        // When `--objects-store` is set, wrap the pool (objects) + `--store`
+        // (manifests) in an in-process `SplitStore`; both sides go through
+        // `stream_store_for_adapter`, so external URLs are rejected on either
+        // side. When absent, behavior is unchanged.
+        if self.globals.objects_store.is_some() {
+            return Ok(Box::new(self.resolve_split_store(None)?));
+        }
         let store_url = self
             .globals
             .store
@@ -1721,7 +2109,82 @@ impl Cli {
         exclude: &[String],
         meter: Option<&Meter>,
     ) -> Result<Manifest> {
-        let root = resolve_root(path).context("resolving manifest path")?;
+        let (root, options) = self.resolve_walk(
+            path,
+            absolute,
+            no_follow,
+            exclude,
+            "resolving manifest path",
+        )?;
+
+        // Select the checksum function. `b3sum` (or unset) is the default; the
+        // CLI reads `SNAPDIR_MANIFEST_CONTEXT` (core stays env-pure) to switch
+        // to keyed BLAKE3. `--checksum-bin` selects md5sum / sha256sum.
+        match checksum_bin {
+            None | Some("b3sum") => {
+                let context = std::env::var("SNAPDIR_MANIFEST_CONTEXT").unwrap_or_default();
+                if context.is_empty() {
+                    walk_with(&root, &options, &Blake3Hasher::new(), meter)
+                } else {
+                    walk_with(&root, &options, &Blake3KeyedHasher::new(context), meter)
+                }
+            }
+            Some("md5sum") => walk_with(&root, &options, &Md5Hasher::new(), meter),
+            Some("sha256sum") => walk_with(&root, &options, &Sha256Hasher::new(), meter),
+            Some(other) => {
+                anyhow::bail!("snapdir: unsupported --checksum-bin '{other}'")
+            }
+        }
+    }
+
+    /// Sibling of [`Self::build_manifest`] that ALSO returns the walk's
+    /// [`CopyGuard`] side channel — used ONLY by `run_stage` so the local-cache
+    /// [`FileStore`]'s stat-validated clone-skip can engage. The resolved
+    /// `(root, options, hasher)` are identical to [`Self::build_manifest`] (both
+    /// route through [`Self::resolve_walk`]), so the returned [`Manifest`] — and
+    /// hence the snapshot id — is byte-identical. The map keys are the walk's
+    /// absolute file paths (`root.join(rel)`), exactly what `push` looks up.
+    fn build_manifest_with_guards(
+        &self,
+        path: Option<&Path>,
+        absolute: bool,
+        no_follow: bool,
+        checksum_bin: Option<&str>,
+        exclude: &[String],
+        meter: Option<&Meter>,
+    ) -> Result<(Manifest, std::collections::HashMap<PathBuf, CopyGuard>)> {
+        let (root, options) =
+            self.resolve_walk(path, absolute, no_follow, exclude, "resolving stage path")?;
+
+        match checksum_bin {
+            None | Some("b3sum") => {
+                let context = std::env::var("SNAPDIR_MANIFEST_CONTEXT").unwrap_or_default();
+                if context.is_empty() {
+                    walk_with_guards_ctx(&root, &options, &Blake3Hasher::new(), meter)
+                } else {
+                    walk_with_guards_ctx(&root, &options, &Blake3KeyedHasher::new(context), meter)
+                }
+            }
+            Some("md5sum") => walk_with_guards_ctx(&root, &options, &Md5Hasher::new(), meter),
+            Some("sha256sum") => walk_with_guards_ctx(&root, &options, &Sha256Hasher::new(), meter),
+            Some(other) => {
+                anyhow::bail!("snapdir: unsupported --checksum-bin '{other}'")
+            }
+        }
+    }
+
+    /// Resolves the walk root and [`WalkOptions`] shared by
+    /// [`Self::build_manifest`] and [`Self::build_manifest_with_guards`] so both
+    /// derive an IDENTICAL traversal (`follow`/`path_mode`/`exclude`/`walk_jobs`).
+    fn resolve_walk(
+        &self,
+        path: Option<&Path>,
+        absolute: bool,
+        no_follow: bool,
+        exclude: &[String],
+        context: &'static str,
+    ) -> Result<(PathBuf, WalkOptions)> {
+        let root = resolve_root(path).context(context)?;
 
         // Expand the exclude patterns. Each `--exclude` value is expanded
         // independently — `%system%` / `%common%` macros must be expanded
@@ -1755,26 +2218,9 @@ impl Cli {
             follow,
             path_mode,
             exclude: matcher,
+            walk_jobs: self.globals.walk_jobs,
         };
-
-        // Select the checksum function. `b3sum` (or unset) is the default; the
-        // CLI reads `SNAPDIR_MANIFEST_CONTEXT` (core stays env-pure) to switch
-        // to keyed BLAKE3. `--checksum-bin` selects md5sum / sha256sum.
-        match checksum_bin {
-            None | Some("b3sum") => {
-                let context = std::env::var("SNAPDIR_MANIFEST_CONTEXT").unwrap_or_default();
-                if context.is_empty() {
-                    walk_with(&root, &options, &Blake3Hasher::new(), meter)
-                } else {
-                    walk_with(&root, &options, &Blake3KeyedHasher::new(context), meter)
-                }
-            }
-            Some("md5sum") => walk_with(&root, &options, &Md5Hasher::new(), meter),
-            Some("sha256sum") => walk_with(&root, &options, &Sha256Hasher::new(), meter),
-            Some(other) => {
-                anyhow::bail!("snapdir: unsupported --checksum-bin '{other}'")
-            }
-        }
+        Ok((root, options))
     }
 }
 
@@ -1903,13 +2349,36 @@ fn read_checksum_lines(reader: impl BufRead) -> Result<Vec<String>> {
 
 /// Drops duplicate checksums, keeping the FIRST occurrence of each and the
 /// relative order of survivors. The pack/diff libs document deduplication as
-/// the caller's job ([`StreamStore::objects_needed`], [`write_pack`]), so the
-/// CLI is where it happens.
+/// the caller's job ([`StreamStore::objects_needed`], [`write_pack_with_format`]),
+/// so the CLI is where it happens.
 fn dedupe_preserving_order(ids: Vec<String>) -> Vec<String> {
     let mut seen = std::collections::HashSet::with_capacity(ids.len());
     ids.into_iter()
         .filter(|id| seen.insert(id.clone()))
         .collect()
+}
+
+/// Resolves the receive-pack crash-durability mode from `SNAPDIR_FSYNC`.
+///
+/// `batch` (the default when unset/empty) enables batched durability — exactly
+/// two full syncs per pack so a durable manifest implies durable objects. `off`
+/// restores the historical no-fsync filing. Any OTHER value is a hard error
+/// (fail closed): we never silently fall back to a weaker durability than the
+/// operator asked for.
+fn fsync_durability_from_env() -> Result<Durability> {
+    match std::env::var("SNAPDIR_FSYNC") {
+        Err(std::env::VarError::NotPresent) => Ok(Durability::Batch),
+        Ok(raw) => match raw.trim() {
+            "" | "batch" => Ok(Durability::Batch),
+            "off" => Ok(Durability::Off),
+            other => anyhow::bail!(
+                "invalid SNAPDIR_FSYNC {other:?}: expected `batch` (default) or `off`"
+            ),
+        },
+        Err(std::env::VarError::NotUnicode(_)) => anyhow::bail!(
+            "invalid SNAPDIR_FSYNC: value is not valid UTF-8; expected `batch` (default) or `off`"
+        ),
+    }
 }
 
 /// A [`PackSink`] decorator that records WHICH manifest id the stream
@@ -1950,6 +2419,14 @@ impl PackSink for RecordingSink<'_> {
         self.inner.put_manifest(id, manifest)?;
         self.manifest_id = Some(id.to_owned());
         Ok(())
+    }
+
+    fn flush_barrier(&mut self) -> Result<(), StoreError> {
+        // MUST delegate: `read_pack` fires the barrier through the sink it
+        // drives (the RecordingSink), right before the manifest. Without this
+        // override the no-op trait default would swallow it and the inner
+        // FileSink's durability would silently never activate.
+        self.inner.flush_barrier()
     }
 }
 
@@ -2086,13 +2563,27 @@ fn reformat_env_default(key: &str, value: &str) -> String {
 /// `anyhow` error with context.
 ///
 /// [`WalkError`]: snapdir_core::WalkError
-fn walk_with<H: Hasher>(
+fn walk_with<H: Hasher + HashFile + Sync>(
     root: &Path,
     options: &WalkOptions,
     hasher: &H,
     meter: Option<&Meter>,
 ) -> Result<Manifest> {
     walk_with_meter(root, options, hasher, meter)
+        .with_context(|| format!("walking {}", root.display()))
+}
+
+/// Like [`walk_with`], but ALSO returns the walk's [`CopyGuard`] side channel
+/// (keyed by each plain regular file's absolute working-tree path). Used only by
+/// the stage→local-cache push so [`FileStore`]'s stat-validated clone-skip can
+/// engage; the [`Manifest`] is byte-identical to [`walk_with`]'s.
+fn walk_with_guards_ctx<H: Hasher + HashFile + Sync>(
+    root: &Path,
+    options: &WalkOptions,
+    hasher: &H,
+    meter: Option<&Meter>,
+) -> Result<(Manifest, std::collections::HashMap<PathBuf, CopyGuard>)> {
+    walk_with_guards(root, options, hasher, meter)
         .with_context(|| format!("walking {}", root.display()))
 }
 

--- a/crates/snapdir-cli/src/diff.rs
+++ b/crates/snapdir-cli/src/diff.rs
@@ -1,0 +1,276 @@
+//! Pure `snapdir diff` logic: union manifests into per-side path maps and
+//! classify each path as Added / Deleted / Modified / Unchanged.
+//!
+//! This module is intentionally I/O-free and store-free: it operates on
+//! already-read [`Manifest`]s only. The CLI seam in [`crate::cli`] reads the
+//! manifests (MANIFESTS ONLY — never an object store) and hands their entries
+//! here. Keeping the comparison here makes `diff` a thin map-diff over manifest
+//! entries, reusing [`ManifestEntry`] verbatim as the comparison key.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::fmt::Write as _;
+
+use snapdir_core::{Manifest, ManifestEntry};
+
+/// The per-path change classification, mirroring git's porcelain letters.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Status {
+    /// In TO but not FROM.
+    Added,
+    /// In FROM but not TO.
+    Deleted,
+    /// In both, but the entry differs (checksum, mode, or size).
+    Modified,
+    /// In both and identical. Hidden unless `--all`.
+    Unchanged,
+}
+
+impl Status {
+    /// The porcelain letter for a changed status, or `None` for `Unchanged`
+    /// (which has no `A|D|M` letter — it is surfaced under `--all` only).
+    #[must_use]
+    pub fn letter(self) -> Option<&'static str> {
+        match self {
+            Status::Added => Some("A"),
+            Status::Deleted => Some("D"),
+            Status::Modified => Some("M"),
+            Status::Unchanged => None,
+        }
+    }
+
+    /// The JSON `status` token, including the `unchanged` marker used by
+    /// `--all`.
+    #[must_use]
+    pub fn json_token(self) -> &'static str {
+        match self {
+            Status::Added => "A",
+            Status::Deleted => "D",
+            Status::Modified => "M",
+            Status::Unchanged => "=",
+        }
+    }
+}
+
+/// The conflict policy for an intra-side path collision (the SAME path with
+/// DIFFERING content unioned across two refs on one side).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OnConflict {
+    /// Default: a differing-content collision is a hard error.
+    Error,
+    /// The last ref contributing the path wins.
+    LastWins,
+}
+
+/// A single diff result row: the classification + the path.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DiffEntry {
+    /// The change classification.
+    pub status: Status,
+    /// The entry path (verbatim, `./`-prefixed, directories trailing `/`).
+    pub path: String,
+}
+
+/// An intra-side collision: the same path carried DIFFERING content by two refs
+/// unioned on one side, under [`OnConflict::Error`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Collision {
+    /// The colliding path.
+    pub path: String,
+}
+
+/// The comparable fingerprint of a manifest entry: everything that, when
+/// changed, classifies the path as Modified.
+///
+/// For a FILE this is the full [`ManifestEntry`] tuple `(path_type,
+/// permissions, checksum, size)`, so a mode-only OR a content/size delta both
+/// surface as `M`.
+///
+/// For a DIRECTORY the `checksum` is the subtree MERKLE and `size` is the
+/// derived directory size — both change whenever ANY descendant changes. A diff
+/// reports the changed descendants on their OWN lines, so a directory must NOT
+/// also surface as `M` merely because its children moved; we compare a
+/// directory by `(path_type, permissions)` only. A genuine directory mode-only
+/// change still surfaces as `M` (its permissions differ), and two refs carrying
+/// the same directory with the same permissions never collide.
+fn fingerprint(entry: &ManifestEntry) -> (snapdir_core::PathType, &str, Option<&str>, Option<u64>) {
+    match entry.path_type {
+        snapdir_core::PathType::File => (
+            entry.path_type,
+            entry.permissions.as_str(),
+            Some(entry.checksum.as_str()),
+            Some(entry.size),
+        ),
+        snapdir_core::PathType::Directory => {
+            (entry.path_type, entry.permissions.as_str(), None, None)
+        }
+    }
+}
+
+/// Two entries describe the same content iff their fingerprints match (the
+/// directory merkle/size are excluded — see [`fingerprint`]).
+fn same_content(a: &ManifestEntry, b: &ManifestEntry) -> bool {
+    fingerprint(a) == fingerprint(b)
+}
+
+/// Unions a side's manifests (in ref order) into a `path -> ManifestEntry` map.
+///
+/// Two refs carrying the SAME path with IDENTICAL content union silently. The
+/// SAME path with DIFFERING content is a collision: under
+/// [`OnConflict::Error`] the first such path is returned as `Err`; under
+/// [`OnConflict::LastWins`] the later ref's entry overwrites the earlier one.
+///
+/// # Errors
+///
+/// Returns the first [`Collision`] when `on_conflict` is [`OnConflict::Error`]
+/// and two refs disagree on a path's content.
+pub fn union_side(
+    manifests: &[Manifest],
+    on_conflict: OnConflict,
+) -> Result<BTreeMap<String, ManifestEntry>, Collision> {
+    let mut map: BTreeMap<String, ManifestEntry> = BTreeMap::new();
+    for manifest in manifests {
+        for entry in manifest.entries() {
+            match map.get(&entry.path) {
+                Some(existing) if same_content(existing, entry) => {
+                    // Identical content for the same path: no conflict.
+                }
+                Some(_existing) => match on_conflict {
+                    OnConflict::Error => {
+                        return Err(Collision {
+                            path: entry.path.clone(),
+                        });
+                    }
+                    OnConflict::LastWins => {
+                        map.insert(entry.path.clone(), entry.clone());
+                    }
+                },
+                None => {
+                    map.insert(entry.path.clone(), entry.clone());
+                }
+            }
+        }
+    }
+    Ok(map)
+}
+
+/// Classifies every path across the two side maps, returning the rows sorted by
+/// path (byte order — the `BTreeMap` keys are already byte-ordered `String`s).
+///
+/// `include_unchanged` (the `--all` flag) keeps equal paths as
+/// [`Status::Unchanged`]; otherwise they are dropped.
+#[must_use]
+pub fn classify(
+    from: &BTreeMap<String, ManifestEntry>,
+    to: &BTreeMap<String, ManifestEntry>,
+    include_unchanged: bool,
+) -> Vec<DiffEntry> {
+    // Union of all paths, byte-sorted (BTreeSet iteration order).
+    let mut paths: BTreeSet<&str> = BTreeSet::new();
+    for p in from.keys() {
+        paths.insert(p.as_str());
+    }
+    for p in to.keys() {
+        paths.insert(p.as_str());
+    }
+
+    let mut rows = Vec::new();
+    for path in &paths {
+        let in_from = from.get(*path);
+        let in_to = to.get(*path);
+
+        // `diff` reports FILE-level differences. A directory entry carries a
+        // subtree merkle/size that changes whenever a descendant changes, and
+        // those descendants are reported on their own lines — so a path that is
+        // a directory on every side it appears in is NOT a diff row of its own
+        // (added/deleted/modified subtrees surface via their file entries). A
+        // file<->directory type change at a path is still a real difference and
+        // falls through to the classification below.
+        let is_dir = |e: &ManifestEntry| e.path_type == snapdir_core::PathType::Directory;
+        let present_only_dirs = match (in_from, in_to) {
+            (Some(f), Some(t)) => is_dir(f) && is_dir(t),
+            (Some(e), None) | (None, Some(e)) => is_dir(e),
+            (None, None) => false,
+        };
+        if present_only_dirs {
+            continue;
+        }
+
+        let status = match (in_from, in_to) {
+            (None, Some(_)) => Status::Added,
+            (Some(_), None) => Status::Deleted,
+            (Some(f), Some(t)) => {
+                if same_content(f, t) {
+                    Status::Unchanged
+                } else {
+                    Status::Modified
+                }
+            }
+            (None, None) => unreachable!("a path in the union must be in at least one side"),
+        };
+        if status == Status::Unchanged && !include_unchanged {
+            continue;
+        }
+        rows.push(DiffEntry {
+            status,
+            path: (*path).to_owned(),
+        });
+    }
+    rows
+}
+
+/// Renders the diff rows as porcelain `X\t./path` lines (one per row, sorted by
+/// path because `rows` already is). Unchanged rows (only present under `--all`)
+/// use a `=` marker, which the porcelain consumer treats as "not A/D/M".
+#[must_use]
+pub fn render_porcelain(rows: &[DiffEntry]) -> String {
+    let mut out = String::new();
+    for row in rows {
+        let letter = row.status.letter().unwrap_or("=");
+        out.push_str(letter);
+        out.push('\t');
+        out.push_str(&row.path);
+        out.push('\n');
+    }
+    out
+}
+
+/// Renders the diff rows as a JSON array of `{"status":"X","path":"./p"}`
+/// objects. `status` is the `A|D|M` letter (or `=` for an unchanged row under
+/// `--all`); `path` is JSON-string-escaped.
+#[must_use]
+pub fn render_json(rows: &[DiffEntry]) -> String {
+    let mut out = String::from("[");
+    for (i, row) in rows.iter().enumerate() {
+        if i > 0 {
+            out.push(',');
+        }
+        out.push_str("{\"status\":\"");
+        out.push_str(row.status.json_token());
+        out.push_str("\",\"path\":\"");
+        out.push_str(&json_escape(&row.path));
+        out.push_str("\"}");
+    }
+    out.push(']');
+    out
+}
+
+/// Minimal JSON string escaping for a manifest path (quote, backslash, and the
+/// control chars JSON requires escaping). Manifest paths are UTF-8 text; the
+/// remaining bytes pass through verbatim so unicode/space paths round-trip.
+fn json_escape(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for ch in s.chars() {
+        match ch {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            c if (c as u32) < 0x20 => {
+                let _ = write!(out, "\\u{:04x}", c as u32);
+            }
+            c => out.push(c),
+        }
+    }
+    out
+}

--- a/crates/snapdir-cli/src/lib.rs
+++ b/crates/snapdir-cli/src/lib.rs
@@ -19,6 +19,9 @@
 //! are made beyond "the `snapdir` binary keeps behaving as documented".
 
 mod cli;
+// Pure `snapdir diff` comparison logic (manifest map-diff + porcelain/JSON
+// rendering); the store reads live in `cli`.
+mod diff;
 // The progress renderer engine, wired into every transfer command and gated by
 // the --no-progress/--quiet/--color flags.
 mod progress;

--- a/crates/snapdir-cli/tests/cmd/help-ancestors.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-ancestors.trycmd
@@ -20,6 +20,11 @@ Options:
           
           [env: SNAPDIR_STORE=]
 
+      --objects-store <URI>
+          Shared object-pool store URI: when set, content OBJECTS route to this pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`
+          
+          [env: SNAPDIR_OBJECTS_STORE=]
+
       --id <ID>
           Snapshot ID to operate on
 
@@ -70,6 +75,11 @@ Options:
           Max concurrent object transfers (0/auto = number of CPUs, capped)
           
           [env: SNAPDIR_JOBS=]
+
+      --walk-jobs <N>
+          Max parallel file-hashing jobs during the directory walk (0/auto = number of CPUs, capped). Distinct from --jobs (transfer concurrency)
+          
+          [env: SNAPDIR_WALK_JOBS=]
 
       --limit-rate <RATE>
           Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)

--- a/crates/snapdir-cli/tests/cmd/help-checkout.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-checkout.trycmd
@@ -24,6 +24,11 @@ Options:
           
           [env: SNAPDIR_STORE=]
 
+      --objects-store <URI>
+          Shared object-pool store URI: when set, content OBJECTS route to this pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`
+          
+          [env: SNAPDIR_OBJECTS_STORE=]
+
       --id <ID>
           Snapshot ID to operate on
 
@@ -74,6 +79,11 @@ Options:
           Max concurrent object transfers (0/auto = number of CPUs, capped)
           
           [env: SNAPDIR_JOBS=]
+
+      --walk-jobs <N>
+          Max parallel file-hashing jobs during the directory walk (0/auto = number of CPUs, capped). Distinct from --jobs (transfer concurrency)
+          
+          [env: SNAPDIR_WALK_JOBS=]
 
       --limit-rate <RATE>
           Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)

--- a/crates/snapdir-cli/tests/cmd/help-defaults.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-defaults.trycmd
@@ -20,6 +20,11 @@ Options:
           
           [env: SNAPDIR_STORE=]
 
+      --objects-store <URI>
+          Shared object-pool store URI: when set, content OBJECTS route to this pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`
+          
+          [env: SNAPDIR_OBJECTS_STORE=]
+
       --id <ID>
           Snapshot ID to operate on
 
@@ -70,6 +75,11 @@ Options:
           Max concurrent object transfers (0/auto = number of CPUs, capped)
           
           [env: SNAPDIR_JOBS=]
+
+      --walk-jobs <N>
+          Max parallel file-hashing jobs during the directory walk (0/auto = number of CPUs, capped). Distinct from --jobs (transfer concurrency)
+          
+          [env: SNAPDIR_WALK_JOBS=]
 
       --limit-rate <RATE>
           Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)

--- a/crates/snapdir-cli/tests/cmd/help-diff.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-diff.trycmd
@@ -1,0 +1,143 @@
+```
+$ snapdir diff --help
+Compare two sides, each a set of manifests, reporting file-level differences — reading MANIFESTS ONLY
+
+Usage: snapdir diff [OPTIONS]
+
+Options:
+      --cache-dir <DIR>
+          Directory where the object cache is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
+      --from <REF>
+          FROM-side ref: a manifest-store URI (enumerated) and/or, with the global `--id`, a single pinned manifest. Repeatable; refs are UNIONED into the FROM side
+
+      --catalog <NAME>
+          Catalog adapter to use
+          
+          [env: SNAPDIR_CATALOG=]
+
+      --to <REF>
+          TO-side ref: a manifest-store URI (enumerated) and/or a pinned manifest. Repeatable; refs are UNIONED into the TO side
+
+      --all
+          Also emit unchanged (equal) paths
+
+      --store <URI>
+          Store URI: `protocol://location/path`
+          
+          [env: SNAPDIR_STORE=]
+
+      --json
+          Emit a JSON array of `{status, path}` objects instead of porcelain
+
+      --objects-store <URI>
+          Shared object-pool store URI: when set, content OBJECTS route to this pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`
+          
+          [env: SNAPDIR_OBJECTS_STORE=]
+
+      --exit-code
+          Exit 1 when any difference is found (git `diff --exit-code` semantics); the default exits 0 regardless
+
+      --id <ID>
+          Snapshot ID to operate on
+
+      --exclude <PATTERN>
+          Exclude paths matching PATTERN
+
+      --on-conflict <POLICY>
+          Policy for an intra-side path collision (same path, differing content unioned on one side)
+
+          Possible values:
+          - error:     A differing-content collision is a hard error (default)
+          - last-wins: The last ref contributing the path wins
+          
+          [default: error]
+
+      --paths <PATTERN>
+          Only include paths matching PATTERN
+
+      --linked
+          Use symlinks instead of copies
+
+      --force
+          Force an action to run
+
+      --purge
+          Purge objects with invalid checksums
+
+      --keep
+          Keep the staging directory
+
+      --dryrun
+          Run without making any changes
+
+      --verbose
+          Enable verbose output
+
+      --debug
+          Enable debug output
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+          
+          [default: auto]
+
+      --location <DIR|STORE>
+          Context (directory or store) for catalog queries
+
+  -j, --jobs <N>
+          Max concurrent object transfers (0/auto = number of CPUs, capped)
+          
+          [env: SNAPDIR_JOBS=]
+
+      --walk-jobs <N>
+          Max parallel file-hashing jobs during the directory walk (0/auto = number of CPUs, capped). Distinct from --jobs (transfer concurrency)
+          
+          [env: SNAPDIR_WALK_JOBS=]
+
+      --limit-rate <RATE>
+          Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)
+          
+          [env: SNAPDIR_LIMIT_RATE=]
+
+      --adaptive[=<FRACTION>]
+          Adaptively tune transfer concurrency/bandwidth toward a fraction (default 0.8) of measured CPU/network capacity; backs off under contention. Opt-in; default is full speed.
+          
+          Presence (with or without a value) opts in; the optional value is the politeness fraction in `(0.0, 1.0]`.
+          
+          [env: SNAPDIR_ADAPTIVE=]
+
+      --max-jobs <N>
+          Adaptive concurrency ceiling (only meaningful with `--adaptive`). When unset, defaults to the auto concurrency; clamped to a sane upper bound
+          
+          [env: SNAPDIR_MAX_JOBS=]
+
+      --max-retries <N>
+          Total retry attempts per network request, including the first (default 5)
+
+      --retry-base-ms <MS>
+          Base backoff delay in milliseconds for request retries (default 250)
+
+      --retry-max-ms <MS>
+          Maximum backoff delay in milliseconds for request retries (default 30000)
+
+      --max-requests <N>
+          Cap request rate (req/s); 0/unset uses the per-backend default
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+
+```

--- a/crates/snapdir-cli/tests/cmd/help-fetch.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-fetch.trycmd
@@ -20,6 +20,11 @@ Options:
           
           [env: SNAPDIR_STORE=]
 
+      --objects-store <URI>
+          Shared object-pool store URI: when set, content OBJECTS route to this pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`
+          
+          [env: SNAPDIR_OBJECTS_STORE=]
+
       --id <ID>
           Snapshot ID to operate on
 
@@ -70,6 +75,11 @@ Options:
           Max concurrent object transfers (0/auto = number of CPUs, capped)
           
           [env: SNAPDIR_JOBS=]
+
+      --walk-jobs <N>
+          Max parallel file-hashing jobs during the directory walk (0/auto = number of CPUs, capped). Distinct from --jobs (transfer concurrency)
+          
+          [env: SNAPDIR_WALK_JOBS=]
 
       --limit-rate <RATE>
           Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)

--- a/crates/snapdir-cli/tests/cmd/help-flush-cache.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-flush-cache.trycmd
@@ -20,6 +20,11 @@ Options:
           
           [env: SNAPDIR_STORE=]
 
+      --objects-store <URI>
+          Shared object-pool store URI: when set, content OBJECTS route to this pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`
+          
+          [env: SNAPDIR_OBJECTS_STORE=]
+
       --id <ID>
           Snapshot ID to operate on
 
@@ -70,6 +75,11 @@ Options:
           Max concurrent object transfers (0/auto = number of CPUs, capped)
           
           [env: SNAPDIR_JOBS=]
+
+      --walk-jobs <N>
+          Max parallel file-hashing jobs during the directory walk (0/auto = number of CPUs, capped). Distinct from --jobs (transfer concurrency)
+          
+          [env: SNAPDIR_WALK_JOBS=]
 
       --limit-rate <RATE>
           Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)

--- a/crates/snapdir-cli/tests/cmd/help-id.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-id.trycmd
@@ -24,6 +24,11 @@ Options:
           
           [env: SNAPDIR_STORE=]
 
+      --objects-store <URI>
+          Shared object-pool store URI: when set, content OBJECTS route to this pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`
+          
+          [env: SNAPDIR_OBJECTS_STORE=]
+
       --id <ID>
           Snapshot ID to operate on
 
@@ -74,6 +79,11 @@ Options:
           Max concurrent object transfers (0/auto = number of CPUs, capped)
           
           [env: SNAPDIR_JOBS=]
+
+      --walk-jobs <N>
+          Max parallel file-hashing jobs during the directory walk (0/auto = number of CPUs, capped). Distinct from --jobs (transfer concurrency)
+          
+          [env: SNAPDIR_WALK_JOBS=]
 
       --limit-rate <RATE>
           Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)

--- a/crates/snapdir-cli/tests/cmd/help-locations.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-locations.trycmd
@@ -20,6 +20,11 @@ Options:
           
           [env: SNAPDIR_STORE=]
 
+      --objects-store <URI>
+          Shared object-pool store URI: when set, content OBJECTS route to this pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`
+          
+          [env: SNAPDIR_OBJECTS_STORE=]
+
       --id <ID>
           Snapshot ID to operate on
 
@@ -70,6 +75,11 @@ Options:
           Max concurrent object transfers (0/auto = number of CPUs, capped)
           
           [env: SNAPDIR_JOBS=]
+
+      --walk-jobs <N>
+          Max parallel file-hashing jobs during the directory walk (0/auto = number of CPUs, capped). Distinct from --jobs (transfer concurrency)
+          
+          [env: SNAPDIR_WALK_JOBS=]
 
       --limit-rate <RATE>
           Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)

--- a/crates/snapdir-cli/tests/cmd/help-manifest.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-manifest.trycmd
@@ -36,6 +36,11 @@ Options:
       --exclude <PATTERN>
           Exclude paths matching the extended-regex PATTERN (supports the `%system%` / `%common%` macros)
 
+      --objects-store <URI>
+          Shared object-pool store URI: when set, content OBJECTS route to this pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`
+          
+          [env: SNAPDIR_OBJECTS_STORE=]
+
       --id <ID>
           Snapshot ID to operate on
 
@@ -83,6 +88,11 @@ Options:
           Max concurrent object transfers (0/auto = number of CPUs, capped)
           
           [env: SNAPDIR_JOBS=]
+
+      --walk-jobs <N>
+          Max parallel file-hashing jobs during the directory walk (0/auto = number of CPUs, capped). Distinct from --jobs (transfer concurrency)
+          
+          [env: SNAPDIR_WALK_JOBS=]
 
       --limit-rate <RATE>
           Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)

--- a/crates/snapdir-cli/tests/cmd/help-pull.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-pull.trycmd
@@ -24,6 +24,11 @@ Options:
           
           [env: SNAPDIR_STORE=]
 
+      --objects-store <URI>
+          Shared object-pool store URI: when set, content OBJECTS route to this pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`
+          
+          [env: SNAPDIR_OBJECTS_STORE=]
+
       --id <ID>
           Snapshot ID to operate on
 
@@ -74,6 +79,11 @@ Options:
           Max concurrent object transfers (0/auto = number of CPUs, capped)
           
           [env: SNAPDIR_JOBS=]
+
+      --walk-jobs <N>
+          Max parallel file-hashing jobs during the directory walk (0/auto = number of CPUs, capped). Distinct from --jobs (transfer concurrency)
+          
+          [env: SNAPDIR_WALK_JOBS=]
 
       --limit-rate <RATE>
           Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)

--- a/crates/snapdir-cli/tests/cmd/help-push.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-push.trycmd
@@ -24,6 +24,11 @@ Options:
           
           [env: SNAPDIR_STORE=]
 
+      --objects-store <URI>
+          Shared object-pool store URI: when set, content OBJECTS route to this pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`
+          
+          [env: SNAPDIR_OBJECTS_STORE=]
+
       --id <ID>
           Snapshot ID to operate on
 
@@ -74,6 +79,11 @@ Options:
           Max concurrent object transfers (0/auto = number of CPUs, capped)
           
           [env: SNAPDIR_JOBS=]
+
+      --walk-jobs <N>
+          Max parallel file-hashing jobs during the directory walk (0/auto = number of CPUs, capped). Distinct from --jobs (transfer concurrency)
+          
+          [env: SNAPDIR_WALK_JOBS=]
 
       --limit-rate <RATE>
           Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)

--- a/crates/snapdir-cli/tests/cmd/help-revisions.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-revisions.trycmd
@@ -20,6 +20,11 @@ Options:
           
           [env: SNAPDIR_STORE=]
 
+      --objects-store <URI>
+          Shared object-pool store URI: when set, content OBJECTS route to this pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`
+          
+          [env: SNAPDIR_OBJECTS_STORE=]
+
       --id <ID>
           Snapshot ID to operate on
 
@@ -70,6 +75,11 @@ Options:
           Max concurrent object transfers (0/auto = number of CPUs, capped)
           
           [env: SNAPDIR_JOBS=]
+
+      --walk-jobs <N>
+          Max parallel file-hashing jobs during the directory walk (0/auto = number of CPUs, capped). Distinct from --jobs (transfer concurrency)
+          
+          [env: SNAPDIR_WALK_JOBS=]
 
       --limit-rate <RATE>
           Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)

--- a/crates/snapdir-cli/tests/cmd/help-stage.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-stage.trycmd
@@ -24,6 +24,11 @@ Options:
           
           [env: SNAPDIR_STORE=]
 
+      --objects-store <URI>
+          Shared object-pool store URI: when set, content OBJECTS route to this pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`
+          
+          [env: SNAPDIR_OBJECTS_STORE=]
+
       --id <ID>
           Snapshot ID to operate on
 
@@ -74,6 +79,11 @@ Options:
           Max concurrent object transfers (0/auto = number of CPUs, capped)
           
           [env: SNAPDIR_JOBS=]
+
+      --walk-jobs <N>
+          Max parallel file-hashing jobs during the directory walk (0/auto = number of CPUs, capped). Distinct from --jobs (transfer concurrency)
+          
+          [env: SNAPDIR_WALK_JOBS=]
 
       --limit-rate <RATE>
           Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)

--- a/crates/snapdir-cli/tests/cmd/help-sync.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-sync.trycmd
@@ -23,10 +23,21 @@ Options:
       --to <STORE>
           Destination store URI: `protocol://location/path`
 
+      --from-objects <URI>
+          Explicit SOURCE object pool URI (split source): objects are read from here while manifests come from `--from`. Absent => `--from` is a plain colocated store. Distinct from the global `--objects-store`
+
       --store <URI>
           Store URI: `protocol://location/path`
           
           [env: SNAPDIR_STORE=]
+
+      --objects-store <URI>
+          Shared object-pool store URI: when set, content OBJECTS route to this pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`
+          
+          [env: SNAPDIR_OBJECTS_STORE=]
+
+      --to-objects <URI>
+          Explicit DESTINATION object pool URI (split dest): objects are written here while manifests go to `--to`. Absent => `--to` is a plain colocated store. Distinct from the global `--objects-store`
 
       --id <ID>
           Snapshot ID to operate on
@@ -78,6 +89,11 @@ Options:
           Max concurrent object transfers (0/auto = number of CPUs, capped)
           
           [env: SNAPDIR_JOBS=]
+
+      --walk-jobs <N>
+          Max parallel file-hashing jobs during the directory walk (0/auto = number of CPUs, capped). Distinct from --jobs (transfer concurrency)
+          
+          [env: SNAPDIR_WALK_JOBS=]
 
       --limit-rate <RATE>
           Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)

--- a/crates/snapdir-cli/tests/cmd/help-verify-cache.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-verify-cache.trycmd
@@ -20,6 +20,11 @@ Options:
           
           [env: SNAPDIR_STORE=]
 
+      --objects-store <URI>
+          Shared object-pool store URI: when set, content OBJECTS route to this pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`
+          
+          [env: SNAPDIR_OBJECTS_STORE=]
+
       --id <ID>
           Snapshot ID to operate on
 
@@ -70,6 +75,11 @@ Options:
           Max concurrent object transfers (0/auto = number of CPUs, capped)
           
           [env: SNAPDIR_JOBS=]
+
+      --walk-jobs <N>
+          Max parallel file-hashing jobs during the directory walk (0/auto = number of CPUs, capped). Distinct from --jobs (transfer concurrency)
+          
+          [env: SNAPDIR_WALK_JOBS=]
 
       --limit-rate <RATE>
           Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)

--- a/crates/snapdir-cli/tests/cmd/help-verify.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-verify.trycmd
@@ -20,6 +20,11 @@ Options:
           
           [env: SNAPDIR_STORE=]
 
+      --objects-store <URI>
+          Shared object-pool store URI: when set, content OBJECTS route to this pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`
+          
+          [env: SNAPDIR_OBJECTS_STORE=]
+
       --id <ID>
           Snapshot ID to operate on
 
@@ -70,6 +75,11 @@ Options:
           Max concurrent object transfers (0/auto = number of CPUs, capped)
           
           [env: SNAPDIR_JOBS=]
+
+      --walk-jobs <N>
+          Max parallel file-hashing jobs during the directory walk (0/auto = number of CPUs, capped). Distinct from --jobs (transfer concurrency)
+          
+          [env: SNAPDIR_WALK_JOBS=]
 
       --limit-rate <RATE>
           Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)

--- a/crates/snapdir-cli/tests/cmd/help.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help.trycmd
@@ -20,6 +20,7 @@ Commands:
   revisions     List snapshot IDs created on a location (store or absolute path)
   defaults      Print default settings and arguments
   sync          Copy a snapshot (its manifest + objects) directly between two stores, streaming through memory — no local staging
+  diff          Compare two sides, each a set of manifests, reporting file-level differences — reading MANIFESTS ONLY
   version       Print the version
   help          Print this message or the help of the given subcommand(s)
 
@@ -38,6 +39,11 @@ Options:
           Store URI: `protocol://location/path`
           
           [env: SNAPDIR_STORE=]
+
+      --objects-store <URI>
+          Shared object-pool store URI: when set, content OBJECTS route to this pool's `.objects/` while MANIFESTS route to `--store`'s `.manifests/`
+          
+          [env: SNAPDIR_OBJECTS_STORE=]
 
       --id <ID>
           Snapshot ID to operate on
@@ -89,6 +95,11 @@ Options:
           Max concurrent object transfers (0/auto = number of CPUs, capped)
           
           [env: SNAPDIR_JOBS=]
+
+      --walk-jobs <N>
+          Max parallel file-hashing jobs during the directory walk (0/auto = number of CPUs, capped). Distinct from --jobs (transfer concurrency)
+          
+          [env: SNAPDIR_WALK_JOBS=]
 
       --limit-rate <RATE>
           Limit total transfer bandwidth, e.g. 10M, 512K, 1G (wget-style; aggregate across all transfers)

--- a/crates/snapdir-cli/tests/diff.rs
+++ b/crates/snapdir-cli/tests/diff.rs
@@ -1,0 +1,1581 @@
+//! Black-box spec suite for the `snapdir diff` subcommand (phase 28, gate
+//! `diff-command-spec-tests`).
+//!
+//! AUTHORED FROM THE SPEC ONLY — the `diff` / `run_diff` implementation does NOT
+//! exist yet, so this suite is EXPECTED to fail until the impl lands. It is staged
+//! in `.gatesmith/pending-tests/` so the workspace keeps compiling; the cli impl
+//! teammate moves it to `crates/snapdir-cli/tests/diff.rs` and wires it.
+//!
+//! SPEC under test
+//! ===============
+//! `snapdir diff --from <ref> [--from <ref> …] --to <ref> [--to <ref> …]` compares
+//! two SIDES, each a SET of one-or-more manifests, and reports file-level
+//! differences. It reads MANIFESTS ONLY — it NEVER constructs an object store or
+//! downloads a blob.
+//!
+//! - Each `<ref>` selects manifests from a manifest-store prefix (enumerated via
+//!   the landed `list_manifest_ids`) and/or an explicit `--id`/id. MULTIPLE refs
+//!   per side are UNIONED into a `path -> (path_type, permissions, checksum, size)`
+//!   map.
+//! - Classification by path: in TO-not-FROM = `A` (added); in FROM-not-TO = `D`
+//!   (deleted); in BOTH with differing checksum = `M` (modified — also surface
+//!   mode-only / size-only deltas); EQUAL = hidden unless `--all`.
+//! - Output: porcelain `X\t./path` (X in `A|D|M`), sorted by path; plus `--json`
+//!   (array of `{status, path, …}`). `--all` includes unchanged.
+//! - `--exit-code`: any difference -> exit 1 (git `diff --exit-code` semantics);
+//!   DEFAULT exit 0 regardless of differences.
+//! - Intra-side path collision (the SAME path with DIFFERING content across two
+//!   refs unioned on ONE side): default = ERROR with an actionable message;
+//!   `--on-conflict last-wins` overrides (last ref wins).
+//!
+//! CRITICAL CONTRACT pinned here: `diff` reads manifests only, NEVER objects. We
+//! run `diff` against a manifest store whose `.objects` pool is bogus / absent /
+//! empty and assert it STILL succeeds with correct output (see
+//! `diff_reads_manifests_only_ignores_bogus_objects_pool` and friends).
+//!
+//! These are end-to-end CLI tests driving the REAL `snapdir` binary over `file://`
+//! manifest stores with NO credentials, mirroring the existing CLI harness
+//! conventions (`objects_store.rs`, `store_roundtrip.rs`, `store_env.rs`).
+//!
+//! Note on arg/ref grammar: the SPEC does not fix the exact `<ref>` token shape.
+//! These tests assume a `<ref>` is a `file://` manifest-store URL, and that a
+//! store holding exactly ONE manifest contributes exactly that manifest's entries
+//! to its side (the store is enumerated via `list_manifest_ids`). Where a single
+//! specific manifest must be pinned we ALSO pass `--id <id>`; the impl teammate may
+//! adjust the exact ref token but MUST preserve the BEHAVIORS pinned here.
+
+// The crate enables `clippy::pedantic` workspace-wide; suppress test-only
+// stylistic lints (mirroring the `#[allow(...)]` in sibling suites) so the staged
+// suite compiles under `-D warnings` WITHOUT touching any assertion.
+#![allow(
+    clippy::too_many_lines,
+    clippy::similar_names,
+    clippy::items_after_statements,
+    clippy::manual_let_else,
+    clippy::doc_markdown,
+    clippy::manual_split_once,
+    clippy::needless_splitn
+)]
+
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+/// Path to the compiled `snapdir` binary under test.
+fn snapdir_bin() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("snapdir")
+}
+
+/// A unique temp directory; created and returned.
+fn temp_dir(tag: &str) -> PathBuf {
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "snapdir-diff-{tag}-{}-{:?}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// A `file://<dir>` store URI for `dir`.
+fn file_url(dir: &Path) -> String {
+    format!("file://{}", dir.display())
+}
+
+/// Runs the `snapdir` binary with the cache pinned under `cache` and the store
+/// env vars REMOVED so the developer's env can't mask a bug.
+fn run_raw(args: &[&str], cache: &Path, extra_env: &[(&str, &str)]) -> Output {
+    let mut cmd = Command::new(snapdir_bin());
+    cmd.args(args)
+        .env("SNAPDIR_CACHE_DIR", cache)
+        .env_remove("SNAPDIR_STORE")
+        .env_remove("SNAPDIR_OBJECTS_STORE");
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("run snapdir")
+}
+
+/// Runs `snapdir <args>`, asserts success (exit 0), returns trimmed stdout.
+fn run_ok(args: &[&str], cache: &Path, extra_env: &[(&str, &str)]) -> String {
+    let out = run_raw(args, cache, extra_env);
+    assert!(
+        out.status.success(),
+        "snapdir {args:?} exited {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8(out.stdout)
+        .expect("stdout is UTF-8")
+        .trim_end()
+        .to_owned()
+}
+
+/// stderr of an `Output`, lossy, NOT lowercased.
+fn stderr_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+/// Extracts one flat JSON string field's value from a fragment (mirrors the
+/// `json_field` helper in `catalog_commands.rs` so this suite stays dep-free — no
+/// `serde_json` in the cli test crate). Returns the value of the FIRST `"key":"…"`
+/// found in `fragment`.
+fn json_str_field<'a>(fragment: &'a str, key: &str) -> Option<&'a str> {
+    let needle = format!("\"{key}\":");
+    let start = fragment.find(&needle)? + needle.len();
+    let rest = fragment[start..].trim_start();
+    let stripped = rest.strip_prefix('"')?;
+    let end = stripped.find('"')?;
+    Some(&stripped[..end])
+}
+
+/// Splits a JSON array body into its top-level object fragments by brace depth,
+/// tolerant of strings (so `{` inside a path string doesn't split). Sufficient for
+/// the flat `[{"status":"A","path":"./x"}, …]` shape the SPEC defines.
+fn json_array_objects(json: &str) -> Vec<String> {
+    let trimmed = json.trim();
+    assert!(
+        trimmed.starts_with('[') && trimmed.ends_with(']'),
+        "--json must be a JSON array; got:\n{json}"
+    );
+    let inner = &trimmed[1..trimmed.len() - 1];
+    let mut objs = Vec::new();
+    let mut depth = 0i32;
+    let mut in_str = false;
+    let mut escaped = false;
+    let mut start = None;
+    for (i, ch) in inner.char_indices() {
+        if in_str {
+            if escaped {
+                escaped = false;
+            } else if ch == '\\' {
+                escaped = true;
+            } else if ch == '"' {
+                in_str = false;
+            }
+            continue;
+        }
+        match ch {
+            '"' => in_str = true,
+            '{' => {
+                if depth == 0 {
+                    start = Some(i);
+                }
+                depth += 1;
+            }
+            '}' => {
+                depth -= 1;
+                if depth == 0 {
+                    let s = start.take().unwrap();
+                    objs.push(inner[s..=i].to_owned());
+                }
+            }
+            _ => {}
+        }
+    }
+    assert_eq!(depth, 0, "unbalanced braces in --json output:\n{json}");
+    objs
+}
+
+/// Builds a tree with deterministic perms so it manifests to a stable id.
+/// `leaves` is `(relative_path, contents, mode)`.
+fn build_tree(dir: &Path, leaves: &[(&str, &[u8], u32)]) {
+    for (rel, bytes, mode) in leaves {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&path, bytes).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(*mode)).unwrap();
+    }
+    set_dir_perms_recursive(dir);
+}
+
+fn set_dir_perms_recursive(dir: &Path) {
+    fs::set_permissions(dir, fs::Permissions::from_mode(0o755)).unwrap();
+    for entry in fs::read_dir(dir).unwrap().flatten() {
+        if entry.file_type().unwrap().is_dir() {
+            set_dir_perms_recursive(&entry.path());
+        }
+    }
+}
+
+/// Pushes `leaves` (built into a fresh source dir) into a FRESH `file://` manifest
+/// store, returning `(store_dir, store_url, snapshot_id)`. Each store ends up
+/// holding exactly ONE manifest, so referencing the store contributes exactly that
+/// capture's entries to a diff side.
+fn capture(tag: &str, cache: &Path, leaves: &[(&str, &[u8], u32)]) -> (PathBuf, String, String) {
+    let src = temp_dir(&format!("{tag}-src"));
+    let store = temp_dir(&format!("{tag}-store"));
+    build_tree(&src, leaves);
+    let src_str = src.to_string_lossy().into_owned();
+    let store_url = file_url(&store);
+    let id = run_ok(&["push", "--store", &store_url, &src_str], cache, &[]);
+    assert_eq!(id.len(), 64, "snapshot id is 64 hex chars");
+    fs::remove_dir_all(&src).ok();
+    (store, store_url, id)
+}
+
+/// Pushes `leaves` into an EXISTING manifest store (a second capture into the same
+/// store), returning the snapshot id. Used to build multi-manifest stores.
+fn capture_into(tag: &str, cache: &Path, store_url: &str, leaves: &[(&str, &[u8], u32)]) -> String {
+    let src = temp_dir(&format!("{tag}-src"));
+    build_tree(&src, leaves);
+    let src_str = src.to_string_lossy().into_owned();
+    let id = run_ok(&["push", "--store", store_url, &src_str], cache, &[]);
+    fs::remove_dir_all(&src).ok();
+    id
+}
+
+/// Recursively deletes the `.objects/` pool of a `file://` store and replaces it
+/// with GARBAGE, to prove `diff` never reads it. After this, any code path that
+/// tries to open the object store or fetch a blob would fail.
+fn sabotage_objects_pool(store: &Path) {
+    let objects = store.join(".objects");
+    if objects.exists() {
+        fs::remove_dir_all(&objects).ok();
+    }
+    // Re-create `.objects` as a regular FILE containing junk: an object store that
+    // tried to treat this as its sharded pool root would error out.
+    fs::write(&objects, b"NOT-AN-OBJECT-POOL\x00\xff garbage").unwrap();
+}
+
+/// Parses porcelain `diff` stdout into a sorted `Vec<(status, path)>`.
+/// Each line is exactly `X\t<path>` with X in {A,D,M}.
+fn parse_porcelain(stdout: &str) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = stdout
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|line| {
+            let mut it = line.splitn(2, '\t');
+            let status = it.next().unwrap_or("").to_owned();
+            let path = it
+                .next()
+                .unwrap_or_else(|| panic!("porcelain line {line:?} must be 'X\\t<path>'"))
+                .to_owned();
+            assert!(
+                status == "A" || status == "D" || status == "M",
+                "status letter must be one of A|D|M, got {status:?} in {line:?}"
+            );
+            (status, path)
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+/// Asserts the porcelain stdout is EXACTLY `expected` (status, path) pairs, and
+/// that the RAW output is already sorted by path (sort-stability contract).
+fn assert_porcelain_eq(stdout: &str, expected: &[(&str, &str)]) {
+    // Raw order must already be sorted by path (the SPEC says "sorted by path").
+    let raw_paths: Vec<&str> = stdout
+        .lines()
+        .filter(|l| !l.is_empty())
+        .map(|l| l.splitn(2, '\t').nth(1).expect("tab-separated path"))
+        .collect();
+    let mut sorted_paths = raw_paths.clone();
+    sorted_paths.sort_unstable();
+    assert_eq!(
+        raw_paths, sorted_paths,
+        "porcelain output MUST be sorted by path; got {raw_paths:?}"
+    );
+
+    let got = parse_porcelain(stdout);
+    let mut want: Vec<(String, String)> = expected
+        .iter()
+        .map(|(s, p)| ((*s).to_owned(), (*p).to_owned()))
+        .collect();
+    want.sort();
+    assert_eq!(
+        got, want,
+        "porcelain diff mismatch.\n got: {got:?}\nwant: {want:?}\nraw stdout:\n{stdout}"
+    );
+}
+
+// ===========================================================================
+// (1) A/D/M CLASSIFICATION — the core porcelain contract.
+// ===========================================================================
+
+/// SPEC classification: a path in TO-not-FROM is `A`, in FROM-not-TO is `D`, in
+/// BOTH with a differing checksum is `M`; equal paths are HIDDEN by default. Pins
+/// all three letters at once with the exact `X\t./path` shape, sorted by path.
+#[test]
+fn classifies_added_deleted_modified_and_hides_equal() {
+    let cache = temp_dir("adm-cache");
+
+    // FROM has: keep.txt (unchanged), gone.txt (deleted), changed.txt (v1).
+    let (_from_store, from_url, _from_id) = capture(
+        "adm-from",
+        &cache,
+        &[
+            ("keep.txt", b"same", 0o644),
+            ("gone.txt", b"removed in TO", 0o644),
+            ("changed.txt", b"version one", 0o644),
+        ],
+    );
+    // TO has: keep.txt (unchanged), changed.txt (v2), new.txt (added).
+    let (_to_store, to_url, _to_id) = capture(
+        "adm-to",
+        &cache,
+        &[
+            ("keep.txt", b"same", 0o644),
+            ("changed.txt", b"version TWO is longer", 0o644),
+            ("new.txt", b"brand new", 0o644),
+        ],
+    );
+
+    let stdout = run_ok(&["diff", "--from", &from_url, "--to", &to_url], &cache, &[]);
+
+    // keep.txt + the two directory entries (`./`) are EQUAL -> hidden by default.
+    assert_porcelain_eq(
+        &stdout,
+        &[
+            ("M", "./changed.txt"),
+            ("D", "./gone.txt"),
+            ("A", "./new.txt"),
+        ],
+    );
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+/// SPEC `--all`: with `--all`, unchanged paths are ALSO emitted (there must be at
+/// least one unchanged entry, `keep.txt`, shown alongside the changed ones), while
+/// without `--all` it is hidden. Pins the inclusion of equal paths under `--all`.
+#[test]
+fn all_flag_includes_unchanged_paths() {
+    let cache = temp_dir("all-cache");
+
+    let (_from_store, from_url, _from_id) = capture(
+        "all-from",
+        &cache,
+        &[("keep.txt", b"identical", 0o644), ("drop.txt", b"x", 0o644)],
+    );
+    let (_to_store, to_url, _to_id) = capture(
+        "all-to",
+        &cache,
+        &[("keep.txt", b"identical", 0o644), ("add.txt", b"y", 0o644)],
+    );
+
+    // Without --all: keep.txt is hidden.
+    let plain = run_ok(&["diff", "--from", &from_url, "--to", &to_url], &cache, &[]);
+    assert!(
+        !plain.contains("keep.txt"),
+        "unchanged keep.txt must be HIDDEN without --all; got:\n{plain}"
+    );
+    assert!(plain.contains("drop.txt") && plain.contains("add.txt"));
+
+    // With --all: keep.txt appears too. The SPEC fixes A|D|M letters for changed
+    // entries; an unchanged entry is surfaced under some non-A/D/M marker, so we
+    // assert by path presence + that the changed letters are still correct.
+    let all = run_ok(
+        &["diff", "--from", &from_url, "--to", &to_url, "--all"],
+        &cache,
+        &[],
+    );
+    assert!(
+        all.contains("keep.txt"),
+        "--all must INCLUDE the unchanged keep.txt; got:\n{all}"
+    );
+    assert!(
+        all.lines()
+            .any(|l| l.ends_with("./drop.txt") && l.starts_with('D')),
+        "drop.txt must still be D under --all; got:\n{all}"
+    );
+    assert!(
+        all.lines()
+            .any(|l| l.ends_with("./add.txt") && l.starts_with('A')),
+        "add.txt must still be A under --all; got:\n{all}"
+    );
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+// ===========================================================================
+// (2) THE MANIFESTS-ONLY CONTRACT — diff NEVER reads objects.  *PINNED HARD*
+// ===========================================================================
+
+/// SPEC critical contract: `diff` reads MANIFESTS ONLY and NEVER constructs an
+/// object store or fetches a blob. PROOF: after capturing two trees we SABOTAGE
+/// each store's `.objects/` pool (replace it with garbage), then run `diff` with a
+/// FRESH cache (so nothing is served from a local object cache). If `diff` ever
+/// tried to open the object store or fetch any blob it would FAIL here; it must
+/// instead SUCCEED and produce the correct A/D/M output.
+#[test]
+fn diff_reads_manifests_only_ignores_bogus_objects_pool() {
+    let cache = temp_dir("mo-cache");
+
+    let (from_store, from_url, _fid) = capture(
+        "mo-from",
+        &cache,
+        &[
+            ("keep.txt", b"same", 0o644),
+            ("old.txt", b"old only", 0o644),
+        ],
+    );
+    let (to_store, to_url, _tid) = capture(
+        "mo-to",
+        &cache,
+        &[
+            ("keep.txt", b"same", 0o644),
+            ("new.txt", b"new only", 0o644),
+        ],
+    );
+
+    // Destroy BOTH object pools — diff must not touch them.
+    sabotage_objects_pool(&from_store);
+    sabotage_objects_pool(&to_store);
+
+    // A pristine cache: no object can be served locally either.
+    let fresh_cache = temp_dir("mo-freshcache");
+    let out = run_raw(
+        &["diff", "--from", &from_url, "--to", &to_url],
+        &fresh_cache,
+        &[],
+    );
+    assert!(
+        out.status.success(),
+        "diff MUST succeed against a manifest store with a bogus/absent .objects \
+         pool (it reads manifests only); exited {:?}\nstderr: {}",
+        out.status.code(),
+        stderr_of(&out),
+    );
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+    assert_porcelain_eq(&stdout, &[("D", "./old.txt"), ("A", "./new.txt")]);
+
+    fs::remove_dir_all(&cache).ok();
+    fs::remove_dir_all(&fresh_cache).ok();
+}
+
+/// SPEC manifests-only (absent pool variant): a manifest store with NO `.objects/`
+/// directory at all (only `.manifests/`) still diffs correctly. Belt-and-braces
+/// against an impl that lazily creates/opens an object store only when present.
+#[test]
+fn diff_works_with_absent_objects_directory() {
+    let cache = temp_dir("ao-cache");
+
+    let (from_store, from_url, _fid) = capture("ao-from", &cache, &[("a.txt", b"one", 0o644)]);
+    let (to_store, to_url, _tid) = capture("ao-to", &cache, &[("a.txt", b"two-changed", 0o644)]);
+
+    // Remove `.objects/` entirely from both stores (leave `.manifests/`).
+    for s in [&from_store, &to_store] {
+        let objects = s.join(".objects");
+        if objects.exists() {
+            fs::remove_dir_all(&objects).ok();
+        }
+        assert!(
+            s.join(".manifests").exists(),
+            "the manifest dir must remain so diff has something to read"
+        );
+    }
+
+    let fresh_cache = temp_dir("ao-freshcache");
+    let stdout = run_ok(
+        &["diff", "--from", &from_url, "--to", &to_url],
+        &fresh_cache,
+        &[],
+    );
+    assert_porcelain_eq(&stdout, &[("M", "./a.txt")]);
+
+    fs::remove_dir_all(&cache).ok();
+    fs::remove_dir_all(&fresh_cache).ok();
+}
+
+// ===========================================================================
+// (3) --exit-code — git diff --exit-code semantics (BOTH branches).
+// ===========================================================================
+
+/// SPEC `--exit-code` (differences present): with `--exit-code`, ANY difference
+/// makes `diff` exit 1 (git semantics) — while STILL printing the porcelain to
+/// stdout.
+#[test]
+fn exit_code_one_when_differences_present() {
+    let cache = temp_dir("ec1-cache");
+
+    let (_fs, from_url, _fid) = capture("ec1-from", &cache, &[("x.txt", b"a", 0o644)]);
+    let (_ts, to_url, _tid) = capture("ec1-to", &cache, &[("x.txt", b"b-changed", 0o644)]);
+
+    let out = run_raw(
+        &["diff", "--exit-code", "--from", &from_url, "--to", &to_url],
+        &cache,
+        &[],
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "--exit-code with a difference must exit 1; stderr: {}",
+        stderr_of(&out)
+    );
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+    assert_porcelain_eq(&stdout, &[("M", "./x.txt")]);
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+/// SPEC `--exit-code` (no differences): with `--exit-code` and ZERO differences,
+/// `diff` exits 0 with no output.
+#[test]
+fn exit_code_zero_when_no_differences() {
+    let cache = temp_dir("ec0-cache");
+
+    // Identical trees in two different stores.
+    let leaves: &[(&str, &[u8], u32)] = &[("x.txt", b"same", 0o644), ("y.txt", b"same2", 0o644)];
+    let (_fs, from_url, fid) = capture("ec0-from", &cache, leaves);
+    let (_ts, to_url, tid) = capture("ec0-to", &cache, leaves);
+    assert_eq!(fid, tid, "identical trees must share the snapshot id");
+
+    let out = run_raw(
+        &["diff", "--exit-code", "--from", &from_url, "--to", &to_url],
+        &cache,
+        &[],
+    );
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "--exit-code with NO differences must exit 0; stderr: {}",
+        stderr_of(&out)
+    );
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+    assert!(
+        stdout.trim().is_empty(),
+        "no differences -> no porcelain output; got:\n{stdout}"
+    );
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+/// SPEC default exit (no `--exit-code`): WITHOUT `--exit-code`, `diff` exits 0
+/// REGARDLESS of differences (the difference is reported on stdout, not the code).
+#[test]
+fn default_exit_zero_even_with_differences() {
+    let cache = temp_dir("ed-cache");
+
+    let (_fs, from_url, _fid) = capture("ed-from", &cache, &[("x.txt", b"a", 0o644)]);
+    let (_ts, to_url, _tid) = capture("ed-to", &cache, &[("x.txt", b"changed", 0o644)]);
+
+    let out = run_raw(&["diff", "--from", &from_url, "--to", &to_url], &cache, &[]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "default (no --exit-code) must exit 0 even WITH differences; stderr: {}",
+        stderr_of(&out)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).contains("./x.txt"),
+        "the difference must still be reported on stdout"
+    );
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+// ===========================================================================
+// (4) EMPTY / IDENTICAL / DEGENERATE.
+// ===========================================================================
+
+/// SPEC empty-vs-empty: when BOTH sides resolve to nothing (empty manifest stores,
+/// no manifests), `diff` produces NO output and exits 0.
+#[test]
+fn empty_vs_empty_no_output_exit_zero() {
+    let cache = temp_dir("ee-cache");
+
+    // Two empty manifest stores (created, but never pushed to).
+    let from_store = temp_dir("ee-from");
+    let to_store = temp_dir("ee-to");
+    let from_url = file_url(&from_store);
+    let to_url = file_url(&to_store);
+
+    let out = run_raw(&["diff", "--from", &from_url, "--to", &to_url], &cache, &[]);
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "empty-vs-empty must exit 0; stderr: {}",
+        stderr_of(&out)
+    );
+    assert!(
+        String::from_utf8_lossy(&out.stdout).trim().is_empty(),
+        "empty-vs-empty must produce no output"
+    );
+
+    // Even with --exit-code: no differences -> still exit 0.
+    let out2 = run_raw(
+        &["diff", "--exit-code", "--from", &from_url, "--to", &to_url],
+        &cache,
+        &[],
+    );
+    assert_eq!(
+        out2.status.code(),
+        Some(0),
+        "empty-vs-empty with --exit-code is still 0 (no differences)"
+    );
+
+    fs::remove_dir_all(&cache).ok();
+    fs::remove_dir_all(&from_store).ok();
+    fs::remove_dir_all(&to_store).ok();
+}
+
+/// SPEC identical: identical manifests on both sides produce NO output (unless
+/// `--all`), exit 0 — and WITH `--all` every shared path is surfaced.
+#[test]
+fn identical_manifests_no_output_unless_all() {
+    let cache = temp_dir("id-cache");
+
+    let leaves: &[(&str, &[u8], u32)] =
+        &[("a.txt", b"alpha", 0o644), ("dir/b.txt", b"bravo", 0o644)];
+    let (_fs, from_url, fid) = capture("id-from", &cache, leaves);
+    let (_ts, to_url, tid) = capture("id-to", &cache, leaves);
+    assert_eq!(fid, tid);
+
+    let plain = run_ok(&["diff", "--from", &from_url, "--to", &to_url], &cache, &[]);
+    assert!(
+        plain.trim().is_empty(),
+        "identical manifests must produce no output without --all; got:\n{plain}"
+    );
+
+    let all = run_ok(
+        &["diff", "--from", &from_url, "--to", &to_url, "--all"],
+        &cache,
+        &[],
+    );
+    assert!(
+        all.contains("./a.txt") && all.contains("./dir/b.txt"),
+        "--all must surface the shared (unchanged) paths even when identical; got:\n{all}"
+    );
+    // No change letters: nothing is A/D/M here.
+    for line in all.lines().filter(|l| !l.is_empty()) {
+        let status = line.splitn(2, '\t').next().unwrap_or("");
+        assert!(
+            status != "A" && status != "D" && status != "M",
+            "identical-side --all must not mark any path A/D/M; got {line:?}"
+        );
+    }
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+// ===========================================================================
+// (5) MODE-ONLY and SIZE-ONLY changes — classified `M` per SPEC.
+// ===========================================================================
+
+/// SPEC mode-only: a pure permissions change (SAME checksum/content, DIFFERENT
+/// mode) is classified `M` (the SPEC says "surface mode-only ... deltas").
+#[test]
+fn mode_only_change_is_modified() {
+    let cache = temp_dir("mode-cache");
+
+    // Same content "exec me", different permissions (0644 vs 0755).
+    let (_fs, from_url, fid) = capture("mode-from", &cache, &[("s.sh", b"exec me", 0o644)]);
+    let (_ts, to_url, tid) = capture("mode-to", &cache, &[("s.sh", b"exec me", 0o755)]);
+
+    // The CONTENT is identical (same blob checksum) but the manifest id differs
+    // because permissions are part of the merkle. So this is a real mode-only M.
+    assert_ne!(
+        fid, tid,
+        "a permission change must change the snapshot id (perms are in the merkle)"
+    );
+
+    let stdout = run_ok(&["diff", "--from", &from_url, "--to", &to_url], &cache, &[]);
+    assert_porcelain_eq(&stdout, &[("M", "./s.sh")]);
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+/// SPEC size-only/content: a content change that also changes the size is
+/// classified `M` (differing checksum). Pins that a size+content delta surfaces as
+/// a single `M` for that path, not an A+D pair.
+#[test]
+fn content_size_change_is_single_modified() {
+    let cache = temp_dir("size-cache");
+
+    let (_fs, from_url, _fid) = capture("size-from", &cache, &[("f.txt", b"tiny", 0o644)]);
+    let (_ts, to_url, _tid) = capture(
+        "size-to",
+        &cache,
+        &[("f.txt", b"a substantially longer body of text", 0o644)],
+    );
+
+    let stdout = run_ok(&["diff", "--from", &from_url, "--to", &to_url], &cache, &[]);
+    // Exactly ONE M for the path — NOT an A and a D.
+    assert_porcelain_eq(&stdout, &[("M", "./f.txt")]);
+    let m_count = stdout.lines().filter(|l| l.starts_with('M')).count();
+    assert_eq!(m_count, 1, "a changed path is ONE M line, not A+D");
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+// ===========================================================================
+// (6) --json — stable, parseable shape.
+// ===========================================================================
+
+/// SPEC `--json`: emits a JSON ARRAY of objects, each with at least `status` and
+/// `path`, where `status` is one of `A|D|M` and `path` matches the porcelain path.
+/// Pins that the JSON is parseable, an array, and agrees with the porcelain set.
+#[test]
+fn json_output_is_array_of_status_path_objects() {
+    let cache = temp_dir("json-cache");
+
+    let (_fs, from_url, _fid) = capture(
+        "json-from",
+        &cache,
+        &[
+            ("keep.txt", b"same", 0o644),
+            ("gone.txt", b"x", 0o644),
+            ("chg.txt", b"v1", 0o644),
+        ],
+    );
+    let (_ts, to_url, _tid) = capture(
+        "json-to",
+        &cache,
+        &[
+            ("keep.txt", b"same", 0o644),
+            ("add.txt", b"y", 0o644),
+            ("chg.txt", b"v2-longer", 0o644),
+        ],
+    );
+
+    let json = run_ok(
+        &["diff", "--json", "--from", &from_url, "--to", &to_url],
+        &cache,
+        &[],
+    );
+
+    // Must be a JSON array of objects; default (no --all) -> 3 changed entries.
+    let objs = json_array_objects(&json);
+    let mut pairs: Vec<(String, String)> = objs
+        .iter()
+        .map(|obj| {
+            let status = json_str_field(obj, "status")
+                .unwrap_or_else(|| panic!("each entry must have a string `status`; got {obj}"))
+                .to_owned();
+            let path = json_str_field(obj, "path")
+                .unwrap_or_else(|| panic!("each entry must have a string `path`; got {obj}"))
+                .to_owned();
+            assert!(
+                status == "A" || status == "D" || status == "M",
+                "json status must be A|D|M, got {status:?}"
+            );
+            (status, path)
+        })
+        .collect();
+    pairs.sort();
+
+    let mut want = vec![
+        ("A".to_owned(), "./add.txt".to_owned()),
+        ("D".to_owned(), "./gone.txt".to_owned()),
+        ("M".to_owned(), "./chg.txt".to_owned()),
+    ];
+    want.sort();
+    assert_eq!(
+        pairs, want,
+        "json entries must match the change set; got:\n{json}"
+    );
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+// ===========================================================================
+// (7) MULTI-REF UNION on a side.
+// ===========================================================================
+
+/// SPEC multi-ref union (disjoint): two `--from` refs with DISJOINT paths are
+/// UNIONED into the FROM side, so a TO that lacks both shows two `D`s, one per
+/// unioned path. Pins that multiple refs per side compose into one map.
+#[test]
+fn multi_ref_from_union_disjoint_paths() {
+    let cache = temp_dir("mru-cache");
+
+    // Two FROM stores with disjoint files.
+    let (_f1, from1_url, _f1id) = capture("mru-from1", &cache, &[("only1.txt", b"one", 0o644)]);
+    let (_f2, from2_url, _f2id) = capture("mru-from2", &cache, &[("only2.txt", b"two", 0o644)]);
+    // TO has neither file (a different file entirely).
+    let (_ts, to_url, _tid) = capture("mru-to", &cache, &[("other.txt", b"o", 0o644)]);
+
+    let stdout = run_ok(
+        &[
+            "diff", "--from", &from1_url, "--from", &from2_url, "--to", &to_url,
+        ],
+        &cache,
+        &[],
+    );
+    // Both only1/only2 deleted; other.txt added.
+    assert_porcelain_eq(
+        &stdout,
+        &[
+            ("A", "./other.txt"),
+            ("D", "./only1.txt"),
+            ("D", "./only2.txt"),
+        ],
+    );
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+/// SPEC multi-ref union (same path, SAME content = no conflict): two refs on one
+/// side carrying the SAME path with IDENTICAL content union WITHOUT error, and the
+/// entry behaves as a single entry against the other side.
+#[test]
+fn multi_ref_same_path_same_content_no_conflict() {
+    let cache = temp_dir("mrs-cache");
+
+    // Two FROM stores BOTH containing dup.txt with the SAME content.
+    let (_f1, from1_url, _f1id) = capture(
+        "mrs-from1",
+        &cache,
+        &[("dup.txt", b"identical", 0o644), ("a.txt", b"a", 0o644)],
+    );
+    let (_f2, from2_url, _f2id) = capture(
+        "mrs-from2",
+        &cache,
+        &[("dup.txt", b"identical", 0o644), ("b.txt", b"b", 0o644)],
+    );
+    // TO has dup.txt with the SAME content (so it stays unchanged/hidden).
+    let (_ts, to_url, _tid) = capture("mrs-to", &cache, &[("dup.txt", b"identical", 0o644)]);
+
+    let out = run_raw(
+        &[
+            "diff", "--from", &from1_url, "--from", &from2_url, "--to", &to_url,
+        ],
+        &cache,
+        &[],
+    );
+    assert!(
+        out.status.success(),
+        "same-path/same-content union must NOT be a conflict; stderr: {}",
+        stderr_of(&out)
+    );
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+    // dup.txt equal on both sides -> hidden; a.txt and b.txt only in FROM -> D.
+    assert_porcelain_eq(&stdout, &[("D", "./a.txt"), ("D", "./b.txt")]);
+    assert!(
+        !stdout.contains("dup.txt"),
+        "an unchanged unioned path must stay hidden; got:\n{stdout}"
+    );
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+// ===========================================================================
+// (8) INTRA-SIDE COLLISION POLICY — default ERROR, --on-conflict last-wins.
+// ===========================================================================
+
+/// SPEC collision (default = ERROR): the SAME path with DIFFERING content across
+/// two refs UNIONED on ONE side is an ERROR by default, with an actionable message
+/// that names the colliding path. NO porcelain is produced; exit is non-zero.
+#[test]
+fn intra_side_collision_errors_by_default() {
+    let cache = temp_dir("col-cache");
+
+    // Two FROM stores BOTH containing clash.txt but with DIFFERENT content.
+    let (_f1, from1_url, _f1id) = capture(
+        "col-from1",
+        &cache,
+        &[("clash.txt", b"left version", 0o644)],
+    );
+    let (_f2, from2_url, _f2id) = capture(
+        "col-from2",
+        &cache,
+        &[("clash.txt", b"RIGHT version", 0o644)],
+    );
+    let (_ts, to_url, _tid) = capture("col-to", &cache, &[("z.txt", b"z", 0o644)]);
+
+    let out = run_raw(
+        &[
+            "diff", "--from", &from1_url, "--from", &from2_url, "--to", &to_url,
+        ],
+        &cache,
+        &[],
+    );
+    assert!(
+        !out.status.success(),
+        "an intra-side collision (same path, differing content) must be a hard \
+         error by default; got success.\nstdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = stderr_of(&out);
+    let lc = stderr.to_lowercase();
+    assert!(
+        lc.contains("conflict") || lc.contains("collision") || lc.contains("clash"),
+        "the error must explain the collision actionably; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("clash.txt") || stderr.contains("./clash.txt"),
+        "the error must name the colliding path; got: {stderr}"
+    );
+    // It must NOT have silently emitted porcelain as if all was well.
+    assert!(
+        !String::from_utf8_lossy(&out.stdout).contains("clash.txt"),
+        "a collision must not be silently resolved into normal porcelain output"
+    );
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+/// SPEC collision (`--on-conflict last-wins`): with `--on-conflict last-wins`, the
+/// LAST ref on the side wins, so the colliding path resolves to the last ref's
+/// content. Pins that the override SUCCEEDS and selects the last ref's entry.
+#[test]
+fn intra_side_collision_last_wins_selects_last_ref() {
+    let cache = temp_dir("lw-cache");
+
+    // FROM = [from1: clash=LEFT] ++ [from2: clash=RIGHT-WINS]; last (from2) wins.
+    let (_f1, from1_url, _f1id) =
+        capture("lw-from1", &cache, &[("clash.txt", b"LEFT loses", 0o644)]);
+    let (_f2, from2_url, _f2id) =
+        capture("lw-from2", &cache, &[("clash.txt", b"RIGHT-WINS", 0o644)]);
+    // TO carries clash.txt == the WINNING (last) FROM content, so if last-wins is
+    // honored the path is EQUAL and hidden; if first-wins (wrong) it would be M.
+    let (_ts, to_url, _tid) = capture("lw-to", &cache, &[("clash.txt", b"RIGHT-WINS", 0o644)]);
+
+    let stdout = run_ok(
+        &[
+            "diff",
+            "--on-conflict",
+            "last-wins",
+            "--from",
+            &from1_url,
+            "--from",
+            &from2_url,
+            "--to",
+            &to_url,
+        ],
+        &cache,
+        &[],
+    );
+    // last-wins -> FROM clash == "RIGHT-WINS" == TO clash -> EQUAL -> hidden.
+    assert!(
+        stdout.trim().is_empty(),
+        "last-wins must select the LAST ref's content (RIGHT-WINS), matching TO, \
+         so clash.txt is equal and hidden; got:\n{stdout}"
+    );
+
+    // Cross-check: if TO instead held the LOSING (first) content, last-wins yields M.
+    let (_ts2, to2_url, _tid2) = capture("lw-to2", &cache, &[("clash.txt", b"LEFT loses", 0o644)]);
+    let stdout2 = run_ok(
+        &[
+            "diff",
+            "--on-conflict",
+            "last-wins",
+            "--from",
+            &from1_url,
+            "--from",
+            &from2_url,
+            "--to",
+            &to2_url,
+        ],
+        &cache,
+        &[],
+    );
+    assert_porcelain_eq(&stdout2, &[("M", "./clash.txt")]);
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+// ===========================================================================
+// (9) UNICODE / SPACE / ./-PREFIXED PATHS — stable sort + round-trip.
+// ===========================================================================
+
+/// SPEC unicode/space sort stability: paths containing unicode and spaces sort
+/// STABLY in porcelain (already byte-sorted) and round-trip exactly (the `./`
+/// prefix and the literal bytes are preserved). The set is chosen so a naive vs
+/// byte sort would differ if mishandled.
+#[test]
+fn unicode_and_space_paths_sort_stably_and_round_trip() {
+    let cache = temp_dir("uni-cache");
+
+    // All ADDED (TO only), so each appears once with status A, exercising sort.
+    let leaves: &[(&str, &[u8], u32)] = &[
+        ("zeta.txt", b"z", 0o644),
+        ("a file with spaces.txt", b"s", 0o644),
+        ("café.txt", b"c", 0o644),
+        ("naïve dir/inner.txt", b"i", 0o644),
+        ("Apple.txt", b"A", 0o644), // uppercase sorts before lowercase by byte
+    ];
+    let (_fs, from_url, _fid) = capture("uni-from", &cache, &[("placeholder.txt", b"p", 0o644)]);
+    let (_ts, to_url, _tid) = capture("uni-to", &cache, leaves);
+
+    let stdout = run_ok(&["diff", "--from", &from_url, "--to", &to_url], &cache, &[]);
+
+    // Every expected path must appear, ./-prefixed and byte-exact.
+    for (rel, _, _) in leaves {
+        let want = format!("./{rel}");
+        assert!(
+            stdout.lines().any(|l| l == format!("A\t{want}")),
+            "expected an `A\\t{want}` line (byte-exact, ./-prefixed); got:\n{stdout}"
+        );
+    }
+    // placeholder.txt (FROM only) is a D.
+    assert!(stdout.lines().any(|l| l == "D\t./placeholder.txt"));
+
+    // Porcelain must already be sorted by path (byte order) — assert_porcelain_eq
+    // checks raw==sorted, so reuse it for the full set.
+    let mut expected: Vec<(&str, &str)> = vec![("D", "./placeholder.txt")];
+    let owned: Vec<String> = leaves.iter().map(|(r, _, _)| format!("./{r}")).collect();
+    for p in &owned {
+        expected.push(("A", p.as_str()));
+    }
+    assert_porcelain_eq(&stdout, &expected);
+
+    // And the same set in --json must preserve the exact path bytes too.
+    let json = run_ok(
+        &["diff", "--json", "--from", &from_url, "--to", &to_url],
+        &cache,
+        &[],
+    );
+    let paths: Vec<String> = json_array_objects(&json)
+        .iter()
+        .map(|o| {
+            json_str_field(o, "path")
+                .unwrap_or_else(|| panic!("each json entry needs a `path`; got {o}"))
+                .to_owned()
+        })
+        .collect();
+    for (rel, _, _) in leaves {
+        assert!(
+            paths.contains(&format!("./{rel}")),
+            "json must carry the exact unicode/space path ./{rel}; got: {paths:?}"
+        );
+    }
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+// ===========================================================================
+// (10) DIRECTION SANITY — swapping --from/--to flips A <-> D.
+// ===========================================================================
+
+/// SPEC classification direction: A means "in TO not FROM", D means "in FROM not
+/// TO". Swapping the two sides must FLIP A<->D for the same trees (and keep M as M).
+#[test]
+fn swapping_from_to_flips_added_and_deleted() {
+    let cache = temp_dir("dir-cache");
+
+    let (_fs, left_url, _lid) = capture(
+        "dir-left",
+        &cache,
+        &[
+            ("keep.txt", b"k", 0o644),
+            ("leftonly.txt", b"L", 0o644),
+            ("chg.txt", b"v1", 0o644),
+        ],
+    );
+    let (_ts, right_url, _rid) = capture(
+        "dir-right",
+        &cache,
+        &[
+            ("keep.txt", b"k", 0o644),
+            ("rightonly.txt", b"R", 0o644),
+            ("chg.txt", b"v2", 0o644),
+        ],
+    );
+
+    // FROM=left, TO=right.
+    let fwd = run_ok(
+        &["diff", "--from", &left_url, "--to", &right_url],
+        &cache,
+        &[],
+    );
+    assert_porcelain_eq(
+        &fwd,
+        &[
+            ("M", "./chg.txt"),
+            ("D", "./leftonly.txt"),
+            ("A", "./rightonly.txt"),
+        ],
+    );
+
+    // FROM=right, TO=left -> A and D must flip; M stays M.
+    let rev = run_ok(
+        &["diff", "--from", &right_url, "--to", &left_url],
+        &cache,
+        &[],
+    );
+    assert_porcelain_eq(
+        &rev,
+        &[
+            ("M", "./chg.txt"),
+            ("A", "./leftonly.txt"),
+            ("D", "./rightonly.txt"),
+        ],
+    );
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+// ===========================================================================
+// (11) --id PINS a specific manifest within a multi-manifest store.
+// ===========================================================================
+
+/// SPEC ref selection via `--id`: a store may hold MULTIPLE manifests; `--id`
+/// pins ONE specific manifest as the side (rather than unioning the whole store).
+/// Two captures land in one store; pinning each id in turn yields the correct,
+/// DIFFERENT diff — proving `--id` selects a single manifest, not the union.
+#[test]
+fn from_id_pins_single_manifest_in_multi_manifest_store() {
+    let cache = temp_dir("pin-cache");
+
+    // Build a FROM store holding TWO different manifests.
+    let from_store = temp_dir("pin-from");
+    let from_url = file_url(&from_store);
+    let id_v1 = capture_into(
+        "pin-v1",
+        &cache,
+        &from_url,
+        &[("f.txt", b"version one", 0o644)],
+    );
+    let id_v2 = capture_into(
+        "pin-v2",
+        &cache,
+        &from_url,
+        &[("f.txt", b"version two!!", 0o644)],
+    );
+    assert_ne!(id_v1, id_v2, "the two captures must be distinct manifests");
+
+    // TO == version two.
+    let (_ts, to_url, to_id) = capture("pin-to", &cache, &[("f.txt", b"version two!!", 0o644)]);
+    assert_eq!(to_id, id_v2);
+
+    // Pin --from --id v1 -> f.txt differs from TO (v2) -> M.
+    let d1 = run_ok(
+        &["diff", "--from", &from_url, "--id", &id_v1, "--to", &to_url],
+        &cache,
+        &[],
+    );
+    assert_porcelain_eq(&d1, &[("M", "./f.txt")]);
+
+    // Pin --from --id v2 -> equal to TO -> no output.
+    let d2 = run_ok(
+        &["diff", "--from", &from_url, "--id", &id_v2, "--to", &to_url],
+        &cache,
+        &[],
+    );
+    assert!(
+        d2.trim().is_empty(),
+        "pinning the matching manifest id must yield no differences; got:\n{d2}"
+    );
+
+    fs::remove_dir_all(&cache).ok();
+    fs::remove_dir_all(&from_store).ok();
+}
+
+// ===========================================================================
+// (12) DIRECTORY HANDLING — `diff` is FILE-LEVEL. (review-gate strengthening)
+//
+// The impl gate fixed two real bugs the spec suite caught: (1) directory
+// entries leaked as `M`/collisions because a dir's subtree-merkle changes with
+// any descendant, and (2) added/deleted directory entries leaked into the
+// porcelain. `src/diff.rs` now compares directories by `(path_type,
+// permissions)` only and DROPS any path that is a directory on every side it
+// appears in. These tests PIN that file-level intent so a regression in the
+// dir-handling fix is caught: every assertion below states the file-level
+// behavior the spec mandates, and any failure is a real bug to report.
+// ===========================================================================
+
+/// A directory line in porcelain is one whose path ends with `/` (manifests
+/// render directory paths with a trailing slash, e.g. `./sub/`). `diff` is
+/// file-level, so NO porcelain line may carry a trailing-slash directory path.
+fn assert_no_directory_lines(stdout: &str) {
+    for line in stdout.lines().filter(|l| !l.is_empty()) {
+        let path = line.splitn(2, '\t').nth(1).unwrap_or("");
+        assert!(
+            !path.ends_with('/'),
+            "diff is file-level: NO directory line may appear, got {line:?} in:\n{stdout}"
+        );
+    }
+}
+
+/// SPEC file-level (a): a file MODIFIED inside a directory present on both sides
+/// shows the FILE as `M`, and the containing directory does NOT appear — even
+/// though the directory's subtree merkle changed with the descendant. Pins
+/// bug-fix #1 (dir not surfaced as `M` for a descendant change).
+#[test]
+fn modified_file_in_dir_shows_file_not_dir() {
+    let cache = temp_dir("dirM-cache");
+
+    let (_fs, from_url, _fid) = capture(
+        "dirM-from",
+        &cache,
+        &[
+            ("top.txt", b"top-same", 0o644),
+            ("sub/inner.txt", b"inner v1", 0o644),
+        ],
+    );
+    let (_ts, to_url, _tid) = capture(
+        "dirM-to",
+        &cache,
+        &[
+            ("top.txt", b"top-same", 0o644),
+            ("sub/inner.txt", b"inner v2 is longer", 0o644),
+        ],
+    );
+
+    let stdout = run_ok(&["diff", "--from", &from_url, "--to", &to_url], &cache, &[]);
+    // ONLY the file is M; the dir `./sub/` (whose merkle changed) is omitted,
+    // top.txt is unchanged/hidden, and the root `./` is omitted too.
+    assert_porcelain_eq(&stdout, &[("M", "./sub/inner.txt")]);
+    assert_no_directory_lines(&stdout);
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+/// SPEC file-level (b): a directory present on BOTH sides whose ONLY change is a
+/// descendant file (the dir's own type+perms are unchanged) is NOT itself
+/// reported — neither as `M` (its merkle differs) nor under any other letter.
+/// Belt-and-braces for bug-fix #1, asserting via the explicit set + no dir line.
+#[test]
+fn dir_with_only_descendant_change_is_not_reported() {
+    let cache = temp_dir("dirDesc-cache");
+
+    // A nested directory whose ONLY delta is a leaf two levels deep.
+    let (_fs, from_url, _fid) = capture(
+        "dirDesc-from",
+        &cache,
+        &[("a/b/leaf.txt", b"leaf one", 0o644)],
+    );
+    let (_ts, to_url, _tid) = capture(
+        "dirDesc-to",
+        &cache,
+        &[("a/b/leaf.txt", b"leaf two changed", 0o644)],
+    );
+
+    let stdout = run_ok(&["diff", "--from", &from_url, "--to", &to_url], &cache, &[]);
+    // Only the leaf is M; ./, ./a/ and ./a/b/ (all merkle-changed dirs) are gone.
+    assert_porcelain_eq(&stdout, &[("M", "./a/b/leaf.txt")]);
+    assert_no_directory_lines(&stdout);
+    // No ancestor directory entry (matched on the FULL line's path field, not a
+    // substring — `./a/b/leaf.txt` legitimately *contains* `./a/`).
+    assert!(
+        !stdout.lines().any(|l| {
+            let p = l.splitn(2, '\t').nth(1).unwrap_or("");
+            p == "./" || p == "./a/" || p == "./a/b/"
+        }),
+        "no ancestor directory line may surface for a descendant-only change; got:\n{stdout}"
+    );
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+/// SPEC file-level (c): a WHOLE NEW subdirectory of files (TO has a directory
+/// tree FROM lacks) surfaces as `A` for each FILE, with NO directory lines.
+/// Pins bug-fix #2 (added directory entries must NOT leak into porcelain).
+#[test]
+fn new_subdir_appears_as_files_only_no_dir_lines() {
+    let cache = temp_dir("dirNew-cache");
+
+    let (_fs, from_url, _fid) = capture("dirNew-from", &cache, &[("root.txt", b"r", 0o644)]);
+    // TO adds an entire `pkg/` subtree (two files at two depths) plus keeps root.
+    let (_ts, to_url, _tid) = capture(
+        "dirNew-to",
+        &cache,
+        &[
+            ("root.txt", b"r", 0o644),
+            ("pkg/one.txt", b"1", 0o644),
+            ("pkg/nested/two.txt", b"2", 0o644),
+        ],
+    );
+
+    let stdout = run_ok(&["diff", "--from", &from_url, "--to", &to_url], &cache, &[]);
+    // Each NEW FILE is A; the new dirs `./pkg/` and `./pkg/nested/` are omitted.
+    assert_porcelain_eq(
+        &stdout,
+        &[("A", "./pkg/nested/two.txt"), ("A", "./pkg/one.txt")],
+    );
+    assert_no_directory_lines(&stdout);
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+/// SPEC file-level (c, mirror): a whole subdirectory REMOVED (FROM has it, TO
+/// lacks it) surfaces as `D` for each FILE, no dir lines. Confirms bug-fix #2
+/// for the deletion direction (deleted dir entries must not leak as `D`).
+#[test]
+fn removed_subdir_appears_as_files_only_no_dir_lines() {
+    let cache = temp_dir("dirRm-cache");
+
+    let (_fs, from_url, _fid) = capture(
+        "dirRm-from",
+        &cache,
+        &[
+            ("root.txt", b"r", 0o644),
+            ("pkg/one.txt", b"1", 0o644),
+            ("pkg/nested/two.txt", b"2", 0o644),
+        ],
+    );
+    let (_ts, to_url, _tid) = capture("dirRm-to", &cache, &[("root.txt", b"r", 0o644)]);
+
+    let stdout = run_ok(&["diff", "--from", &from_url, "--to", &to_url], &cache, &[]);
+    assert_porcelain_eq(
+        &stdout,
+        &[("D", "./pkg/nested/two.txt"), ("D", "./pkg/one.txt")],
+    );
+    assert_no_directory_lines(&stdout);
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+/// SPEC file-level (d): a directory whose PERMISSIONS change while NO file under
+/// it changes. Per the impl, `diff` is FILE-level — directories are dropped from
+/// file-level output, so a pure directory-mode change yields NO output. We PIN
+/// the impl's documented file-level intent here: a dir-only perm change is NOT a
+/// file-level difference and is omitted. (If the project later decides a dir
+/// perm change SHOULD surface, this is the assertion to flip — and it would then
+/// be a deliberate spec change, not a silent regression.)
+#[test]
+fn dir_only_permission_change_is_omitted_file_level() {
+    let cache = temp_dir("dirPerm-cache");
+
+    // Same file content + same file perms on both sides; ONLY a subdirectory's
+    // mode differs (0o755 vs 0o700). The shared `build_tree`/`capture` helpers
+    // force 0o755 on every dir, so we build the two source trees BY HAND here to
+    // make the nested dir's perms the sole difference.
+    let from_src = temp_dir("dirPerm-from-src");
+    let to_src = temp_dir("dirPerm-to-src");
+    for src in [&from_src, &to_src] {
+        fs::create_dir_all(src.join("d")).unwrap();
+        fs::write(src.join("d/f.txt"), b"same").unwrap();
+        fs::set_permissions(src.join("d/f.txt"), fs::Permissions::from_mode(0o644)).unwrap();
+        fs::set_permissions(src, fs::Permissions::from_mode(0o755)).unwrap();
+    }
+    // The ONLY difference: the `d/` directory's mode.
+    fs::set_permissions(from_src.join("d"), fs::Permissions::from_mode(0o755)).unwrap();
+    fs::set_permissions(to_src.join("d"), fs::Permissions::from_mode(0o700)).unwrap();
+
+    let from_store = temp_dir("dirPerm-from-store");
+    let to_store = temp_dir("dirPerm-to-store");
+    let from_url = file_url(&from_store);
+    let to_url = file_url(&to_store);
+    let fid = run_ok(
+        &["push", "--store", &from_url, &from_src.to_string_lossy()],
+        &cache,
+        &[],
+    );
+    let tid = run_ok(
+        &["push", "--store", &to_url, &to_src.to_string_lossy()],
+        &cache,
+        &[],
+    );
+    // The dir-mode delta DOES change the snapshot id (perms are in the merkle),
+    // so the two sides genuinely differ at the manifest level...
+    assert_ne!(
+        fid, tid,
+        "a directory permission change must change the snapshot id (perms are in the merkle)"
+    );
+
+    // ...yet `diff`, being FILE-level, reports NOTHING: the only changed entry is
+    // a directory, and directories are dropped from file-level output.
+    let stdout = run_ok(&["diff", "--from", &from_url, "--to", &to_url], &cache, &[]);
+    assert!(
+        stdout.trim().is_empty(),
+        "a dir-ONLY permission change is not a file-level difference -> no output; got:\n{stdout}"
+    );
+    assert_no_directory_lines(&stdout);
+
+    fs::remove_dir_all(&cache).ok();
+    fs::remove_dir_all(&from_src).ok();
+    fs::remove_dir_all(&to_src).ok();
+    fs::remove_dir_all(&from_store).ok();
+    fs::remove_dir_all(&to_store).ok();
+}
+
+/// SPEC file-level (e): a path that is a FILE on one side and a DIRECTORY on the
+/// other (type change). At the manifest level the file is `./x` and the
+/// directory is `./x/` (dirs carry a trailing slash), so the replacement
+/// surfaces as a DELETED file `./x` plus an ADDED file for the new dir's
+/// leaf(s) — and the directory entry `./x/` itself never appears. Pins the
+/// file<->dir type-change behavior end to end.
+#[test]
+fn file_replaced_by_directory_is_file_level_delete_plus_add() {
+    let cache = temp_dir("dirType-cache");
+
+    // FROM: `x` is a FILE. TO: `x` is a DIRECTORY containing `x/inner.txt`.
+    let (_fs, from_url, _fid) = capture(
+        "dirType-from",
+        &cache,
+        &[("keep.txt", b"k", 0o644), ("x", b"i am a file", 0o644)],
+    );
+    let (_ts, to_url, _tid) = capture(
+        "dirType-to",
+        &cache,
+        &[
+            ("keep.txt", b"k", 0o644),
+            ("x/inner.txt", b"now a dir", 0o644),
+        ],
+    );
+
+    let stdout = run_ok(&["diff", "--from", &from_url, "--to", &to_url], &cache, &[]);
+    // `./x` (file) deleted; `./x/inner.txt` (file under the new dir) added; the
+    // directory entry `./x/` itself is dropped (file-level).
+    assert_porcelain_eq(&stdout, &[("A", "./x/inner.txt"), ("D", "./x")]);
+    assert_no_directory_lines(&stdout);
+
+    // The reverse direction (dir replaced by file) must flip A<->D symmetrically.
+    let rev = run_ok(&["diff", "--from", &to_url, "--to", &from_url], &cache, &[]);
+    assert_porcelain_eq(&rev, &[("A", "./x"), ("D", "./x/inner.txt")]);
+    assert_no_directory_lines(&rev);
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+/// SPEC file-level + `--all`: even under `--all` (which surfaces UNCHANGED
+/// paths), directory entries are STILL dropped — `--all` widens the FILE set,
+/// never re-introduces directory rows. Pins that the dir-drop is unconditional,
+/// not merely a side effect of hiding unchanged rows.
+#[test]
+fn all_flag_still_drops_directory_entries() {
+    let cache = temp_dir("dirAll-cache");
+
+    let (_fs, from_url, fid) = capture(
+        "dirAll-from",
+        &cache,
+        &[("top.txt", b"t", 0o644), ("sub/inner.txt", b"same", 0o644)],
+    );
+    let (_ts, to_url, tid) = capture(
+        "dirAll-to",
+        &cache,
+        &[("top.txt", b"t", 0o644), ("sub/inner.txt", b"same", 0o644)],
+    );
+    assert_eq!(fid, tid, "identical trees share the snapshot id");
+
+    let all = run_ok(
+        &["diff", "--from", &from_url, "--to", &to_url, "--all"],
+        &cache,
+        &[],
+    );
+    // The files appear (unchanged, non-A/D/M marker); the dirs `./` and `./sub/`
+    // must NOT — even under --all.
+    assert!(
+        all.contains("./top.txt") && all.contains("./sub/inner.txt"),
+        "--all must surface the unchanged FILES; got:\n{all}"
+    );
+    assert_no_directory_lines(&all);
+    assert!(
+        !all.lines().any(|l| {
+            let p = l.splitn(2, '\t').nth(1).unwrap_or("");
+            p == "./" || p == "./sub/"
+        }),
+        "--all must not re-introduce the directory entries ./ or ./sub/; got:\n{all}"
+    );
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+/// SPEC dir-drop interaction with collision policy: two FROM refs that BOTH carry
+/// the same directory subtree but DIFFER only in a descendant file's content must
+/// collide on the FILE (default error), NOT on the enclosing directory — proving
+/// the dir's merkle/size are excluded from the collision key (bug-fix #1 applied
+/// to `union_side`, not just `classify`). The error must name the FILE path.
+#[test]
+fn intra_side_collision_keys_on_file_not_enclosing_dir() {
+    let cache = temp_dir("dirCol-cache");
+
+    // Two FROM refs: identical dir layout, but `sub/inner.txt` differs. Their
+    // `./sub/` (and `./`) merkles differ, but those dirs must NOT be the
+    // collision — only the file does.
+    let (_f1, from1_url, _f1id) = capture(
+        "dirCol-from1",
+        &cache,
+        &[("sub/inner.txt", b"left content", 0o644)],
+    );
+    let (_f2, from2_url, _f2id) = capture(
+        "dirCol-from2",
+        &cache,
+        &[("sub/inner.txt", b"RIGHT content", 0o644)],
+    );
+    let (_ts, to_url, _tid) = capture("dirCol-to", &cache, &[("z.txt", b"z", 0o644)]);
+
+    let out = run_raw(
+        &[
+            "diff", "--from", &from1_url, "--from", &from2_url, "--to", &to_url,
+        ],
+        &cache,
+        &[],
+    );
+    assert!(
+        !out.status.success(),
+        "differing descendant content across two FROM refs must collide (error); got success.\nstdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = stderr_of(&out);
+    assert!(
+        stderr.contains("sub/inner.txt"),
+        "the collision must name the FILE ./sub/inner.txt, not the dir; got: {stderr}"
+    );
+    // It must NOT report a directory path as the collision.
+    assert!(
+        !stderr.contains("\"./sub/\"") && !stderr.contains("\"./\""),
+        "the collision must NOT key on the enclosing directory ./sub/ or ./; got: {stderr}"
+    );
+
+    // And under last-wins it resolves to the LAST ref's file content (a real M
+    // vs a TO that holds neither -> the file is added, not the dir).
+    let (_ts2, to2_url, _tid2) = capture(
+        "dirCol-to2",
+        &cache,
+        &[("sub/inner.txt", b"RIGHT content", 0o644)],
+    );
+    let stdout = run_ok(
+        &[
+            "diff",
+            "--on-conflict",
+            "last-wins",
+            "--from",
+            &from1_url,
+            "--from",
+            &from2_url,
+            "--to",
+            &to2_url,
+        ],
+        &cache,
+        &[],
+    );
+    // last-wins picks from2 (RIGHT) == to2 -> file equal -> hidden; no dir lines.
+    assert!(
+        stdout.trim().is_empty(),
+        "last-wins selects the LAST ref's file content, matching TO -> no diff; got:\n{stdout}"
+    );
+    assert_no_directory_lines(&stdout);
+
+    fs::remove_dir_all(&cache).ok();
+}
+
+/// SPEC dir-drop in `--json`: the directory-drop rule applies identically to the
+/// JSON renderer — a descendant-only change yields a JSON array carrying ONLY the
+/// file entry, no directory object. Pins parity between porcelain and JSON for
+/// the dir-handling fix.
+#[test]
+fn json_drops_directory_entries_too() {
+    let cache = temp_dir("dirJson-cache");
+
+    let (_fs, from_url, _fid) = capture("dirJson-from", &cache, &[("d/leaf.txt", b"v1", 0o644)]);
+    let (_ts, to_url, _tid) = capture("dirJson-to", &cache, &[("d/leaf.txt", b"v2 longer", 0o644)]);
+
+    let json = run_ok(
+        &["diff", "--json", "--from", &from_url, "--to", &to_url],
+        &cache,
+        &[],
+    );
+    let paths: Vec<String> = json_array_objects(&json)
+        .iter()
+        .map(|o| {
+            json_str_field(o, "path")
+                .unwrap_or_else(|| panic!("each json entry needs a `path`; got {o}"))
+                .to_owned()
+        })
+        .collect();
+    assert_eq!(
+        paths,
+        vec!["./d/leaf.txt".to_owned()],
+        "json must carry ONLY the file entry, no directory object; got:\n{json}"
+    );
+    for p in &paths {
+        assert!(
+            !p.ends_with('/'),
+            "no json path may be a directory (trailing slash); got {p:?}"
+        );
+    }
+
+    fs::remove_dir_all(&cache).ok();
+}

--- a/crates/snapdir-cli/tests/fast_walk.rs
+++ b/crates/snapdir-cli/tests/fast_walk.rs
@@ -1,0 +1,271 @@
+//! Fast-walk CLI contract tests (snapdir-cli, black-box) — ADVERSARY.
+//!
+//! Authored from the gate SPEC ONLY, driving the `snapdir` BINARY (no impl
+//! visibility). Mirrors the existing CLI harness (`assert_cmd` + `assert_fs`,
+//! cache pinned via `SNAPDIR_CACHE_DIR`) used by `tests/e2e.rs`.
+//!
+//! The contract: a new global `--walk-jobs <N>` flag + `SNAPDIR_WALK_JOBS` env
+//! controls cross-file hashing parallelism and is SEPARATE from `--jobs` /
+//! `SNAPDIR_JOBS` (transfer concurrency). It must NEVER change a snapshot id:
+//! `snapdir id <fixture>` is byte-identical across `--walk-jobs 1`,
+//! `--walk-jobs 8`, and `SNAPDIR_WALK_JOBS` unset, and across repeated runs.
+//!
+//! These tests reference `--walk-jobs` / `SNAPDIR_WALK_JOBS`, which do NOT exist
+//! in the current binary (`snapdir id --walk-jobs 4` currently errors with
+//! "unexpected argument '--walk-jobs'"), so the suite cannot pass until the CLI
+//! lane lands the flag.
+
+use std::path::Path;
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+use assert_fs::prelude::*;
+use assert_fs::TempDir;
+
+/// A fresh `snapdir` command with the cache pinned so tests never touch the
+/// user's real cache, and with the transfer-jobs / walk-jobs env vars cleared so
+/// the ambient environment can't perturb a run.
+fn snapdir(cache: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("snapdir").expect("snapdir binary built");
+    cmd.env("SNAPDIR_CACHE_DIR", cache);
+    cmd.env_remove("SNAPDIR_WALK_JOBS");
+    cmd.env_remove("SNAPDIR_JOBS");
+    cmd
+}
+
+/// Runs `snapdir <args>` (cache pinned), asserts success, returns trimmed stdout.
+fn id_ok(cache: &Path, args: &[&str]) -> String {
+    let out = snapdir(cache).args(args).output().expect("run snapdir");
+    assert!(
+        out.status.success(),
+        "snapdir {args:?} failed ({:?})\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8(out.stdout).unwrap().trim_end().to_owned()
+}
+
+/// The deterministic bench-style ramp (`(i*31 + 7) & 0xff`), so the materialized
+/// fixture (and thus its golden id) is reproducible across runs and machines.
+fn deterministic_bytes(len: usize) -> Vec<u8> {
+    (0..len)
+        .map(|i| u8::try_from(i.wrapping_mul(31).wrapping_add(7) & 0xff).expect("masked to u8"))
+        .collect()
+}
+
+#[cfg(unix)]
+fn pin_mode(path: &Path, mode: u32) {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, PermissionsExt::from_mode(mode)).expect("set_permissions");
+}
+#[cfg(not(unix))]
+fn pin_mode(_path: &Path, _mode: u32) {}
+
+/// Materializes a fixture tree mixing MANY small files + a FEW large (> 256 KiB,
+/// exercising the blake3 mmap path) + empty files + a unicode/space path, with
+/// every file/dir mode pinned (umask-independent) so the golden id is stable.
+///
+/// This is the SAME recipe used to capture `GOLDEN_ID` from the current binary,
+/// at two different parent locations (the id was identical and stable across
+/// repeated runs), so the hardcoded golden is legitimate and location-independent.
+fn build_fixture(root: &TempDir) {
+    let base = root.path();
+    pin_mode(base, 0o755);
+
+    for i in 0..20 {
+        let f = root.child(format!("small_{i:03}.bin"));
+        f.write_binary(&deterministic_bytes(64)).unwrap();
+        pin_mode(f.path(), 0o644);
+    }
+    // A few large files > 256 KiB so the parallel mmap path is exercised.
+    for i in 0..3 {
+        let f = root.child(format!("large_{i:02}.bin"));
+        f.write_binary(&deterministic_bytes(300 * 1024)).unwrap();
+        pin_mode(f.path(), 0o644);
+    }
+    // Empty files.
+    for name in ["empty_a.bin", "empty_b.bin"] {
+        let f = root.child(name);
+        f.write_binary(&[]).unwrap();
+        pin_mode(f.path(), 0o644);
+    }
+    // Unicode + space paths.
+    let uni_dir = root.child("uni dir");
+    uni_dir.create_dir_all().unwrap();
+    pin_mode(uni_dir.path(), 0o755);
+    let uf = root.child("uni dir/déjà vu.txt");
+    uf.write_binary(&deterministic_bytes(128)).unwrap();
+    pin_mode(uf.path(), 0o644);
+    let crab = root.child("🦀 crab.bin");
+    crab.write_binary(&deterministic_bytes(700 * 1024)).unwrap();
+    pin_mode(crab.path(), 0o644);
+    // A sub dir mixing sizes (incl. a > 256 KiB file with a space in the name).
+    let sub = root.child("sub");
+    sub.create_dir_all().unwrap();
+    pin_mode(sub.path(), 0o755);
+    let ssmall = root.child("sub/s small.bin");
+    ssmall.write_binary(&deterministic_bytes(10)).unwrap();
+    pin_mode(ssmall.path(), 0o644);
+    let slarge = root.child("sub/s large.bin");
+    slarge
+        .write_binary(&deterministic_bytes(512 * 1024))
+        .unwrap();
+    pin_mode(slarge.path(), 0o644);
+}
+
+/// Golden snapshot id of `build_fixture`'s tree, captured from the CURRENT
+/// (pre-change) `snapdir` binary on the byte-identical fixture. Location- and
+/// run-independent (verified). `--walk-jobs` must NEVER change it.
+const GOLDEN_ID: &str = "3d890b612c02d71c0c51aeb18a04357702f869da85f7691a709e1b88aea657ba";
+
+// ===========================================================================
+// CLI clause 1: byte-identical id across --walk-jobs 1 / 8 / unset + repeated runs.
+// ===========================================================================
+
+#[test]
+fn id_is_byte_identical_across_walk_jobs_and_unset() {
+    // Spec clause: `snapdir id <fixture>` is byte-identical across --walk-jobs 1,
+    // --walk-jobs 8, and SNAPDIR_WALK_JOBS unset, and across repeated runs.
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    build_fixture(&src);
+    let src_str = src.path().to_string_lossy().into_owned();
+
+    // Baseline: no walk-jobs flag, no env (the "unset" case) — must equal golden.
+    let unset = id_ok(cache.path(), &["id", &src_str]);
+    assert_eq!(
+        unset, GOLDEN_ID,
+        "baseline id must equal the recorded golden"
+    );
+
+    // --walk-jobs 1 and 8 must each equal the baseline (and golden).
+    let j1 = id_ok(cache.path(), &["id", "--walk-jobs", "1", &src_str]);
+    let j8 = id_ok(cache.path(), &["id", "--walk-jobs", "8", &src_str]);
+    assert_eq!(j1, unset, "--walk-jobs 1 must match the unset id");
+    assert_eq!(j8, unset, "--walk-jobs 8 must match the unset id");
+    assert_eq!(j1, j8, "--walk-jobs 1 and 8 must agree");
+
+    // Repeated runs are stable.
+    let rerun = id_ok(cache.path(), &["id", "--walk-jobs", "8", &src_str]);
+    assert_eq!(rerun, j8, "repeated --walk-jobs 8 run must be stable");
+}
+
+#[test]
+fn id_via_env_var_matches_flag_and_unset() {
+    // Spec clause: SNAPDIR_WALK_JOBS env is honored and produces the same id as
+    // the flag and the unset case (env and flag are equivalent knobs).
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    build_fixture(&src);
+    let src_str = src.path().to_string_lossy().into_owned();
+
+    let unset = id_ok(cache.path(), &["id", &src_str]);
+
+    // Env-driven walk-jobs (note: snapdir() clears the env, so set it explicitly).
+    let env_run = {
+        let out = snapdir(cache.path())
+            .env("SNAPDIR_WALK_JOBS", "3")
+            .args(["id", &src_str])
+            .output()
+            .expect("run snapdir");
+        assert!(
+            out.status.success(),
+            "snapdir id with SNAPDIR_WALK_JOBS=3 failed: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8(out.stdout).unwrap().trim_end().to_owned()
+    };
+    assert_eq!(env_run, unset, "SNAPDIR_WALK_JOBS must not change the id");
+    assert_eq!(env_run, GOLDEN_ID);
+}
+
+// ===========================================================================
+// CLI clause 2: sort stability over a tree with small + large + empty + unicode/space.
+// ===========================================================================
+
+#[test]
+fn sort_stability_over_mixed_unicode_and_space_tree() {
+    // Spec clause: cover a tree mixing many small + a few large (>256KiB) + empty
+    // + unicode/space paths; sort stability must hold (the id is stable run over
+    // run and across job counts, which is the observable proof of stable sort).
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    build_fixture(&src);
+    let src_str = src.path().to_string_lossy().into_owned();
+
+    let mut ids = Vec::new();
+    for jobs in ["1", "2", "4", "8", "16"] {
+        ids.push(id_ok(cache.path(), &["id", "--walk-jobs", jobs, &src_str]));
+    }
+    for id in &ids {
+        assert_eq!(id, &ids[0], "id must be stable across every job count");
+        assert_eq!(id, GOLDEN_ID, "id must equal the recorded golden");
+    }
+}
+
+// ===========================================================================
+// CLI clause 3: --walk-jobs is SEPARATE from --jobs (both may be set, no conflict).
+// ===========================================================================
+
+#[test]
+fn walk_jobs_is_separate_from_transfer_jobs() {
+    // Spec clause: --walk-jobs is SEPARATE from --jobs (transfer concurrency).
+    // Setting BOTH on `id` must NOT error and must produce the same golden id —
+    // proving they are independent knobs, not aliases.
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    build_fixture(&src);
+    let src_str = src.path().to_string_lossy().into_owned();
+
+    // Both flags together: must succeed (no "conflicting/duplicate argument").
+    let both = id_ok(
+        cache.path(),
+        &["id", "--walk-jobs", "4", "--jobs", "2", &src_str],
+    );
+    assert_eq!(
+        both, GOLDEN_ID,
+        "combining --walk-jobs and --jobs must not change the id"
+    );
+
+    // --walk-jobs alone must not error even though it differs from --jobs.
+    let walk_only = id_ok(cache.path(), &["id", "--walk-jobs", "4", &src_str]);
+    assert_eq!(walk_only, both);
+
+    // Both env vars set together: still no conflict, same id.
+    let env_both = {
+        let out = snapdir(cache.path())
+            .env("SNAPDIR_WALK_JOBS", "4")
+            .env("SNAPDIR_JOBS", "2")
+            .args(["id", &src_str])
+            .output()
+            .expect("run snapdir");
+        assert!(
+            out.status.success(),
+            "both env vars set must not conflict: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+        String::from_utf8(out.stdout).unwrap().trim_end().to_owned()
+    };
+    assert_eq!(env_both, GOLDEN_ID);
+}
+
+#[test]
+fn walk_jobs_flag_is_advertised_in_help() {
+    // Spec corollary: the CLI lane documents --walk-jobs / SNAPDIR_WALK_JOBS in
+    // help text. Assert the top-level help mentions the flag and the env var.
+    let cache = TempDir::new().unwrap();
+    let out = snapdir(cache.path())
+        .arg("--help")
+        .output()
+        .expect("run snapdir --help");
+    assert!(out.status.success(), "--help must succeed");
+    let help = String::from_utf8_lossy(&out.stdout);
+    assert!(
+        help.contains("--walk-jobs"),
+        "help must advertise the --walk-jobs flag"
+    );
+    assert!(
+        help.contains("SNAPDIR_WALK_JOBS"),
+        "help must advertise the SNAPDIR_WALK_JOBS env var"
+    );
+}

--- a/crates/snapdir-cli/tests/manifest.rs
+++ b/crates/snapdir-cli/tests/manifest.rs
@@ -4,7 +4,7 @@
 //! built with **explicit, fixed permissions** (files `0o644`, dirs `0o755`) so
 //! its `TYPE PERMS CHECKSUM SIZE PATH` stdout is fully deterministic, and assert
 //! it against **embedded golden constants**. They previously diffed against the
-//! frozen Bash version (now deleted from the branch); the frozen
+//! frozen Bash differential oracle (now deleted from the branch); the frozen
 //! byte-format contract is anchored by
 //! `crates/snapdir-core/tests/compat_golden.rs`. What remains here is
 //! the CLI-binary wiring coverage: that the `manifest` subcommand honors

--- a/crates/snapdir-cli/tests/objects_store.rs
+++ b/crates/snapdir-cli/tests/objects_store.rs
@@ -1,0 +1,1299 @@
+//! Black-box spec suite for the global `--objects-store <URI>` / env
+//! `$SNAPDIR_OBJECTS_STORE` CLI flag (phase 28, gate
+//! `objects-store-cli-spec-tests`).
+//!
+//! AUTHORED FROM THE SPEC ONLY — the `--objects-store` CLI wiring does NOT exist
+//! yet, so this suite is EXPECTED to fail until the impl lands. It is staged in
+//! `.gatesmith/pending-tests/` so the workspace keeps compiling; the cli impl
+//! teammate moves it to `crates/snapdir-cli/tests/objects_store.rs` and wires it.
+//!
+//! SPEC under test
+//! ===============
+//! A new GLOBAL flag `--objects-store <URI>` / env `$SNAPDIR_OBJECTS_STORE` holds
+//! a SHARED object pool, while `--store <URI>` holds the (per-capture) MANIFEST
+//! location. When `--objects-store` is set, `push`/`fetch`/`pull` route content
+//! OBJECTS to the pool's `.objects/` and MANIFESTS to `--store`'s `.manifests/`
+//! (via the already-landed `SplitStore`). When UNSET, behavior is byte-for-byte
+//! unchanged (the colocated store as today).
+//!
+//! These are end-to-end CLI tests driving the REAL `snapdir` binary over
+//! `file://` stores with NO credentials, mirroring the existing CLI harness
+//! conventions (`store_roundtrip.rs`, `store_env.rs`, `catalog_commands.rs`).
+//!
+//! Note on arg shape: the SPEC says `--objects-store` is a GLOBAL flag, so it is
+//! accepted both BEFORE the subcommand (`snapdir --objects-store … push …`) and
+//! after (`snapdir push … --objects-store …`). The existing suites mix both
+//! orderings; clap global flags accept either. The impl teammate may adjust the
+//! exact call shape, but must preserve the BEHAVIORS pinned here.
+
+// The crate enables `clippy::pedantic` workspace-wide; these test-only stylistic
+// lints (mirroring the `#[allow(...)]` in sibling suites like `progress_e2e.rs`)
+// are suppressed so the staged suite compiles under `-D warnings` WITHOUT
+// touching any assertion or behavior.
+#![allow(
+    clippy::too_many_lines,
+    clippy::similar_names,
+    clippy::items_after_statements,
+    clippy::manual_let_else
+)]
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+use snapdir_core::{Blake3Hasher, Hasher};
+
+/// Path to the compiled `snapdir` binary under test (the bin target lives in the
+/// `snapdir` crate; `assert_cmd` resolves it from the shared target dir).
+fn snapdir_bin() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("snapdir")
+}
+
+/// A unique temp directory; created and returned.
+fn temp_dir(tag: &str) -> PathBuf {
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "snapdir-objstore-{tag}-{}-{:?}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// A `file://<dir>` store URI for `dir`.
+fn file_url(dir: &Path) -> String {
+    format!("file://{}", dir.display())
+}
+
+/// Runs the `snapdir` binary with the cache pinned under `cache` and
+/// `SNAPDIR_OBJECTS_STORE`/`SNAPDIR_STORE` REMOVED (so the developer's env can't
+/// mask a bug); tests that exercise env-equivalence re-add them via `extra_env`.
+/// Returns the raw `Output`.
+fn run_raw(args: &[&str], cache: &Path, extra_env: &[(&str, &str)]) -> Output {
+    let mut cmd = Command::new(snapdir_bin());
+    cmd.args(args)
+        .env("SNAPDIR_CACHE_DIR", cache)
+        .env_remove("SNAPDIR_STORE")
+        .env_remove("SNAPDIR_OBJECTS_STORE");
+    for (k, v) in extra_env {
+        cmd.env(k, v);
+    }
+    cmd.output().expect("run snapdir")
+}
+
+/// Runs `snapdir <args>`, asserts success, returns trimmed stdout.
+fn run_ok(args: &[&str], cache: &Path, extra_env: &[(&str, &str)]) -> String {
+    let out = run_raw(args, cache, extra_env);
+    assert!(
+        out.status.success(),
+        "snapdir {args:?} exited {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8(out.stdout)
+        .expect("stdout is UTF-8")
+        .trim_end()
+        .to_owned()
+}
+
+/// `.objects/<h[0..3]>/<h[3..6]>/<h[6..9]>/<h[9..]>` — the frozen sharded layout.
+fn sharded(prefix: &str, hex: &str) -> String {
+    format!(
+        "{prefix}/{}/{}/{}/{}",
+        &hex[0..3],
+        &hex[3..6],
+        &hex[6..9],
+        &hex[9..]
+    )
+}
+
+/// Recursively collects every regular FILE under `dir` (the leaf object/manifest
+/// blobs), returned as paths relative to `dir`. Returns empty if `dir` is absent.
+fn collect_files(dir: &Path) -> BTreeSet<PathBuf> {
+    let mut out = BTreeSet::new();
+    fn walk(base: &Path, dir: &Path, out: &mut BTreeSet<PathBuf>) {
+        let rd = match fs::read_dir(dir) {
+            Ok(rd) => rd,
+            Err(_) => return,
+        };
+        for entry in rd.flatten() {
+            let p = entry.path();
+            let ft = match entry.file_type() {
+                Ok(ft) => ft,
+                Err(_) => continue,
+            };
+            if ft.is_dir() {
+                walk(base, &p, out);
+            } else if ft.is_file() {
+                out.insert(p.strip_prefix(base).unwrap().to_path_buf());
+            }
+        }
+    }
+    walk(dir, dir, &mut out);
+    out
+}
+
+/// Number of leaf blobs under `<pool>/.objects/`.
+fn count_pool_objects(pool: &Path) -> usize {
+    collect_files(&pool.join(".objects")).len()
+}
+
+/// Builds a known tree with explicit, deterministic permissions so a checked-out
+/// copy must restore them to re-manifest to the same id. `leaves` is a slice of
+/// `(relative_path, contents)`.
+fn build_tree(dir: &Path, leaves: &[(&str, &[u8])]) {
+    for (rel, bytes) in leaves {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&path, bytes).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+    }
+    // Normalize directory perms top-down so the id is deterministic.
+    set_dir_perms_recursive(dir);
+}
+
+fn set_dir_perms_recursive(dir: &Path) {
+    fs::set_permissions(dir, fs::Permissions::from_mode(0o755)).unwrap();
+    for entry in fs::read_dir(dir).unwrap().flatten() {
+        if entry.file_type().unwrap().is_dir() {
+            set_dir_perms_recursive(&entry.path());
+        }
+    }
+}
+
+/// Asserts the tree at `dest` reproduces every `(rel, bytes)` leaf in `expected`.
+fn assert_tree_contents(dest: &Path, expected: &[(&str, &[u8])]) {
+    for (rel, bytes) in expected {
+        let got = fs::read(dest.join(rel))
+            .unwrap_or_else(|e| panic!("read {rel} from dest {}: {e}", dest.display()));
+        assert_eq!(&got[..], *bytes, "contents of {rel} must match source");
+    }
+}
+
+// ===========================================================================
+// (a) SHARED POOL, MANY MANIFEST LOCATIONS — one blob copy, both manifests pull
+// ===========================================================================
+
+/// SPEC (a): pushing the SAME tree with the SAME `--objects-store` pool but TWO
+/// DIFFERENT `--store` manifest locations stores exactly ONE copy of each blob in
+/// the pool (no duplication across captures), and BOTH manifests resolve and
+/// `pull` to byte-identical trees.
+#[test]
+fn shared_pool_dedupes_objects_across_two_manifest_locations() {
+    let src = temp_dir("a-src");
+    let pool = temp_dir("a-pool");
+    let cap_a = temp_dir("a-capA");
+    let cap_b = temp_dir("a-capB");
+    let cache = temp_dir("a-cache");
+
+    let leaves: &[(&str, &[u8])] = &[
+        ("a.txt", b"hello"),
+        ("sub/b.txt", b"world!!"),
+        ("sub/c.txt", b"another blob"),
+    ];
+    build_tree(&src, leaves);
+
+    let src_str = src.to_string_lossy().into_owned();
+    let pool_url = file_url(&pool);
+    let cap_a_url = file_url(&cap_a);
+    let cap_b_url = file_url(&cap_b);
+
+    // The id the source manifests to, independent of any store.
+    let src_id = run_ok(&["id", &src_str], &cache, &[]);
+    assert_eq!(src_id.len(), 64, "snapshot id is 64 hex chars");
+
+    // Capture A: objects -> pool, manifest -> cap-A.
+    let id_a = run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &pool_url,
+            "--store",
+            &cap_a_url,
+            &src_str,
+        ],
+        &cache,
+        &[],
+    );
+    assert_eq!(id_a, src_id, "push must print the source snapshot id");
+
+    let pool_after_a = count_pool_objects(&pool);
+    assert_eq!(
+        pool_after_a, 3,
+        "pool must hold exactly one blob per distinct file (3), not duplicates"
+    );
+
+    // The manifest landed in cap-A's `.manifests/`, NOT in the pool.
+    assert!(
+        cap_a.join(sharded(".manifests", &id_a)).is_file(),
+        "manifest must land in --store (cap-A) .manifests/"
+    );
+    assert!(
+        !pool.join(sharded(".manifests", &id_a)).exists(),
+        "manifest must NOT be written into the shared pool"
+    );
+
+    // The objects landed in the POOL's `.objects/`, NOT in cap-A.
+    for (_, bytes) in leaves {
+        let sum = Blake3Hasher::new().hash_hex(bytes);
+        assert!(
+            pool.join(sharded(".objects", &sum)).is_file(),
+            "object must land in the pool .objects/"
+        );
+    }
+    assert!(
+        collect_files(&cap_a.join(".objects")).is_empty(),
+        "no objects may be written into the manifest-only --store (cap-A)"
+    );
+
+    // Capture B: SAME tree, SAME pool, DIFFERENT manifest store cap-B.
+    let id_b = run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &pool_url,
+            "--store",
+            &cap_b_url,
+            &src_str,
+        ],
+        &cache,
+        &[],
+    );
+    assert_eq!(id_b, src_id, "identical tree must produce the identical id");
+
+    // The pool STILL holds exactly one copy of each blob: zero re-upload.
+    assert_eq!(
+        count_pool_objects(&pool),
+        3,
+        "second capture into the shared pool must NOT duplicate any blob"
+    );
+
+    // Both manifests exist in their own --store locations.
+    assert!(
+        cap_b.join(sharded(".manifests", &id_b)).is_file(),
+        "cap-B manifest must land in cap-B .manifests/"
+    );
+
+    // BOTH manifests pull to byte-identical trees (and re-manifest to src id).
+    for (cap_url, dest_tag) in [(&cap_a_url, "a-destA"), (&cap_b_url, "a-destB")] {
+        let dest = temp_dir(dest_tag);
+        let dest_str = dest.to_string_lossy().into_owned();
+        run_ok(
+            &[
+                "pull",
+                "--objects-store",
+                &pool_url,
+                "--store",
+                cap_url,
+                "--id",
+                &src_id,
+                &dest_str,
+            ],
+            &cache,
+            &[],
+        );
+        assert_tree_contents(&dest, leaves);
+        assert_eq!(
+            run_ok(&["id", &dest_str], &cache, &[]),
+            src_id,
+            "pulled tree from {cap_url} must re-manifest to the source id"
+        );
+        fs::remove_dir_all(&dest).ok();
+    }
+
+    for d in [&src, &pool, &cap_a, &cap_b, &cache] {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+/// SPEC (a)/fetch: `fetch` with `--objects-store` populates the cache from the
+/// pool's objects + the `--store`'s manifest, and a later offline `checkout`
+/// reproduces the tree.
+#[test]
+fn fetch_with_objects_store_populates_cache_then_checkout() {
+    let src = temp_dir("af-src");
+    let pool = temp_dir("af-pool");
+    let cap = temp_dir("af-cap");
+    let dest = temp_dir("af-dest");
+    let cache = temp_dir("af-cache");
+
+    let leaves: &[(&str, &[u8])] = &[("only.txt", b"solo")];
+    build_tree(&src, leaves);
+
+    let src_str = src.to_string_lossy().into_owned();
+    let dest_str = dest.to_string_lossy().into_owned();
+    let pool_url = file_url(&pool);
+    let cap_url = file_url(&cap);
+
+    let id = run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &pool_url,
+            "--store",
+            &cap_url,
+            &src_str,
+        ],
+        &cache,
+        &[],
+    );
+
+    // fetch pulls the manifest (from cap) + objects (from pool) into the cache.
+    run_ok(
+        &[
+            "fetch",
+            "--objects-store",
+            &pool_url,
+            "--store",
+            &cap_url,
+            "--id",
+            &id,
+        ],
+        &cache,
+        &[],
+    );
+    assert!(
+        cache.join(sharded(".manifests", &id)).is_file(),
+        "fetch must cache the manifest"
+    );
+
+    // checkout works offline from the cache only (no store flags needed).
+    run_ok(&["checkout", "--id", &id, &dest_str], &cache, &[]);
+    assert_tree_contents(&dest, leaves);
+    assert_eq!(run_ok(&["id", &dest_str], &cache, &[]), id);
+
+    for d in [&src, &pool, &cap, &dest, &cache] {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+// ===========================================================================
+// (b) BACKWARD COMPAT — colocated store unchanged when --objects-store UNSET
+// ===========================================================================
+
+/// SPEC (b): an existing colocated `push`/`pull` with NO `--objects-store` (just
+/// `--store`) still works IDENTICALLY to today — both objects AND manifest land
+/// in the SAME store, and a round trip reproduces the tree byte-for-byte.
+#[test]
+fn backward_compat_colocated_store_unchanged_without_objects_store() {
+    let src = temp_dir("b-src");
+    let store = temp_dir("b-store");
+    let dest = temp_dir("b-dest");
+    let cache = temp_dir("b-cache");
+
+    let leaves: &[(&str, &[u8])] = &[("a.txt", b"hello"), ("sub/b.txt", b"world!!")];
+    build_tree(&src, leaves);
+
+    let src_str = src.to_string_lossy().into_owned();
+    let dest_str = dest.to_string_lossy().into_owned();
+    let store_url = file_url(&store);
+
+    let src_id = run_ok(&["id", &src_str], &cache, &[]);
+
+    // Colocated push: NO --objects-store.
+    let id = run_ok(&["push", "--store", &store_url, &src_str], &cache, &[]);
+    assert_eq!(id, src_id);
+
+    // Objects AND manifest both land in the SAME store (colocated, as today).
+    assert!(
+        store.join(sharded(".manifests", &id)).is_file(),
+        "manifest must land colocated in --store"
+    );
+    for (_, bytes) in leaves {
+        let sum = Blake3Hasher::new().hash_hex(bytes);
+        assert!(
+            store.join(sharded(".objects", &sum)).is_file(),
+            "object must land colocated in the SAME --store .objects/"
+        );
+    }
+
+    // Round-trip: pull (no --objects-store) reproduces the tree + id.
+    run_ok(
+        &["pull", "--store", &store_url, "--id", &id, &dest_str],
+        &cache,
+        &[],
+    );
+    assert_tree_contents(&dest, leaves);
+    assert_eq!(
+        run_ok(&["id", &dest_str], &cache, &[]),
+        src_id,
+        "colocated round trip must re-manifest to the source id"
+    );
+
+    for d in [&src, &store, &dest, &cache] {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+// ===========================================================================
+// (c) $SNAPDIR_OBJECTS_STORE ENV EQUIVALENCE
+// ===========================================================================
+
+/// SPEC (c): `$SNAPDIR_OBJECTS_STORE` is equivalent to the `--objects-store`
+/// flag. A push using the ENV (flag omitted) routes objects to the pool exactly
+/// like the flag, and a pull using the ENV restores byte-identically.
+#[test]
+fn env_objects_store_equivalent_to_flag() {
+    let src = temp_dir("c-src");
+    let pool = temp_dir("c-pool");
+    let cap = temp_dir("c-cap");
+    let dest = temp_dir("c-dest");
+    let cache = temp_dir("c-cache");
+
+    let leaves: &[(&str, &[u8])] = &[("a.txt", b"hello"), ("d.txt", b"distinct")];
+    build_tree(&src, leaves);
+
+    let src_str = src.to_string_lossy().into_owned();
+    let dest_str = dest.to_string_lossy().into_owned();
+    let pool_url = file_url(&pool);
+    let cap_url = file_url(&cap);
+
+    let src_id = run_ok(&["id", &src_str], &cache, &[]);
+
+    // Push using $SNAPDIR_OBJECTS_STORE (flag omitted); --store still explicit.
+    let id = run_ok(
+        &["push", "--store", &cap_url, &src_str],
+        &cache,
+        &[("SNAPDIR_OBJECTS_STORE", &pool_url)],
+    );
+    assert_eq!(id, src_id, "env-driven push must print the source id");
+
+    // Objects routed to the POOL, manifest to cap — same as the flag.
+    for (_, bytes) in leaves {
+        let sum = Blake3Hasher::new().hash_hex(bytes);
+        assert!(
+            pool.join(sharded(".objects", &sum)).is_file(),
+            "env $SNAPDIR_OBJECTS_STORE must route objects to the pool"
+        );
+    }
+    assert!(
+        cap.join(sharded(".manifests", &id)).is_file(),
+        "manifest must land in --store under env equivalence"
+    );
+    assert_eq!(
+        count_pool_objects(&pool),
+        2,
+        "exactly two distinct blobs land in the env-named pool"
+    );
+
+    // Pull using the env restores byte-identically.
+    run_ok(
+        &["pull", "--store", &cap_url, "--id", &id, &dest_str],
+        &cache,
+        &[("SNAPDIR_OBJECTS_STORE", &pool_url)],
+    );
+    assert_tree_contents(&dest, leaves);
+    assert_eq!(run_ok(&["id", &dest_str], &cache, &[]), src_id);
+
+    for d in [&src, &pool, &cap, &dest, &cache] {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+/// SPEC (c): the explicit `--objects-store` FLAG overrides `$SNAPDIR_OBJECTS_STORE`
+/// when both are set (flag > env, mirroring `--store`/`$SNAPDIR_STORE`).
+#[test]
+fn flag_objects_store_overrides_env() {
+    let src = temp_dir("ce-src");
+    let env_pool = temp_dir("ce-envpool");
+    let flag_pool = temp_dir("ce-flagpool");
+    let cap = temp_dir("ce-cap");
+    let cache = temp_dir("ce-cache");
+
+    let leaves: &[(&str, &[u8])] = &[("a.txt", b"hello")];
+    build_tree(&src, leaves);
+
+    let src_str = src.to_string_lossy().into_owned();
+    let env_url = file_url(&env_pool);
+    let flag_url = file_url(&flag_pool);
+    let cap_url = file_url(&cap);
+
+    // ENV names env_pool, FLAG names flag_pool: the flag must win.
+    run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &flag_url,
+            "--store",
+            &cap_url,
+            &src_str,
+        ],
+        &cache,
+        &[("SNAPDIR_OBJECTS_STORE", &env_url)],
+    );
+
+    let sum = Blake3Hasher::new().hash_hex(b"hello");
+    assert!(
+        flag_pool.join(sharded(".objects", &sum)).is_file(),
+        "explicit --objects-store flag must receive the objects"
+    );
+    assert!(
+        !env_pool.join(sharded(".objects", &sum)).exists(),
+        "the $SNAPDIR_OBJECTS_STORE pool must be untouched when the flag is explicit"
+    );
+
+    for d in [&src, &env_pool, &flag_pool, &cap, &cache] {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+// ===========================================================================
+// FAILURE MODE: wrong/empty pool on read FAILS; right pool succeeds.
+// (Proves objects really come from the pool, not the manifest location.)
+// ===========================================================================
+
+/// SPEC failure mode: `pull` against a DIFFERENT/EMPTY `--objects-store` than the
+/// one the objects were pushed to FAILS (objects-not-found, non-zero exit, clear
+/// error) — while the SAME `pull` against the RIGHT pool SUCCEEDS. This proves
+/// objects are sourced from the pool, not the manifest `--store`.
+#[test]
+fn pull_with_wrong_or_empty_pool_fails_right_pool_succeeds() {
+    let src = temp_dir("w-src");
+    let pool = temp_dir("w-pool");
+    let empty_pool = temp_dir("w-emptypool");
+    let cap_b = temp_dir("w-capB");
+    let cache = temp_dir("w-cache");
+
+    let leaves: &[(&str, &[u8])] = &[("a.txt", b"hello"), ("b.txt", b"second")];
+    build_tree(&src, leaves);
+
+    let src_str = src.to_string_lossy().into_owned();
+    let pool_url = file_url(&pool);
+    let empty_url = file_url(&empty_pool);
+    let cap_b_url = file_url(&cap_b);
+
+    // Capture into cap-B with the real pool.
+    let id_b = run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &pool_url,
+            "--store",
+            &cap_b_url,
+            &src_str,
+        ],
+        &cache,
+        &[],
+    );
+
+    // Fresh cache so the read MUST hit the pool (not a locally cached object).
+    // pull --id <B> --store cap-B with the WRONG/EMPTY pool must FAIL.
+    let read_cache = temp_dir("w-readcache");
+    let dest_bad = temp_dir("w-destbad");
+    let out = run_raw(
+        &[
+            "pull",
+            "--objects-store",
+            &empty_url,
+            "--store",
+            &cap_b_url,
+            "--id",
+            &id_b,
+            &dest_bad.to_string_lossy(),
+        ],
+        &read_cache,
+        &[],
+    );
+    assert!(
+        !out.status.success(),
+        "pull with an empty/wrong --objects-store must fail (objects not found)"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+    assert!(
+        stderr.contains("not found")
+            || stderr.contains("missing")
+            || stderr.contains("object")
+            || stderr.contains("no such"),
+        "error must explain objects could not be found in the pool; got: {stderr}"
+    );
+
+    // The SAME pull against the RIGHT pool (still a fresh cache) SUCCEEDS.
+    let read_cache2 = temp_dir("w-readcache2");
+    let dest_ok = temp_dir("w-destok");
+    let dest_ok_str = dest_ok.to_string_lossy().into_owned();
+    run_ok(
+        &[
+            "pull",
+            "--objects-store",
+            &pool_url,
+            "--store",
+            &cap_b_url,
+            "--id",
+            &id_b,
+            &dest_ok_str,
+        ],
+        &read_cache2,
+        &[],
+    );
+    assert_tree_contents(&dest_ok, leaves);
+
+    for d in [
+        &src,
+        &pool,
+        &empty_pool,
+        &cap_b,
+        &cache,
+        &read_cache,
+        &read_cache2,
+        &dest_bad,
+        &dest_ok,
+    ] {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+// ===========================================================================
+// FAILURE MODE: external adapter rejected on EITHER side (in-process only).
+// ===========================================================================
+
+/// SPEC failure mode: a non-in-process scheme as `--objects-store` is rejected
+/// with an actionable error (only in-process file/s3/b2/gcs are allowed — the
+/// same constraint as `sync`).
+#[test]
+fn external_objects_store_scheme_rejected() {
+    let src = temp_dir("x-src");
+    let cap = temp_dir("x-cap");
+    let cache = temp_dir("x-cache");
+    build_tree(&src, &[("a.txt", b"hello")]);
+
+    let src_str = src.to_string_lossy().into_owned();
+    let cap_url = file_url(&cap);
+
+    let out = run_raw(
+        &[
+            "push",
+            "--objects-store",
+            "custom://x",
+            "--store",
+            &cap_url,
+            &src_str,
+        ],
+        &cache,
+        &[],
+    );
+    assert!(
+        !out.status.success(),
+        "a non-in-process --objects-store scheme must be rejected"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+    assert!(
+        stderr.contains("in-process")
+            || stderr.contains("not supported")
+            || stderr.contains("file/s3/b2/gcs"),
+        "rejection must be actionable (in-process file/s3/b2/gcs only); got: {stderr}"
+    );
+
+    for d in [&src, &cap, &cache] {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+/// SPEC failure mode: the external/in-process constraint applies on the
+/// MANIFEST side too — a non-in-process `--store` (with a valid `--objects-store`
+/// pool) is likewise rejected with an actionable error.
+#[test]
+fn external_store_scheme_rejected_with_objects_store_set() {
+    let src = temp_dir("xm-src");
+    let pool = temp_dir("xm-pool");
+    let cache = temp_dir("xm-cache");
+    build_tree(&src, &[("a.txt", b"hello")]);
+
+    let src_str = src.to_string_lossy().into_owned();
+    let pool_url = file_url(&pool);
+
+    let out = run_raw(
+        &[
+            "push",
+            "--objects-store",
+            &pool_url,
+            "--store",
+            "custom://x",
+            &src_str,
+        ],
+        &cache,
+        &[],
+    );
+    assert!(
+        !out.status.success(),
+        "a non-in-process --store (manifest side) must be rejected when split"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+    assert!(
+        stderr.contains("in-process")
+            || stderr.contains("not supported")
+            || stderr.contains("file/s3/b2/gcs"),
+        "manifest-side rejection must be actionable; got: {stderr}"
+    );
+
+    for d in [&src, &pool, &cache] {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+// ===========================================================================
+// FAILURE MODE: --objects-store set but --store missing -> clear error (no panic)
+// ===========================================================================
+
+/// SPEC failure mode: `--objects-store` set but `--store` (and `$SNAPDIR_STORE`)
+/// MISSING must produce a clear, actionable error — NOT a panic and NOT a silent
+/// success. (Without a manifest location there is nowhere to write the manifest.)
+#[test]
+fn objects_store_set_but_store_missing_errors_cleanly() {
+    let src = temp_dir("m-src");
+    let pool = temp_dir("m-pool");
+    let cache = temp_dir("m-cache");
+    build_tree(&src, &[("a.txt", b"hello")]);
+
+    let src_str = src.to_string_lossy().into_owned();
+    let pool_url = file_url(&pool);
+
+    // No --store, and run_raw removes $SNAPDIR_STORE, so the manifest location
+    // is genuinely unset.
+    let out = run_raw(
+        &["push", "--objects-store", &pool_url, &src_str],
+        &cache,
+        &[],
+    );
+    assert!(
+        !out.status.success(),
+        "--objects-store without --store must fail"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    // Must be a clean, actionable error — never a Rust panic.
+    assert!(
+        !stderr.contains("panicked")
+            && !stderr.contains("RUST_BACKTRACE")
+            && !stderr.to_lowercase().contains("internal error"),
+        "missing --store must be a clean error, not a panic; got: {stderr}"
+    );
+    let lc = stderr.to_lowercase();
+    assert!(
+        lc.contains("--store") || lc.contains("store"),
+        "error must name the missing --store/manifest location; got: {stderr}"
+    );
+
+    for d in [&src, &pool, &cache] {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+// ===========================================================================
+// CATALOG records the MANIFEST-side URI (--store), not the pool.
+// ===========================================================================
+
+/// SPEC: if the CLI surfaces locations/catalog, the catalog records the
+/// MANIFEST-side URI (`--store`), NOT the `--objects-store` pool. A split push
+/// then `locations`/`revisions --location=<--store>` must show the manifest
+/// store, and the pool URI must NOT appear as a catalog location.
+#[test]
+fn catalog_records_manifest_store_not_pool() {
+    let src = temp_dir("cat-src");
+    let pool = temp_dir("cat-pool");
+    let cap = temp_dir("cat-cap");
+    let cache = temp_dir("cat-cache");
+    let catalog = cache.join("catalog.redb");
+    build_tree(&src, &[("a.txt", b"hello")]);
+
+    let src_str = src.to_string_lossy().into_owned();
+    let pool_url = file_url(&pool);
+    let cap_url = file_url(&cap);
+    let catalog_str = catalog.to_string_lossy().into_owned();
+    // The catalog is selected via $SNAPDIR_CATALOG (== the global --catalog flag),
+    // mirroring `catalog_commands.rs`.
+    let cat_env: &[(&str, &str)] = &[("SNAPDIR_CATALOG", &catalog_str)];
+
+    let id = run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &pool_url,
+            "--store",
+            &cap_url,
+            &src_str,
+        ],
+        &cache,
+        cat_env,
+    );
+    assert_eq!(id.len(), 64);
+
+    // `revisions --location=<--store>` lists the revision under the MANIFEST URI.
+    let revisions = run_ok(&["revisions", "--location", &cap_url], &cache, cat_env);
+    assert!(
+        revisions.contains(&id),
+        "catalog must record the revision under the --store (manifest) URI; got: {revisions:?}"
+    );
+
+    // `locations` records the manifest store, and NEVER the pool.
+    let locations = run_ok(&["locations"], &cache, cat_env);
+    assert!(
+        locations.contains(&cap_url),
+        "catalog locations must include the --store (manifest) URI; got: {locations:?}"
+    );
+    assert!(
+        !locations.contains(&pool_url),
+        "catalog must NOT record the --objects-store pool as a location; got: {locations:?}"
+    );
+
+    // Sanity: querying by the POOL URI yields no revisions (it isn't a location).
+    let pool_revs = run_ok(&["revisions", "--location", &pool_url], &cache, cat_env);
+    assert!(
+        pool_revs.trim().is_empty(),
+        "the pool URI must NOT be a recorded catalog location; got: {pool_revs:?}"
+    );
+
+    for d in [&src, &pool, &cap, &cache] {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+// ===========================================================================
+// DELTA COST: a changed source file on the second capture uploads only the
+// CHANGED object to the pool, not the whole tree.
+// ===========================================================================
+
+/// SPEC: when a single source file changes on the second capture (same shared
+/// pool), only the CHANGED object is uploaded to the pool — the unchanged blobs
+/// are skipped (delta cost). After the second push the pool holds the original
+/// blobs PLUS exactly ONE new blob (the changed file's), not a whole new tree.
+#[test]
+fn second_capture_uploads_only_changed_object_to_pool() {
+    let src = temp_dir("d-src");
+    let pool = temp_dir("d-pool");
+    let cap1 = temp_dir("d-cap1");
+    let cap2 = temp_dir("d-cap2");
+    let cache = temp_dir("d-cache");
+
+    // Three distinct files -> three distinct blobs on the first capture.
+    let v1: &[(&str, &[u8])] = &[
+        ("a.txt", b"alpha"),
+        ("b.txt", b"bravo"),
+        ("c.txt", b"charlie"),
+    ];
+    build_tree(&src, v1);
+
+    let src_str = src.to_string_lossy().into_owned();
+    let pool_url = file_url(&pool);
+    let cap1_url = file_url(&cap1);
+    let cap2_url = file_url(&cap2);
+
+    run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &pool_url,
+            "--store",
+            &cap1_url,
+            &src_str,
+        ],
+        &cache,
+        &[],
+    );
+    let after_first = count_pool_objects(&pool);
+    assert_eq!(
+        after_first, 3,
+        "first capture seeds the pool with 3 distinct blobs"
+    );
+
+    // Change exactly ONE file; the other two blobs are unchanged.
+    fs::write(src.join("b.txt"), b"BRAVO-CHANGED").unwrap();
+    fs::set_permissions(src.join("b.txt"), fs::Permissions::from_mode(0o644)).unwrap();
+
+    // Second capture into the SAME pool, a NEW manifest store cap2.
+    run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &pool_url,
+            "--store",
+            &cap2_url,
+            &src_str,
+        ],
+        &cache,
+        &[],
+    );
+
+    let after_second = count_pool_objects(&pool);
+    assert_eq!(
+        after_second,
+        after_first + 1,
+        "second capture must upload ONLY the one changed object (delta cost), \
+         leaving the pool at {} blobs, not re-uploading the whole tree",
+        after_first + 1
+    );
+
+    // The new blob is exactly the changed file's content; the old blobs remain.
+    let changed_sum = Blake3Hasher::new().hash_hex(b"BRAVO-CHANGED");
+    assert!(
+        pool.join(sharded(".objects", &changed_sum)).is_file(),
+        "the changed file's new object must be present in the pool"
+    );
+    for original in [&b"alpha"[..], &b"bravo"[..], &b"charlie"[..]] {
+        let sum = Blake3Hasher::new().hash_hex(original);
+        assert!(
+            pool.join(sharded(".objects", &sum)).is_file(),
+            "original blobs must remain in the shared pool"
+        );
+    }
+
+    for d in [&src, &pool, &cap1, &cap2, &cache] {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+// ===========================================================================
+// REVIEW-GATE STRENGTHENING (phase 28, objects-store-cli-tests-review)
+// Added after the impl became visible. Each test below pins a concrete impl
+// branch the black-box e2e suite could only assert loosely. They are e2e
+// against the real `snapdir` binary, mirroring the suite's existing style.
+// ===========================================================================
+
+/// Reads `stderr` from a `run_raw` `Output` as a lossy `String` (NOT lowercased,
+/// so message-exactness assertions can match the real casing/scheme).
+fn stderr_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+/// REVIEW (error exactness, OBJECTS side): an external `custom://` `--objects-store`
+/// is rejected with the SAME `sync`-style message the impl reuses
+/// (`stream_store_for_adapter`'s `Adapter::External` arm), and that message NAMES
+/// the offending object-pool URL — not merely a generic "not supported". This
+/// pins that the objects side is built via the shared rejecting router and that
+/// the surfaced URL is the OBJECTS URL (so the user can tell which side failed).
+#[test]
+fn external_objects_store_error_names_offending_pool_url() {
+    let src = temp_dir("xn-src");
+    let cap = temp_dir("xn-cap");
+    let cache = temp_dir("xn-cache");
+    build_tree(&src, &[("a.txt", b"hello")]);
+
+    let src_str = src.to_string_lossy().into_owned();
+    let cap_url = file_url(&cap);
+    // A distinctive authority so we can assert the OBJECTS url is the one named.
+    let bad_pool = "custom://objects-side-pool";
+
+    let out = run_raw(
+        &[
+            "push",
+            "--objects-store",
+            bad_pool,
+            "--store",
+            &cap_url,
+            &src_str,
+        ],
+        &cache,
+        &[],
+    );
+    assert!(
+        !out.status.success(),
+        "external --objects-store must be rejected"
+    );
+    let stderr = stderr_of(&out);
+    // The impl reuses the `sync` rejection verbatim: pin the actionable phrase ...
+    assert!(
+        stderr.contains("in-process stores (file/s3/b2/gcs)"),
+        "objects-side rejection must reuse the sync 'in-process stores (file/s3/b2/gcs)' \
+         message; got: {stderr}"
+    );
+    // ... and that it names the OFFENDING OBJECTS url (not the manifest --store).
+    assert!(
+        stderr.contains(bad_pool),
+        "rejection must name the offending --objects-store url {bad_pool:?}; got: {stderr}"
+    );
+    assert!(
+        !stderr.contains(&cap_url),
+        "the valid manifest --store {cap_url:?} must NOT be blamed; got: {stderr}"
+    );
+
+    for d in [&src, &cap, &cache] {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+/// REVIEW (error exactness, MANIFEST side): with a VALID `--objects-store` pool, an
+/// external `custom://` `--store` (manifest side) is rejected with the same
+/// `sync`-style message, and that message NAMES the offending MANIFEST url. Pins
+/// that the manifest side is ALSO routed through the rejecting
+/// `stream_store_for_adapter` (not silently accepted because the pool was valid),
+/// and that the blamed url is the manifest one.
+#[test]
+fn external_manifest_store_error_names_offending_store_url() {
+    let src = temp_dir("xmn-src");
+    let pool = temp_dir("xmn-pool");
+    let cache = temp_dir("xmn-cache");
+    build_tree(&src, &[("a.txt", b"hello")]);
+
+    let src_str = src.to_string_lossy().into_owned();
+    let pool_url = file_url(&pool);
+    let bad_store = "custom://manifest-side-store";
+
+    let out = run_raw(
+        &[
+            "push",
+            "--objects-store",
+            &pool_url,
+            "--store",
+            bad_store,
+            &src_str,
+        ],
+        &cache,
+        &[],
+    );
+    assert!(
+        !out.status.success(),
+        "external manifest --store must be rejected even when --objects-store is valid"
+    );
+    let stderr = stderr_of(&out);
+    assert!(
+        stderr.contains("in-process stores (file/s3/b2/gcs)"),
+        "manifest-side rejection must reuse the sync message; got: {stderr}"
+    );
+    assert!(
+        stderr.contains(bad_store),
+        "rejection must name the offending --store url {bad_store:?}; got: {stderr}"
+    );
+    // The valid pool must not be written to (rejected before any object write).
+    assert_eq!(
+        count_pool_objects(&pool),
+        0,
+        "no objects may be written when the manifest side is rejected"
+    );
+
+    for d in [&src, &pool, &cache] {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+/// REVIEW (missing --store, clean error): `--objects-store` set but `--store`
+/// genuinely UNSET (env removed) must fail with a clean, NON-panicking error that
+/// names `--store`. Strengthens the staged case by pinning that the message is the
+/// canonical `missing --store option` (the impl surfaces it BEFORE touching either
+/// store) and that NOTHING is written to the pool. NOTE: the impl's nicer
+/// `resolve_split_store` message that also names `$SNAPDIR_STORE` is shadowed on
+/// the push path by the earlier `store_url` guard, so this pins the ACTUAL
+/// observed message rather than over-asserting `$SNAPDIR_STORE`.
+#[test]
+fn missing_store_with_objects_store_is_clean_named_error() {
+    let src = temp_dir("mn-src");
+    let pool = temp_dir("mn-pool");
+    let cache = temp_dir("mn-cache");
+    build_tree(&src, &[("a.txt", b"hello")]);
+
+    let src_str = src.to_string_lossy().into_owned();
+    let pool_url = file_url(&pool);
+
+    let out = run_raw(
+        &["push", "--objects-store", &pool_url, &src_str],
+        &cache,
+        &[],
+    );
+    assert!(
+        !out.status.success(),
+        "--objects-store without --store must fail"
+    );
+    let stderr = stderr_of(&out);
+    assert!(
+        !stderr.contains("panicked")
+            && !stderr.contains("RUST_BACKTRACE")
+            && !stderr.to_lowercase().contains("internal error"),
+        "missing --store must be a clean error, not a panic; got: {stderr}"
+    );
+    assert!(
+        stderr.contains("--store"),
+        "error must name --store; got: {stderr}"
+    );
+    assert_eq!(
+        count_pool_objects(&pool),
+        0,
+        "a missing-manifest-store failure must not write objects to the pool"
+    );
+
+    for d in [&src, &pool, &cache] {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+/// REVIEW (flag > env, exact): the `--objects-store` FLAG wins even when
+/// `$SNAPDIR_OBJECTS_STORE` names an INVALID (external) pool. clap's env wiring
+/// must let the flag fully shadow the env: a valid flag pool + a poison env pool
+/// must SUCCEED (env never consulted) and route objects to the FLAG pool. This is
+/// stronger than the staged `flag_objects_store_overrides_env` (which used two
+/// valid pools): here the env value would be a hard error if it were ever read.
+#[test]
+fn flag_objects_store_beats_poison_env() {
+    let src = temp_dir("fp-src");
+    let flag_pool = temp_dir("fp-flagpool");
+    let cap = temp_dir("fp-cap");
+    let cache = temp_dir("fp-cache");
+    build_tree(&src, &[("a.txt", b"hello")]);
+
+    let src_str = src.to_string_lossy().into_owned();
+    let flag_url = file_url(&flag_pool);
+    let cap_url = file_url(&cap);
+
+    // Env points at an external (would-fail) pool; the flag must completely win.
+    let out = run_raw(
+        &[
+            "push",
+            "--objects-store",
+            &flag_url,
+            "--store",
+            &cap_url,
+            &src_str,
+        ],
+        &cache,
+        &[("SNAPDIR_OBJECTS_STORE", "custom://poison-env-pool")],
+    );
+    assert!(
+        out.status.success(),
+        "the explicit --objects-store flag must shadow an invalid env entirely; \
+         stderr: {}",
+        stderr_of(&out)
+    );
+    let sum = Blake3Hasher::new().hash_hex(b"hello");
+    assert!(
+        flag_pool.join(sharded(".objects", &sum)).is_file(),
+        "objects must land in the FLAG pool"
+    );
+
+    for d in [&src, &flag_pool, &cap, &cache] {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+/// REVIEW (`store_is_external` short-circuit): a split store (`--objects-store` set)
+/// is treated as IN-PROCESS, so push takes the in-process tree/scratch branch and
+/// NEVER the external emit-command path. Proven end-to-end: with a `file://` pool
+/// and a `file://` manifest store, the pushed objects land as real blobs in the
+/// pool's `.objects/` (the in-process `FileStore` layout), and a fresh-cache fetch
+/// then offline checkout reproduces the tree — which only the in-process path
+/// yields. (The external path would instead emit per-object commands against a
+/// sharded cache root and write nothing to a pool tree.)
+#[test]
+fn split_store_uses_in_process_path_not_external_emit() {
+    let src = temp_dir("sp-src");
+    let pool = temp_dir("sp-pool");
+    let cap = temp_dir("sp-cap");
+    let dest = temp_dir("sp-dest");
+    let cache = temp_dir("sp-cache");
+
+    let leaves: &[(&str, &[u8])] = &[("x.txt", b"in-process-only"), ("y.txt", b"second")];
+    build_tree(&src, leaves);
+
+    let src_str = src.to_string_lossy().into_owned();
+    let dest_str = dest.to_string_lossy().into_owned();
+    let pool_url = file_url(&pool);
+    let cap_url = file_url(&cap);
+
+    let id = run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &pool_url,
+            "--store",
+            &cap_url,
+            &src_str,
+        ],
+        &cache,
+        &[],
+    );
+
+    // In-process FileStore wrote real sharded blobs into the pool tree (the
+    // external emit path would have written nothing here).
+    for (_, bytes) in leaves {
+        let sum = Blake3Hasher::new().hash_hex(bytes);
+        assert!(
+            pool.join(sharded(".objects", &sum)).is_file(),
+            "split push must write in-process blobs into the pool .objects/"
+        );
+    }
+
+    // A fresh-cache fetch from the split store reads the in-process blobs back,
+    // and an OFFLINE checkout reproduces the tree byte-for-byte. Drives the
+    // in-process fetch branch that the `store_is_external() == false`
+    // short-circuit selects.
+    let read_cache = temp_dir("sp-readcache");
+    run_ok(
+        &[
+            "fetch",
+            "--objects-store",
+            &pool_url,
+            "--store",
+            &cap_url,
+            "--id",
+            &id,
+        ],
+        &read_cache,
+        &[],
+    );
+    run_ok(&["checkout", "--id", &id, &dest_str], &read_cache, &[]);
+    assert_tree_contents(&dest, leaves);
+    assert_eq!(
+        run_ok(&["id", &dest_str], &read_cache, &[]),
+        id,
+        "split round trip via the in-process path must re-manifest to the source id"
+    );
+
+    for d in [&src, &pool, &cap, &dest, &cache, &read_cache] {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+/// REVIEW (precedence completeness): the THIRD precedence permutation the staged
+/// suite left implicit — env-named OBJECTS pool combined with a FLAG-named manifest
+/// `--store` (mixed sources) must compose correctly: objects to the env pool,
+/// manifest to the flag store, and the round trip restores. Pins that the two
+/// global args resolve independently (each honoring its own flag-or-env source).
+#[test]
+fn env_objects_with_flag_store_compose() {
+    let src = temp_dir("mx-src");
+    let pool = temp_dir("mx-pool");
+    let cap = temp_dir("mx-cap");
+    let dest = temp_dir("mx-dest");
+    let cache = temp_dir("mx-cache");
+
+    let leaves: &[(&str, &[u8])] = &[("a.txt", b"hello"), ("z.txt", b"zeta")];
+    build_tree(&src, leaves);
+
+    let src_str = src.to_string_lossy().into_owned();
+    let dest_str = dest.to_string_lossy().into_owned();
+    let pool_url = file_url(&pool);
+    let cap_url = file_url(&cap);
+
+    // OBJECTS via env, MANIFEST via flag.
+    let id = run_ok(
+        &["push", "--store", &cap_url, &src_str],
+        &cache,
+        &[("SNAPDIR_OBJECTS_STORE", &pool_url)],
+    );
+    for (_, bytes) in leaves {
+        let sum = Blake3Hasher::new().hash_hex(bytes);
+        assert!(
+            pool.join(sharded(".objects", &sum)).is_file(),
+            "env-named pool must receive the objects"
+        );
+    }
+    assert!(
+        cap.join(sharded(".manifests", &id)).is_file(),
+        "flag-named --store must receive the manifest"
+    );
+
+    // Round trip with the same mixed sources restores byte-for-byte.
+    run_ok(
+        &["pull", "--store", &cap_url, "--id", &id, &dest_str],
+        &cache,
+        &[("SNAPDIR_OBJECTS_STORE", &pool_url)],
+    );
+    assert_tree_contents(&dest, leaves);
+
+    for d in [&src, &pool, &cap, &dest, &cache] {
+        fs::remove_dir_all(d).ok();
+    }
+}

--- a/crates/snapdir-cli/tests/plumbing.rs
+++ b/crates/snapdir-cli/tests/plumbing.rs
@@ -143,9 +143,11 @@ fn files_under(dir: &Path) -> Vec<std::path::PathBuf> {
 // ---------------------------------------------------------------------------
 
 /// The capability line is EXACTLY `snapdir <semver> wire=1
-/// caps=objects-needed,send-pack,receive-pack\n` — pinned both to the literal
-/// wire-1 grammar the remote probe matches AND to the lib constants it must
-/// bake in (so a constant bump can't silently desync the CLI).
+/// caps=objects-needed,send-pack,receive-pack,snappack-zstd\n` — pinned both to
+/// the literal wire-1 grammar the remote probe matches AND to the lib constants
+/// it must bake in (so a constant bump can't silently desync the CLI). The
+/// `snappack-zstd` token is additive: the wire integer stays `1`, so older peers
+/// (whose `_snapdir_caps_ok` ignores unknown tokens) keep negotiating cleanly.
 #[test]
 fn plumbing_capabilities_line_exact() {
     let cache = TempDir::new().unwrap();
@@ -155,13 +157,20 @@ fn plumbing_capabilities_line_exact() {
         .expect("run snapdir");
     assert!(out.status.success());
     let stdout = String::from_utf8(out.stdout).unwrap();
-    // Literal wire-1 pin (the probe negotiates on this exact integer).
+    // Literal wire-1 pin (the probe negotiates on this exact integer); the
+    // `snappack-zstd` token is present and last.
     assert_eq!(
         stdout,
         format!(
-            "snapdir {} wire=1 caps=objects-needed,send-pack,receive-pack\n",
+            "snapdir {} wire=1 caps=objects-needed,send-pack,receive-pack,snappack-zstd\n",
             env!("CARGO_PKG_VERSION")
         )
+    );
+    // The new zstd capability MUST be advertised (and via the lib const, never a
+    // hand-written literal that could drift from `WIRE_CAPS`).
+    assert!(
+        stdout.contains("snappack-zstd"),
+        "version --capabilities must advertise snappack-zstd: {stdout:?}"
     );
     // And the same line re-derived from the lib constants.
     assert_eq!(
@@ -370,6 +379,129 @@ fn plumbing_pack_roundtrip_via_pipe() {
             std::fs::read(store_b.path().join(&rel)).expect("object in B"),
             std::fs::read(store_a.path().join(&rel)).expect("object in A"),
             "object {rel} must be byte-equal"
+        );
+    }
+}
+
+/// Spawns `send-pack --store file://A --ids - --manifest-id <id>` against the
+/// fixture store, feeding the object-id list on its stdin and appending any
+/// `extra` flags (e.g. `--pack-format zstd`), and returns the raw pack bytes it
+/// emitted to stdout (after asserting the command succeeded). The fixture lives
+/// in the caller-owned `store_a`/`id`/`object_ids`.
+fn run_send_pack_bytes(
+    cache: &Path,
+    url_a: &str,
+    id: &str,
+    object_ids: &[String],
+    extra: &[&str],
+) -> Vec<u8> {
+    let mut args = vec![
+        "send-pack",
+        "--store",
+        url_a,
+        "--ids",
+        "-",
+        "--manifest-id",
+        id,
+    ];
+    args.extend_from_slice(extra);
+    let mut send = snapdir(cache)
+        .args(&args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn send-pack");
+    send.stdin
+        .take()
+        .expect("send-pack stdin")
+        .write_all(format!("{}\n", object_ids.join("\n")).as_bytes())
+        .expect("write id list");
+    let out = send.wait_with_output().expect("send-pack exit");
+    assert!(
+        out.status.success(),
+        "send-pack {extra:?} failed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out.stdout
+}
+
+/// The hidden `--pack-format zstd` flag emits the additive `SNAPPACK 1Z` magic
+/// (distinct from the default v1 `SNAPPACK 1` magic), and that zstd stream
+/// `receive-pack`s into a store that is BYTE-IDENTICAL to the v1 roundtrip — the
+/// receiver sniffs the magic and needs no matching flag.
+#[test]
+fn plumbing_send_pack_zstd_roundtrip_is_byte_identical_to_v1() {
+    let cache = TempDir::new().unwrap();
+    let (store_a, id, object_ids) = pushed_fixture(cache.path());
+    let url_a = format!("file://{}", store_a.path().display());
+
+    // The default (no flag) and the explicit `--pack-format v1` both open with
+    // the plain v1 magic; the zstd form opens with the 1Z magic.
+    let v1_bytes = run_send_pack_bytes(cache.path(), &url_a, &id, &object_ids, &[]);
+    let v1_explicit = run_send_pack_bytes(
+        cache.path(),
+        &url_a,
+        &id,
+        &object_ids,
+        &["--pack-format", "v1"],
+    );
+    let zstd_bytes = run_send_pack_bytes(
+        cache.path(),
+        &url_a,
+        &id,
+        &object_ids,
+        &["--pack-format", "zstd"],
+    );
+    assert!(
+        v1_bytes.starts_with(b"SNAPPACK 1\n"),
+        "default send-pack must emit the plain v1 magic"
+    );
+    assert_eq!(
+        v1_explicit, v1_bytes,
+        "--pack-format v1 must be byte-identical to the default (no flag)"
+    );
+    assert!(
+        zstd_bytes.starts_with(b"SNAPPACK 1Z\n"),
+        "--pack-format zstd must emit the additive 1Z magic"
+    );
+    assert_ne!(
+        zstd_bytes, v1_bytes,
+        "the zstd stream must differ on the wire from the v1 stream"
+    );
+
+    // Receive the zstd stream into a fresh store and compare it object-for-object
+    // and manifest-for-manifest against the v1 source store: the decoded result
+    // must be byte-identical despite the different transport encoding.
+    let store_z = TempDir::new().unwrap();
+    let url_z = format!("file://{}", store_z.path().display());
+    let recv = run_with_stdin(
+        cache.path(),
+        &["receive-pack", "--store", &url_z, "--require-manifest", &id],
+        &zstd_bytes,
+    );
+    assert!(
+        recv.status.success(),
+        "receive-pack of the zstd stream failed: {}",
+        String::from_utf8_lossy(&recv.stderr)
+    );
+    assert!(
+        recv.stdout.is_empty(),
+        "receive-pack must print nothing to stdout"
+    );
+
+    let man_rel = manifest_path(&id);
+    assert_eq!(
+        std::fs::read(store_z.path().join(&man_rel)).expect("manifest in Z"),
+        std::fs::read(store_a.path().join(&man_rel)).expect("manifest in A"),
+        "zstd-decoded manifest must be byte-equal to the v1 source"
+    );
+    for checksum in &object_ids {
+        let rel = object_path(checksum);
+        assert_eq!(
+            std::fs::read(store_z.path().join(&rel)).expect("object in Z"),
+            std::fs::read(store_a.path().join(&rel)).expect("object in A"),
+            "zstd-decoded object {rel} must be byte-equal to the v1 source"
         );
     }
 }
@@ -622,5 +754,153 @@ fn plumbing_send_pack_malformed_id_emits_nothing() {
     assert!(
         out.stdout.is_empty(),
         "fail closed: not a single pack byte may be emitted"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// SNAPDIR_FSYNC durability knob (env-only; no CLI surface change)
+// ---------------------------------------------------------------------------
+
+/// Builds a minimal, VALID single-object pack stream (correct content address,
+/// terminated with `end\n`) — the smallest input that drives `receive-pack`
+/// all the way through filing + the durability barrier.
+fn valid_single_object_pack() -> (Vec<u8>, String) {
+    let payload = b"snapdir fsync knob payload";
+    let checksum = hex_of(payload);
+    let mut stream = b"SNAPPACK 1\n".to_vec();
+    stream.extend_from_slice(format!("obj {checksum} {}\n", payload.len()).as_bytes());
+    stream.extend_from_slice(payload);
+    stream.extend_from_slice(b"end\n");
+    (stream, checksum)
+}
+
+/// Runs `receive-pack` with `SNAPDIR_FSYNC` either set to `value` (`Some`) or
+/// explicitly removed (`None`), feeding `stdin_bytes` in. Mirrors
+/// `run_with_stdin` but pins the knob so a leaked parent env can't perturb it.
+fn run_recv_with_fsync(
+    cache: &Path,
+    store_url: &str,
+    fsync: Option<&str>,
+    stdin_bytes: &[u8],
+) -> Output {
+    let mut cmd = snapdir(cache);
+    cmd.args(["receive-pack", "--store", store_url]);
+    match fsync {
+        Some(v) => {
+            cmd.env("SNAPDIR_FSYNC", v);
+        }
+        None => {
+            cmd.env_remove("SNAPDIR_FSYNC");
+        }
+    }
+    let mut child = cmd
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .expect("spawn receive-pack");
+    child
+        .stdin
+        .take()
+        .expect("piped stdin")
+        .write_all(stdin_bytes)
+        .expect("write stdin");
+    child.wait_with_output().expect("receive-pack output")
+}
+
+/// Default (`SNAPDIR_FSYNC` unset) is the batched-durability path: a valid pack
+/// is accepted and the object lands byte-equal at its sharded address. This
+/// also exercises the end-to-end barrier (`RecordingSink::flush_barrier` must
+/// delegate, or the Batch durability would silently no-op).
+#[test]
+fn plumbing_fsync_default_is_batch_and_files_object() {
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store_url = format!("file://{}", store_dir.path().display());
+    let (stream, checksum) = valid_single_object_pack();
+
+    let out = run_recv_with_fsync(cache.path(), &store_url, None, &stream);
+    assert!(
+        out.status.success(),
+        "default receive-pack must succeed: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let filed = store_dir.path().join(object_path(&checksum));
+    assert!(filed.exists(), "object must be filed at its sharded path");
+    assert_eq!(
+        std::fs::read(&filed).unwrap(),
+        b"snapdir fsync knob payload",
+        "filed object must be byte-equal to the payload"
+    );
+}
+
+/// `SNAPDIR_FSYNC=off` is the historical no-fsync path and is accepted: the
+/// same valid pack still files the object correctly.
+#[test]
+fn plumbing_fsync_off_is_accepted_and_files_object() {
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store_url = format!("file://{}", store_dir.path().display());
+    let (stream, checksum) = valid_single_object_pack();
+
+    let out = run_recv_with_fsync(cache.path(), &store_url, Some("off"), &stream);
+    assert!(
+        out.status.success(),
+        "SNAPDIR_FSYNC=off must be accepted: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        store_dir.path().join(object_path(&checksum)).exists(),
+        "object must be filed under SNAPDIR_FSYNC=off"
+    );
+}
+
+/// `SNAPDIR_FSYNC=batch` is accepted explicitly (the named default).
+#[test]
+fn plumbing_fsync_batch_is_accepted_explicitly() {
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store_url = format!("file://{}", store_dir.path().display());
+    let (stream, checksum) = valid_single_object_pack();
+
+    let out = run_recv_with_fsync(cache.path(), &store_url, Some("batch"), &stream);
+    assert!(
+        out.status.success(),
+        "SNAPDIR_FSYNC=batch must be accepted: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        store_dir.path().join(object_path(&checksum)).exists(),
+        "object must be filed under SNAPDIR_FSYNC=batch"
+    );
+}
+
+/// An unknown `SNAPDIR_FSYNC` value FAILS CLOSED: exit != 0 with a clear
+/// message naming the accepted values, and NOTHING is filed (we never silently
+/// downgrade durability the operator asked for).
+#[test]
+fn plumbing_fsync_unknown_value_fails_closed() {
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store_url = format!("file://{}", store_dir.path().display());
+    let (stream, checksum) = valid_single_object_pack();
+
+    let out = run_recv_with_fsync(cache.path(), &store_url, Some("fsyncall"), &stream);
+    assert!(
+        !out.status.success(),
+        "an unknown SNAPDIR_FSYNC value must fail closed"
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("SNAPDIR_FSYNC"),
+        "error must name the env var: {stderr}"
+    );
+    assert!(
+        stderr.contains("batch") && stderr.contains("off"),
+        "error must name the accepted values `batch`/`off`: {stderr}"
+    );
+    assert!(
+        !store_dir.path().join(object_path(&checksum)).exists(),
+        "fail closed: nothing may be filed when the knob is rejected"
     );
 }

--- a/crates/snapdir-cli/tests/sync_split.rs
+++ b/crates/snapdir-cli/tests/sync_split.rs
@@ -1,0 +1,1224 @@
+//! Black-box spec suite for per-side object-pool sync flags
+//! `--from-objects <URI>` / `--to-objects <URI>` (phase 28, gate
+//! `sync-objects-split-spec-tests`).
+//!
+//! AUTHORED FROM THE SPEC ONLY — the `--from-objects`/`--to-objects` sync wiring
+//! does NOT exist yet, so this suite is EXPECTED to fail until the impl lands. It
+//! is staged in `.gatesmith/pending-tests/` so the workspace keeps compiling; the
+//! cli impl teammate moves it to `crates/snapdir-cli/tests/sync_split.rs` and
+//! wires it (it may adjust exact arg/SyncReport spelling but MUST preserve the
+//! BEHAVIORS pinned here).
+//!
+//! SPEC under test
+//! ===============
+//! `snapdir sync --from <STORE> --to <STORE> --id <id>` copies one snapshot
+//! store->store (exists today, colocated). This feature adds PER-SIDE object-pool
+//! flags:
+//!   * `--from-objects <URI>` — explicit SOURCE object pool (distinct from the
+//!     global `--objects-store`; source & dest can be DIFFERENT buckets/pools).
+//!   * `--to-objects <URI>`   — explicit DEST object pool.
+//!   * When a side's `*-objects` flag is present, that side is a SPLIT store
+//!     (objects = the flag, manifests = `--from`/`--to`). Absent => plain
+//!     COLOCATED store as today.
+//!   * The `sync_snapshot` engine is UNCHANGED — a `SplitStore` is already a
+//!     `StreamStore`, so object/manifest reads & writes route to the correct
+//!     split side automatically.
+//!
+//! INVARIANTS pinned here (file:// stores, NO creds, drive the REAL binary e2e):
+//!   (a) Cross-pool skip: if the DEST object pool ALREADY holds the snapshot's
+//!       blobs, the sync copies the MANIFEST to the dest manifest location but
+//!       RE-COPIES ZERO objects (dest pool `.objects` count unchanged + the
+//!       SyncReport shows the skipped/zero-copied count).
+//!   (b) Both-sides-split round trip: source split -> dest split, then the
+//!       snapshot is fully retrievable from the dest (pull via the dest manifest
+//!       location + dest pool) byte-identical to the original.
+//!
+//! FAILURE MODES / EDGE CASES attacked here:
+//!   * Asymmetric: only `--from-objects` (source split / dest colocated) and only
+//!     `--to-objects` (source colocated / dest split) — both work; objects land
+//!     in / read from the right place per side.
+//!   * Dest manifest already present => whole sync is a no-op (fast path).
+//!   * Missing source object (a blob referenced by the source manifest absent
+//!     from the source pool) => sync ERRORS and writes NO dest manifest
+//!     (manifest-last / all-or-nothing).
+//!   * Manifest-last across the split: after a FAILED sync the dest manifest
+//!     location has no `.manifests/<id>` even if some objects landed in the dest
+//!     pool.
+//!   * Distinct source/dest pools: objects written to the DEST pool, NOT the
+//!     source pool; the source pool is read-only / untouched.
+//!
+//! Note on arg shape: tests assume the surface
+//!   `snapdir sync --from <S> --to <S> --id <id> [--from-objects <U>] [--to-objects <U>]`.
+//! The impl teammate may adjust exact flag spelling / SyncReport text; the
+//! BEHAVIORS encoded here are what must hold.
+
+// The crate enables `clippy::pedantic` workspace-wide; these test-only stylistic
+// lints (mirroring the `#![allow(...)]` in sibling suites like `objects_store.rs`
+// and `progress_e2e.rs`) are suppressed so the staged suite compiles under
+// `-D warnings` WITHOUT touching any assertion or behavior.
+#![allow(
+    clippy::too_many_lines,
+    clippy::similar_names,
+    clippy::items_after_statements,
+    clippy::manual_let_else,
+    clippy::doc_markdown
+)]
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::os::unix::fs::PermissionsExt;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+// ===========================================================================
+// Harness (mirrors crates/snapdir-cli/tests/sync_e2e.rs + objects_store.rs)
+// ===========================================================================
+
+/// Path to the compiled `snapdir` binary under test (the bin target lives in the
+/// `snapdir` crate; `assert_cmd` resolves it from the shared target dir).
+fn snapdir_bin() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("snapdir")
+}
+
+/// A unique temp directory; created and returned. `tag` only aids debugging.
+fn temp_dir(tag: &str) -> PathBuf {
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "snapdir-syncsplit-{tag}-{}-{:?}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// A `file://<dir>` store URI for `dir`.
+fn file_url(dir: &Path) -> String {
+    format!("file://{}", dir.display())
+}
+
+/// Runs the `snapdir` binary with the cache pinned under `cache` and the
+/// store/objects env vars REMOVED (so the developer's env cannot mask a bug).
+/// Returns the raw `Output`.
+fn run_raw(args: &[&str], cache: &Path) -> Output {
+    Command::new(snapdir_bin())
+        .args(args)
+        .env("SNAPDIR_CACHE_DIR", cache)
+        .env_remove("SNAPDIR_STORE")
+        .env_remove("SNAPDIR_OBJECTS_STORE")
+        .output()
+        .expect("run snapdir")
+}
+
+/// Runs `snapdir <args>`, asserts SUCCESS, returns trimmed stdout.
+fn run_ok(args: &[&str], cache: &Path) -> String {
+    let out = run_raw(args, cache);
+    assert!(
+        out.status.success(),
+        "snapdir {args:?} exited {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8(out.stdout)
+        .expect("stdout is UTF-8")
+        .trim_end()
+        .to_owned()
+}
+
+/// Recursively collects every regular FILE under `dir` as paths relative to
+/// `dir`. Returns empty if `dir` is absent.
+fn collect_files(dir: &Path) -> BTreeSet<PathBuf> {
+    let mut out = BTreeSet::new();
+    fn walk(base: &Path, dir: &Path, out: &mut BTreeSet<PathBuf>) {
+        let rd = match fs::read_dir(dir) {
+            Ok(rd) => rd,
+            Err(_) => return,
+        };
+        for entry in rd.flatten() {
+            let p = entry.path();
+            let ft = match entry.file_type() {
+                Ok(ft) => ft,
+                Err(_) => continue,
+            };
+            if ft.is_dir() {
+                walk(base, &p, out);
+            } else if ft.is_file() {
+                out.insert(p.strip_prefix(base).unwrap().to_path_buf());
+            }
+        }
+    }
+    walk(dir, dir, &mut out);
+    out
+}
+
+/// Number of leaf blobs under `<pool>/.objects/` (0 if absent).
+fn count_pool_objects(pool: &Path) -> usize {
+    collect_files(&pool.join(".objects")).len()
+}
+
+/// Number of leaf manifest blobs under `<loc>/.manifests/` (0 if absent).
+fn count_manifests(loc: &Path) -> usize {
+    collect_files(&loc.join(".manifests")).len()
+}
+
+/// True iff the manifest location at `loc` physically holds the snapshot `id` —
+/// i.e. SOME file under `<loc>/.manifests/` whose sharded path (the `3/3/3/rest`
+/// split, separators stripped) reconstructs EXACTLY to `id`. Sharding-agnostic:
+/// it does not hardcode the split widths, only that the on-disk key is the id
+/// with directory separators inserted. Lets a test assert the SPECIFIC failed id
+/// is absent from the dest, not merely that the `.manifests/` count is 0.
+fn dest_serves_manifest_id(loc: &Path, id: &str) -> bool {
+    collect_files(&loc.join(".manifests")).iter().any(|rel| {
+        let joined: String = rel
+            .components()
+            .filter_map(|c| c.as_os_str().to_str())
+            .collect();
+        joined == id
+    })
+}
+
+/// Builds a known multi-file tree with deterministic permissions so a checked-out
+/// copy must restore them to re-manifest to the same id. `leaves` is a slice of
+/// `(relative_path, contents)`. Distinct contents => distinct blobs.
+fn build_tree(dir: &Path, leaves: &[(&str, &[u8])]) {
+    for (rel, bytes) in leaves {
+        let path = dir.join(rel);
+        if let Some(parent) = path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&path, bytes).unwrap();
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o644)).unwrap();
+    }
+    set_dir_perms_recursive(dir);
+}
+
+fn set_dir_perms_recursive(dir: &Path) {
+    fs::set_permissions(dir, fs::Permissions::from_mode(0o755)).unwrap();
+    for entry in fs::read_dir(dir).unwrap().flatten() {
+        if entry.file_type().unwrap().is_dir() {
+            set_dir_perms_recursive(&entry.path());
+        }
+    }
+}
+
+/// A canonical 4-distinct-blob tree reused across tests.
+fn sample_leaves() -> &'static [(&'static str, &'static [u8])] {
+    &[
+        ("top.txt", b"alpha-body"),
+        ("sub/one.txt", b"bravo-body-bravo"),
+        ("sub/two.bin", b"charlie!!!"),
+        ("sub/deep/three.dat", b"delta-delta-delta"),
+    ]
+}
+
+/// Asserts the tree at `dest` reproduces every `(rel, bytes)` leaf.
+fn assert_tree_contents(dest: &Path, expected: &[(&str, &[u8])]) {
+    for (rel, bytes) in expected {
+        let got = fs::read(dest.join(rel))
+            .unwrap_or_else(|e| panic!("read {rel} from dest {}: {e}", dest.display()));
+        assert_eq!(&got[..], *bytes, "contents of {rel} must match source");
+    }
+}
+
+/// Parses the integer immediately preceding `word` in an "N copied, M skipped"
+/// style SyncReport summary line. Returns `None` if `word` is not present.
+fn parse_count(line: &str, word: &str) -> Option<usize> {
+    let idx = line.find(word)?;
+    line[..idx]
+        .split_whitespace()
+        .next_back()
+        .and_then(|tok| tok.parse().ok())
+}
+
+/// Finds the SyncReport summary line in `stderr` (the line mentioning the synced
+/// id and a copied count). Panics with the full stderr if absent.
+fn summary_line(stderr: &str) -> &str {
+    stderr
+        .lines()
+        .find(|l| l.contains("copied"))
+        .unwrap_or_else(|| panic!("expected a sync summary line with a copied count:\n{stderr}"))
+}
+
+/// Deletes ONE leaf blob from `<pool>/.objects/` (to simulate a missing source
+/// object). Returns the path removed. Panics if the pool has no objects.
+fn delete_one_object(pool: &Path) -> PathBuf {
+    let objs = collect_files(&pool.join(".objects"));
+    let rel = objs
+        .iter()
+        .next()
+        .unwrap_or_else(|| panic!("pool {} has no objects to delete", pool.display()))
+        .clone();
+    let abs = pool.join(".objects").join(&rel);
+    fs::remove_file(&abs).unwrap_or_else(|e| panic!("remove {}: {e}", abs.display()));
+    abs
+}
+
+// ===========================================================================
+// (b) BOTH-SIDES-SPLIT ROUND TRIP
+// ===========================================================================
+
+/// SPEC (b): source split (`--from` + `--from-objects`) -> dest split (`--to` +
+/// `--to-objects`); afterward the snapshot is FULLY retrievable from the dest
+/// (pull via the dest manifest location + dest pool) byte-identical to the
+/// original, and re-manifests to the source id.
+#[test]
+fn sync_split_both_sides_round_trips() {
+    let src = temp_dir("b-src");
+    let src_mani = temp_dir("b-srcmani");
+    let src_pool = temp_dir("b-srcpool");
+    let dst_mani = temp_dir("b-dstmani");
+    let dst_pool = temp_dir("b-dstpool");
+    let cache = temp_dir("b-cache");
+
+    let leaves = sample_leaves();
+    build_tree(&src, leaves);
+    let src_str = src.to_string_lossy().into_owned();
+
+    let src_mani_url = file_url(&src_mani);
+    let src_pool_url = file_url(&src_pool);
+    let dst_mani_url = file_url(&dst_mani);
+    let dst_pool_url = file_url(&dst_pool);
+
+    // Push the source as a SPLIT store: objects -> src_pool, manifest -> src_mani.
+    let src_id = run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &src_pool_url,
+            "--store",
+            &src_mani_url,
+            &src_str,
+        ],
+        &cache,
+    );
+    assert_eq!(src_id.len(), 64, "snapshot id is 64 hex chars");
+    assert_eq!(
+        count_pool_objects(&src_pool),
+        leaves.len(),
+        "source pool must hold one blob per distinct file"
+    );
+
+    // sync source-split -> dest-split.
+    let out = run_raw(
+        &[
+            "sync",
+            "--id",
+            &src_id,
+            "--from",
+            &src_mani_url,
+            "--from-objects",
+            &src_pool_url,
+            "--to",
+            &dst_mani_url,
+            "--to-objects",
+            &dst_pool_url,
+        ],
+        &cache,
+    );
+    assert!(
+        out.status.success(),
+        "both-sides-split sync must succeed\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert_eq!(
+        String::from_utf8(out.stdout).unwrap().trim_end(),
+        src_id,
+        "sync must print the snapshot id to stdout"
+    );
+
+    // The DEST manifest landed in the dest manifest location; objects in the dest
+    // POOL (NOT the dest manifest location).
+    assert_eq!(
+        count_manifests(&dst_mani),
+        1,
+        "the manifest must land in the dest manifest location's .manifests/"
+    );
+    assert_eq!(
+        count_pool_objects(&dst_pool),
+        leaves.len(),
+        "every blob must land in the dest pool"
+    );
+    assert_eq!(
+        count_pool_objects(&dst_mani),
+        0,
+        "no objects may land in the dest MANIFEST location (split: objects go to --to-objects)"
+    );
+
+    // The dest serves the snapshot: pull via the dest split (manifest + pool).
+    let dest = temp_dir("b-out");
+    let dest_str = dest.to_string_lossy().into_owned();
+    let pullcache = temp_dir("b-pullcache");
+    run_ok(
+        &[
+            "pull",
+            "--objects-store",
+            &dst_pool_url,
+            "--store",
+            &dst_mani_url,
+            "--id",
+            &src_id,
+            &dest_str,
+        ],
+        &pullcache,
+    );
+    assert_tree_contents(&dest, leaves);
+    assert_eq!(
+        run_ok(&["id", &dest_str], &pullcache),
+        src_id,
+        "tree pulled from the dest split must re-manifest to the source id"
+    );
+}
+
+// ===========================================================================
+// (a) CROSS-POOL SKIP — dest pool already has the blobs => ZERO objects re-copied
+// ===========================================================================
+
+/// SPEC (a): when the DEST object pool ALREADY holds the snapshot's blobs (pushed
+/// there earlier), a sync copies the MANIFEST to the dest manifest location but
+/// re-copies ZERO objects. Asserted two ways: (1) the dest pool's `.objects`
+/// count is UNCHANGED across the sync, and (2) the SyncReport reports 0 copied /
+/// all skipped.
+#[test]
+fn sync_split_dest_pool_has_blobs_recopies_zero_objects() {
+    let src = temp_dir("a-src");
+    let src_mani = temp_dir("a-srcmani");
+    let src_pool = temp_dir("a-srcpool");
+    let dst_mani = temp_dir("a-dstmani");
+    let dst_pool = temp_dir("a-dstpool");
+    let cache = temp_dir("a-cache");
+
+    let leaves = sample_leaves();
+    build_tree(&src, leaves);
+    let src_str = src.to_string_lossy().into_owned();
+
+    let src_mani_url = file_url(&src_mani);
+    let src_pool_url = file_url(&src_pool);
+    let dst_mani_url = file_url(&dst_mani);
+    let dst_pool_url = file_url(&dst_pool);
+
+    // Source split push: objects -> src_pool, manifest -> src_mani.
+    let src_id = run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &src_pool_url,
+            "--store",
+            &src_mani_url,
+            &src_str,
+        ],
+        &cache,
+    );
+
+    // PRE-SEED the DEST POOL with the exact same blobs by pushing the SAME tree
+    // there earlier (manifest goes to a throwaway location, NOT dst_mani — we want
+    // only the blobs present in the dest pool, not the manifest in dst_mani).
+    let seed_mani = temp_dir("a-seedmani");
+    let seed_mani_url = file_url(&seed_mani);
+    run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &dst_pool_url,
+            "--store",
+            &seed_mani_url,
+            &src_str,
+        ],
+        &cache,
+    );
+    let dst_pool_objects_before = count_pool_objects(&dst_pool);
+    assert_eq!(
+        dst_pool_objects_before,
+        leaves.len(),
+        "the pre-seed must put every blob into the dest pool"
+    );
+    // The dest MANIFEST location must NOT yet hold the snapshot manifest (only the
+    // blobs are pre-present), so the sync still has manifest work to do.
+    assert_eq!(
+        count_manifests(&dst_mani),
+        0,
+        "dest manifest location must start without the snapshot manifest"
+    );
+
+    // sync source-split -> dest-split. The dest pool already has every blob.
+    let out = run_raw(
+        &[
+            "sync",
+            "--id",
+            &src_id,
+            "--from",
+            &src_mani_url,
+            "--from-objects",
+            &src_pool_url,
+            "--to",
+            &dst_mani_url,
+            "--to-objects",
+            &dst_pool_url,
+        ],
+        &cache,
+    );
+    assert!(
+        out.status.success(),
+        "cross-pool sync must succeed\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    let summary = summary_line(&stderr);
+
+    // (1) ZERO objects re-copied: the dest pool's object count is UNCHANGED.
+    assert_eq!(
+        count_pool_objects(&dst_pool),
+        dst_pool_objects_before,
+        "no objects may be re-uploaded when the dest pool already holds them:\n{summary}"
+    );
+
+    // (2) The SyncReport must show the skip: 0 copied (and all blobs skipped).
+    let copied = parse_count(summary, "copied")
+        .unwrap_or_else(|| panic!("no copied count in summary:\n{summary}"));
+    assert_eq!(
+        copied, 0,
+        "every blob is already in the dest pool => 0 objects copied:\n{summary}"
+    );
+    if let Some(skipped) = parse_count(summary, "skipped") {
+        assert_eq!(
+            skipped,
+            leaves.len(),
+            "all {} present blobs must be reported skipped:\n{summary}",
+            leaves.len()
+        );
+    }
+
+    // BUT the manifest WAS copied to the dest manifest location.
+    assert_eq!(
+        count_manifests(&dst_mani),
+        1,
+        "the manifest must be copied to the dest manifest location even when 0 objects copied"
+    );
+
+    // And the dest now serves the snapshot byte-identically.
+    let dest = temp_dir("a-out");
+    let dest_str = dest.to_string_lossy().into_owned();
+    let pullcache = temp_dir("a-pullcache");
+    run_ok(
+        &[
+            "pull",
+            "--objects-store",
+            &dst_pool_url,
+            "--store",
+            &dst_mani_url,
+            "--id",
+            &src_id,
+            &dest_str,
+        ],
+        &pullcache,
+    );
+    assert_tree_contents(&dest, leaves);
+    assert_eq!(
+        run_ok(&["id", &dest_str], &pullcache),
+        src_id,
+        "the zero-object sync must still leave the dest fully serving the snapshot"
+    );
+}
+
+// ===========================================================================
+// ASYMMETRIC: only --from-objects (source split, dest colocated)
+// ===========================================================================
+
+/// SPEC (asymmetric): only `--from-objects` is set — the SOURCE is a split store
+/// (objects in src_pool, manifest in src_mani) and the DEST is plain COLOCATED
+/// (objects AND manifest both land under `--to`). Objects must be READ from the
+/// source pool and WRITTEN colocated into the dest, which then fully serves it.
+#[test]
+fn sync_split_source_only_dest_colocated() {
+    let src = temp_dir("fo-src");
+    let src_mani = temp_dir("fo-srcmani");
+    let src_pool = temp_dir("fo-srcpool");
+    let dst = temp_dir("fo-dst");
+    let cache = temp_dir("fo-cache");
+
+    let leaves = sample_leaves();
+    build_tree(&src, leaves);
+    let src_str = src.to_string_lossy().into_owned();
+
+    let src_mani_url = file_url(&src_mani);
+    let src_pool_url = file_url(&src_pool);
+    let dst_url = file_url(&dst);
+
+    let src_id = run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &src_pool_url,
+            "--store",
+            &src_mani_url,
+            &src_str,
+        ],
+        &cache,
+    );
+
+    // sync: source split (--from + --from-objects) -> dest colocated (--to only).
+    let out = run_raw(
+        &[
+            "sync",
+            "--id",
+            &src_id,
+            "--from",
+            &src_mani_url,
+            "--from-objects",
+            &src_pool_url,
+            "--to",
+            &dst_url,
+        ],
+        &cache,
+    );
+    assert!(
+        out.status.success(),
+        "source-split/dest-colocated sync must succeed\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Dest is COLOCATED: both objects AND manifest land under --to.
+    assert_eq!(
+        count_pool_objects(&dst),
+        leaves.len(),
+        "colocated dest must hold every object under its own .objects/"
+    );
+    assert_eq!(
+        count_manifests(&dst),
+        1,
+        "colocated dest must hold the manifest under its own .manifests/"
+    );
+
+    // Pull from the colocated dest (NO --objects-store): byte-identical.
+    let dest = temp_dir("fo-out");
+    let dest_str = dest.to_string_lossy().into_owned();
+    let pullcache = temp_dir("fo-pullcache");
+    run_ok(
+        &["pull", "--store", &dst_url, "--id", &src_id, &dest_str],
+        &pullcache,
+    );
+    assert_tree_contents(&dest, leaves);
+    assert_eq!(
+        run_ok(&["id", &dest_str], &pullcache),
+        src_id,
+        "colocated dest must fully serve the snapshot"
+    );
+}
+
+// ===========================================================================
+// ASYMMETRIC: only --to-objects (source colocated, dest split)
+// ===========================================================================
+
+/// SPEC (asymmetric): only `--to-objects` is set — the SOURCE is plain COLOCATED
+/// (`--from` holds objects AND manifest) and the DEST is a split store (objects
+/// to to_pool, manifest to `--to`). Objects must be READ colocated from the
+/// source and WRITTEN to the dest POOL (NOT the dest manifest location).
+#[test]
+fn sync_split_dest_only_source_colocated() {
+    let src = temp_dir("to-src");
+    let src_store = temp_dir("to-srcstore");
+    let dst_mani = temp_dir("to-dstmani");
+    let dst_pool = temp_dir("to-dstpool");
+    let cache = temp_dir("to-cache");
+
+    let leaves = sample_leaves();
+    build_tree(&src, leaves);
+    let src_str = src.to_string_lossy().into_owned();
+
+    let src_store_url = file_url(&src_store);
+    let dst_mani_url = file_url(&dst_mani);
+    let dst_pool_url = file_url(&dst_pool);
+
+    // Source is COLOCATED (no --objects-store): objects + manifest both under
+    // src_store.
+    let src_id = run_ok(&["push", "--store", &src_store_url, &src_str], &cache);
+    assert_eq!(
+        count_pool_objects(&src_store),
+        leaves.len(),
+        "colocated source must hold its objects colocated"
+    );
+
+    // sync: source colocated (--from only) -> dest split (--to + --to-objects).
+    let out = run_raw(
+        &[
+            "sync",
+            "--id",
+            &src_id,
+            "--from",
+            &src_store_url,
+            "--to",
+            &dst_mani_url,
+            "--to-objects",
+            &dst_pool_url,
+        ],
+        &cache,
+    );
+    assert!(
+        out.status.success(),
+        "source-colocated/dest-split sync must succeed\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // Objects landed in the dest POOL; the manifest in the dest manifest location;
+    // and NO objects in the dest manifest location.
+    assert_eq!(
+        count_pool_objects(&dst_pool),
+        leaves.len(),
+        "split dest must write objects to --to-objects"
+    );
+    assert_eq!(
+        count_manifests(&dst_mani),
+        1,
+        "split dest must write the manifest to --to"
+    );
+    assert_eq!(
+        count_pool_objects(&dst_mani),
+        0,
+        "split dest must NOT write objects into the manifest location"
+    );
+
+    // Pull from the dest split: byte-identical.
+    let dest = temp_dir("to-out");
+    let dest_str = dest.to_string_lossy().into_owned();
+    let pullcache = temp_dir("to-pullcache");
+    run_ok(
+        &[
+            "pull",
+            "--objects-store",
+            &dst_pool_url,
+            "--store",
+            &dst_mani_url,
+            "--id",
+            &src_id,
+            &dest_str,
+        ],
+        &pullcache,
+    );
+    assert_tree_contents(&dest, leaves);
+    assert_eq!(
+        run_ok(&["id", &dest_str], &pullcache),
+        src_id,
+        "split dest must fully serve the snapshot"
+    );
+}
+
+// ===========================================================================
+// DEST MANIFEST ALREADY PRESENT => whole sync is a NO-OP (fast path)
+// ===========================================================================
+
+/// SPEC (fast path): when the dest manifest location ALREADY holds `<id>` (the
+/// snapshot was synced there before), re-running the SAME split sync is a NO-OP:
+/// it succeeds, reports 0 copied, and leaves BOTH the dest manifest location and
+/// the dest pool physically unchanged.
+#[test]
+fn sync_split_dest_manifest_present_is_noop() {
+    let src = temp_dir("noop-src");
+    let src_mani = temp_dir("noop-srcmani");
+    let src_pool = temp_dir("noop-srcpool");
+    let dst_mani = temp_dir("noop-dstmani");
+    let dst_pool = temp_dir("noop-dstpool");
+    let cache = temp_dir("noop-cache");
+
+    let leaves = sample_leaves();
+    build_tree(&src, leaves);
+    let src_str = src.to_string_lossy().into_owned();
+
+    let src_mani_url = file_url(&src_mani);
+    let src_pool_url = file_url(&src_pool);
+    let dst_mani_url = file_url(&dst_mani);
+    let dst_pool_url = file_url(&dst_pool);
+
+    let src_id = run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &src_pool_url,
+            "--store",
+            &src_mani_url,
+            &src_str,
+        ],
+        &cache,
+    );
+
+    let sync_args = [
+        "sync",
+        "--id",
+        &src_id,
+        "--from",
+        &src_mani_url,
+        "--from-objects",
+        &src_pool_url,
+        "--to",
+        &dst_mani_url,
+        "--to-objects",
+        &dst_pool_url,
+    ];
+
+    // First sync populates the dest split.
+    run_ok(&sync_args, &cache);
+    let dst_mani_after_first = collect_files(&dst_mani);
+    let dst_pool_after_first = collect_files(&dst_pool);
+    assert!(
+        !dst_mani_after_first.is_empty() && !dst_pool_after_first.is_empty(),
+        "the first sync must populate both dest sides"
+    );
+
+    // Second sync of the same id: the dest manifest is already present => no-op.
+    let out2 = run_raw(&sync_args, &cache);
+    assert!(out2.status.success(), "the no-op sync must succeed");
+    let stderr2 = String::from_utf8(out2.stderr).unwrap();
+    let summary2 = summary_line(&stderr2);
+    let copied2 = parse_count(summary2, "copied")
+        .unwrap_or_else(|| panic!("no copied count in second summary:\n{summary2}"));
+    assert_eq!(
+        copied2, 0,
+        "a sync whose dest manifest is already present must copy 0 objects:\n{summary2}"
+    );
+
+    // Both dest sides physically UNCHANGED.
+    assert_eq!(
+        collect_files(&dst_mani),
+        dst_mani_after_first,
+        "the no-op sync must leave the dest manifest location unchanged"
+    );
+    assert_eq!(
+        collect_files(&dst_pool),
+        dst_pool_after_first,
+        "the no-op sync must leave the dest pool unchanged"
+    );
+}
+
+// ===========================================================================
+// MISSING SOURCE OBJECT => sync ERRORS + NO dest manifest (manifest-last)
+// ===========================================================================
+
+/// SPEC (missing source object + manifest-last): if a blob referenced by the
+/// source manifest is ABSENT from the source pool, the sync ERRORS (non-zero
+/// exit) AND writes NO dest manifest — the dest manifest location must NOT gain
+/// `.manifests/<id>`, even though some other objects may have landed in the dest
+/// pool (all-or-nothing / manifest-last across the split).
+#[test]
+fn sync_split_missing_source_object_errors_and_writes_no_dest_manifest() {
+    let src = temp_dir("miss-src");
+    let src_mani = temp_dir("miss-srcmani");
+    let src_pool = temp_dir("miss-srcpool");
+    let dst_mani = temp_dir("miss-dstmani");
+    let dst_pool = temp_dir("miss-dstpool");
+    let cache = temp_dir("miss-cache");
+
+    let leaves = sample_leaves();
+    build_tree(&src, leaves);
+    let src_str = src.to_string_lossy().into_owned();
+
+    let src_mani_url = file_url(&src_mani);
+    let src_pool_url = file_url(&src_pool);
+    let dst_mani_url = file_url(&dst_mani);
+    let dst_pool_url = file_url(&dst_pool);
+
+    let src_id = run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &src_pool_url,
+            "--store",
+            &src_mani_url,
+            &src_str,
+        ],
+        &cache,
+    );
+
+    // Corrupt the SOURCE pool: delete one blob the manifest references. The
+    // manifest in src_mani still lists it, so the sync will fail mid-copy.
+    let removed = delete_one_object(&src_pool);
+    assert!(
+        !removed.exists(),
+        "the referenced blob must actually be gone from the source pool"
+    );
+
+    // sync must FAIL (the missing object cannot be copied).
+    let out = run_raw(
+        &[
+            "sync",
+            "--id",
+            &src_id,
+            "--from",
+            &src_mani_url,
+            "--from-objects",
+            &src_pool_url,
+            "--to",
+            &dst_mani_url,
+            "--to-objects",
+            &dst_pool_url,
+        ],
+        &cache,
+    );
+    assert!(
+        !out.status.success(),
+        "a sync with a missing source object must FAIL (non-zero exit), stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // MANIFEST-LAST / all-or-nothing: the dest manifest location must NOT have
+    // gained the snapshot manifest, regardless of any objects that landed.
+    assert_eq!(
+        count_manifests(&dst_mani),
+        0,
+        "a FAILED sync must NOT publish the manifest to the dest manifest location (manifest-last)"
+    );
+    // STRENGTHEN (adversary review): assert the SPECIFIC failed id is physically
+    // absent from the dest `.manifests/` shard tree — not just that the leaf count
+    // is 0. A count of 0 could be satisfied vacuously if manifests landed
+    // elsewhere; this pins that NO on-disk key under the dest reconstructs to the
+    // failed snapshot id (manifest-last, by exact id).
+    assert!(
+        !dest_serves_manifest_id(&dst_mani, &src_id),
+        "the dest .manifests/ tree must NOT physically contain the failed id {src_id}"
+    );
+    // Belt-and-suspenders: the specific id must not be resolvable from the dest.
+    // (Arg-shape fix: `manifest` is a local-tree describe command and does NOT
+    // resolve a pinned id from a store — `fetch` is snapdir's store-resolution
+    // surface, so this is the correct way to express the SAME assertion that the
+    // dest does not serve a manifest for the failed id. The pull cache is fresh,
+    // so the manifest must come from the dest store, which has none => failure.)
+    let probecache = temp_dir("miss-probecache");
+    let probe = run_raw(
+        &[
+            "fetch",
+            "--objects-store",
+            &dst_pool_url,
+            "--store",
+            &dst_mani_url,
+            "--id",
+            &src_id,
+        ],
+        &probecache,
+    );
+    assert!(
+        !probe.status.success(),
+        "the dest must not serve a manifest for the failed sync's id"
+    );
+}
+
+// ===========================================================================
+// DISTINCT POOLS — objects go to the DEST pool; the SOURCE pool is untouched
+// ===========================================================================
+
+/// SPEC (distinct source/dest pools / read-only source): with DISTINCT source and
+/// dest pools, a successful split sync writes the blobs into the DEST pool and
+/// leaves the SOURCE pool BYTE-FOR-BYTE unchanged (read-only) — neither new
+/// objects nor a manifest appear in the source pool / source manifest location.
+#[test]
+fn sync_split_source_pool_untouched_objects_land_in_dest_pool() {
+    let src = temp_dir("ro-src");
+    let src_mani = temp_dir("ro-srcmani");
+    let src_pool = temp_dir("ro-srcpool");
+    let dst_mani = temp_dir("ro-dstmani");
+    let dst_pool = temp_dir("ro-dstpool");
+    let cache = temp_dir("ro-cache");
+
+    let leaves = sample_leaves();
+    build_tree(&src, leaves);
+    let src_str = src.to_string_lossy().into_owned();
+
+    let src_mani_url = file_url(&src_mani);
+    let src_pool_url = file_url(&src_pool);
+    let dst_mani_url = file_url(&dst_mani);
+    let dst_pool_url = file_url(&dst_pool);
+
+    let src_id = run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &src_pool_url,
+            "--store",
+            &src_mani_url,
+            &src_str,
+        ],
+        &cache,
+    );
+
+    // Snapshot the SOURCE sides before the sync.
+    let src_pool_before = collect_files(&src_pool);
+    let src_mani_before = collect_files(&src_mani);
+    assert!(
+        !src_pool_before.is_empty(),
+        "source pool must hold the blobs before the sync"
+    );
+
+    // sync split -> split (distinct pools).
+    run_ok(
+        &[
+            "sync",
+            "--id",
+            &src_id,
+            "--from",
+            &src_mani_url,
+            "--from-objects",
+            &src_pool_url,
+            "--to",
+            &dst_mani_url,
+            "--to-objects",
+            &dst_pool_url,
+        ],
+        &cache,
+    );
+
+    // The SOURCE sides are untouched (read-only).
+    assert_eq!(
+        collect_files(&src_pool),
+        src_pool_before,
+        "the source pool must be byte-for-byte unchanged (read-only) after the sync"
+    );
+    assert_eq!(
+        collect_files(&src_mani),
+        src_mani_before,
+        "the source manifest location must be unchanged after the sync"
+    );
+
+    // The blobs landed in the DEST pool, NOT duplicated back into the source pool.
+    assert_eq!(
+        count_pool_objects(&dst_pool),
+        leaves.len(),
+        "objects must be written to the DEST pool"
+    );
+    // The dest pool is a DISTINCT directory from the source pool.
+    assert_ne!(
+        dst_pool, src_pool,
+        "source and dest pools must be distinct directories in this test"
+    );
+}
+
+// ===========================================================================
+// PER-SIDE EXTERNAL-ADAPTER REJECTION on --from-objects / --to-objects
+// ===========================================================================
+
+/// SPEC (in-process-only / per-side rejection): an external `snapdir-*-store`
+/// URL (any non file/s3/b2/gcs scheme, here `custom://`) is REJECTED on EITHER
+/// `*-objects` leg — sync requires in-process stores. This pins that the split
+/// is built via the same `stream_store_for_adapter` gate as the rest of sync, so
+/// an external object pool cannot sneak in on a per-side flag. Asserts (1) a
+/// non-zero exit and (2) the actionable in-process error message — and that NO
+/// child `snapdir-*-store` binary is shelled out (the rejection precedes any
+/// subprocess: a `custom://` adapter has no such binary, so a non-rejecting impl
+/// that tried to spawn it would fail with a DIFFERENT, exec-not-found error).
+#[test]
+fn sync_split_external_objects_uri_rejected_per_side() {
+    let src = temp_dir("ext-src");
+    let src_mani = temp_dir("ext-srcmani");
+    let src_pool = temp_dir("ext-srcpool");
+    let dst_mani = temp_dir("ext-dstmani");
+    let dst_pool = temp_dir("ext-dstpool");
+    let cache = temp_dir("ext-cache");
+
+    let leaves = sample_leaves();
+    build_tree(&src, leaves);
+    let src_str = src.to_string_lossy().into_owned();
+
+    let src_mani_url = file_url(&src_mani);
+    let src_pool_url = file_url(&src_pool);
+    let dst_mani_url = file_url(&dst_mani);
+    let dst_pool_url = file_url(&dst_pool);
+
+    let src_id = run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &src_pool_url,
+            "--store",
+            &src_mani_url,
+            &src_str,
+        ],
+        &cache,
+    );
+
+    // An external object pool on the SOURCE side (--from-objects) is rejected.
+    let from_ext = run_raw(
+        &[
+            "sync",
+            "--id",
+            &src_id,
+            "--from",
+            &src_mani_url,
+            "--from-objects",
+            "custom://external/source/pool",
+            "--to",
+            &dst_mani_url,
+            "--to-objects",
+            &dst_pool_url,
+        ],
+        &cache,
+    );
+    assert!(
+        !from_ext.status.success(),
+        "an external --from-objects URL must be rejected (non-zero exit)"
+    );
+    let from_err = String::from_utf8_lossy(&from_ext.stderr);
+    assert!(
+        from_err.contains("in-process") || from_err.contains("not supported"),
+        "the rejection must name the in-process-only contract, got:\n{from_err}"
+    );
+    // The rejection happens BEFORE any store mutation: the dest got nothing.
+    assert_eq!(
+        count_manifests(&dst_mani),
+        0,
+        "a rejected external --from-objects sync must not publish a dest manifest"
+    );
+    assert_eq!(
+        count_pool_objects(&dst_pool),
+        0,
+        "a rejected external --from-objects sync must not write dest objects"
+    );
+
+    // An external object pool on the DEST side (--to-objects) is rejected too.
+    let to_ext = run_raw(
+        &[
+            "sync",
+            "--id",
+            &src_id,
+            "--from",
+            &src_mani_url,
+            "--from-objects",
+            &src_pool_url,
+            "--to",
+            &dst_mani_url,
+            "--to-objects",
+            "custom://external/dest/pool",
+        ],
+        &cache,
+    );
+    assert!(
+        !to_ext.status.success(),
+        "an external --to-objects URL must be rejected (non-zero exit)"
+    );
+    let to_err = String::from_utf8_lossy(&to_ext.stderr);
+    assert!(
+        to_err.contains("in-process") || to_err.contains("not supported"),
+        "the rejection must name the in-process-only contract, got:\n{to_err}"
+    );
+    assert_eq!(
+        count_manifests(&dst_mani),
+        0,
+        "a rejected external --to-objects sync must not publish a dest manifest"
+    );
+}
+
+// ===========================================================================
+// PER-SIDE --from-objects/--to-objects are INDEPENDENT of the global
+// --objects-store (the global must not influence sync routing)
+// ===========================================================================
+
+/// SPEC (per-side distinct from the global `--objects-store`): the SPEC names
+/// `--from-objects`/`--to-objects` as DISTINCT from the global `--objects-store`.
+/// Pin that the global is IGNORED by sync routing: even with a global
+/// `--objects-store` pointed at a bogus/empty pool present on the SAME command,
+/// the per-side flags drive the routing — objects are READ from `--from-objects`
+/// and WRITTEN to `--to-objects`, and the bogus global pool is never touched
+/// (stays empty) and never masks the per-side pools. Proves the per-side flags
+/// are not silently aliased to / overridden by the global.
+#[test]
+fn sync_split_objects_flags_independent_of_global_objects_store() {
+    let src = temp_dir("ind-src");
+    let src_mani = temp_dir("ind-srcmani");
+    let src_pool = temp_dir("ind-srcpool");
+    let dst_mani = temp_dir("ind-dstmani");
+    let dst_pool = temp_dir("ind-dstpool");
+    let bogus_global = temp_dir("ind-bogusglobal");
+    let cache = temp_dir("ind-cache");
+
+    let leaves = sample_leaves();
+    build_tree(&src, leaves);
+    let src_str = src.to_string_lossy().into_owned();
+
+    let src_mani_url = file_url(&src_mani);
+    let src_pool_url = file_url(&src_pool);
+    let dst_mani_url = file_url(&dst_mani);
+    let dst_pool_url = file_url(&dst_pool);
+    let bogus_global_url = file_url(&bogus_global);
+
+    let src_id = run_ok(
+        &[
+            "push",
+            "--objects-store",
+            &src_pool_url,
+            "--store",
+            &src_mani_url,
+            &src_str,
+        ],
+        &cache,
+    );
+
+    // Sync with the per-side flags AND a global --objects-store at a bogus, empty
+    // pool. The global must be ignored: routing follows --from-objects/--to-objects.
+    let out = run_raw(
+        &[
+            "sync",
+            "--objects-store",
+            &bogus_global_url,
+            "--id",
+            &src_id,
+            "--from",
+            &src_mani_url,
+            "--from-objects",
+            &src_pool_url,
+            "--to",
+            &dst_mani_url,
+            "--to-objects",
+            &dst_pool_url,
+        ],
+        &cache,
+    );
+    assert!(
+        out.status.success(),
+        "sync must succeed routing by the per-side flags, ignoring the global \
+         --objects-store\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    // The blobs landed in the per-side DEST pool, NOT the bogus global pool.
+    assert_eq!(
+        count_pool_objects(&dst_pool),
+        leaves.len(),
+        "objects must land in --to-objects, not the global --objects-store pool"
+    );
+    assert_eq!(
+        count_pool_objects(&bogus_global),
+        0,
+        "the global --objects-store pool must be untouched by sync (ignored)"
+    );
+    // Manifest landed in --to; the dest serves the snapshot's id.
+    assert_eq!(
+        count_manifests(&dst_mani),
+        1,
+        "the manifest must land in --to"
+    );
+    assert!(
+        dest_serves_manifest_id(&dst_mani, &src_id),
+        "the dest .manifests/ tree must physically hold the synced id {src_id}"
+    );
+
+    // And it is fully retrievable from the per-side dest split.
+    let dest = temp_dir("ind-out");
+    let dest_str = dest.to_string_lossy().into_owned();
+    let pullcache = temp_dir("ind-pullcache");
+    run_ok(
+        &[
+            "pull",
+            "--objects-store",
+            &dst_pool_url,
+            "--store",
+            &dst_mani_url,
+            "--id",
+            &src_id,
+            &dest_str,
+        ],
+        &pullcache,
+    );
+    assert_tree_contents(&dest, leaves);
+    assert_eq!(
+        run_ok(&["id", &dest_str], &pullcache),
+        src_id,
+        "the per-side-routed sync must leave the dest fully serving the snapshot"
+    );
+}

--- a/crates/snapdir-core/Cargo.toml
+++ b/crates/snapdir-core/Cargo.toml
@@ -11,9 +11,10 @@ description = "snapdir core: manifest format, BLAKE3 merkle hashing, store trait
 readme = "README.md"
 
 [dependencies]
-blake3 = "1.8.5"
+blake3 = { version = "1.8.5", features = ["mmap", "rayon"] }
 libc = "0.2"
 md-5 = "0.11"
+rayon = "1.12.0"
 regex = "1"
 sha2 = "0.11"
 thiserror.workspace = true

--- a/crates/snapdir-core/src/copy_guard.rs
+++ b/crates/snapdir-core/src/copy_guard.rs
@@ -1,0 +1,94 @@
+//! Out-of-band per-file stat snapshot used by the clone fast-path.
+//!
+//! A [`CopyGuard`] captures the `(size, mtime, ctime, ino)` of a **plain
+//! regular file** at walk time so that a store performing a copy-on-write
+//! clone (e.g. APFS `clonefile`) can re-`stat` the same source path at clone
+//! time and *skip the redundant post-copy re-hash* iff the file is provably
+//! unchanged. It is a behaviour-neutral side channel: it is **never serialized
+//! into the manifest** (the frozen manifest text format is unaffected) and is
+//! returned only from the additive [`walk_with_guards`](crate::walk::walk_with_guards)
+//! entry point — the existing [`walk`](crate::walk::walk) /
+//! [`walk_with_meter`](crate::walk::walk_with_meter) signatures are unchanged.
+//!
+//! ## Trust model (why these four fields)
+//!
+//! The guard is the *write-time* half of "stat-validated trust": the store
+//! compares the recorded guard against a fresh `stat` of the source just
+//! before the clone and only trusts the clone (skipping the re-hash) when all
+//! four fields still match. `size` catches truncation/append, `mtime_ns`
+//! catches a content rewrite, `ctime_ns` catches an in-place metadata/content
+//! change that preserved `mtime` (e.g. `touch -t` of the data is still bounded
+//! because a write bumps `ctime`), and `ino` catches an atomic rename-replace
+//! of the path with a different file. A benign mid-stage race is caught here;
+//! an adversarial forge that defeats all four is still caught at **read time**
+//! by the object's BLAKE3 re-verification in `get_object`/`fetch` — so the
+//! worst case is a slower path, never a silently mis-addressed object.
+//!
+//! ## Platform
+//!
+//! The fields are unix `stat` quantities ([`std::os::unix::fs::MetadataExt`]).
+//! On non-unix targets a guard is simply never produced (the map omits the
+//! file), so the downstream clone-skip optimization never engages there — no
+//! regression and no platform break; the crate still compiles everywhere.
+
+/// A captured `(size, mtime, ctime, ino)` snapshot of a single regular file,
+/// used out-of-band by the store to validate a clone before skipping the
+/// post-copy re-hash. See the [module docs](self) for the trust model.
+///
+/// `mtime_ns` / `ctime_ns` are full-nanosecond unix timestamps composed as
+/// `secs * 1_000_000_000 + nsecs` from the file's own `stat`. The whole struct
+/// is `Copy` and cheap to store in a `HashMap<PathBuf, CopyGuard>`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct CopyGuard {
+    /// File content size in bytes (`st_size`).
+    pub size: u64,
+    /// Modification time as whole nanoseconds since the unix epoch
+    /// (`st_mtime * 1e9 + st_mtime_nsec`).
+    pub mtime_ns: i64,
+    /// Inode change time as whole nanoseconds since the unix epoch
+    /// (`st_ctime * 1e9 + st_ctime_nsec`).
+    pub ctime_ns: i64,
+    /// Inode number (`st_ino`).
+    pub ino: u64,
+}
+
+impl CopyGuard {
+    /// Builds a [`CopyGuard`] from a file's own metadata.
+    ///
+    /// On unix this reads `size`/`mtime`/`ctime`/`ino` from the **same**
+    /// [`Metadata`](std::fs::Metadata) object the walk already obtained (no
+    /// extra syscall) via [`std::os::unix::fs::MetadataExt`]. On non-unix it
+    /// returns `None`, so the guard map omits the file and the clone-skip
+    /// optimization never engages.
+    ///
+    /// The caller is responsible for only ever building a guard for a **plain
+    /// regular file whose hashed content path equals its own path** (i.e. not
+    /// a followed symlink); see [`walk_with_guards`](crate::walk::walk_with_guards).
+    #[cfg(unix)]
+    #[must_use]
+    pub fn from_metadata(meta: &std::fs::Metadata) -> Option<Self> {
+        use std::os::unix::fs::MetadataExt;
+        Some(CopyGuard {
+            size: meta.size(),
+            mtime_ns: compose_ns(meta.mtime(), meta.mtime_nsec()),
+            ctime_ns: compose_ns(meta.ctime(), meta.ctime_nsec()),
+            ino: meta.ino(),
+        })
+    }
+
+    /// Non-unix stub: a guard is never produced, so the downstream clone-skip
+    /// optimization never engages and the crate still compiles on every target.
+    #[cfg(not(unix))]
+    #[must_use]
+    pub fn from_metadata(_meta: &std::fs::Metadata) -> Option<Self> {
+        None
+    }
+}
+
+/// Composes a unix `(secs, nsecs)` timestamp pair into full nanoseconds as a
+/// single `i64` (`secs * 1_000_000_000 + nsecs`), using saturating arithmetic
+/// so a pathological far-future timestamp cannot panic the walk.
+#[cfg(unix)]
+fn compose_ns(secs: i64, nsecs: i64) -> i64 {
+    secs.saturating_mul(1_000_000_000).saturating_add(nsecs)
+}

--- a/crates/snapdir-core/src/hash_file.rs
+++ b/crates/snapdir-core/src/hash_file.rs
@@ -1,0 +1,176 @@
+//! Memory-friendly, file-path-driven content hashing for the directory walk.
+//!
+//! The [`merkle::Hasher`](crate::merkle::Hasher) trait hashes an in-memory
+//! `&[u8]`; that is the right shape for the directory-merkle rule (which hashes
+//! short concatenations of child checksums) but a poor fit for hashing *file
+//! contents*, where reading every file fully into a `Vec<u8>` before hashing is
+//! both an allocation per file and a peak-memory hazard on large trees.
+//!
+//! This module adds a complementary [`HashFile`] trait whose
+//! [`hash_file_hex`](HashFile::hash_file_hex) takes a [`Path`] and returns the
+//! lowercase-hex checksum *and* the byte length, letting each hasher pick the
+//! most memory-friendly engine:
+//!
+//! - **Unkeyed BLAKE3** ([`Blake3Hasher`](crate::Blake3Hasher)): for files at or
+//!   above [`MMAP_THRESHOLD`] it memory-maps the file and hashes it with
+//!   `update_mmap_rayon`, which both avoids a large heap copy and uses the
+//!   `rayon` thread-pool to hash a single large file in parallel. Files below
+//!   the threshold (and **all empty / 0-byte files**) take the plain
+//!   [`std::fs::read`] branch — see the SIGBUS caveat below for why an empty
+//!   file is never mmapped. The streaming `Hasher::new()+update+finalize`
+//!   shape is byte-identical to the one-shot [`blake3::hash`], so the per-file
+//!   checksums — and therefore the snapshot ids — are unchanged from the
+//!   read-then-`hash_hex` path.
+//! - **Keyed BLAKE3** ([`Blake3KeyedHasher`](crate::Blake3KeyedHasher)): the
+//!   derive-key context lives in a private field of the frozen
+//!   [`merkle`](crate::merkle) module, so this module cannot re-seed a raw
+//!   [`blake3::Hasher`] with it. It therefore reads the whole file and defers
+//!   to [`Hasher::hash_hex`](crate::merkle::Hasher::hash_hex), which is
+//!   byte-identical to the previous `fs::read` + `hash_hex` pair (keyed mode is
+//!   only used by the interop matrix, not the default snapshot path, so it does
+//!   not gate the large-tree memory win).
+//! - **MD5 / SHA-256** ([`Md5Hasher`](crate::Md5Hasher) /
+//!   [`Sha256Hasher`](crate::Sha256Hasher)): these read the whole file and
+//!   defer to [`Hasher::hash_hex`](crate::merkle::Hasher::hash_hex), staying
+//!   byte-identical to the previous `fs::read` + `hash_hex` pair.
+//!
+//! ## SIGBUS on concurrent truncation (mmap caveat)
+//!
+//! `update_mmap_rayon` memory-maps the file and reads it through the mapping.
+//! A snapshot assumes a **static tree**: if another process **truncates or
+//! shrinks** a file *while it is being hashed*, accessing the now-invalid pages
+//! raises `SIGBUS` and aborts the process. This is the **same exposure as
+//! `b3sum`** (which mmaps by default) and is intrinsic to mmap-based hashing;
+//! we deliberately do **not** install a `SIGBUS` handler. Callers that cannot
+//! guarantee a quiescent tree should hash a copied/quiesced snapshot. Empty
+//! and sub-threshold files take the plain-read branch and are not exposed to
+//! this hazard.
+
+use std::fs;
+use std::io;
+use std::path::Path;
+
+use crate::merkle::{Blake3Hasher, Blake3KeyedHasher, Hasher, Md5Hasher, Sha256Hasher};
+
+/// Files at or above this size (256 KiB) take the BLAKE3 mmap+rayon path; below
+/// it (and any empty file) take the plain [`std::fs::read`] path.
+///
+/// 256 KiB matches `b3sum`'s own heuristic for when memory-mapping starts to
+/// pay off; below it the syscall/setup overhead of mmap outweighs the copy a
+/// plain read makes.
+pub const MMAP_THRESHOLD: u64 = 256 * 1024;
+
+/// Hashes a file's contents *by path*, returning `(lowercase_hex, byte_len)`.
+///
+/// This is the memory-friendly companion to
+/// [`Hasher::hash_hex`](crate::merkle::Hasher::hash_hex): instead of taking an
+/// already-materialized `&[u8]`, an implementation may stream or memory-map the
+/// file so large files are hashed without a full heap copy. The returned hex is
+/// **byte-identical** to `self.hash_hex(&fs::read(path)?)`, and the returned
+/// length is the number of content bytes hashed (the file size).
+pub trait HashFile {
+    /// Hashes the file at `path`, returning its lowercase-hex checksum and its
+    /// byte length.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying [`io::Error`] if the file's metadata cannot be
+    /// read or its contents cannot be read / mapped.
+    fn hash_file_hex(&self, path: &Path) -> io::Result<(String, u64)>;
+
+    /// Like [`hash_file_hex`](HashFile::hash_file_hex), but guaranteed not to
+    /// spawn its own nested `rayon` tasks for a single file.
+    ///
+    /// The byte-identical result is the same as [`hash_file_hex`]; only the
+    /// *engine* differs. The cross-file parallel walk uses this variant when it
+    /// already has at least as many pending files as worker threads, so each
+    /// worker hashes one file single-threaded and the bounded walk pool is not
+    /// oversubscribed by intra-file BLAKE3 `rayon` tasks. The default
+    /// implementation forwards to [`hash_file_hex`]; only the unkeyed BLAKE3
+    /// hasher (whose [`hash_file_hex`] uses `update_mmap_rayon`) overrides it to
+    /// drop down to the single-threaded `update_mmap` engine.
+    ///
+    /// # Errors
+    ///
+    /// Returns the underlying [`io::Error`] under the same conditions as
+    /// [`hash_file_hex`].
+    fn hash_file_hex_seq(&self, path: &Path) -> io::Result<(String, u64)> {
+        self.hash_file_hex(path)
+    }
+}
+
+/// Hashes a BLAKE3 `hasher` over the file at `path`, choosing the mmap+rayon
+/// engine for files `>= MMAP_THRESHOLD` and a plain read otherwise.
+///
+/// `hasher` arrives pre-seeded (plain `new()` for unkeyed, `new_derive_key` for
+/// keyed); this only selects the read strategy. Returns `(hex, byte_len)`.
+fn blake3_hash_file(mut hasher: blake3::Hasher, path: &Path) -> io::Result<(String, u64)> {
+    let len = fs::metadata(path)?.len();
+    if len >= MMAP_THRESHOLD {
+        // Large file: memory-map + hash in parallel, no large heap copy. Never
+        // reached for an empty file (len 0 < MMAP_THRESHOLD), so mmap of a
+        // zero-length file — which can SIGBUS — never happens.
+        hasher.update_mmap_rayon(path)?;
+    } else {
+        // Small/empty file: a plain read is cheaper than the mmap setup, and
+        // the streaming update is byte-identical to the one-shot hash.
+        let bytes = fs::read(path)?;
+        hasher.update(&bytes);
+    }
+    Ok((hasher.finalize().to_hex().to_string(), len))
+}
+
+/// Single-threaded BLAKE3 file hash: same mmap/plain-read selection as
+/// [`blake3_hash_file`] but using `update_mmap` (no nested `rayon`) for large
+/// files. Byte-identical output; only the engine differs.
+fn blake3_hash_file_seq(mut hasher: blake3::Hasher, path: &Path) -> io::Result<(String, u64)> {
+    let len = fs::metadata(path)?.len();
+    if len >= MMAP_THRESHOLD {
+        // Large file: memory-map + hash single-threaded (no intra-file rayon
+        // fan-out). Empty files never reach this branch (len 0 < threshold).
+        hasher.update_mmap(path)?;
+    } else {
+        let bytes = fs::read(path)?;
+        hasher.update(&bytes);
+    }
+    Ok((hasher.finalize().to_hex().to_string(), len))
+}
+
+impl HashFile for Blake3Hasher {
+    fn hash_file_hex(&self, path: &Path) -> io::Result<(String, u64)> {
+        blake3_hash_file(blake3::Hasher::new(), path)
+    }
+
+    fn hash_file_hex_seq(&self, path: &Path) -> io::Result<(String, u64)> {
+        blake3_hash_file_seq(blake3::Hasher::new(), path)
+    }
+}
+
+impl HashFile for Blake3KeyedHasher {
+    fn hash_file_hex(&self, path: &Path) -> io::Result<(String, u64)> {
+        // The derive-key context is a private field of the frozen `merkle`
+        // module, so we cannot seed a raw blake3 hasher with it here. Read the
+        // whole file and defer to `hash_hex` (the keyed `new_derive_key` +
+        // update path), byte-identical to the previous fs::read + hash_hex pair.
+        let bytes = fs::read(path)?;
+        Ok((self.hash_hex(&bytes), bytes.len() as u64))
+    }
+}
+
+impl HashFile for Md5Hasher {
+    fn hash_file_hex(&self, path: &Path) -> io::Result<(String, u64)> {
+        // MD5 has no mmap fast-path here: read the whole file and defer to
+        // hash_hex, byte-identical to the previous fs::read + hash_hex pair.
+        let bytes = fs::read(path)?;
+        Ok((self.hash_hex(&bytes), bytes.len() as u64))
+    }
+}
+
+impl HashFile for Sha256Hasher {
+    fn hash_file_hex(&self, path: &Path) -> io::Result<(String, u64)> {
+        // SHA-256: read the whole file and defer to hash_hex, byte-identical to
+        // the previous fs::read + hash_hex pair.
+        let bytes = fs::read(path)?;
+        Ok((self.hash_hex(&bytes), bytes.len() as u64))
+    }
+}

--- a/crates/snapdir-core/src/lib.rs
+++ b/crates/snapdir-core/src/lib.rs
@@ -18,7 +18,9 @@
 //! follow/no-follow option semantics.
 
 pub mod cache;
+pub mod copy_guard;
 pub mod excludes;
+pub mod hash_file;
 pub mod manifest;
 pub mod merkle;
 pub mod progress;
@@ -30,6 +32,7 @@ pub use cache::{
     check_manifest_integrity, check_snapshot_integrity, flush_cache, load_cached_manifest,
     verify_cache, CacheError, CacheReport,
 };
+pub use copy_guard::CopyGuard;
 pub use excludes::{
     expand_excludes, ExcludeError, ExcludeMatcher, ExpandedExclude, FollowMode,
     COMMON_EXCLUDE_DIRS, SYSTEM_EXCLUDE_DIRS,
@@ -42,4 +45,4 @@ pub use merkle::{
 pub use progress::{Meter, MeterSnapshot, Phase};
 pub use resources::{resident_set_bytes, total_ram_bytes, CpuSampler};
 pub use store::{manifest_path, object_path, Store, StoreError, MANIFESTS_DIR, OBJECTS_DIR};
-pub use walk::{walk, walk_with_meter, PathMode, WalkError, WalkOptions};
+pub use walk::{walk, walk_with_guards, walk_with_meter, PathMode, WalkError, WalkOptions};

--- a/crates/snapdir-core/src/walk.rs
+++ b/crates/snapdir-core/src/walk.rs
@@ -41,14 +41,17 @@
 //! for behavior: the root, options, excludes and hasher all arrive as
 //! parameters, and errors surface as the typed [`WalkError`].
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, HashMap};
 use std::io;
 use std::os::unix::fs::PermissionsExt;
 use std::path::{Path, PathBuf};
 
+use rayon::prelude::*;
 use thiserror::Error;
 
+use crate::copy_guard::CopyGuard;
 use crate::excludes::{ExcludeMatcher, FollowMode};
+use crate::hash_file::HashFile;
 use crate::manifest::{Manifest, ManifestEntry, PathType};
 use crate::merkle::Hasher;
 use crate::progress::{Meter, Phase};
@@ -81,6 +84,27 @@ pub struct WalkOptions {
     /// An optional compiled exclude matcher. When `Some`, any directory or
     /// file whose absolute path matches is dropped (`grep -E -v`).
     pub exclude: Option<ExcludeMatcher>,
+    /// Desired cross-file hashing parallelism (`--walk-jobs` /
+    /// `$SNAPDIR_WALK_JOBS`).
+    ///
+    /// Resolution: `Some(n)` with `n > 0` uses exactly `n` worker threads;
+    /// `Some(0)` and `None` fall back to a default of
+    /// [`available_parallelism`](std::thread::available_parallelism) capped by
+    /// [`MAX_WALK_JOBS`]. `Some(1)` is an honest single-threaded path. The walk
+    /// enumerates the tree single-threaded, then hashes every discovered file in
+    /// parallel inside a *bounded*, scoped [`rayon::ThreadPool`] sized to the
+    /// resolved count (never the global pool).
+    ///
+    /// The value **never changes the output**: results are written back into a
+    /// fixed per-file slot keyed by discovery identity, so the manifest and the
+    /// snapshot id are byte-identical regardless of hash-completion order (the
+    /// directory checksum sorts+dedups its children and the manifest sorts by
+    /// path). Large files are still hashed memory-mapped (see
+    /// [`hash_file`](crate::hash_file)); when there are at least as many pending
+    /// files as worker threads each file is hashed single-threaded to avoid
+    /// oversubscribing the bounded pool, otherwise BLAKE3's intra-file `rayon`
+    /// path is allowed so spare cores still help a lone big file.
+    pub walk_jobs: Option<usize>,
 }
 
 /// Errors raised while walking the filesystem.
@@ -135,13 +159,48 @@ fn path_str(path: &Path) -> Result<&str, WalkError> {
         .ok_or_else(|| WalkError::NonUtf8Path(path.to_path_buf()))
 }
 
-/// A discovered file entry, before path rewriting.
+/// Upper bound on the auto-resolved cross-file hashing parallelism.
+///
+/// When `walk_jobs` is `None`/`Some(0)` the walk uses
+/// [`available_parallelism`](std::thread::available_parallelism) capped at this
+/// value, so a many-core host does not spawn an unbounded hashing pool. An
+/// explicit `Some(n)` is honored verbatim (the caller asked for exactly `n`).
+const MAX_WALK_JOBS: usize = 16;
+
+/// Resolves the desired [`WalkOptions::walk_jobs`] to a concrete worker count
+/// (always `>= 1`). `Some(n>0)` → `n` (honored verbatim); `Some(0)`/`None` →
+/// `available_parallelism` capped by [`MAX_WALK_JOBS`], falling back to `1`.
+fn resolve_jobs(walk_jobs: Option<usize>) -> usize {
+    match walk_jobs {
+        Some(n) if n > 0 => n,
+        _ => std::thread::available_parallelism()
+            .map_or(1, std::num::NonZeroUsize::get)
+            .clamp(1, MAX_WALK_JOBS),
+    }
+}
+
+/// A discovered file entry, before path rewriting. During discovery the
+/// `checksum`/`size` slots are left empty and the file's content is hashed in a
+/// later parallel pass keyed by `(dir_key, file_index)`, then written back here.
 struct FileRecord {
     /// Absolute path of the file.
     abs_path: String,
     permissions: String,
+    /// Filled by the parallel hashing pass (empty during discovery).
     checksum: String,
     size: u64,
+}
+
+/// A file discovered but not yet hashed: its content path plus the identity of
+/// the [`FileRecord`] slot (its owning directory key + index in that
+/// directory's `files` vec) to write the `(checksum, size)` result back into.
+struct PendingHash {
+    /// Absolute path of the directory owning this file (the `dirs` map key).
+    dir_key: String,
+    /// Index of this file in its directory's `files` vec.
+    file_index: usize,
+    /// Path to hash the content through (follows symlinks).
+    content_path: PathBuf,
 }
 
 /// A discovered directory, holding its absolute path and (filled during the
@@ -171,7 +230,7 @@ struct DirRecord {
 ///
 /// Returns [`WalkError`] if `root` is not absolute, is not a directory, holds a
 /// non-UTF-8 path, or if an I/O error occurs while reading the tree.
-pub fn walk<H: Hasher>(
+pub fn walk<H: Hasher + HashFile + Sync>(
     root: &Path,
     options: &WalkOptions,
     hasher: &H,
@@ -194,12 +253,65 @@ pub fn walk<H: Hasher>(
 /// # Errors
 ///
 /// Returns [`WalkError`] under the same conditions as [`walk`].
-pub fn walk_with_meter<H: Hasher>(
+pub fn walk_with_meter<H: Hasher + HashFile + Sync>(
     root: &Path,
     options: &WalkOptions,
     hasher: &H,
     meter: Option<&Meter>,
 ) -> Result<Manifest, WalkError> {
+    // Discard the guard side channel: the manifest is byte-identical whether or
+    // not guards are captured. The existing entry points return just the
+    // `Manifest`, unchanged.
+    walk_inner(root, options, hasher, meter, false).map(|(manifest, _guards)| manifest)
+}
+
+/// Like [`walk_with_meter`], but ALSO returns a [`CopyGuard`] side channel: a
+/// `HashMap` keyed by the **absolute working-tree path** of each captured file
+/// (`FileRecord.abs_path`, i.e. the path a store later clones from), valued by
+/// its `(size, mtime, ctime, ino)` [`CopyGuard`].
+///
+/// This is an *additive* second return: the [`Manifest`] is **byte-identical**
+/// to what [`walk`] / [`walk_with_meter`] produce for the same tree — the guard
+/// map is never serialized into the manifest and never influences traversal,
+/// ordering, checksums or the snapshot id. A store may re-`stat` a guarded
+/// source path at clone time and skip the redundant post-copy re-hash iff all
+/// four fields still match (see [`copy_guard`](crate::copy_guard)).
+///
+/// ## Which entries get a guard (symlink-conservative)
+///
+/// A guard is emitted **only for a plain regular file whose hashed content
+/// path equals its own path** — i.e. a real (non-symlink) file. Followed
+/// symlinks (`find -L`), where the manifest entry path and the dereferenced
+/// content path differ, are **omitted**: the path the store would re-`stat`
+/// (the symlink's own `lstat`) is not the path whose bytes were hashed, so
+/// trusting it would be unsound. Omitting them simply means the store re-hashes
+/// (no skip) — always safe. Directories, broken symlinks, and special files
+/// never get a guard. On non-unix targets the map is always empty
+/// ([`CopyGuard::from_metadata`] returns `None`), so the optimization is inert.
+///
+/// # Errors
+///
+/// Returns [`WalkError`] under the same conditions as [`walk`].
+pub fn walk_with_guards<H: Hasher + HashFile + Sync>(
+    root: &Path,
+    options: &WalkOptions,
+    hasher: &H,
+    meter: Option<&Meter>,
+) -> Result<(Manifest, HashMap<PathBuf, CopyGuard>), WalkError> {
+    walk_inner(root, options, hasher, meter, true)
+}
+
+/// Shared implementation behind [`walk`], [`walk_with_meter`] and
+/// [`walk_with_guards`]. When `capture_guards` is `true` it populates and
+/// returns the [`CopyGuard`] map; otherwise the map is empty. The traversal,
+/// hashing and emitted [`Manifest`] are identical regardless of the flag.
+fn walk_inner<H: Hasher + HashFile + Sync>(
+    root: &Path,
+    options: &WalkOptions,
+    hasher: &H,
+    meter: Option<&Meter>,
+    capture_guards: bool,
+) -> Result<(Manifest, HashMap<PathBuf, CopyGuard>), WalkError> {
     if let Some(meter) = meter {
         meter.set_phase(Phase::Hashing);
     }
@@ -225,17 +337,31 @@ pub fn walk_with_meter<H: Hasher>(
     // Discover every directory (depth-first, following symlinks per `follow`),
     // recording its direct files and direct child directories. We collect into
     // an ordered map keyed by absolute path so the post-order pass can compute
-    // directory checksums bottom-up.
+    // directory checksums bottom-up. Discovery is SINGLE-THREADED and does NOT
+    // hash file contents — each leaf file is recorded as a `PendingHash` whose
+    // `(dir_key, file_index)` identifies the fixed `FileRecord` slot to fill.
     let mut dirs: BTreeMap<String, DirRecord> = BTreeMap::new();
+    let mut pending: Vec<PendingHash> = Vec::new();
+    // The out-of-band guard side channel: populated only when requested, and
+    // only for plain regular files (see `walk_with_guards`). Keyed by the
+    // file's absolute working-tree path (what a store later clones from).
+    let mut guards: HashMap<PathBuf, CopyGuard> = HashMap::new();
+    let mut guard_sink = capture_guards.then_some(&mut guards);
     discover_dir(
         root,
         &root_str,
         root_permissions,
         options,
-        hasher,
-        meter,
         &mut dirs,
+        &mut pending,
+        &mut guard_sink,
     )?;
+
+    // Hash every discovered file in parallel, writing each `(checksum, size)`
+    // result back into its FIXED slot. The result is order-independent, so the
+    // manifest and snapshot id are byte-identical regardless of which worker
+    // finishes first. Bounded by a scoped pool sized to the resolved job count.
+    hash_pending(&pending, options.walk_jobs, hasher, meter, &mut dirs)?;
 
     // Compute each directory's checksum + member-size bottom-up. `dirs` is keyed
     // by path in a BTreeMap (lexicographic), so a child path always sorts after
@@ -292,20 +418,20 @@ pub fn walk_with_meter<H: Hasher>(
         }
     }
     manifest.sort();
-    Ok(manifest)
+    Ok((manifest, guards))
 }
 
 /// Recursively discovers the directory at `abs_path` (already known to be a
 /// directory), recording its direct files and child directories, then recurses
 /// into each child directory.
-fn discover_dir<H: Hasher>(
+fn discover_dir(
     dir: &Path,
     abs_path: &str,
     permissions: String,
     options: &WalkOptions,
-    hasher: &H,
-    meter: Option<&Meter>,
     dirs: &mut BTreeMap<String, DirRecord>,
+    pending: &mut Vec<PendingHash>,
+    guards: &mut Option<&mut HashMap<PathBuf, CopyGuard>>,
 ) -> Result<(), WalkError> {
     // `permissions` is the directory's own `lstat` octal mode (a symlinked
     // directory keeps the symlink's perms, matching the oracle's non-following
@@ -379,27 +505,46 @@ fn discover_dir<H: Hasher>(
                 &entry_abs,
                 own_permissions,
                 options,
-                hasher,
-                meter,
                 dirs,
+                pending,
+                guards,
             )?;
         } else if file_type.is_file() {
-            // Read content through the link for the checksum; take SIZE from the
-            // entry's own `lstat` (for a symlink that is the target-path length,
-            // matching the oracle's `%z` / `%s` on the un-dereferenced symlink).
-            let bytes = std::fs::read(&entry_path).map_err(|e| WalkError::io(&entry_path, e))?;
-            let checksum = hasher.hash_hex(&bytes);
-            // Advisory progress: record the bytes hashed and count this file as
-            // one finished object. This never affects the manifest output.
-            if let Some(meter) = meter {
-                meter.add_in(bytes.len() as u64);
-                meter.object_finished();
+            // Record the file with an EMPTY checksum slot and queue a pending
+            // hash job. The content is hashed (through the link) in the later
+            // parallel pass; the result is written back into this exact slot,
+            // identified by `(abs_path, file_index)`. SIZE comes from the
+            // entry's own `lstat` (for a symlink the target-path length,
+            // matching the oracle's `%z` / `%s` on the un-dereferenced symlink)
+            // — NOT the dereferenced content length the hasher would report.
+            // SYMLINK SAFETY: capture a `CopyGuard` ONLY for a plain regular
+            // file whose hashed content path equals its own path — i.e. NOT a
+            // followed symlink. For a real file `link_meta` (the entry's own
+            // `lstat`) equals its `stat`, and `entry_path` is exactly the path
+            // a store would later re-`stat` before cloning. For a followed
+            // symlink-to-file the path the store re-stats (the symlink's own
+            // `lstat`) is not the path whose bytes were hashed, so trusting it
+            // would be unsound: we OMIT the guard and the store re-hashes (no
+            // skip = always safe). On non-unix `from_metadata` returns `None`.
+            if !is_symlink {
+                if let Some(sink) = guards.as_deref_mut() {
+                    if let Some(guard) = CopyGuard::from_metadata(&link_meta) {
+                        sink.insert(entry_path.clone(), guard);
+                    }
+                }
             }
+
+            let file_index = record.files.len();
             record.files.push(FileRecord {
                 abs_path: entry_abs,
                 permissions: own_permissions,
-                checksum,
+                checksum: String::new(),
                 size: link_meta.len(),
+            });
+            pending.push(PendingHash {
+                dir_key: abs_path.to_owned(),
+                file_index,
+                content_path: entry_path,
             });
         }
         // Anything else (sockets, fifos, devices) is neither `-type d` nor
@@ -407,6 +552,84 @@ fn discover_dir<H: Hasher>(
     }
 
     dirs.insert(record.abs_path.clone(), record);
+    Ok(())
+}
+
+/// Hashes every [`PendingHash`] in parallel inside a bounded, scoped
+/// [`rayon::ThreadPool`] sized to the resolved [`WalkOptions::walk_jobs`] count,
+/// writing each `(checksum, len)` back into its fixed `FileRecord` slot.
+///
+/// The write-back is keyed by the discovery identity (`dir_key` + `file_index`),
+/// so the manifest is byte-identical regardless of completion order. Advisory
+/// [`Meter`] updates (`add_in` + `object_finished`) happen once per file inside
+/// the worker closure; the meter is atomic/`Sync`, so only interleaving changes.
+///
+/// # Errors
+///
+/// Returns the first [`WalkError::io`] if any file fails to hash; the *which*
+/// error is unspecified but the walk deterministically fails.
+fn hash_pending<H: Hasher + HashFile + Sync>(
+    pending: &[PendingHash],
+    walk_jobs: Option<usize>,
+    hasher: &H,
+    meter: Option<&Meter>,
+    dirs: &mut BTreeMap<String, DirRecord>,
+) -> Result<(), WalkError> {
+    if pending.is_empty() {
+        return Ok(());
+    }
+
+    let jobs = resolve_jobs(walk_jobs);
+    // Oversubscription guard (perf, not correctness): when there are at least as
+    // many pending files as worker threads, every thread already has a whole
+    // file to hash — so hash each file SINGLE-THREADED (no intra-file BLAKE3
+    // rayon fan-out) to keep the bounded pool from oversubscribing. When there
+    // are fewer files than threads, let BLAKE3 use its rayon path so the spare
+    // cores still accelerate a lone big file.
+    let per_file_seq = pending.len() >= jobs;
+
+    let hash_one = |item: &PendingHash| -> Result<(String, usize, String), WalkError> {
+        let (checksum, hashed_bytes) = if per_file_seq {
+            hasher.hash_file_hex_seq(&item.content_path)
+        } else {
+            hasher.hash_file_hex(&item.content_path)
+        }
+        .map_err(|e| WalkError::io(&item.content_path, e))?;
+        if let Some(meter) = meter {
+            meter.add_in(hashed_bytes);
+            meter.object_finished();
+        }
+        Ok((item.dir_key.clone(), item.file_index, checksum))
+    };
+
+    // A single honest single-threaded path when only one job is requested:
+    // hash in place with no pool at all.
+    let results: Vec<(String, usize, String)> = if jobs == 1 {
+        pending.iter().map(hash_one).collect::<Result<_, _>>()?
+    } else {
+        // Build a bounded, scoped pool sized to the resolved job count and run
+        // the parallel hash inside `install`, so total threads are explicitly
+        // capped (never the global pool).
+        let pool = rayon::ThreadPoolBuilder::new()
+            .num_threads(jobs)
+            .build()
+            .map_err(|e| WalkError::io(PathBuf::from("<walk thread pool>"), io::Error::other(e)))?;
+        pool.install(|| {
+            pending
+                .par_iter()
+                .map(hash_one)
+                .collect::<Result<Vec<_>, _>>()
+        })?
+    };
+
+    // Write each result back into its fixed slot. Order-independent: the slot is
+    // addressed by (dir_key, file_index), so completion order is irrelevant.
+    for (dir_key, file_index, checksum) in results {
+        let record = dirs
+            .get_mut(&dir_key)
+            .expect("pending file's owning dir was discovered");
+        record.files[file_index].checksum = checksum;
+    }
     Ok(())
 }
 
@@ -561,6 +784,7 @@ mod tests {
             follow,
             path_mode,
             exclude: exclude.map(|p| ExcludeMatcher::new(p).expect("valid exclude regex")),
+            ..WalkOptions::default()
         }
     }
 

--- a/crates/snapdir-core/tests/fast_walk.rs
+++ b/crates/snapdir-core/tests/fast_walk.rs
@@ -1,0 +1,872 @@
+//! Fast-walk contract tests (snapdir-core integration) — ADVERSARY, black-box.
+//!
+//! Authored from the gate SPEC ONLY, with zero visibility into the not-yet-written
+//! implementation. These tests pin the "fast walk" contract: making the directory
+//! walk + file hashing parallel and memory-friendly while keeping snapshot ids
+//! **BYTE-IDENTICAL**.
+//!
+//! Contracted symbols referenced here (so the suite cannot pass until the impl
+//! lands):
+//!   - `snapdir_core::hash_file::{HashFile, MMAP_THRESHOLD}` — a `HashFile`
+//!     extension trait `fn hash_file_hex(&self, path: &Path) -> io::Result<(String, u64)>`
+//!     with concrete impls for Blake3Hasher / Blake3KeyedHasher / Md5Hasher /
+//!     Sha256Hasher, returning `(lowercase_hex, byte_len)`.
+//!   - `WalkOptions.walk_jobs: Option<usize>` — cross-file hashing parallelism.
+//!
+//! GOLDENS: captured by running the CURRENT (pre-change) `snapdir` binary on the
+//! SAME deterministic fixtures these tests materialize. The fixtures pin every
+//! file mode to 0o644 and every dir mode to 0o755 (umask-independent), and the
+//! snapshot id is computed over `./`-relative paths, so the golden is independent
+//! of the tempdir location (verified: two different parent dirs yield the same id).
+//! The fixture byte content is the same deterministic ramp the `benches` crate's
+//! `deterministic_bytes` uses — `(i*31 + 7) & 0xff` — so the trees, and therefore
+//! the ids, are reproducible across runs and machines.
+//!
+//! NOTE for the impl lane: this file is self-contained (no `tempfile`, no
+//! `snapdir-benches` dev-dep). It uses a deterministic, hand-rolled scratch dir
+//! under `std::env::temp_dir()` that mirrors the bench `Shape` materializers, so
+//! it can land at `crates/snapdir-core/tests/fast_walk.rs` with only the `proptest`
+//! dev-dep that already exists.
+
+// Test-shape allows (impl-lane wiring, NOT assertion changes): this adversary
+// suite deliberately casts across the MMAP_THRESHOLD boundary (u64/i64/usize),
+// asserts on the contract const, keeps the full contracted import set, and
+// writes prose doc-comments — all of which trip the workspace's pedantic-clippy
+// gate on the test crate. None of these affect any assertion or golden.
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::assertions_on_constants,
+    clippy::doc_markdown,
+    clippy::map_unwrap_or,
+    unused_imports
+)]
+
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use proptest::prelude::*;
+
+use snapdir_core::hash_file::{HashFile, MMAP_THRESHOLD};
+use snapdir_core::{
+    snapshot_id, walk, Blake3Hasher, Blake3KeyedHasher, Hasher, Manifest, Md5Hasher, Sha256Hasher,
+    WalkOptions,
+};
+
+// ---------------------------------------------------------------------------
+// Deterministic fixtures — std-only, mirroring benches/src/lib.rs Shape logic.
+// ---------------------------------------------------------------------------
+
+/// Umask-independent, explicit modes (match the bench generator + the goldens).
+const FILE_MODE: u32 = 0o644;
+const DIR_MODE: u32 = 0o755;
+
+/// A process-unique, monotonically increasing counter so each scratch tree gets
+/// a distinct directory (no `tempfile` dependency, no collisions across tests
+/// run in parallel by the test harness).
+static SCRATCH_SEQ: AtomicU64 = AtomicU64::new(0);
+
+/// An RAII scratch directory under `std::env::temp_dir()`, removed on drop.
+struct Scratch {
+    path: PathBuf,
+}
+
+impl Scratch {
+    fn new(tag: &str) -> Scratch {
+        let seq = SCRATCH_SEQ.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "snapdir_fastwalk_{}_{}_{}_{}",
+            tag,
+            std::process::id(),
+            seq,
+            // A second disambiguator so re-running back-to-back never reuses a
+            // stale dir left by a crashed prior run.
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .map(|d| d.as_nanos())
+                .unwrap_or(0)
+        ));
+        let _ = std::fs::remove_dir_all(&path);
+        mkdir(&path);
+        Scratch { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.path);
+    }
+}
+
+/// The bench `deterministic_bytes` ramp: a cheap, fully deterministic, non-uniform
+/// byte pattern. MUST stay byte-identical to `benches::deterministic_bytes` so the
+/// captured goldens hold.
+fn deterministic_bytes(len: usize) -> Vec<u8> {
+    (0..len)
+        .map(|i| u8::try_from(i.wrapping_mul(31).wrapping_add(7) & 0xff).expect("masked to u8"))
+        .collect()
+}
+
+#[cfg(unix)]
+fn chmod(path: &Path, mode: u32) {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, PermissionsExt::from_mode(mode)).expect("set_permissions");
+}
+
+#[cfg(not(unix))]
+fn chmod(_path: &Path, _mode: u32) {}
+
+fn mkdir(dir: &Path) {
+    std::fs::create_dir_all(dir).expect("create_dir_all");
+    chmod(dir, DIR_MODE);
+}
+
+fn write_file(path: &Path, content: &[u8]) {
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).expect("create parent");
+    }
+    std::fs::write(path, content).expect("write file");
+    chmod(path, FILE_MODE);
+}
+
+/// The bench `Shape` catalog this gate's KEYSTONE pins. Materializes each tree
+/// byte-identically to `benches/src/lib.rs` (gate-tier sizes), so the goldens
+/// captured from the current binary hold.
+#[derive(Clone, Copy)]
+enum Shape {
+    ManySmall,
+    FewLarge,
+    WideDir,
+    Mixed,
+    DupContent,
+    EmptyFilesAndDirs,
+}
+
+impl Shape {
+    fn name(self) -> &'static str {
+        match self {
+            Shape::ManySmall => "many_small",
+            Shape::FewLarge => "few_large",
+            Shape::WideDir => "wide_dir",
+            Shape::Mixed => "mixed",
+            Shape::DupContent => "dup_content",
+            Shape::EmptyFilesAndDirs => "empty_files_and_dirs",
+        }
+    }
+
+    fn materialize(self, dir: &Path) {
+        match self {
+            // ManySmall { files: 24, bytes: 16, dirs: 4 }
+            Shape::ManySmall => {
+                for d in 0..4 {
+                    mkdir(&dir.join(format!("d{d:03}")));
+                }
+                let content = deterministic_bytes(16);
+                for i in 0..24 {
+                    let sub = dir.join(format!("d{:03}", i % 4));
+                    write_file(&sub.join(format!("f{i:05}.bin")), &content);
+                }
+            }
+            // FewLarge { files: 3, bytes: 4096 }
+            Shape::FewLarge => {
+                let content = deterministic_bytes(4 * 1024);
+                for i in 0..3 {
+                    write_file(&dir.join(format!("big{i:02}.bin")), &content);
+                }
+            }
+            // WideFanout { children: 32, bytes: 16 } -> "wide_dir"
+            Shape::WideDir => {
+                let fan = dir.join("fan");
+                mkdir(&fan);
+                let content = deterministic_bytes(16);
+                for i in 0..32 {
+                    write_file(&fan.join(format!("c{i:04}.bin")), &content);
+                }
+            }
+            // Mixed (exact bench recipe).
+            Shape::Mixed => {
+                for (name, n) in [
+                    ("root_a.bin", 16usize),
+                    ("root_b.bin", 256),
+                    ("root_c.bin", 0),
+                ] {
+                    write_file(&dir.join(name), &deterministic_bytes(n));
+                }
+                let nested = dir.join("dir_a").join("nested");
+                mkdir(&nested);
+                write_file(&dir.join("dir_a").join("a1.bin"), &deterministic_bytes(48));
+                write_file(&nested.join("deep.bin"), &deterministic_bytes(72));
+                let dir_b = dir.join("dir_b");
+                mkdir(&dir_b);
+                write_file(&dir_b.join("b1.bin"), &deterministic_bytes(128));
+                write_file(&dir_b.join("b2.bin"), &deterministic_bytes(8));
+            }
+            // Dedup { copies: 8, bytes: 32 } -> "dup_content"
+            Shape::DupContent => {
+                let content = deterministic_bytes(32);
+                for i in 0..8 {
+                    write_file(&dir.join(format!("dup{i:03}.bin")), &content);
+                }
+            }
+            // Edge: empty files AND empty dirs -> "empty_files_and_dirs"
+            Shape::EmptyFilesAndDirs => {
+                write_file(&dir.join("empty_a.bin"), &[]);
+                write_file(&dir.join("empty_b.bin"), &[]);
+                mkdir(&dir.join("empty_dir_a"));
+                mkdir(&dir.join("empty_dir_b"));
+                let sub = dir.join("sub");
+                mkdir(&sub);
+                write_file(&sub.join("empty_c.bin"), &[]);
+            }
+        }
+    }
+}
+
+/// The KEYSTONE goldens, captured by running the CURRENT (pre-change) `snapdir`
+/// binary on the SAME `Shape`-materialized fixtures (modes pinned, `./`-relative
+/// id, location-independent). Every later gate must preserve these byte-for-byte.
+fn golden_id(shape: Shape) -> &'static str {
+    match shape {
+        Shape::ManySmall => "1a05825401b777f2c21baba7621c14387b60b059f59449b04d1cb86f3fefe2d1",
+        Shape::FewLarge => "5741158d9191ca1a78b2663568859b7a7b3cf9ebae81214a4e195973a2df5e9f",
+        Shape::WideDir => "20765645a0af81bc50d6f8180792deacf88b0ef7f4a41868e410cb2d23c28c92",
+        Shape::Mixed => "20e480591db13694baaad6559337f682b0e1a9e7e85ccbf25702ec612d5c2b4f",
+        Shape::DupContent => "d5604b4f35fbc05f0e8604e747b1e471faa0c55fceaced01519c159b04fb1c14",
+        Shape::EmptyFilesAndDirs => {
+            "33ed645bf0884cbe82710b2837bfa156dfa9d15388f3c9407e81d6b5c330afdf"
+        }
+    }
+}
+
+const ALL_SHAPES: [Shape; 6] = [
+    Shape::ManySmall,
+    Shape::FewLarge,
+    Shape::WideDir,
+    Shape::Mixed,
+    Shape::DupContent,
+    Shape::EmptyFilesAndDirs,
+];
+
+/// Walks `dir` with the default options + BLAKE3 and returns the snapshot id.
+fn id_of(dir: &Path) -> String {
+    let hasher = Blake3Hasher::new();
+    let manifest = walk(dir, &WalkOptions::default(), &hasher).expect("walk succeeds");
+    snapshot_id(&manifest, &hasher)
+}
+
+// ===========================================================================
+// 1. KEYSTONE golden ids — every Shape's snapshot id matches the recorded golden.
+// ===========================================================================
+
+#[test]
+fn keystone_golden_snapshot_ids_per_shape() {
+    // Spec clause: KEYSTONE — for each bench Shape, walk + snapshot_id == the
+    // GOLDEN captured from the current binary. These anchor every later gate;
+    // parallelism / mmap MUST NOT change them.
+    for shape in ALL_SHAPES {
+        let scratch = Scratch::new(shape.name());
+        shape.materialize(scratch.path());
+        let got = id_of(scratch.path());
+        assert_eq!(
+            got,
+            golden_id(shape),
+            "snapshot id for shape {} drifted from the golden",
+            shape.name()
+        );
+    }
+}
+
+#[test]
+fn keystone_golden_id_is_location_independent() {
+    // Spec clause: the snapshot id is over `./`-relative paths, so materializing
+    // the SAME shape under two DIFFERENT parents yields the SAME golden id (this
+    // is what makes the hardcoded cross-machine golden legitimate).
+    let shape = Shape::Mixed;
+    let a = Scratch::new("loc_a");
+    let b = Scratch::new("loc_b_longer_name");
+    shape.materialize(a.path());
+    shape.materialize(b.path());
+    assert_eq!(id_of(a.path()), golden_id(shape));
+    assert_eq!(id_of(b.path()), golden_id(shape));
+    assert_eq!(id_of(a.path()), id_of(b.path()));
+}
+
+// ===========================================================================
+// 2. walk-twice determinism (deterministic + proptest).
+// ===========================================================================
+
+#[test]
+fn walk_twice_yields_identical_manifest_and_id_per_shape() {
+    // Spec clause: walk-twice determinism. The same tree, walked twice, yields
+    // identical Manifest Display AND identical snapshot_id (a strong anchor even
+    // where a hardcoded golden might be fragile).
+    let hasher = Blake3Hasher::new();
+    for shape in ALL_SHAPES {
+        let scratch = Scratch::new(shape.name());
+        shape.materialize(scratch.path());
+
+        let m1 = walk(scratch.path(), &WalkOptions::default(), &hasher).expect("walk 1");
+        let m2 = walk(scratch.path(), &WalkOptions::default(), &hasher).expect("walk 2");
+        assert_eq!(
+            m1.to_string(),
+            m2.to_string(),
+            "Manifest Display differs across walks for {}",
+            shape.name()
+        );
+        assert_eq!(
+            snapshot_id(&m1, &hasher),
+            snapshot_id(&m2, &hasher),
+            "snapshot_id differs across walks for {}",
+            shape.name()
+        );
+    }
+}
+
+/// Materializes a random-but-DETERMINISTIC tree (driven by a proptest-supplied
+/// shape selection + sizes) and returns the scratch dir.
+fn materialize_random_tree(dir: &Path, dir_count: usize, files: &[(usize, usize)]) {
+    // `files` is a list of (target_dir_index, byte_len). dir_count subdirs plus
+    // the root; deterministic byte content from the ramp.
+    for d in 0..dir_count {
+        mkdir(&dir.join(format!("sub{d:03}")));
+    }
+    for (i, (which, len)) in files.iter().enumerate() {
+        let target = if dir_count == 0 || *which == 0 {
+            dir.to_path_buf()
+        } else {
+            dir.join(format!("sub{:03}", which % dir_count))
+        };
+        write_file(
+            &target.join(format!("file{i:04}.bin")),
+            &deterministic_bytes(*len),
+        );
+    }
+}
+
+proptest! {
+    #![proptest_config(ProptestConfig::with_cases(64))]
+
+    /// Spec clause: walk-twice determinism (proptest). A random deterministic
+    /// tree, walked twice, yields identical Manifest Display + identical
+    /// snapshot_id. Includes sizes straddling MMAP_THRESHOLD so both hashing
+    /// branches are exercised under determinism.
+    #[test]
+    fn proptest_walk_twice_determinism(
+        dir_count in 0usize..5,
+        files in prop::collection::vec(
+            (0usize..5, prop_oneof![0usize..2048, Just(256 * 1024 - 1), Just(256 * 1024), Just(256 * 1024 + 1)]),
+            0..12,
+        ),
+    ) {
+        let scratch = Scratch::new("prop");
+        materialize_random_tree(scratch.path(), dir_count, &files);
+
+        let hasher = Blake3Hasher::new();
+        let m1 = walk(scratch.path(), &WalkOptions::default(), &hasher).expect("walk 1");
+        let m2 = walk(scratch.path(), &WalkOptions::default(), &hasher).expect("walk 2");
+        prop_assert_eq!(m1.to_string(), m2.to_string());
+        prop_assert_eq!(snapshot_id(&m1, &hasher), snapshot_id(&m2, &hasher));
+    }
+}
+
+// ===========================================================================
+// 3. Per-hasher equivalence: hash_file_hex(path).0 == hash_hex(&fs::read(path)),
+//    and .1 == file size, for every contracted hasher.
+// ===========================================================================
+
+/// Writes `content` to a fresh scratch file and returns (scratch, path).
+fn scratch_file(tag: &str, content: &[u8]) -> (Scratch, PathBuf) {
+    let scratch = Scratch::new(tag);
+    let path = scratch.path().join("payload.bin");
+    write_file(&path, content);
+    (scratch, path)
+}
+
+/// For one hasher, assert hash_file_hex == hash_hex(read) and the byte len for an
+/// empty file, a sub-threshold file, and a multi-MB (> MMAP_THRESHOLD) file.
+fn assert_hasher_equivalence<H: Hasher + HashFile>(hasher: &H, tag: &str) {
+    let cases: [(&str, Vec<u8>); 3] = [
+        ("empty", Vec::new()),
+        ("small_1k", deterministic_bytes(1024)),
+        // > 256 KiB so the blake3 mmap+rayon path is exercised; multi-MB.
+        ("multi_mb", deterministic_bytes(3 * 1024 * 1024 + 5)),
+    ];
+    for (label, content) in cases {
+        let (_scratch, path) = scratch_file(&format!("{tag}_{label}"), &content);
+        let (hex, len) = hasher
+            .hash_file_hex(&path)
+            .expect("hash_file_hex must succeed on a readable file");
+        let expected_hex = hasher.hash_hex(&std::fs::read(&path).unwrap());
+        assert_eq!(
+            hex, expected_hex,
+            "hash_file_hex hex must equal hash_hex(read) [{tag} {label}]"
+        );
+        assert_eq!(
+            len,
+            content.len() as u64,
+            "hash_file_hex byte len must equal the file size [{tag} {label}]"
+        );
+        // Lowercase-hex contract.
+        assert!(
+            hex.chars()
+                .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase()),
+            "hash_file_hex must return lowercase hex [{tag} {label}]: {hex}"
+        );
+    }
+}
+
+#[test]
+fn hash_file_hex_blake3_equivalence() {
+    // Spec clause: per-hasher equivalence (Blake3Hasher), incl. the mmap path.
+    assert_hasher_equivalence(&Blake3Hasher::new(), "blake3");
+}
+
+#[test]
+fn hash_file_hex_blake3_keyed_equivalence() {
+    // Spec clause: per-hasher equivalence (Blake3KeyedHasher / derive-key).
+    assert_hasher_equivalence(
+        &Blake3KeyedHasher::new("snapdir fast-walk adversary context"),
+        "blake3keyed",
+    );
+}
+
+#[test]
+fn hash_file_hex_md5_equivalence() {
+    // Spec clause: per-hasher equivalence (Md5Hasher) — read whole file + hash_hex.
+    assert_hasher_equivalence(&Md5Hasher::new(), "md5");
+}
+
+#[test]
+fn hash_file_hex_sha256_equivalence() {
+    // Spec clause: per-hasher equivalence (Sha256Hasher) — read whole file + hash_hex.
+    assert_hasher_equivalence(&Sha256Hasher::new(), "sha256");
+}
+
+#[test]
+fn hash_file_hex_keyed_differs_from_unkeyed() {
+    // Spec corollary: the keyed blake3 file hash must NOT equal the unkeyed one
+    // for the same bytes (proves keyed mode is actually keyed via the file path).
+    let content = deterministic_bytes(512 * 1024); // exercise the mmap branch
+    let (_s, path) = scratch_file("keyed_vs_unkeyed", &content);
+    let unkeyed = Blake3Hasher::new().hash_file_hex(&path).unwrap().0;
+    let keyed = Blake3KeyedHasher::new("snapdir ctx")
+        .hash_file_hex(&path)
+        .unwrap()
+        .0;
+    assert_ne!(unkeyed, keyed, "keyed file hash must differ from unkeyed");
+}
+
+// ===========================================================================
+// 4. mmap-threshold boundary: THRESHOLD-1 / THRESHOLD / THRESHOLD+1 hash
+//    identically whether the mmap branch or the plain-read branch is taken.
+// ===========================================================================
+
+#[test]
+fn mmap_threshold_boundary_blake3_identical_both_branches() {
+    // Spec clause: mmap-threshold BOUNDARY. Files of exactly MMAP_THRESHOLD-1,
+    // MMAP_THRESHOLD, and MMAP_THRESHOLD+1 bytes must hash identically to the
+    // blake3 one-shot of the same bytes (i.e. the mmap branch and the plain-read
+    // branch agree across the const boundary). MMAP_THRESHOLD referenced via the
+    // contracted path so this fails to compile until the impl lands.
+    let threshold = MMAP_THRESHOLD;
+    assert_eq!(threshold, 256 * 1024, "MMAP_THRESHOLD contract = 256 KiB");
+
+    let blake3 = Blake3Hasher::new();
+    for delta in [-1i64, 0, 1] {
+        let len = (threshold as i64 + delta) as usize;
+        let content = deterministic_bytes(len);
+        let (_s, path) = scratch_file(&format!("boundary_{len}"), &content);
+
+        let (hex, byte_len) = blake3.hash_file_hex(&path).unwrap();
+        // Independent oracle: a single one-shot blake3 over the same bytes.
+        let oneshot = ::blake3::hash(&content).to_hex().to_string();
+        assert_eq!(
+            hex, oneshot,
+            "blake3 hash_file_hex must equal one-shot blake3 at len {len}"
+        );
+        // And it must equal hash_hex(read) too (the two engines must agree).
+        assert_eq!(hex, blake3.hash_hex(&content));
+        assert_eq!(byte_len, len as u64);
+    }
+}
+
+// ===========================================================================
+// 5. Empty file: blake3 hash_file_hex == known empty-input BLAKE3 and never
+//    mmapped (must not panic / SIGBUS).
+// ===========================================================================
+
+#[test]
+fn empty_file_blake3_hash_is_known_constant_and_never_mmapped() {
+    // Spec clause: a 0-byte file's blake3 hash_file_hex == the known empty-input
+    // BLAKE3, and must never be mmapped (mmap of 0 bytes can SIGBUS). The fact
+    // that this returns cleanly (no SIGBUS) is itself the "never mmapped" proof.
+    const EMPTY_BLAKE3: &str = "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262";
+    let (_s, path) = scratch_file("empty", &[]);
+    let (hex, len) = Blake3Hasher::new().hash_file_hex(&path).unwrap();
+    assert_eq!(hex, EMPTY_BLAKE3, "empty blake3 must be the known constant");
+    assert_eq!(len, 0, "empty file byte len must be 0");
+    // Empty file is strictly below MMAP_THRESHOLD, so it takes the plain-read branch.
+    assert!(0 < MMAP_THRESHOLD, "0 bytes is below the mmap threshold");
+}
+
+// ===========================================================================
+// 6. walk_jobs determinism — walk_jobs = Some(1) vs Some(8) yield the identical
+//    snapshot_id (and Manifest) for a tree mixing many small + a few large files.
+// ===========================================================================
+
+/// Builds a tree mixing many small files + a few large (> MMAP_THRESHOLD) files,
+/// for the cross-job determinism check.
+fn materialize_small_and_large(dir: &Path) {
+    for i in 0..40 {
+        write_file(
+            &dir.join(format!("small_{i:03}.bin")),
+            &deterministic_bytes(64),
+        );
+    }
+    for i in 0..3 {
+        write_file(
+            &dir.join(format!("large_{i:02}.bin")),
+            &deterministic_bytes(MMAP_THRESHOLD as usize + 4096),
+        );
+    }
+    let sub = dir.join("sub");
+    mkdir(&sub);
+    write_file(&sub.join("nested small.bin"), &deterministic_bytes(10));
+    write_file(
+        &sub.join("nested large.bin"),
+        &deterministic_bytes(MMAP_THRESHOLD as usize * 2),
+    );
+}
+
+#[test]
+fn walk_jobs_1_vs_8_yield_identical_id_and_manifest() {
+    // Spec clause: walk_jobs determinism. WalkOptions.walk_jobs = Some(1) vs
+    // Some(8) must produce identical snapshot_id AND identical Manifest Display
+    // for a many-small + few-large tree. References WalkOptions.walk_jobs so it
+    // cannot compile until the field lands.
+    let scratch = Scratch::new("walk_jobs");
+    materialize_small_and_large(scratch.path());
+
+    let hasher = Blake3Hasher::new();
+    let opts_1 = WalkOptions {
+        walk_jobs: Some(1),
+        ..WalkOptions::default()
+    };
+    let opts_8 = WalkOptions {
+        walk_jobs: Some(8),
+        ..WalkOptions::default()
+    };
+
+    let m1 = walk(scratch.path(), &opts_1, &hasher).expect("walk jobs=1");
+    let m8 = walk(scratch.path(), &opts_8, &hasher).expect("walk jobs=8");
+
+    assert_eq!(
+        m1.to_string(),
+        m8.to_string(),
+        "Manifest Display must be identical across walk_jobs"
+    );
+    assert_eq!(
+        snapshot_id(&m1, &hasher),
+        snapshot_id(&m8, &hasher),
+        "snapshot_id must be identical across walk_jobs"
+    );
+
+    // And both must match the default (None) walk over the same tree.
+    let m_default = walk(scratch.path(), &WalkOptions::default(), &hasher).expect("walk default");
+    assert_eq!(snapshot_id(&m1, &hasher), snapshot_id(&m_default, &hasher));
+}
+
+#[test]
+fn walk_jobs_does_not_change_golden_shapes() {
+    // Spec corollary: setting walk_jobs must NOT change the KEYSTONE goldens.
+    // Re-run every Shape under walk_jobs = Some(4) and assert the golden holds.
+    let hasher = Blake3Hasher::new();
+    for shape in ALL_SHAPES {
+        let scratch = Scratch::new(shape.name());
+        shape.materialize(scratch.path());
+        let opts = WalkOptions {
+            walk_jobs: Some(4),
+            ..WalkOptions::default()
+        };
+        let manifest = walk(scratch.path(), &opts, &hasher).expect("walk jobs=4");
+        assert_eq!(
+            snapshot_id(&manifest, &hasher),
+            golden_id(shape),
+            "walk_jobs=4 changed the golden for {}",
+            shape.name()
+        );
+    }
+}
+
+// ===========================================================================
+// 7. REVIEW-MODE additions (impl now visible). The landed walk has TWO distinct
+//    hashing engines selected by `pending.len() >= jobs` (walk.rs hash_pending):
+//      - fewer pending files than jobs -> `hash_file_hex` (blake3 `update_mmap_rayon`,
+//        intra-file rayon fan-out on a lone big file);
+//      - at least `jobs` pending files  -> `hash_file_hex_seq` (blake3 `update_mmap`,
+//        single-threaded per file).
+//    Both MUST yield byte-identical ids. These cases drive each branch on purpose
+//    and pin the NEW `hash_file_hex_seq` symbol the impl revealed.
+// ===========================================================================
+
+/// One huge file (> MMAP_THRESHOLD), ALONE in a dir. With a high `walk_jobs`
+/// (so `pending.len() (==1) < walk_jobs`) the walk takes the intra-file
+/// `update_mmap_rayon` branch; with `walk_jobs = Some(1)` it takes the
+/// single-threaded engine. Both ids must match each other AND the default walk.
+#[test]
+fn single_huge_file_intra_file_rayon_matches_seq() {
+    // Spec clause (review): the intra-file `update_mmap_rayon` path (pending < jobs)
+    // must produce the SAME id as the sequential/`walk_jobs=1` path for one big file.
+    let scratch = Scratch::new("huge_alone");
+    // Strictly above the threshold so the mmap branch (not plain-read) is taken,
+    // and multi-MB so update_mmap_rayon genuinely has work to fan out.
+    let content = deterministic_bytes(MMAP_THRESHOLD as usize * 12 + 123);
+    write_file(&scratch.path().join("only_big.bin"), &content);
+
+    let hasher = Blake3Hasher::new();
+    // Many jobs, ONE pending file => pending.len() (1) < jobs => update_mmap_rayon.
+    let opts_rayon = WalkOptions {
+        walk_jobs: Some(8),
+        ..WalkOptions::default()
+    };
+    // One job => the honest single-threaded engine (update_mmap, no pool).
+    let opts_seq = WalkOptions {
+        walk_jobs: Some(1),
+        ..WalkOptions::default()
+    };
+
+    let m_rayon = walk(scratch.path(), &opts_rayon, &hasher).expect("walk rayon branch");
+    let m_seq = walk(scratch.path(), &opts_seq, &hasher).expect("walk seq branch");
+    let m_default = walk(scratch.path(), &WalkOptions::default(), &hasher).expect("walk default");
+
+    assert_eq!(
+        m_rayon.to_string(),
+        m_seq.to_string(),
+        "intra-file rayon manifest must equal the single-threaded manifest"
+    );
+    assert_eq!(
+        snapshot_id(&m_rayon, &hasher),
+        snapshot_id(&m_seq, &hasher),
+        "intra-file rayon id must equal the single-threaded id"
+    );
+    assert_eq!(
+        snapshot_id(&m_rayon, &hasher),
+        snapshot_id(&m_default, &hasher),
+        "intra-file rayon id must equal the default-walk id"
+    );
+
+    // And the lone big file's checksum must equal a one-shot blake3 of its bytes
+    // (the manifest row carries the per-file content hash).
+    let oneshot = ::blake3::hash(&content).to_hex().to_string();
+    assert!(
+        m_rayon.to_string().contains(&oneshot),
+        "the big file's row must carry the one-shot blake3 of its bytes"
+    );
+}
+
+/// A tree with FAR more files than worker threads (`pending.len() >= jobs`) so the
+/// cross-file rayon pool + per-file `hash_file_hex_seq` (`update_mmap` for the big
+/// ones) branch is exercised. Determinism + golden-stability across job counts.
+#[test]
+fn many_files_cross_file_seq_branch_is_deterministic() {
+    // Spec clause (review): the cross-file rayon + per-file `hash_file_hex_seq`
+    // (update_mmap) path (pending >= jobs) must be deterministic and id-stable
+    // across job counts, including some large files forced through update_mmap.
+    let scratch = Scratch::new("many_files_seq");
+    // 50 small files (sub-threshold, plain-read) ...
+    for i in 0..50 {
+        write_file(
+            &scratch.path().join(format!("s_{i:03}.bin")),
+            &deterministic_bytes(48 + (i % 7)),
+        );
+    }
+    // ... plus several > MMAP_THRESHOLD files so the per-file update_mmap engine
+    // (the seq branch, NOT update_mmap_rayon) hashes a big file. With many pending
+    // files and only a few jobs, pending.len() >= jobs holds for every count below.
+    for i in 0..4 {
+        write_file(
+            &scratch.path().join(format!("big_{i:02}.bin")),
+            &deterministic_bytes(MMAP_THRESHOLD as usize + 1024 * (i + 1)),
+        );
+    }
+
+    let hasher = Blake3Hasher::new();
+    // job counts well below the file count (54), so pending >= jobs => seq engine.
+    let mut ids = Vec::new();
+    for jobs in [1usize, 2, 4, 8] {
+        let opts = WalkOptions {
+            walk_jobs: Some(jobs),
+            ..WalkOptions::default()
+        };
+        let m = walk(scratch.path(), &opts, &hasher).expect("walk seq branch");
+        ids.push(snapshot_id(&m, &hasher));
+    }
+    for id in &ids {
+        assert_eq!(
+            id, &ids[0],
+            "cross-file seq-branch id must be identical across job counts"
+        );
+    }
+    // Stable across a re-run too (golden-stability without a hardcoded value:
+    // the tree mixes sizes the bench Shapes don't, so the id is computed, not
+    // pinned — but it MUST be reproducible).
+    let opts1 = WalkOptions {
+        walk_jobs: Some(1),
+        ..WalkOptions::default()
+    };
+    let rerun = snapshot_id(
+        &walk(scratch.path(), &opts1, &hasher).expect("rerun"),
+        &hasher,
+    );
+    assert_eq!(
+        rerun, ids[0],
+        "seq-branch id must be reproducible across runs"
+    );
+}
+
+/// Pins the NEW symbol the impl revealed: `HashFile::hash_file_hex_seq`. It must
+/// produce hex byte-identical to `hash_file_hex` (the rayon path) AND to a one-shot
+/// blake3, across the MMAP_THRESHOLD boundary (-1 / 0 / +1 and well above).
+#[test]
+fn hash_file_hex_seq_equals_rayon_and_oneshot_across_threshold() {
+    // Spec clause (review): hash_file_hex_seq (update_mmap / non-rayon mmap) ==
+    // hash_file_hex (update_mmap_rayon) == one-shot blake3, for every size around
+    // and above the threshold. The seq engine is a perf variant ONLY; its bytes
+    // must never diverge.
+    let blake3 = Blake3Hasher::new();
+    let threshold = MMAP_THRESHOLD as usize;
+    let sizes = [
+        0usize,
+        1,
+        threshold - 1,
+        threshold,
+        threshold + 1,
+        threshold * 4 + 7,
+    ];
+    for len in sizes {
+        let content = deterministic_bytes(len);
+        let (_s, path) = scratch_file(&format!("seq_eq_{len}"), &content);
+
+        let (rayon_hex, rayon_len) = blake3.hash_file_hex(&path).expect("hash_file_hex");
+        let (seq_hex, seq_len) = blake3.hash_file_hex_seq(&path).expect("hash_file_hex_seq");
+        let oneshot = ::blake3::hash(&content).to_hex().to_string();
+
+        assert_eq!(
+            seq_hex, rayon_hex,
+            "hash_file_hex_seq must equal hash_file_hex at len {len}"
+        );
+        assert_eq!(
+            seq_hex, oneshot,
+            "hash_file_hex_seq must equal one-shot blake3 at len {len}"
+        );
+        assert_eq!(seq_len, len as u64, "seq byte len at {len}");
+        assert_eq!(rayon_len, len as u64, "rayon byte len at {len}");
+    }
+}
+
+// ===========================================================================
+// 8. walk_jobs = Some(0) (auto) must be deterministic and == Some(1).
+// ===========================================================================
+
+#[test]
+fn walk_jobs_auto_zero_matches_one_and_default() {
+    // Spec clause (review): `Some(0)` resolves to the auto (available_parallelism,
+    // capped) worker count — it must still be deterministic and produce the
+    // identical id as `Some(1)` and the default walk. (walk.rs resolve_jobs treats
+    // Some(0) like None.)
+    let scratch = Scratch::new("auto_zero");
+    materialize_small_and_large(scratch.path());
+
+    let hasher = Blake3Hasher::new();
+    let opts_auto = WalkOptions {
+        walk_jobs: Some(0),
+        ..WalkOptions::default()
+    };
+    let opts_one = WalkOptions {
+        walk_jobs: Some(1),
+        ..WalkOptions::default()
+    };
+
+    let m_auto = walk(scratch.path(), &opts_auto, &hasher).expect("walk jobs=0");
+    let m_one = walk(scratch.path(), &opts_one, &hasher).expect("walk jobs=1");
+    let m_default = walk(scratch.path(), &WalkOptions::default(), &hasher).expect("walk default");
+
+    assert_eq!(
+        m_auto.to_string(),
+        m_one.to_string(),
+        "walk_jobs=Some(0) (auto) manifest must equal Some(1)"
+    );
+    assert_eq!(
+        snapshot_id(&m_auto, &hasher),
+        snapshot_id(&m_one, &hasher),
+        "walk_jobs=Some(0) id must equal Some(1)"
+    );
+    assert_eq!(
+        snapshot_id(&m_auto, &hasher),
+        snapshot_id(&m_default, &hasher),
+        "walk_jobs=Some(0) id must equal the default (None) walk"
+    );
+
+    // Auto is itself stable run-over-run (no thread-count nondeterminism).
+    let rerun = walk(scratch.path(), &opts_auto, &hasher).expect("rerun jobs=0");
+    assert_eq!(snapshot_id(&m_auto, &hasher), snapshot_id(&rerun, &hasher));
+}
+
+// ===========================================================================
+// 9. Symlink-followed file: the walk follows symlinks by DEFAULT (find -L). A
+//    followed symlink-to-file hashes the TARGET's content (checksum read through
+//    the link), while its SIZE column is the symlink's own lstat length. The
+//    parallel hasher must hash through the link, not the symlink bytes. (Pins the
+//    `content_path = entry_path` + `size = link_meta.len()` split in walk.rs.)
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn followed_symlink_file_hashes_target_content() {
+    // Spec clause (review): a symlink-to-file, followed by default, appears as an
+    // `F` row whose CHECKSUM is the blake3 of the TARGET's bytes (hashed through
+    // the link by the parallel hasher), proving the walk hashes the target, not
+    // the symlink. Drive a > MMAP_THRESHOLD target so the followed link is hashed
+    // through the mmap path.
+    let scratch = Scratch::new("symlink_file");
+    let root = scratch.path();
+
+    // A real target file, large enough to take the mmap branch through the link.
+    let target_content = deterministic_bytes(MMAP_THRESHOLD as usize + 4096);
+    write_file(&root.join("real.bin"), &target_content);
+
+    // A symlink to it (relative target name, same dir).
+    std::os::unix::fs::symlink("real.bin", root.join("link.bin")).expect("symlink file");
+
+    let hasher = Blake3Hasher::new();
+    // Force the cross-file seq engine AND the intra-file rayon engine; both must
+    // hash the target through the link to the same checksum.
+    let target_hex = ::blake3::hash(&target_content).to_hex().to_string();
+    for jobs in [Some(1usize), Some(8), Some(0), None] {
+        let opts = WalkOptions {
+            walk_jobs: jobs,
+            ..WalkOptions::default()
+        };
+        let manifest = walk(root, &opts, &hasher).expect("walk follows symlinks by default");
+        let text = manifest.to_string();
+        // The real file row.
+        assert!(
+            text.lines().any(|l| l.starts_with("F ")
+                && l.contains(&target_hex)
+                && l.ends_with(" ./real.bin")),
+            "real file row must carry the target's blake3 [{jobs:?}]: {text}"
+        );
+        // The followed symlink row: SAME content checksum (hashed through the link).
+        assert!(
+            text.lines().any(|l| l.starts_with("F ")
+                && l.contains(&target_hex)
+                && l.ends_with(" ./link.bin")),
+            "followed symlink row must carry the TARGET's blake3 [{jobs:?}]: {text}"
+        );
+    }
+}

--- a/crates/snapdir-ssh-store/src/ssh_engine.rs
+++ b/crates/snapdir-ssh-store/src/ssh_engine.rs
@@ -102,6 +102,16 @@ const PUSH_CAPS: &str = "objects-needed,receive-pack";
 /// The cap the fetch dispatch requires of the remote `snapdir`.
 const FETCH_CAPS: &str = "send-pack";
 
+/// The OPTIONAL capability token gating the additive SNAPPACK 1Z (zstd)
+/// transport encoding. Unlike [`PUSH_CAPS`]/[`FETCH_CAPS`] it is NEVER part of
+/// `FORCE_ACCEL` negotiation: a peer that lacks it simply receives a v1 stream
+/// (the receiver sniffs the magic and accepts both forms forever), so accel is
+/// still taken — only the on-wire encoding falls back. It is a LOCAL constant
+/// (the shipped lib depends only on `snapdir-core`); the
+/// `zstd_cap_matches_snapdir_stores` test pins it to the
+/// `snapdir_stores::WIRE_CAPS` token so a rename cannot silently desync.
+const ZSTD_CAP: &str = "snappack-zstd";
+
 /// The shell that aborts on any probe transport failure: a nonzero
 /// `_snapdir_ssh` exit is connectivity (the probe's remote command itself
 /// always exits 0), surfaced with the real exit code — it NEVER maps to
@@ -154,8 +164,21 @@ fn accel_prelude() -> String {
     format!(
         r#"snapdir_local="${{SNAPDIR_SSH_LOCAL_SNAPDIR:-snapdir}}"
 snapdir_local_ok=0
+snapdir_local_zstd=0
 if command -v "$snapdir_local" >/dev/null 2>&1; then
   snapdir_local_ok=1
+  # Probe the LOCAL binary's caps for the zstd transport. An OLDER local
+  # snapdir (e.g. 1.5.0) rejects `version --capabilities` nonzero; the
+  # `|| true` keeps that from tripping `set -e`, and the empty/cap-less
+  # output simply leaves snapdir_local_zstd=0 (clean v1 fallback).
+  snapdir_local_caps="$("$snapdir_local" version --capabilities 2>/dev/null || true)"
+  case " $snapdir_local_caps " in
+  *' wire={WIRE_VERSION} '*)
+    case "$snapdir_local_caps" in
+    *caps=*{ZSTD_CAP}*) snapdir_local_zstd=1 ;;
+    esac
+    ;;
+  esac
 fi
 _snapdir_caps_ok() {{
   snapdir_caps_line=''
@@ -240,7 +263,11 @@ else
   : >"$snapdir_tmp/need"
 fi
 snapdir_stream_status=0
-"$snapdir_local" send-pack --store {staging_url} --ids "$snapdir_tmp/need" --manifest-id {id_q} | _snapdir_ssh {recv} || snapdir_stream_status=$?
+if [ "$snapdir_push_zstd" = "1" ]; then
+  "$snapdir_local" send-pack --store {staging_url} --ids "$snapdir_tmp/need" --manifest-id {id_q} --pack-format zstd | _snapdir_ssh {recv} || snapdir_stream_status=$?
+else
+  "$snapdir_local" send-pack --store {staging_url} --ids "$snapdir_tmp/need" --manifest-id {id_q} | _snapdir_ssh {recv} || snapdir_stream_status=$?
+fi
 if [ "$snapdir_stream_status" -ne 0 ]; then
   printf 'snapdir-ssh-store: accelerated push stream failed (exit %s); retrying the push resumes incrementally\n' "$snapdir_stream_status" >&2
   exit "$snapdir_stream_status"
@@ -262,14 +289,22 @@ fi
 /// hash-verifies every record. Stream failure exits nonzero (no silent dumb
 /// fallback mid-stream).
 fn accel_fetch_fn(base: &str, cache_abs: &str) -> String {
-    let send_cmd = format!(
-        "snapdir send-pack --store {} --ids -",
-        sh_quote(&format!("file://{base}")),
-    );
+    let store_q = sh_quote(&format!("file://{base}"));
+    // TWO statically-baked, fully-quoted remote send-pack variants (same
+    // ids/ids_all pattern). The trailing ` --pack-format zstd` is a literal,
+    // NEVER a runtime env value interpolated into the baked remote string —
+    // the dispatch only CHOOSES which constant variant to send. The local
+    // receive-pack sniffs the incoming magic, so v1 and 1Z are both accepted.
+    let send_cmd = format!("snapdir send-pack --store {store_q} --ids -");
+    let send_cmd_zstd = format!("snapdir send-pack --store {store_q} --ids - --pack-format zstd");
     format!(
         r#"_snapdir_accel_fetch() {{
 snapdir_stream_status=0
-_snapdir_ssh {send} <"$snapdir_ids" | "$snapdir_local" receive-pack --store {cache_url} || snapdir_stream_status=$?
+if [ "$snapdir_fetch_zstd" = "1" ]; then
+  _snapdir_ssh {send_zstd} <"$snapdir_ids" | "$snapdir_local" receive-pack --store {cache_url} || snapdir_stream_status=$?
+else
+  _snapdir_ssh {send} <"$snapdir_ids" | "$snapdir_local" receive-pack --store {cache_url} || snapdir_stream_status=$?
+fi
 if [ "$snapdir_stream_status" -ne 0 ]; then
   printf 'snapdir-ssh-store: accelerated fetch stream failed (exit %s); retrying the fetch resumes incrementally\n' "$snapdir_stream_status" >&2
   exit "$snapdir_stream_status"
@@ -277,6 +312,7 @@ fi
 }}
 "#,
         send = sh_quote(&send_cmd),
+        send_zstd = sh_quote(&send_cmd_zstd),
         cache_url = sh_quote(&format!("file://{cache_abs}")),
     )
 }
@@ -460,15 +496,20 @@ pub fn get_push_script(
     // FORCE_ACCEL without caps → designed error; else → dumb.
     let _ = write!(
         script,
-        r#"if [ "${{SNAPDIR_SSH_NO_ACCEL:-0}}" = "1" ] || [ "$snapdir_local_ok" -ne 1 ]; then
+        r#"snapdir_push_zstd=0
+if [ "${{SNAPDIR_SSH_NO_ACCEL:-0}}" = "1" ] || [ "$snapdir_local_ok" -ne 1 ]; then
   _snapdir_dumb_push
 elif _snapdir_caps_ok objects-needed receive-pack; then
+  if [ "$snapdir_local_zstd" = "1" ] && _snapdir_caps_ok {zstd_cap}; then
+    snapdir_push_zstd=1
+  fi
   _snapdir_accel_push
 elif [ "${{SNAPDIR_SSH_FORCE_ACCEL:-0}}" = "1" ]; then
 {err}else
   _snapdir_dumb_push
 fi
 "#,
+        zstd_cap = ZSTD_CAP,
         err = force_accel_error_block(&url.host_arg(), PUSH_CAPS),
     );
     Ok(script)
@@ -655,10 +696,14 @@ fi
 if [ "${{SNAPDIR_SSH_PULL_SENDALL:-0}}" = "1" ]; then
   snapdir_ids="$snapdir_tmp/ids_all"
 fi
+snapdir_fetch_zstd=0
 if [ "${{SNAPDIR_SSH_NO_ACCEL:-0}}" = "1" ] || [ "$snapdir_local_ok" -ne 1 ] || [ ! -s "$snapdir_ids" ]; then
   _snapdir_dumb_fetch
 else
 {probe}if _snapdir_caps_ok send-pack; then
+  if [ "$snapdir_local_zstd" = "1" ] && _snapdir_caps_ok {zstd_cap}; then
+    snapdir_fetch_zstd=1
+  fi
   _snapdir_accel_fetch
 elif [ "${{SNAPDIR_SSH_FORCE_ACCEL:-0}}" = "1" ]; then
 {err}else
@@ -666,6 +711,7 @@ elif [ "${{SNAPDIR_SSH_FORCE_ACCEL:-0}}" = "1" ]; then
 fi
 fi
 "#,
+        zstd_cap = ZSTD_CAP,
         probe = caps_probe_block(),
         err = force_accel_error_block(&url.host_arg(), FETCH_CAPS),
     );
@@ -724,6 +770,19 @@ mod tests {
                 "required cap {cap:?} must be one the CLI advertises"
             );
         }
+    }
+
+    #[test]
+    fn zstd_cap_matches_snapdir_stores() {
+        // The optional zstd transport token is a local constant (the shipped
+        // lib depends only on snapdir-core); this pin against the
+        // dev-dependency that OWNS the cap keeps a future rename from silently
+        // desyncing the runtime zstd negotiation.
+        assert!(
+            snapdir_stores::WIRE_CAPS.contains(&ZSTD_CAP),
+            "ZSTD_CAP {ZSTD_CAP:?} must be a token the CLI advertises in WIRE_CAPS"
+        );
+        assert_eq!(ZSTD_CAP, "snappack-zstd");
     }
 
     #[test]

--- a/crates/snapdir-ssh-store/tests/accel.rs
+++ b/crates/snapdir-ssh-store/tests/accel.rs
@@ -465,6 +465,164 @@ fn accel_push_get_manifest_accel_fetch_roundtrip() {
 }
 
 // ---------------------------------------------------------------------------
+// zstd negotiation (wire2-zstd-ssh): both peers speak snappack-zstd → 1Z;
+// a 1.5.0-style peer (no cap) cleanly falls back to v1 with accel STILL taken
+// ---------------------------------------------------------------------------
+
+/// Installs a remote `snapdir` at `dir/snapdir` that logs every argv to `log`
+/// and execs `real` — same as [`install_logging_snapdir`] but as a standalone
+/// file usable for the LOCAL pipe end (via `SNAPDIR_SSH_LOCAL_SNAPDIR`).
+fn install_logging_snapdir_at(path: &Path, real: &Path, log: &Path) {
+    write_script(
+        path,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >>{log}\nexec {real} \"$@\"\n",
+            log = sh_quote(&log.display().to_string()),
+            real = sh_quote(&real.display().to_string()),
+        ),
+    );
+}
+
+#[test]
+fn zstd_push_and_fetch_engage_when_both_peers_advertise_the_cap() {
+    let Some(real) =
+        require_snapdir("zstd_push_and_fetch_engage_when_both_peers_advertise_the_cap")
+    else {
+        return;
+    };
+    let staging = TempDir::new("zz-stage");
+    let remote_root = TempDir::new("zz-remote");
+    let bindir = TempDir::new("zz-bin");
+    let remote_bin = TempDir::new("zz-remote-bin");
+    let local_bin = TempDir::new("zz-local-bin");
+    let cache = TempDir::new("zz-cache");
+    let cache_pin = TempDir::new("zz-cachepin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path(), cache_pin.path());
+
+    // Remote AND local are the REAL binary behind logging shims (the real
+    // binary's caps include snappack-zstd), so both negotiate zstd.
+    let remote_log = remote_bin.path().join("invocations.log");
+    install_logging_snapdir(remote_bin.path(), &real, &remote_log);
+    let local_log = local_bin.path().join("local.log");
+    let local_snapdir = local_bin.path().join("snapdir");
+    install_logging_snapdir_at(&local_snapdir, &real, &local_log);
+    env.set(
+        "FAKE_SSH_REMOTE_PATH",
+        &remote_bin.path().display().to_string(),
+    );
+    env.set(
+        "SNAPDIR_SSH_LOCAL_SNAPDIR",
+        &local_snapdir.display().to_string(),
+    );
+
+    let (manifest, _id, sums) = stage_tree(staging.path(), FILES);
+    let base = remote_root.path().join("snap");
+    let store = external_store(&base);
+
+    // Push: the LOCAL send-pack carries --pack-format zstd; the remote
+    // receive-pack still ran (sniffed the 1Z magic).
+    store
+        .push(&manifest, staging.path())
+        .expect("zstd accel push");
+    let local = log_lines(&local_log);
+    assert!(
+        local.contains("send-pack") && local.contains("--pack-format zstd"),
+        "the local send-pack must opt into zstd: {local}"
+    );
+    assert!(
+        log_lines(&remote_log).contains("receive-pack"),
+        "the remote receive-pack still ran (magic-sniffed): {}",
+        log_lines(&remote_log)
+    );
+
+    // Fetch: the REMOTE send-pack carries --pack-format zstd; the local
+    // receive-pack landed every object byte-correctly (it verified each).
+    fs::write(&remote_log, b"").unwrap();
+    store
+        .fetch_files(&manifest, cache.path())
+        .expect("zstd accel fetch");
+    let remote = log_lines(&remote_log);
+    assert!(
+        remote.contains("send-pack") && remote.contains("--pack-format zstd"),
+        "the remote send-pack must opt into zstd: {remote}"
+    );
+    for (sum, (_, content)) in sums.iter().zip(FILES) {
+        assert_eq!(
+            &fs::read(cache.path().join(object_path(sum))).unwrap(),
+            content
+        );
+    }
+}
+
+#[test]
+fn zstd_falls_back_to_v1_against_a_remote_without_the_cap_accel_still_taken() {
+    let Some(real) =
+        require_snapdir("zstd_falls_back_to_v1_against_a_remote_without_the_cap_accel_still_taken")
+    else {
+        return;
+    };
+    let staging = TempDir::new("zr-stage");
+    let remote_root = TempDir::new("zr-remote");
+    let bindir = TempDir::new("zr-bin");
+    let remote_bin = TempDir::new("zr-remote-bin");
+    let cache = TempDir::new("zr-cache");
+    let cache_pin = TempDir::new("zr-cachepin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path(), cache_pin.path());
+
+    // A 1.5.0-style remote: wire=1 with the full v1 caps but WITHOUT
+    // snappack-zstd. The caps-only shim records any non-version invocation, so
+    // we can only exercise the FETCH path (push streams real packs the shim
+    // can't serve) — fetch picks the v1 send-pack variant, accel still taken.
+    let log = remote_bin.path().join("invocations.log");
+    write_script(
+        &remote_bin.path().join("snapdir"),
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >>{log}\n\
+             if [ \"$1\" = version ] && [ \"$2\" = --capabilities ]; then\n  \
+             printf '%s\\n' 'snapdir 1.5.0 wire=1 caps=objects-needed,send-pack,receive-pack'\n  \
+             exit 0\nfi\nexec {real} \"$@\"\n",
+            log = sh_quote(&log.display().to_string()),
+            real = sh_quote(&real.display().to_string()),
+        ),
+    );
+    env.set(
+        "FAKE_SSH_REMOTE_PATH",
+        &remote_bin.path().display().to_string(),
+    );
+    env.set("SNAPDIR_SSH_LOCAL_SNAPDIR", &real.display().to_string());
+
+    // Seed the store directly (dumb-style) so fetch has objects to pull.
+    let (manifest, _id, sums) = stage_tree(staging.path(), FILES);
+    let base = remote_root.path().join("snap");
+    for (sum, (_, content)) in sums.iter().zip(FILES) {
+        let obj = base.join(object_path(sum));
+        fs::create_dir_all(obj.parent().unwrap()).unwrap();
+        fs::write(&obj, content).unwrap();
+    }
+
+    external_store(&base)
+        .fetch_files(&manifest, cache.path())
+        .expect("v1-fallback accel fetch must succeed");
+
+    let remote = log_lines(&log);
+    assert!(
+        remote.contains("send-pack"),
+        "accel was STILL taken: {remote}"
+    );
+    assert!(
+        !remote.contains("--pack-format zstd"),
+        "a cap-less remote must receive the v1 send-pack variant: {remote}"
+    );
+    // Objects landed byte-correctly via the v1 stream.
+    for (sum, (_, content)) in sums.iter().zip(FILES) {
+        assert_eq!(
+            &fs::read(cache.path().join(object_path(sum))).unwrap(),
+            content
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // interrupted-accel completion: manifest-only pack
 // ---------------------------------------------------------------------------
 
@@ -857,10 +1015,25 @@ fn emitted_push_script_carries_combined_probe_and_both_paths() {
         probe_line.contains("caps none"),
         "snapdir-less remotes must degrade inside the same probe: {probe_line}"
     );
+    // Exactly one REMOTE probe round trip (the `_snapdir_ssh`-wrapped one);
+    // the LOCAL-binary zstd probe also calls `version --capabilities` but on
+    // `"$snapdir_local"`, not over ssh.
     assert_eq!(
-        script.matches("version --capabilities").count(),
+        script
+            .lines()
+            .filter(|l| l.contains("version --capabilities") && l.contains("_snapdir_ssh"))
+            .count(),
         1,
-        "exactly one capability probe"
+        "exactly one remote capability probe round trip"
+    );
+    // The LOCAL-binary zstd probe runs the local snapdir, never the remote.
+    assert!(
+        script.contains("\"$snapdir_local\" version --capabilities"),
+        "the local-zstd probe queries the LOCAL binary's caps"
+    );
+    assert!(
+        script.contains("snapdir_local_zstd"),
+        "a local-zstd flag guards the zstd push branch"
     );
 
     // The wire check is a baked literal (emit-time constant), not a runtime
@@ -914,6 +1087,46 @@ fn emitted_push_script_carries_combined_probe_and_both_paths() {
 
     // Stream failures never silently retry dumb.
     assert!(script.contains("retrying the push resumes incrementally"));
+
+    // --- zstd negotiation (wire2-zstd-ssh) ---------------------------------
+    // The zstd push branch is present: the LOCAL send-pack carries a STATIC
+    // `--pack-format zstd` (never a runtime env value), gated on a runtime
+    // flag that requires BOTH local-zstd support AND the remote advertising
+    // the snappack-zstd cap.
+    assert!(
+        script.contains("send-pack --store") && script.contains("--pack-format zstd"),
+        "the local send-pack has a baked --pack-format zstd variant"
+    );
+    assert!(
+        script.contains("$snapdir_push_zstd"),
+        "a runtime flag chooses the zstd vs v1 send-pack variant"
+    );
+    assert!(
+        script.contains("_snapdir_caps_ok snappack-zstd"),
+        "the zstd branch requires the remote to advertise snappack-zstd"
+    );
+    assert!(
+        script.contains("\"$snapdir_local_zstd\" = \"1\""),
+        "the zstd branch also requires the LOCAL binary to support zstd"
+    );
+    // CRITICAL: the remote receive-pack command is UNCHANGED (it sniffs the
+    // magic) — `--pack-format` only ever rides the LOCAL send-pack, never the
+    // remote `receive-pack` invocation (`send-pack`'s `--pack-format` sits to
+    // the LEFT of the `| _snapdir_ssh 'snapdir receive-pack …'` pipe).
+    for line in script.lines() {
+        if let Some(recv_idx) = line.find("receive-pack") {
+            assert!(
+                !line[recv_idx..].contains("--pack-format"),
+                "the remote receive-pack must never carry --pack-format: {line}"
+            );
+        }
+    }
+    // The wire=1 literal is unchanged (zstd is a transport encoding, not a
+    // version bump).
+    assert!(
+        script.contains(" wire=1 "),
+        "wire=1 literal unchanged by zstd"
+    );
 }
 
 #[test]
@@ -937,8 +1150,20 @@ fn emitted_fetch_script_carries_caps_probe_and_both_id_lists() {
     .unwrap();
     assert_skeleton_invariants(&script);
 
-    // Caps-only probe (no manifest test on fetch), exactly one.
-    assert_eq!(script.matches("version --capabilities").count(), 1);
+    // Caps-only probe (no manifest test on fetch): exactly one REMOTE round
+    // trip (the LOCAL-binary zstd probe also queries caps, but never over ssh).
+    assert_eq!(
+        script
+            .lines()
+            .filter(|l| l.contains("version --capabilities") && l.contains("_snapdir_ssh"))
+            .count(),
+        1,
+        "exactly one remote capability probe round trip"
+    );
+    assert!(
+        script.contains("\"$snapdir_local\" version --capabilities"),
+        "the local-zstd probe queries the LOCAL binary's caps"
+    );
     assert!(script.contains(" wire=1 "), "baked literal wire token");
 
     // BOTH paths and BOTH baked id lists; the dispatch picks at runtime.
@@ -957,6 +1182,41 @@ fn emitted_fetch_script_carries_caps_probe_and_both_id_lists() {
         "_snapdir_ssh {} <\"$snapdir_ids\"",
         sh_quote("snapdir send-pack --store 'file:///srv/snap' --ids -")
     )));
+
+    // --- zstd negotiation (wire2-zstd-ssh) ---------------------------------
+    // BOTH remote send-pack variants are statically baked (the same two-baked
+    // pattern as ids/ids_all); the dispatch picks which CONSTANT to send — a
+    // runtime env value is NEVER interpolated into the baked remote string.
+    assert!(
+        script.contains(&format!(
+            "_snapdir_ssh {} <\"$snapdir_ids\"",
+            sh_quote("snapdir send-pack --store 'file:///srv/snap' --ids - --pack-format zstd")
+        )),
+        "the zstd remote send-pack variant is baked, fully quoted: {script}"
+    );
+    assert!(
+        script.contains("$snapdir_fetch_zstd"),
+        "a runtime flag chooses the zstd vs v1 remote send-pack variant"
+    );
+    assert!(
+        script.contains("_snapdir_caps_ok snappack-zstd"),
+        "the zstd branch requires the remote to advertise snappack-zstd"
+    );
+    assert!(
+        script.contains("\"$snapdir_local_zstd\" = \"1\""),
+        "the zstd branch also requires the LOCAL binary to support zstd"
+    );
+    // The LOCAL receive-pack is unchanged (it sniffs the incoming magic):
+    // `--pack-format` only ever rides the REMOTE send-pack (to the LEFT of the
+    // `| "$snapdir_local" receive-pack …` pipe), never receive-pack itself.
+    for line in script.lines() {
+        if let Some(recv_idx) = line.find("receive-pack") {
+            assert!(
+                !line[recv_idx..].contains("--pack-format"),
+                "the local receive-pack must never carry --pack-format: {line}"
+            );
+        }
+    }
     assert!(
         script.contains(&format!(
             "receive-pack --store {}",
@@ -975,4 +1235,504 @@ fn emitted_fetch_script_carries_caps_probe_and_both_id_lists() {
 
     assert!(script.contains("retrying the fetch resumes incrementally"));
     assert!(script.contains("unset SNAPDIR_SSH_FORCE_ACCEL"));
+}
+
+// ===========================================================================
+// wire2-compat-matrix (phase 27): the full back/forward SNAPPACK
+// compatibility matrix (plan B5). The accel cases below reuse the existing
+// `install_caps_only_snapdir` / `install_logging_snapdir` fakes and the
+// `fake_remote_env` harness; the on-wire-byte cases (magic + zstd-smaller-than-v1)
+// drive the REAL `snapdir send-pack` binary directly so the assertions read the
+// actual stream bytes, never an inferred property.
+// ===========================================================================
+
+/// A highly compressible fixture: one large, very repetitive object plus a
+/// couple of small distinct ones. Used by the new<->new matrix case so the 1Z
+/// pack is unambiguously smaller than the v1 pack.
+/// Builds the compressible fixture: one large, very repetitive 64 KiB object
+/// (zstd crushes it to a tiny frame → 1Z pack < v1 pack) plus a couple of
+/// small distinct ones. Owned so the big payload lives on the heap, not the
+/// stack.
+fn compressible_files() -> Vec<(&'static str, Vec<u8>)> {
+    vec![
+        ("repeat.txt", vec![b'A'; 64 * 1024]),
+        ("small-a.txt", b"distinct small payload a\n".to_vec()),
+        ("small-b.txt", b"distinct small payload b\n".to_vec()),
+    ]
+}
+
+/// The fixture as the `&[(&str, &[u8])]` slice `stage_tree` expects.
+fn as_file_slice<'a>(files: &'a [(&'static str, Vec<u8>)]) -> Vec<(&'static str, &'a [u8])> {
+    files.iter().map(|(n, c)| (*n, c.as_slice())).collect()
+}
+
+/// Runs the REAL `snapdir send-pack --store file://<staging> --ids <file>`
+/// (optionally `--pack-format zstd`) and returns the raw stdout pack bytes.
+/// This is the on-wire byte stream the ssh `send-pack` half pipes to
+/// `receive-pack`, captured hermetically (no ssh, no fixture).
+fn send_pack_bytes(real: &Path, staging: &Path, ids_file: &Path, zstd: bool) -> Vec<u8> {
+    let mut cmd = std::process::Command::new(real);
+    cmd.arg("send-pack")
+        .arg("--store")
+        .arg(format!("file://{}", staging.display()))
+        .arg("--ids")
+        .arg(ids_file)
+        .arg("--quiet");
+    if zstd {
+        cmd.arg("--pack-format").arg("zstd");
+    }
+    let out = cmd.output().expect("run snapdir send-pack");
+    assert!(
+        out.status.success(),
+        "send-pack failed (zstd={zstd}): {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    out.stdout
+}
+
+/// Writes the deduped object checksums (one per line) to `path`.
+fn write_ids(path: &Path, sums: &[String]) {
+    fs::write(path, format!("{}\n", sums.join("\n"))).expect("write ids file");
+}
+
+// ---------------------------------------------------------------------------
+// (1) new<->new = SNAPPACK 1Z on the wire
+// ---------------------------------------------------------------------------
+
+#[test]
+fn matrix_new_to_new_is_snappack_1z_byte_identical_store_and_smaller_pack() {
+    let Some(real) =
+        require_snapdir("matrix_new_to_new_is_snappack_1z_byte_identical_store_and_smaller_pack")
+    else {
+        return;
+    };
+
+    // --- on-wire bytes (hermetic, no ssh): the 1Z magic AND a SMALLER pack on
+    //     a compressible fixture, driving the real send-pack directly. -------
+    let staging = TempDir::new("nn-stage");
+    let ids = TempDir::new("nn-ids");
+    let fixture = compressible_files();
+    let fixture_slice = as_file_slice(&fixture);
+    let (_manifest, _id, sums) = stage_tree(staging.path(), &fixture_slice);
+    let ids_file = ids.path().join("ids.txt");
+    write_ids(&ids_file, &sums);
+
+    let v1 = send_pack_bytes(&real, staging.path(), &ids_file, false);
+    let zz = send_pack_bytes(&real, staging.path(), &ids_file, true);
+
+    // new<->new advertises `--pack-format zstd`, which opens with the 1Z magic.
+    assert!(
+        v1.starts_with(b"SNAPPACK 1\n"),
+        "v1 pack opens with the plain magic"
+    );
+    assert!(
+        zz.starts_with(b"SNAPPACK 1Z\n"),
+        "the new<->new pack is SNAPPACK 1Z on the wire: {:?}",
+        &zz[..zz.len().min(16)]
+    );
+    assert!(
+        zz.len() < v1.len(),
+        "the 1Z pack must be smaller than v1 on a compressible fixture: \
+         zstd={} v1={} bytes",
+        zz.len(),
+        v1.len()
+    );
+
+    // --- accel path: the invocation log records `--pack-format zstd`, and the
+    //     resulting store is byte-identical to a v1 (NO_ACCEL dumb) push. -----
+    let remote_root = TempDir::new("nn-remote");
+    let bindir = TempDir::new("nn-bin");
+    let remote_bin = TempDir::new("nn-remote-bin");
+    let local_bin = TempDir::new("nn-local-bin");
+    let cache_pin = TempDir::new("nn-cachepin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path(), cache_pin.path());
+
+    let (manifest, id, _sums) = stage_tree(staging.path(), &fixture_slice);
+    let root_v1 = remote_root.path().join("v1");
+    let root_zz = remote_root.path().join("zstd");
+
+    // Reference v1 store: forced dumb (no zstd ever on the wire).
+    env.set("SNAPDIR_SSH_NO_ACCEL", "1");
+    external_store(&root_v1)
+        .push(&manifest, staging.path())
+        .expect("forced-dumb v1 push");
+    env.remove("SNAPDIR_SSH_NO_ACCEL");
+
+    // new<->new accel store: both peers are the REAL binary (caps include
+    // snappack-zstd), so the LOCAL send-pack opts into zstd.
+    let remote_log = remote_bin.path().join("invocations.log");
+    install_logging_snapdir(remote_bin.path(), &real, &remote_log);
+    let local_log = local_bin.path().join("local.log");
+    let local_snapdir = local_bin.path().join("snapdir");
+    install_logging_snapdir_at(&local_snapdir, &real, &local_log);
+    env.set(
+        "FAKE_SSH_REMOTE_PATH",
+        &remote_bin.path().display().to_string(),
+    );
+    env.set(
+        "SNAPDIR_SSH_LOCAL_SNAPDIR",
+        &local_snapdir.display().to_string(),
+    );
+    external_store(&root_zz)
+        .push(&manifest, staging.path())
+        .expect("new<->new (zstd) accel push");
+
+    // The wire negotiated 1Z: the LOCAL send-pack carried `--pack-format zstd`.
+    let local = log_lines(&local_log);
+    assert!(
+        local.contains("send-pack") && local.contains("--pack-format zstd"),
+        "new<->new must put --pack-format zstd on the wire: {local}"
+    );
+    assert!(
+        log_lines(&remote_log).contains("receive-pack"),
+        "the remote receive-pack still ran (magic-sniffed the 1Z stream)"
+    );
+
+    // Byte-identical store: the on-wire encoding is transparent to the landed
+    // objects + manifest (the resulting store is identical to v1).
+    let set_v1 = relative_file_set(&root_v1);
+    assert_eq!(
+        set_v1,
+        relative_file_set(&root_zz),
+        "the 1Z store must be byte-identical (same file set) to the v1 store"
+    );
+    assert!(
+        set_v1.contains(&manifest_path(&id)),
+        "snapshot id committed on both"
+    );
+    for rel in &set_v1 {
+        assert_eq!(
+            fs::read(root_v1.join(rel)).unwrap(),
+            fs::read(root_zz.join(rel)).unwrap(),
+            "byte-equal at {rel} across v1 vs 1Z transports"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (2) new client <-> 1.5.0-caps remote (NO snappack-zstd token): accel is
+//     STILL taken, the wire is v1, NO `--pack-format zstd` flag is emitted.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn matrix_new_client_to_1_5_0_remote_takes_accel_on_v1_without_zstd_flag() {
+    let Some(real) =
+        require_snapdir("matrix_new_client_to_1_5_0_remote_takes_accel_on_v1_without_zstd_flag")
+    else {
+        return;
+    };
+    let staging = TempDir::new("n5-stage");
+    let remote_root = TempDir::new("n5-remote");
+    let bindir = TempDir::new("n5-bin");
+    let remote_bin = TempDir::new("n5-remote-bin");
+    let cache = TempDir::new("n5-cache");
+    let cache_pin = TempDir::new("n5-cachepin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path(), cache_pin.path());
+
+    // A 1.5.0-style remote: wire=1 with the full v1 caps but WITHOUT the
+    // snappack-zstd token. The caps-only shim records any non-version
+    // invocation, so the FETCH path is the exercisable one (push streams real
+    // packs the shim cannot serve); fetch picks the v1 send-pack variant.
+    let log = remote_bin.path().join("invocations.log");
+    write_script(
+        &remote_bin.path().join("snapdir"),
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >>{log}\n\
+             if [ \"$1\" = version ] && [ \"$2\" = --capabilities ]; then\n  \
+             printf '%s\\n' 'snapdir 1.5.0 wire=1 caps=objects-needed,send-pack,receive-pack'\n  \
+             exit 0\nfi\nexec {real} \"$@\"\n",
+            log = sh_quote(&log.display().to_string()),
+            real = sh_quote(&real.display().to_string()),
+        ),
+    );
+    env.set(
+        "FAKE_SSH_REMOTE_PATH",
+        &remote_bin.path().display().to_string(),
+    );
+    env.set("SNAPDIR_SSH_LOCAL_SNAPDIR", &real.display().to_string());
+
+    // Seed the store directly so fetch has objects to pull.
+    let (manifest, _id, sums) = stage_tree(staging.path(), FILES);
+    let base = remote_root.path().join("snap");
+    for (sum, (_, content)) in sums.iter().zip(FILES) {
+        let obj = base.join(object_path(sum));
+        fs::create_dir_all(obj.parent().unwrap()).unwrap();
+        fs::write(&obj, content).unwrap();
+    }
+
+    external_store(&base)
+        .fetch_files(&manifest, cache.path())
+        .expect("v1-fallback accel fetch must succeed against a 1.5.0-caps remote");
+
+    let remote = log_lines(&log);
+    // accel STILL taken: the remote send-pack ran.
+    assert!(
+        remote.contains("send-pack"),
+        "accel must STILL be taken against a 1.5.0-caps remote: {remote}"
+    );
+    // the wire is v1: NO --pack-format zstd anywhere in the negotiated commands.
+    assert!(
+        !remote.contains("--pack-format zstd"),
+        "a remote that does NOT advertise snappack-zstd must receive the v1 \
+         send-pack variant (no --pack-format zstd): {remote}"
+    );
+    // objects landed byte-correctly through the v1 stream.
+    for (sum, (_, content)) in sums.iter().zip(FILES) {
+        assert_eq!(
+            &fs::read(cache.path().join(object_path(sum))).unwrap(),
+            content
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (3) 1.5.0 client <-> new remote = v1 (PINNED): a client whose LOCAL binary
+//     does NOT support zstd negotiates v1 even when the remote advertises the
+//     snappack-zstd cap. The local-zstd probe gates the zstd branch.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn matrix_1_5_0_client_to_new_remote_pins_v1_when_local_lacks_zstd() {
+    let Some(real) =
+        require_snapdir("matrix_1_5_0_client_to_new_remote_pins_v1_when_local_lacks_zstd")
+    else {
+        return;
+    };
+    let staging = TempDir::new("c5-stage");
+    let remote_root = TempDir::new("c5-remote");
+    let bindir = TempDir::new("c5-bin");
+    let remote_bin = TempDir::new("c5-remote-bin");
+    let local_bin = TempDir::new("c5-local-bin");
+    let cache = TempDir::new("c5-cache");
+    let cache_pin = TempDir::new("c5-cachepin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path(), cache_pin.path());
+
+    // The REMOTE is the new binary (full caps incl. snappack-zstd), behind a
+    // logging shim, and execs the REAL binary for the actual transfer.
+    let remote_log = remote_bin.path().join("invocations.log");
+    install_logging_snapdir(remote_bin.path(), &real, &remote_log);
+
+    // The LOCAL binary is a 1.5.0-style client: it advertises wire=1 with the
+    // v1 caps but NOT snappack-zstd, and execs the REAL binary for send-pack /
+    // receive-pack (which accept the v1 stream). So the local-zstd probe yields
+    // 0 → the zstd branch is gated off and the wire stays v1.
+    let local_log = local_bin.path().join("local.log");
+    let local_snapdir = local_bin.path().join("snapdir");
+    write_script(
+        &local_snapdir,
+        &format!(
+            "#!/bin/sh\nprintf '%s\\n' \"$*\" >>{log}\n\
+             if [ \"$1\" = version ] && [ \"$2\" = --capabilities ]; then\n  \
+             printf '%s\\n' 'snapdir 1.5.0 wire=1 caps=objects-needed,send-pack,receive-pack'\n  \
+             exit 0\nfi\nexec {real} \"$@\"\n",
+            log = sh_quote(&local_log.display().to_string()),
+            real = sh_quote(&real.display().to_string()),
+        ),
+    );
+    env.set(
+        "FAKE_SSH_REMOTE_PATH",
+        &remote_bin.path().display().to_string(),
+    );
+    env.set(
+        "SNAPDIR_SSH_LOCAL_SNAPDIR",
+        &local_snapdir.display().to_string(),
+    );
+
+    let (manifest, id, sums) = stage_tree(staging.path(), FILES);
+    let base = remote_root.path().join("snap");
+    let store = external_store(&base);
+
+    // Push: accel taken, but the LOCAL send-pack must NOT carry --pack-format
+    // zstd (the local binary doesn't support it → v1 on the wire).
+    store
+        .push(&manifest, staging.path())
+        .expect("1.5.0-client push must take accel on v1");
+    let local = log_lines(&local_log);
+    assert!(
+        local.contains("send-pack"),
+        "accel STILL taken with a 1.5.0 local: {local}"
+    );
+    assert!(
+        !local.contains("--pack-format zstd"),
+        "a 1.5.0 local (no zstd cap) must keep the wire at v1 \
+         even against a zstd-capable remote: {local}"
+    );
+    assert!(
+        log_lines(&remote_log).contains("receive-pack"),
+        "the remote receive-pack ran on the v1 stream"
+    );
+    assert_eq!(
+        fs::read_to_string(base.join(manifest_path(&id))).unwrap(),
+        manifest_bytes(&manifest),
+        "the v1 push committed the manifest"
+    );
+
+    // Fetch: the REMOTE send-pack must likewise stay v1 (the local can only
+    // sniff/verify a v1 stream).
+    fs::write(&remote_log, b"").unwrap();
+    store
+        .fetch_files(&manifest, cache.path())
+        .expect("1.5.0-client fetch on v1");
+    let remote = log_lines(&remote_log);
+    assert!(
+        remote.contains("send-pack") && !remote.contains("--pack-format zstd"),
+        "the remote send-pack must stay v1 for a 1.5.0 local: {remote}"
+    );
+    for (sum, (_, content)) in sums.iter().zip(FILES) {
+        assert_eq!(
+            &fs::read(cache.path().join(object_path(sum))).unwrap(),
+            content
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (4) FORCE_ACCEL error text is zstd-free: the SNAPDIR_SSH_FORCE_ACCEL failure
+//     message must not mention zstd / snappack-zstd (it stayed out of
+//     PUSH_CAPS / FETCH_CAPS — only objects-needed/receive-pack are required).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn matrix_force_accel_error_text_is_zstd_free() {
+    let Some(real) = require_snapdir("matrix_force_accel_error_text_is_zstd_free") else {
+        return;
+    };
+    let staging = TempDir::new("fz-stage");
+    let remote_root = TempDir::new("fz-remote");
+    let bindir = TempDir::new("fz-bin");
+    let remote_bin = TempDir::new("fz-remote-bin");
+    let cache_pin = TempDir::new("fz-cachepin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path(), cache_pin.path());
+
+    install_old_snapdir(remote_bin.path());
+    env.set(
+        "FAKE_SSH_REMOTE_PATH",
+        &remote_bin.path().display().to_string(),
+    );
+    env.set("SNAPDIR_SSH_LOCAL_SNAPDIR", &real.display().to_string());
+    env.set("SNAPDIR_SSH_FORCE_ACCEL", "1");
+
+    let (manifest, id, _sums) = stage_tree(staging.path(), FILES);
+    let base = remote_root.path().join("snap");
+    let err = external_store(&base)
+        .push(&manifest, staging.path())
+        .unwrap_err();
+    match &err {
+        StoreError::Backend { message, .. } => {
+            let lower = message.to_lowercase();
+            assert!(
+                !lower.contains("zstd") && !lower.contains("snappack-zstd"),
+                "the FORCE_ACCEL error must not mention zstd (it is NOT a \
+                 required cap): {message}"
+            );
+            // still the designed error, naming the REQUIRED (zstd-free) caps.
+            assert!(
+                message.contains("objects-needed,receive-pack"),
+                "names only the required caps: {message}"
+            );
+        }
+        other => panic!("expected Backend error, got {other:?}"),
+    }
+
+    // Also pin the EMITTED push/fetch scripts: the FORCE_ACCEL diagnostic the
+    // script prints must be zstd-free too (the required-caps list and the
+    // error are baked literals).
+    let staging_dir = staging.path().display().to_string();
+    let push = ssh_engine::get_push_script(&ssh_url(), &default_cfg(), &id, &staging_dir).unwrap();
+    let fetch_manifest = manifest.to_string();
+    let fetch =
+        ssh_engine::get_fetch_files_script(&ssh_url(), &default_cfg(), &fetch_manifest, "/tmp/c")
+            .unwrap();
+    for (label, script) in [("push", &push), ("fetch", &fetch)] {
+        // The required-caps token the FORCE_ACCEL path prints must NOT include
+        // snappack-zstd. Scan every line that mentions the required-caps
+        // diagnostic / FORCE_ACCEL.
+        for line in script.lines() {
+            if line.contains("SNAPDIR_SSH_FORCE_ACCEL") || line.contains("required:") {
+                assert!(
+                    !line.contains("snappack-zstd"),
+                    "{label} script FORCE_ACCEL/required diagnostic must be \
+                     zstd-free: {line}"
+                );
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// SNAPDIR_FSYNC interplay smoke: the receive-pack durability default (`batch`)
+// works through the full accel path with zstd active — no breakage when both
+// the zstd transport AND batch crash-durability are engaged at once.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fsync_batch_default_interoperates_with_zstd_accel_path() {
+    let Some(real) = require_snapdir("fsync_batch_default_interoperates_with_zstd_accel_path")
+    else {
+        return;
+    };
+    let staging = TempDir::new("fy-stage");
+    let remote_root = TempDir::new("fy-remote");
+    let bindir = TempDir::new("fy-bin");
+    let remote_bin = TempDir::new("fy-remote-bin");
+    let local_bin = TempDir::new("fy-local-bin");
+    let cache = TempDir::new("fy-cache");
+    let cache_pin = TempDir::new("fy-cachepin");
+    let mut env = fake_remote_env(bindir.path(), remote_root.path(), cache_pin.path());
+
+    // Both peers are the REAL binary → zstd negotiated. The remote receive-pack
+    // runs under the default SNAPDIR_FSYNC (batch) durability.
+    let remote_log = remote_bin.path().join("invocations.log");
+    install_logging_snapdir(remote_bin.path(), &real, &remote_log);
+    let local_log = local_bin.path().join("local.log");
+    let local_snapdir = local_bin.path().join("snapdir");
+    install_logging_snapdir_at(&local_snapdir, &real, &local_log);
+    env.set(
+        "FAKE_SSH_REMOTE_PATH",
+        &remote_bin.path().display().to_string(),
+    );
+    env.set(
+        "SNAPDIR_SSH_LOCAL_SNAPDIR",
+        &local_snapdir.display().to_string(),
+    );
+    // The receive-pack durability default is `batch`; pin it EXPLICITLY so the
+    // smoke proves zstd + batch coexist (no accidental `off` in the env).
+    env.set("SNAPDIR_FSYNC", "batch");
+
+    // A compressible fixture so the zstd transport is genuinely exercised.
+    let fixture = compressible_files();
+    let fixture_slice = as_file_slice(&fixture);
+    let (manifest, id, sums) = stage_tree(staging.path(), &fixture_slice);
+    let base = remote_root.path().join("snap");
+    let store = external_store(&base);
+
+    // Push under zstd + batch durability: must complete and commit the manifest.
+    store
+        .push(&manifest, staging.path())
+        .expect("zstd + batch-durability accel push must succeed");
+    assert!(
+        log_lines(&local_log).contains("--pack-format zstd"),
+        "the zstd transport was active on the push"
+    );
+    assert!(
+        log_lines(&remote_log).contains("receive-pack"),
+        "the remote receive-pack ran under batch durability"
+    );
+    assert_eq!(
+        fs::read_to_string(base.join(manifest_path(&id))).unwrap(),
+        manifest_bytes(&manifest),
+        "the manifest committed durably through the zstd accel path"
+    );
+
+    // Fetch back into a cold cache: every object lands byte-correctly (the
+    // LOCAL receive-pack, also under batch durability, verified each record).
+    store
+        .fetch_files(&manifest, cache.path())
+        .expect("zstd + batch-durability accel fetch must succeed");
+    for (sum, (_, content)) in sums.iter().zip(&fixture) {
+        assert_eq!(
+            &fs::read(cache.path().join(object_path(sum))).unwrap(),
+            content
+        );
+    }
 }

--- a/crates/snapdir-ssh-store/tests/loopback_sshd.rs
+++ b/crates/snapdir-ssh-store/tests/loopback_sshd.rs
@@ -452,6 +452,140 @@ fn accel_oracle_roundtrip_and_idempotent_repush_over_sshd() {
 }
 
 // ---------------------------------------------------------------------------
+// 5b. wire2-compat-matrix (phase 27): dumb vs accel-ZSTD byte-identical oracle
+//     over real sshd. Both peers are the REAL binary (caps include
+//     snappack-zstd), so the accel path negotiates the 1Z transport; the
+//     resulting store must be byte-identical to a forced-dumb (v1) push.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn accel_zstd_oracle_byte_identical_to_dumb_over_sshd() {
+    let test = "accel_zstd_oracle_byte_identical_to_dumb_over_sshd";
+    let Some(real) = require_snapdir(test) else {
+        return;
+    };
+    let Some(mut kit) = SshKit::new(test) else {
+        return;
+    };
+
+    // Expose the real snapdir to the REMOTE side behind a logging wrapper.
+    let bin = kit.dir().join("bin");
+    fs::create_dir_all(&bin).expect("create remote bin dir");
+    let remote_log = kit.dir().join("remote-invocations.log");
+    install_logging_snapdir(&bin, &real, &remote_log);
+    let server = kit.spawn(&Flavor::Shell {
+        set_env_path: Some(format!("{}:/usr/bin:/bin:/usr/sbin:/sbin", bin.display())),
+    });
+
+    // DOCUMENTED environmental skip: sshd honors SetEnv PATH only from OpenSSH
+    // 8.7 on (macOS + CI ship newer). Allowed even under REQUIRE.
+    let probe = kit.ssh_exec(server.port, "command -v snapdir");
+    if !probe.status.success() {
+        eprintln!(
+            "SKIP {test}: this sshd does not honor `SetEnv PATH` \
+             (need OpenSSH >= 8.7 server): {}",
+            String::from_utf8_lossy(&probe.stderr).trim()
+        );
+        return;
+    }
+
+    // A LOCAL logging shim so the on-wire `--pack-format zstd` flag is asserted
+    // from the LOCAL send-pack invocation, never assumed. It execs the REAL
+    // binary, whose caps include snappack-zstd → the negotiation picks 1Z.
+    let local_bin = kit.dir().join("local-bin");
+    fs::create_dir_all(&local_bin).expect("create local bin dir");
+    let local_log = local_bin.join("local.log");
+    let local_snapdir = local_bin.join("snapdir");
+    install_logging_snapdir(&local_bin, &real, &local_log);
+
+    // A COMPRESSIBLE fixture so the zstd transport is genuinely engaged.
+    let staging = TempDir::new("az-stage");
+    let cache = TempDir::new("az-cache");
+    let tmp = TempDir::new("az-tmp");
+    let base_dumb = kit.dir().join("remote-zstd-dumb");
+    let base_accel = kit.dir().join("remote-zstd-accel");
+    let repeat = vec![b'A'; 64 * 1024];
+    let compressible: &[(&str, &[u8])] = &[
+        ("repeat.txt", repeat.as_slice()),
+        ("small-a.txt", b"distinct small payload a\n"),
+        ("small-b.txt", b"distinct small payload b\n"),
+    ];
+    let (manifest, id, sums) = stage_tree(staging.path(), compressible);
+
+    let mut env = loopback_env(&kit, server.port, tmp.path());
+    env.set(
+        "SNAPDIR_SSH_LOCAL_SNAPDIR",
+        &local_snapdir.display().to_string(),
+    );
+
+    // Reference: forced-dumb (v1) push into root A.
+    env.set("SNAPDIR_SSH_NO_ACCEL", "1");
+    ssh_store(&base_dumb)
+        .push(&manifest, staging.path())
+        .expect("forced-dumb push");
+    env.remove("SNAPDIR_SSH_NO_ACCEL");
+
+    // Accel-ZSTD push into root B; prove the 1Z transport engaged.
+    let accel = ssh_store(&base_accel);
+    accel
+        .push(&manifest, staging.path())
+        .expect("accel-zstd push");
+    assert!(
+        log_lines(&local_log).contains("--pack-format zstd"),
+        "the LOCAL send-pack must opt into zstd over real sshd: {}",
+        log_lines(&local_log)
+    );
+    assert!(
+        log_lines(&remote_log).contains("receive-pack"),
+        "the remote receive-pack ran (magic-sniffed the 1Z stream): {}",
+        log_lines(&remote_log)
+    );
+
+    // THE ORACLE: byte-identical store (set + contents + committed id) between
+    // the dumb v1 push and the accel 1Z push over a real server.
+    let set_dumb = relative_file_set(&base_dumb);
+    assert_eq!(
+        set_dumb,
+        relative_file_set(&base_accel),
+        "the .objects/** + manifest file sets must be identical (v1 vs 1Z)"
+    );
+    assert!(
+        set_dumb.contains(&manifest_path(&id)),
+        "snapshot id committed on both"
+    );
+    for rel in &set_dumb {
+        assert_eq!(
+            fs::read(base_dumb.join(rel)).unwrap(),
+            fs::read(base_accel.join(rel)).unwrap(),
+            "byte-equal at {rel} across v1 vs 1Z transports"
+        );
+    }
+    assert_eq!(
+        fs::read_to_string(base_accel.join(manifest_path(&id))).unwrap(),
+        manifest_bytes(&manifest),
+        "manifest bytes are the staged manifest's bytes"
+    );
+
+    // Accel-ZSTD fetch into a cold cache: every object lands byte-correctly.
+    fs::write(&remote_log, b"").unwrap();
+    accel
+        .fetch_files(&manifest, cache.path())
+        .expect("accel-zstd fetch");
+    assert!(
+        log_lines(&remote_log).contains("--pack-format zstd"),
+        "the remote send-pack must opt into zstd on fetch: {}",
+        log_lines(&remote_log)
+    );
+    for (sum, (_, content)) in sums.iter().zip(compressible) {
+        assert_eq!(
+            &fs::read(cache.path().join(object_path(sum)))
+                .unwrap_or_else(|_| panic!("object {sum} in cache")),
+            content
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
 // 6. fallback over real sshd: no remote snapdir → dumb; FORCE_ACCEL → error
 // ---------------------------------------------------------------------------
 

--- a/crates/snapdir-stores/Cargo.toml
+++ b/crates/snapdir-stores/Cargo.toml
@@ -23,6 +23,15 @@ integration-mock = []
 snapdir-core.workspace = true
 thiserror.workspace = true
 
+# --- Receiver durability (fsync.rs) -----------------------------------------
+# `libc` exposes the raw `sync_file_range`/`fsync` syscalls behind the batched
+# receive-pack durability barrier (cfg-gated per platform). This is NOT a new
+# supply-chain edge: `libc` is already a DIRECT dependency of `snapdir-core` and
+# `snapdir-cli` (and pervasive in the lock graph), so naming it here adds ZERO
+# crates to `Cargo.lock`. The shipped binary stays dependency-free (no shelling
+# out to fsync/sync).
+libc = "0.2"
+
 # --- SNAPPACK wire format (pack.rs) ------------------------------------------
 # `blake3` powers the INCREMENTAL payload hashing in `pack.rs`: obj payloads
 # stream through the hasher in O(1) memory, which the buffer-only
@@ -31,6 +40,17 @@ thiserror.workspace = true
 # `snapdir-core` already declares, so the lock graph gains no crate and the
 # deny.toml posture is unchanged.
 blake3 = "1.8.5"
+
+# --- SNAPPACK 1Z zstd transport encoding (pack.rs) ---------------------------
+# `zstd` wraps the WHOLE SNAPPACK body in one zstd frame for the additive
+# `SNAPPACK 1Z` form: the writer streams `record* "end\n"` through
+# `zstd::stream::write::Encoder` and the reader feeds `zstd::stream::read::Decoder`
+# to the UNCHANGED record parser (incremental BLAKE3 untouched; the 128B-header /
+# 64MiB-manifest / lying-len bounds all enforced on the DECOMPRESSED bytes). It
+# bundles libzstd via `zstd-sys` (cc/build.rs) — the SAME C-build pattern already
+# exercised by `blake3`, with no system zstd required — and is MIT/BSD-3 (license
+# clean for deny.toml). `ruzstd` is decode-only and is NOT used as the encoder.
+zstd = "0.13"
 
 # --- S3 store (s3:// + S3-compatible) ---------------------------------------
 # CRITICAL TLS constraint: the shipped binary statically links on musl, so the

--- a/crates/snapdir-stores/src/b2_store.rs
+++ b/crates/snapdir-stores/src/b2_store.rs
@@ -190,6 +190,12 @@ impl StreamStore for B2Store {
     fn put_manifest(&self, id: &str, manifest: &Manifest) -> Result<(), StoreError> {
         self.inner.put_manifest(id, manifest)
     }
+
+    fn list_manifest_ids(&self) -> Result<Vec<String>, StoreError> {
+        // B2 has no manifest-listing path of its own — delegate to the wrapped
+        // S3Store (B2's S3-compatible endpoint with path-style addressing).
+        self.inner.list_manifest_ids()
+    }
 }
 
 /// Resolves the S3-compatible endpoint to use, applying the precedence

--- a/crates/snapdir-stores/src/file_store.rs
+++ b/crates/snapdir-stores/src/file_store.rs
@@ -29,15 +29,18 @@
 //!
 //! All I/O is native in-process filesystem I/O; nothing shells out.
 
+use std::collections::HashMap;
 use std::fs;
 use std::io;
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
 
 use std::sync::Arc;
 
 use snapdir_core::manifest::{Manifest, PathType};
 use snapdir_core::merkle::{Blake3Hasher, Hasher};
-use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
+use snapdir_core::store::{manifest_path, object_path, Store, StoreError, MANIFESTS_DIR};
+use snapdir_core::CopyGuard;
 use snapdir_core::Meter;
 
 use crate::adaptive::{
@@ -65,6 +68,47 @@ pub struct FileStore {
     /// default from every constructor) means zero recording and byte-identical
     /// behavior. Set by the CLI via [`FileStore::with_meter`].
     meter: Option<Arc<Meter>>,
+    /// Per-source [`CopyGuard`] side channel (keyed by the user file's absolute
+    /// or join-base-relative path, exactly as the walk recorded it). Populated
+    /// by the CLI before a stage `push` via [`FileStore::with_copy_guards`]; on
+    /// the clone fast-path a source whose live `stat` still matches its recorded
+    /// guard skips the redundant post-copy re-hash (stat-validated trust).
+    ///
+    /// EMPTY (every constructor's default) ⇒ every push source is `Untrusted`
+    /// ⇒ the re-hash is never skipped on stage ⇒ byte-for-byte today's behavior.
+    copy_guards: HashMap<PathBuf, CopyGuard>,
+}
+
+/// How [`copy_file`] actually moved the bytes — the trust input to whether
+/// [`persist`] may skip its post-copy re-hash.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum CopyMethod {
+    /// A genuine copy-on-write clone success via the `CoW` clone fast-path
+    /// (`clonefile` on macOS, `FICLONE` reflink on Linux): the target is
+    /// bit-identical to the source by construction (a copy-on-write clone can
+    /// never corrupt), so — under the right trust — the re-hash can be skipped.
+    Cloned,
+    /// A plain `fs::copy` byte copy (the `fs::copy` fallback, unsupported FS,
+    /// cross-filesystem, or `SNAPDIR_CLONEFILE=0`). A byte copy CAN corrupt, so
+    /// this path ALWAYS re-hashes; the skip is never taken here.
+    Copied,
+}
+
+/// Why (or whether) a clone of a given source may be trusted enough to skip the
+/// post-copy re-hash. Threaded through the copy jobs alongside the expected
+/// checksum; only ever consulted on the [`CopyMethod::Cloned`] path.
+#[derive(Debug, Clone, Copy)]
+enum CopyTrust {
+    /// The source is an immutable, read-verified content-addressed store object
+    /// (the FETCH/checkout path): a clone of it is provably bit-identical to a
+    /// blob that already verified, so the re-hash is always skipped.
+    TrustedObject,
+    /// The source is a mutable user file the walk recorded a [`CopyGuard`] for
+    /// (the STAGE/push path): re-`stat` it at clone time and skip the re-hash
+    /// IFF it still matches; otherwise re-hash (→ Integrity if it now differs).
+    StatGuarded(CopyGuard),
+    /// No trust basis (a stage source with no recorded guard): always re-hash.
+    Untrusted,
 }
 
 impl FileStore {
@@ -102,6 +146,7 @@ impl FileStore {
             root: root.into(),
             config,
             meter: None,
+            copy_guards: HashMap::new(),
         }
     }
 
@@ -114,6 +159,28 @@ impl FileStore {
     pub fn with_meter(mut self, meter: Option<Arc<Meter>>) -> Self {
         self.meter = meter;
         self
+    }
+
+    /// Attaches the per-source [`CopyGuard`] map the walk recorded, enabling the
+    /// stat-validated clone-skip on the stage `push` path. The keys are the
+    /// source file paths exactly as passed to [`push`](Store::push) joins
+    /// (i.e. `source.join(rel)`); a source present in the map and whose live
+    /// `stat` still matches skips the redundant post-copy re-hash on a clone.
+    ///
+    /// Builder form: the CLI calls this with the
+    /// [`walk_with_guards`](snapdir_core::walk_with_guards) map before staging.
+    /// The default (no call) is an empty map ⇒ every push source is
+    /// [`CopyTrust::Untrusted`] ⇒ byte-for-byte today's always-rehash behavior.
+    #[must_use]
+    pub fn with_copy_guards(mut self, copy_guards: HashMap<PathBuf, CopyGuard>) -> Self {
+        self.copy_guards = copy_guards;
+        self
+    }
+
+    /// Replaces the [`CopyGuard`] map in place (setter companion to the
+    /// [`with_copy_guards`](Self::with_copy_guards) builder).
+    pub fn set_copy_guards(&mut self, copy_guards: HashMap<PathBuf, CopyGuard>) {
+        self.copy_guards = copy_guards;
     }
 
     /// Returns the store's root directory.
@@ -148,7 +215,10 @@ impl FileStore {
     /// work (`try_for_each`). A `concurrency` of 1 yields a single-threaded
     /// sequential copy. Each task uses a fresh, cheap, stateless
     /// [`Blake3Hasher`] to sidestep any `Sync` concern.
-    fn parallel_copy(&self, jobs: &[(PathBuf, PathBuf, String)]) -> Result<(), StoreError> {
+    fn parallel_copy(
+        &self,
+        jobs: &[(PathBuf, PathBuf, String, CopyTrust)],
+    ) -> Result<(), StoreError> {
         if jobs.is_empty() {
             return Ok(());
         }
@@ -162,7 +232,10 @@ impl FileStore {
 
     /// Fixed-concurrency rayon copy: pool sized to `config.concurrency`, no gate
     /// or driver. The historical (byte-identical) local-copy path.
-    fn parallel_copy_fixed(&self, jobs: &[(PathBuf, PathBuf, String)]) -> Result<(), StoreError> {
+    fn parallel_copy_fixed(
+        &self,
+        jobs: &[(PathBuf, PathBuf, String, CopyTrust)],
+    ) -> Result<(), StoreError> {
         use rayon::prelude::*;
 
         // `&Meter` is `Sync`, so it is shared across the rayon closures. `None`
@@ -178,22 +251,24 @@ impl FileStore {
             })?;
 
         pool.install(|| {
-            jobs.par_iter().try_for_each(|(source, target, expected)| {
-                if let Some(m) = meter {
-                    m.object_started();
-                }
-                // `persist` reads `source` and writes `target`. Record the
-                // source size as both bytes-in (read) and bytes-out (written);
-                // a missing source surfaces as the persist error below.
-                let len = std::fs::metadata(source).map_or(0, |md| md.len());
-                persist(source, target, expected, &Blake3Hasher::new())?;
-                if let Some(m) = meter {
-                    m.add_in(len);
-                    m.add_out(len);
-                    m.object_finished();
-                }
-                Ok(())
-            })
+            jobs.par_iter()
+                .try_for_each(|(source, target, expected, trust)| {
+                    if let Some(m) = meter {
+                        m.object_started();
+                    }
+                    // `persist` reads `source` and writes `target`. Record the
+                    // source size as both bytes-in (read) and bytes-out
+                    // (written); a missing source surfaces as the persist error
+                    // below.
+                    let len = std::fs::metadata(source).map_or(0, |md| md.len());
+                    persist(source, target, expected, *trust, &Blake3Hasher::new())?;
+                    if let Some(m) = meter {
+                        m.add_in(len);
+                        m.add_out(len);
+                        m.object_finished();
+                    }
+                    Ok(())
+                })
         })
     }
 
@@ -208,7 +283,7 @@ impl FileStore {
     /// differs.
     fn parallel_copy_adaptive(
         &self,
-        jobs: &[(PathBuf, PathBuf, String)],
+        jobs: &[(PathBuf, PathBuf, String, CopyTrust)],
         fraction: f64,
         ceiling: usize,
     ) -> Result<(), StoreError> {
@@ -218,7 +293,7 @@ impl FileStore {
 
         let sizes: Vec<u64> = jobs
             .iter()
-            .map(|(source, _, _)| std::fs::metadata(source).map_or(0, |md| md.len()))
+            .map(|(source, _, _, _)| std::fs::metadata(source).map_or(0, |md| md.len()))
             .collect();
         let p95 = p95_object_size(&sizes);
         let total_ram = snapdir_core::resources::total_ram_bytes().unwrap_or(0);
@@ -251,33 +326,34 @@ impl FileStore {
             })?;
 
         let result = pool.install(|| {
-            jobs.par_iter().try_for_each(|(source, target, expected)| {
-                // Gate to the controller's live limit (effective concurrency).
-                let _permit = gate.acquire_blocking();
-                if let Some(m) = meter {
-                    m.object_started();
-                }
-                let len = std::fs::metadata(source).map_or(0, |md| md.len());
-                let started = std::time::Instant::now();
-                let outcome = persist(source, target, expected, &Blake3Hasher::new());
-                let latency = started.elapsed();
-                let (bytes, op_result) = match &outcome {
-                    Ok(()) => (len, OpResult::Ok),
-                    Err(err) => (0, classify_error(err)),
-                };
-                driver.record_op(OpSample {
-                    bytes,
-                    latency,
-                    result: op_result,
-                });
-                outcome?;
-                if let Some(m) = meter {
-                    m.add_in(len);
-                    m.add_out(len);
-                    m.object_finished();
-                }
-                Ok(())
-            })
+            jobs.par_iter()
+                .try_for_each(|(source, target, expected, trust)| {
+                    // Gate to the controller's live limit (effective concurrency).
+                    let _permit = gate.acquire_blocking();
+                    if let Some(m) = meter {
+                        m.object_started();
+                    }
+                    let len = std::fs::metadata(source).map_or(0, |md| md.len());
+                    let started = std::time::Instant::now();
+                    let outcome = persist(source, target, expected, *trust, &Blake3Hasher::new());
+                    let latency = started.elapsed();
+                    let (bytes, op_result) = match &outcome {
+                        Ok(()) => (len, OpResult::Ok),
+                        Err(err) => (0, classify_error(err)),
+                    };
+                    driver.record_op(OpSample {
+                        bytes,
+                        latency,
+                        result: op_result,
+                    });
+                    outcome?;
+                    if let Some(m) = meter {
+                        m.add_in(len);
+                        m.add_out(len);
+                        m.object_finished();
+                    }
+                    Ok(())
+                })
         });
 
         // Stop the tick thread and join it before returning.
@@ -333,7 +409,7 @@ impl Store for FileStore {
         // the `ObjectNotFound` error when a needed source is missing). The file
         // entries that actually need copying are collected as `(source, target,
         // checksum)` jobs for the parallel phase.
-        let mut jobs: Vec<(PathBuf, PathBuf, String)> = Vec::new();
+        let mut jobs: Vec<(PathBuf, PathBuf, String, CopyTrust)> = Vec::new();
         for entry in manifest.entries() {
             let rel = strip_leading_dot_slash(&entry.path);
             let target = dest.join(rel);
@@ -362,7 +438,15 @@ impl Store for FileStore {
                             checksum: entry.checksum.clone(),
                         });
                     }
-                    jobs.push((source, target, entry.checksum.clone()));
+                    // FETCH: the source is an immutable, content-addressed store
+                    // object → a clone of it is provably bit-identical → always
+                    // skip the re-hash (read-time `get_object` is the backstop).
+                    jobs.push((
+                        source,
+                        target,
+                        entry.checksum.clone(),
+                        CopyTrust::TrustedObject,
+                    ));
                 }
             }
         }
@@ -372,7 +456,7 @@ impl Store for FileStore {
         if let Some(m) = self.meter.as_deref() {
             let total: u64 = jobs
                 .iter()
-                .map(|(source, _, _)| fs::metadata(source).map_or(0, |md| md.len()))
+                .map(|(source, _, _, _)| fs::metadata(source).map_or(0, |md| md.len()))
                 .sum();
             m.set_total(total);
         }
@@ -400,7 +484,7 @@ impl Store for FileStore {
         // Collect every referenced object that is absent (skip-if-present per
         // object: an object already filed under its content address is trusted,
         // it is content-addressable). These are copied BEFORE the manifest.
-        let mut jobs: Vec<(PathBuf, PathBuf, String)> = Vec::new();
+        let mut jobs: Vec<(PathBuf, PathBuf, String, CopyTrust)> = Vec::new();
         for entry in manifest.entries() {
             if entry.path_type != PathType::File {
                 continue;
@@ -415,7 +499,16 @@ impl Store for FileStore {
             }
             let rel = strip_leading_dot_slash(&entry.path);
             let object_source = source.join(rel);
-            jobs.push((object_source, object_target, entry.checksum.clone()));
+            // STAGE: a recorded `CopyGuard` for this source enables the
+            // stat-validated clone-skip (`persist` re-stats + compares); no
+            // guard ⇒ `Untrusted` ⇒ always re-hash (today's behavior). An empty
+            // `copy_guards` map therefore reproduces today's behavior exactly.
+            let trust = self
+                .copy_guards
+                .get(&object_source)
+                .copied()
+                .map_or(CopyTrust::Untrusted, CopyTrust::StatGuarded);
+            jobs.push((object_source, object_target, entry.checksum.clone(), trust));
         }
 
         // Total to push (bytes over the to-push set), recorded so the bar can
@@ -423,7 +516,7 @@ impl Store for FileStore {
         if let Some(m) = self.meter.as_deref() {
             let total: u64 = jobs
                 .iter()
-                .map(|(src, _, _)| fs::metadata(src).map_or(0, |md| md.len()))
+                .map(|(src, _, _, _)| fs::metadata(src).map_or(0, |md| md.len()))
                 .sum();
             m.set_total(total);
         }
@@ -504,6 +597,66 @@ impl StreamStore for FileStore {
             &Blake3Hasher::new(),
         )
     }
+
+    fn list_manifest_ids(&self) -> Result<Vec<String>, StoreError> {
+        let manifests_root = self.root.join(MANIFESTS_DIR);
+
+        // Empty prefix: no `.manifests/` tree yet => Ok(empty), never an error.
+        let walk = match fs::read_dir(&manifests_root) {
+            Ok(walk) => walk,
+            Err(err) if err.kind() == io::ErrorKind::NotFound => return Ok(Vec::new()),
+            Err(err) => return Err(StoreError::Io(err)),
+        };
+
+        // Walk the shard tree, collecting each file's path components RELATIVE
+        // to `.manifests/` (the inverse of `manifest_path`'s `3/3/3/rest`
+        // split). Dedup via the set; a stray / malformed key reconstructs to a
+        // non-id and is skipped without erroring.
+        let mut ids = std::collections::HashSet::new();
+        let mut stack: Vec<(PathBuf, Vec<String>)> = Vec::new();
+        for entry in walk {
+            let entry = entry?;
+            push_manifest_walk_entry(&entry, &Vec::new(), &mut ids, &mut stack)?;
+        }
+        while let Some((dir, segments)) = stack.pop() {
+            for entry in fs::read_dir(&dir)? {
+                let entry = entry?;
+                push_manifest_walk_entry(&entry, &segments, &mut ids, &mut stack)?;
+            }
+        }
+
+        Ok(ids.into_iter().collect())
+    }
+}
+
+/// Classifies one `.manifests/` walk entry: a directory is pushed onto `stack`
+/// to be descended later (carrying its accumulated shard segments); a file's
+/// full segment path is fed to
+/// [`manifest_id_from_shard_segments`](crate::stream::manifest_id_from_shard_segments)
+/// and, if it reconstructs a valid 64-hex id, inserted into `ids` (the set
+/// dedups). A non-id key is skipped without error.
+fn push_manifest_walk_entry(
+    entry: &fs::DirEntry,
+    parent_segments: &[String],
+    ids: &mut std::collections::HashSet<String>,
+    stack: &mut Vec<(PathBuf, Vec<String>)>,
+) -> Result<(), StoreError> {
+    // A non-UTF-8 component can never be part of a hex id; skip it.
+    let Ok(name) = entry.file_name().into_string() else {
+        return Ok(());
+    };
+    let mut segments = parent_segments.to_vec();
+    segments.push(name);
+
+    if entry.file_type()?.is_dir() {
+        stack.push((entry.path(), segments));
+    } else {
+        let refs: Vec<&str> = segments.iter().map(String::as_str).collect();
+        if let Some(id) = crate::stream::manifest_id_from_shard_segments(&refs) {
+            ids.insert(id);
+        }
+    }
+    Ok(())
 }
 
 /// Copies `source` to `target`, verifying the content BLAKE3 against
@@ -513,6 +666,7 @@ fn persist(
     source: &Path,
     target: &Path,
     expected: &str,
+    trust: CopyTrust,
     hasher: &impl Hasher,
 ) -> Result<(), StoreError> {
     if let Some(parent) = target.parent() {
@@ -524,7 +678,53 @@ fn persist(
         // Copy to a unique temp path beside the target so the final rename is
         // an atomic, same-filesystem move (the oracle's `.tmp` discipline).
         let tmp = temp_sibling(target);
-        copy_file(source, &tmp)?;
+        let method = copy_file(source, &tmp)?;
+
+        // CLONE-SKIP: a genuine CoW clone is bit-identical to its source by
+        // construction, so the cloned temp need never be re-hashed — the only
+        // question is whether the SOURCE is trustworthy. On the clone path
+        // (unless the strict `SNAPDIR_VERIFY_COPIES=1` override forces a temp
+        // re-hash) we substitute a single SOURCE check for the redundant temp
+        // re-hash, decided by `CopyTrust`:
+        //
+        //   * `StatGuarded` — the walk already hashed this user file; a fresh
+        //     `stat` that still matches the recorded guard proves it is
+        //     unchanged, so the clone is trusted with NO read at all (the real
+        //     win: the walk's hash is the only read). A changed source falls
+        //     through to the temp re-hash → Integrity on a true content change.
+        //   * `TrustedObject` — a fetch source is an immutable content-addressed
+        //     store blob; we still verify the SOURCE's bytes hash to `expected`
+        //     (catching an out-of-band on-disk corruption) but, since the clone
+        //     equals the source, skip the SECOND (temp) re-hash. This preserves
+        //     the store's verify-on-fetch discipline while dropping the
+        //     redundant re-read of the cloned bytes.
+        //   * `Untrusted` — never skips (falls through to the temp re-hash).
+        //
+        // The `fs::copy` (Copied) path NEVER skips: a byte copy can corrupt, so
+        // it always re-hashes the temp (today's behavior + retry loop, below).
+        if method == CopyMethod::Cloned && !verify_copies_forced() {
+            match clone_skip_decision(source, expected, trust, hasher) {
+                CloneSkip::Skip => {
+                    // Source trusted + clone is bit-identical → rename straight
+                    // into place; the temp re-hash (and its retry loop) is
+                    // unnecessary because a CoW clone cannot corrupt.
+                    fs::rename(&tmp, target)?;
+                    return Ok(());
+                }
+                CloneSkip::SourceCorrupt { actual } => {
+                    // A `TrustedObject` whose on-disk source bytes no longer hash
+                    // to `expected`: the source itself is bad, so retrying cannot
+                    // help (mirrors the source-verify branch below).
+                    let _ = fs::remove_file(&tmp);
+                    return Err(StoreError::Integrity {
+                        address: source.display().to_string(),
+                        expected: expected.to_owned(),
+                        actual,
+                    });
+                }
+                CloneSkip::Rehash => { /* fall through to the temp re-hash */ }
+            }
+        }
 
         let actual = hash_file(&tmp, hasher)?;
         if actual == expected {
@@ -593,12 +793,313 @@ fn write_manifest(
     Ok(())
 }
 
+/// Durable variant of [`write_manifest`] for the batched receive-pack path:
+/// identical verify + atomic-rename discipline, but the temp file's data is
+/// fsynced **before** the rename and the manifest's parent shard directory is
+/// fsynced **after** it, so the manifest's directory entry survives power loss.
+///
+/// This is "full sync #2" of the receive-pack two-sync budget (the matching
+/// object barrier in [`crate::fsync::barrier_objects`] is #1); the caller must
+/// have already barriered the objects this manifest references, so a durable
+/// manifest provably implies durable objects (see the non-journaling-fs caveat
+/// in [`crate::fsync`]).
+///
+/// Used only on the receive-pack path via
+/// [`FileSink`](crate::pack::FileSink); `FileStore::push`/`put_manifest` keep
+/// the historical (non-fsync) [`write_manifest`].
+pub(crate) fn write_manifest_durable(
+    manifest: &Manifest,
+    target: &Path,
+    id: &str,
+    hasher: &impl Hasher,
+) -> Result<(), StoreError> {
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent)?;
+    }
+
+    // Same verify-before-write discipline as `write_manifest`.
+    let actual = snapdir_core::merkle::snapshot_id(manifest, hasher);
+    if actual != id {
+        return Err(StoreError::Integrity {
+            address: target.display().to_string(),
+            expected: id.to_owned(),
+            actual,
+        });
+    }
+
+    let mut text = manifest.to_string();
+    text.push('\n');
+
+    let tmp = temp_sibling(target);
+    {
+        // Write + fsync the temp file's data, THEN rename. fsyncing before the
+        // rename guarantees the bytes are stable before the directory entry
+        // that publishes them.
+        let mut file = fs::File::create(&tmp)?;
+        file.write_all(text.as_bytes())?;
+        crate::fsync::sync_file_data(&file)?;
+    }
+    fs::rename(&tmp, target)?;
+
+    // fsync the parent shard directory so the rename (the new directory entry)
+    // is itself durable — this is the single ordering barrier for the manifest.
+    if let Some(parent) = target.parent() {
+        crate::fsync::sync_dir(parent)?;
+    }
+    Ok(())
+}
+
+/// Process-global count of times the `CoW` clone fast-path (`clonefile` on
+/// macOS, `FICLONE` reflink on Linux) actually fired (a real clone success).
+/// Used by integration tests to assert the fast-path is exercised (not silently
+/// always falling back).
+static CLONEFILE_HITS: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+/// Returns the number of times the `CoW` clone fast-path (`clonefile` on macOS,
+/// `FICLONE` reflink on Linux) has fired in this process (incremented on each
+/// genuine clone success in [`copy_file`]). On a non-reflink filesystem, across
+/// filesystems, or with the fast-path disabled (`SNAPDIR_CLONEFILE=0`) this
+/// stays at its prior value.
+///
+/// Re-exported at the crate root as
+/// [`snapdir_stores::clonefile_hits`](crate::clonefile_hits) so integration
+/// tests can observe the fast-path firing.
+pub fn clonefile_hits() -> u64 {
+    CLONEFILE_HITS.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Returns `true` unless `SNAPDIR_CLONEFILE=0` force-disables the `CoW` clone
+/// fast-path (`clonefile` on macOS, `FICLONE` reflink on Linux). Read **per copy
+/// call** (never cached) so a test can toggle the knob at runtime under its
+/// `ENV_LOCK` and have the very next copy observe it.
+fn clonefile_enabled() -> bool {
+    !matches!(std::env::var("SNAPDIR_CLONEFILE").as_deref(), Ok("0"))
+}
+
+/// Returns `true` when `SNAPDIR_VERIFY_COPIES=1` forces the write-time re-hash
+/// even on the clone fast-path (strict mode). Read **per copy call** (never
+/// cached), mirroring [`clonefile_enabled`], so a test can toggle it at runtime
+/// under its `ENV_LOCK` and have the very next copy observe it. When set, a
+/// clone still FIRES (the fast-path is not disabled) but `persist` re-hashes the
+/// cloned temp exactly as the `fs::copy` path does.
+fn verify_copies_forced() -> bool {
+    matches!(std::env::var("SNAPDIR_VERIFY_COPIES").as_deref(), Ok("1"))
+}
+
+/// The outcome of [`clone_skip_decision`]: whether a successful clone may skip
+/// the post-copy temp re-hash, must fall back to it, or has already proven the
+/// source corrupt.
+enum CloneSkip {
+    /// Trust the clone: rename straight into place, no temp re-hash.
+    Skip,
+    /// Fall through to the historical temp re-hash + retry loop.
+    Rehash,
+    /// A `TrustedObject` source's own bytes no longer hash to `expected` (an
+    /// out-of-band on-disk corruption); carries the source's actual hash for the
+    /// [`StoreError::Integrity`] the caller raises.
+    SourceCorrupt { actual: String },
+}
+
+/// Decides whether a successful clone of `source` may skip the redundant
+/// post-copy temp re-hash, given its [`CopyTrust`]. Only ever called on the
+/// [`CopyMethod::Cloned`] path with `SNAPDIR_VERIFY_COPIES` not forcing.
+///
+///   * [`CopyTrust::TrustedObject`] — verify the SOURCE's bytes hash to
+///     `expected` (one read, preserving the store's verify-on-fetch corruption
+///     discipline); on a match → [`CloneSkip::Skip`] (the bit-identical clone
+///     needs no second re-hash), on a mismatch → [`CloneSkip::SourceCorrupt`].
+///     A `stat`/read error falls back to [`CloneSkip::Rehash`].
+///   * [`CopyTrust::StatGuarded`] — re-`stat` the source and, IFF the fresh
+///     [`CopyGuard`] still equals the recorded one, [`CloneSkip::Skip`] with NO
+///     read (the walk already hashed it); any change / `stat` failure →
+///     [`CloneSkip::Rehash`] (which surfaces a true content change as
+///     [`StoreError::Integrity`]).
+///   * [`CopyTrust::Untrusted`] — [`CloneSkip::Rehash`] (never skips).
+fn clone_skip_decision(
+    source: &Path,
+    expected: &str,
+    trust: CopyTrust,
+    hasher: &impl Hasher,
+) -> CloneSkip {
+    match trust {
+        CopyTrust::Untrusted => CloneSkip::Rehash,
+        CopyTrust::StatGuarded(recorded) => match fs::metadata(source) {
+            Ok(meta) if CopyGuard::from_metadata(&meta) == Some(recorded) => CloneSkip::Skip,
+            _ => CloneSkip::Rehash,
+        },
+        CopyTrust::TrustedObject => {
+            // Verify the immutable store source once (catches on-disk
+            // corruption), but skip the redundant re-hash of the bit-identical
+            // clone. A read error (e.g. source vanished) falls back to the temp
+            // re-hash path, which will surface the same failure.
+            match hash_file(source, hasher) {
+                Ok(actual) if actual == expected => CloneSkip::Skip,
+                Ok(actual) => CloneSkip::SourceCorrupt { actual },
+                Err(_) => CloneSkip::Rehash,
+            }
+        }
+    }
+}
+
 /// Copies a regular file's bytes from `source` to `target` (mirrors the
 /// oracle's `cp -RL -n`: dereference, do not clobber — `target` is a fresh
 /// temp path so the no-clobber aspect is implicit).
-fn copy_file(source: &Path, target: &Path) -> Result<(), StoreError> {
+///
+/// When the clone knob is enabled (`SNAPDIR_CLONEFILE != "0"`), it first
+/// attempts a copy-on-write clone via the platform `CoW` primitive (`clonefile(2)`
+/// on macOS, the `FICLONE` ioctl reflink on Linux). On the not-supported /
+/// cross-filesystem / already-exists errnos it transparently falls back to
+/// [`fs::copy`]; on a genuine I/O error it propagates. The clone result is
+/// normalized to be **observably identical** to `fs::copy` (perms-only metadata;
+/// BSD flags cleared on macOS — Linux inode flags are not cloned, so no
+/// clearing is needed). On other platforms, or with the knob disabled, this is
+/// exactly the historical `fs::copy` path.
+fn copy_file(source: &Path, target: &Path) -> Result<CopyMethod, StoreError> {
+    #[cfg(target_os = "macos")]
+    {
+        if clonefile_enabled() && try_clonefile(source, target)? {
+            return Ok(CopyMethod::Cloned);
+        }
+    }
+    #[cfg(target_os = "linux")]
+    {
+        if clonefile_enabled() && try_reflink(source, target)? {
+            return Ok(CopyMethod::Cloned);
+        }
+    }
     fs::copy(source, target)?;
-    Ok(())
+    Ok(CopyMethod::Copied)
+}
+
+/// Attempts a Linux `FICLONE` (reflink) copy-on-write clone of `source` →
+/// `target` (the analogue of macOS [`try_clonefile`]).
+///
+/// Returns `Ok(true)` on a successful reflink (counter bumped + perms
+/// normalized to `fs::copy` parity); `Ok(false)` when `FICLONE` reports a
+/// not-supported / cross-filesystem / bad-arg condition and the caller should
+/// fall back to [`fs::copy`]; `Err` only on a genuine I/O failure
+/// (ENOSPC/EDQUOT/EIO/EPERM/…).
+///
+/// `target` is a freshly minted temp sibling and must NOT already exist
+/// (`create_new`), so a collision is a genuine error rather than a fallback.
+/// `FICLONE` clones DATA ONLY — inode flags (e.g. `FS_IMMUTABLE_FL`) are NOT
+/// propagated, so there is no un-GC-able-object risk and no flag-clearing is
+/// needed (unlike the macOS `chflags` normalization).
+#[cfg(target_os = "linux")]
+fn try_reflink(source: &Path, target: &Path) -> Result<bool, StoreError> {
+    use std::os::unix::io::AsRawFd;
+    use std::sync::atomic::Ordering;
+
+    // O_RDONLY source; brand-new (create_new) destination — a fresh temp
+    // sibling that must not exist.
+    let src = fs::File::open(source)?;
+    let dst = fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(target)?;
+
+    // Keep `src` + `dst` alive across the ioctl (do NOT into_raw_fd).
+    let ret = unsafe { libc::ioctl(dst.as_raw_fd(), libc::FICLONE as _, src.as_raw_fd()) };
+    if ret != 0 {
+        let err = io::Error::last_os_error();
+        // Either branch abandons the (empty) destination, so clean it up once
+        // before deciding fall-back vs. propagate.
+        drop(dst);
+        let _ = fs::remove_file(target);
+        // Not supported by the FS / cross-filesystem / bad-arg: fall back to a
+        // plain byte copy. Anything else (ENOSPC/EDQUOT/EIO/EPERM/…) is a
+        // genuine I/O error and propagates.
+        if matches!(
+            err.raw_os_error(),
+            Some(
+                libc::EOPNOTSUPP
+                    | libc::ENOTTY
+                    | libc::EXDEV
+                    | libc::EINVAL
+                    | libc::ENOSYS
+                    | libc::EBADF
+            )
+        ) {
+            return Ok(false);
+        }
+        return Err(StoreError::Io(err));
+    }
+
+    // FICLONE clones DATA only, so match `fs::copy`'s perms-only semantics by
+    // copying the source's permission bits onto the target. No flag-clearing is
+    // needed (Linux inode flags are not cloned).
+    let src_perms = fs::metadata(source)?.permissions();
+    fs::set_permissions(target, src_perms)?;
+
+    CLONEFILE_HITS.fetch_add(1, Ordering::Relaxed);
+    Ok(true)
+}
+
+/// Attempts a macOS `clonefile(2)` copy-on-write clone of `source` → `target`.
+///
+/// Returns `Ok(true)` on a successful clone (counter bumped + clone normalized
+/// to `fs::copy` parity); `Ok(false)` when `clonefile` reports a not-supported /
+/// cross-volume / already-exists condition and the caller should fall back to
+/// [`fs::copy`]; `Err` only on a genuine I/O failure.
+#[cfg(target_os = "macos")]
+fn try_clonefile(source: &Path, target: &Path) -> Result<bool, StoreError> {
+    use std::os::unix::ffi::OsStrExt;
+    use std::sync::atomic::Ordering;
+
+    let src_c = std::ffi::CString::new(source.as_os_str().as_bytes())
+        .map_err(|e| StoreError::Io(io::Error::new(io::ErrorKind::InvalidInput, e)))?;
+    let dst_c = std::ffi::CString::new(target.as_os_str().as_bytes())
+        .map_err(|e| StoreError::Io(io::Error::new(io::ErrorKind::InvalidInput, e)))?;
+
+    // `clonefile` with flags=0: copy-on-write clone of a regular file. It also
+    // copies ALL metadata (mode, xattrs, BSD flags), which we normalize below.
+    let ret = unsafe { libc::clonefile(src_c.as_ptr(), dst_c.as_ptr(), 0) };
+    if ret != 0 {
+        let err = io::Error::last_os_error();
+        match err.raw_os_error() {
+            // Not supported by the FS / cross-volume / bad-arg / dst exists:
+            // fall back to a plain byte copy.
+            Some(
+                libc::ENOTSUP
+                | libc::EXDEV
+                | libc::ENOSYS
+                | libc::EINVAL
+                | libc::EOPNOTSUPP
+                | libc::EEXIST,
+            ) => return Ok(false),
+            // A genuine I/O error (permissions, ENOSPC, …): propagate.
+            _ => return Err(StoreError::Io(err)),
+        }
+    }
+
+    // --- Parity normalization: make the clone observably identical to fs::copy.
+    // `fs::copy` sets the destination's permission bits to the source's and
+    // copies no other metadata. `clonefile` copied EVERYTHING, so we (1) clear
+    // BSD flags so an immutable (uchg/UF_IMMUTABLE) source cannot yield an
+    // immutable, un-GC-able object and (2) re-set the perms to exactly the
+    // source's mode bits. chflags(…, 0) does not break the CoW sharing.
+    //
+    // Order matters: clear the flags FIRST. If the source was uchg, the clone
+    // is immutable too, and `set_permissions` (chmod) on an immutable file
+    // returns EPERM — so flags must come down before we touch the perms.
+    let cleared = unsafe { libc::chflags(dst_c.as_ptr(), 0) };
+    if cleared != 0 {
+        let err = io::Error::last_os_error();
+        // EOPNOTSUPP/ENOTSUP: the FS has no BSD flags, so there is nothing to
+        // clear and the object is inherently removable — tolerate. Any other
+        // failure means we may have left flags on a would-be object, so fail
+        // loudly rather than ship an un-GC-able object.
+        match err.raw_os_error() {
+            Some(libc::EOPNOTSUPP | libc::ENOTSUP) => {}
+            _ => return Err(StoreError::Io(err)),
+        }
+    }
+
+    let src_perms = fs::metadata(source)?.permissions();
+    fs::set_permissions(target, src_perms)?;
+
+    CLONEFILE_HITS.fetch_add(1, Ordering::Relaxed);
+    Ok(true)
 }
 
 /// Builds a unique temp sibling path for `target` (same directory, so the

--- a/crates/snapdir-stores/src/fsync.rs
+++ b/crates/snapdir-stores/src/fsync.rs
@@ -1,0 +1,267 @@
+//! Crash-durability primitives for the batched pack receiver (Design A).
+//!
+//! `snapdir` historically fsyncs **nothing**: it relies on temp-file +
+//! atomic-rename + "manifest last" so that, after a clean run, a present
+//! manifest *logically* implies present objects. That ordering survives a
+//! process crash, but it does **not** survive a power loss / kernel panic on a
+//! filesystem that can reorder writeback: the rename of the manifest can hit
+//! stable storage before the object bytes it references, leaving a manifest
+//! that points at empty or torn objects.
+//!
+//! This module adds the minimum durability to close that window on the
+//! receive-pack path, batched so the cost is **exactly two full syncs per
+//! pack** rather than one fsync per object:
+//!
+//! 1. While a pack is being filed, each freshly committed object is given a
+//!    cheap, non-blocking *writeout hint* ([`writeout_hint`]) so its dirty
+//!    pages start heading to disk early (Linux `sync_file_range(WRITE)`; on
+//!    Darwin a plain `fsync`, which is writeout-only there — `F_FULLFSYNC`
+//!    would be one full barrier *per object*, exactly what we are batching
+//!    away).
+//! 2. At the barrier ([`barrier_objects`]) — called once, right before the
+//!    manifest is committed — every written object's data is forced to stable
+//!    storage in one pass (Linux `sync_file_range(WAIT_BEFORE|WRITE|WAIT_AFTER)`;
+//!    elsewhere `fsync`/`sync_data`). This is full sync #1.
+//! 3. The manifest itself is then written via
+//!    [`crate::file_store::write_manifest_durable`]: fsync the temp file,
+//!    rename, fsync the parent shard directory so the rename is durable. That
+//!    is full sync #2.
+//!
+//! ## Non-journaling-fs caveat
+//!
+//! We deliberately do **not** fsync each object's `.objects/<aa>/` shard
+//! directory. On a journaling filesystem (ext4/xfs/apfs/zfs/btrfs — every
+//! mainstream default) the create+rename of an object file is ordered by the
+//! filesystem journal relative to the later manifest-directory fsync, so the
+//! object's directory entry is durable once the manifest barrier completes. On
+//! an exotic **non-journaling** filesystem with no such ordering guarantee, a
+//! crash in the narrow window after the manifest is durable but before the
+//! object directory entries are could still surface a dangling manifest. That
+//! is an accepted trade-off for keeping the cost at two syncs; the alternative
+//! (an fsync per shard directory) defeats the whole point of batching. Use a
+//! journaling filesystem (the universal default) for crash-consistency.
+//!
+//! ## Platform notes
+//!
+//! All raw syscalls go through `libc` — already a direct dependency of
+//! `snapdir-core` and `snapdir-cli`, so this adds **no new crate** to the lock
+//! graph and keeps the shipped binary dependency-free (no shelling out). Every
+//! call is best-effort with respect to *unsupported*: an `ENOTSUP`/`EINVAL`
+//! from `sync_file_range` (e.g. on a filesystem that does not implement it)
+//! transparently falls back to a full `fsync`/`sync_data`. A genuine I/O error
+//! is propagated so the receiver can abort before committing the manifest.
+
+use std::fs::File;
+use std::io;
+use std::os::unix::io::AsRawFd;
+use std::path::Path;
+
+use snapdir_core::store::StoreError;
+
+/// Issues a cheap, non-blocking writeout *hint* for a freshly committed object
+/// so its dirty pages start migrating to disk early — amortizing the cost of
+/// the later [`barrier_objects`] pass. This is **not** a durability point on
+/// its own; it never blocks waiting for completion.
+///
+/// - **Linux:** `sync_file_range(fd, 0, 0, SYNC_FILE_RANGE_WRITE)` — start
+///   writeback for the whole file, do not wait.
+/// - **macOS/other unix:** `fsync(fd)`. On Darwin `fsync` is writeout-only
+///   (it does *not* issue the drive cache-flush barrier that `F_FULLFSYNC` /
+///   `File::sync_all` would — and `F_FULLFSYNC` per object is exactly the
+///   per-object full barrier this batched design avoids), so it is the right
+///   analogue of the Linux writeout hint.
+///
+/// Any error is swallowed (best-effort hint): correctness is owned by
+/// [`barrier_objects`], which *does* propagate errors.
+pub fn writeout_hint(file: &File) {
+    let _ = writeout_hint_inner(file);
+}
+
+#[cfg(target_os = "linux")]
+fn writeout_hint_inner(file: &File) -> io::Result<()> {
+    // offset=0, nbytes=0 => "to end of file". SYNC_FILE_RANGE_WRITE starts
+    // async writeback without waiting.
+    let ret = unsafe { libc::sync_file_range(file.as_raw_fd(), 0, 0, libc::SYNC_FILE_RANGE_WRITE) };
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+#[cfg(not(target_os = "linux"))]
+fn writeout_hint_inner(file: &File) -> io::Result<()> {
+    // On Darwin `fsync` is writeout-only (no drive cache-flush). On other
+    // unixes it is a real flush, which is still a valid (if stronger) hint.
+    let ret = unsafe { libc::fsync(file.as_raw_fd()) };
+    if ret == 0 {
+        Ok(())
+    } else {
+        Err(io::Error::last_os_error())
+    }
+}
+
+/// Durability barrier: forces every object written during this pack to stable
+/// storage in a single pass (full sync #1 of the two-sync budget). Called once,
+/// immediately before the manifest is committed.
+///
+/// `paths` is the receiver's `written: Vec<PathBuf>` — the objects this pack
+/// newly committed (duplicates / pre-seeded objects are not included; they were
+/// made durable by whatever pack first wrote them). A missing path (e.g. a
+/// concurrent GC) is tolerated; any other I/O error aborts the pack so the
+/// manifest is never committed over un-synced data.
+pub fn barrier_objects(paths: &[std::path::PathBuf]) -> Result<(), StoreError> {
+    for path in paths {
+        let file = match File::open(path) {
+            Ok(file) => file,
+            // The object vanished between commit and barrier (concurrent GC /
+            // racing writer). Nothing of ours to make durable here.
+            Err(err) if err.kind() == io::ErrorKind::NotFound => continue,
+            Err(err) => return Err(StoreError::Io(err)),
+        };
+        barrier_one(&file).map_err(StoreError::Io)?;
+    }
+    Ok(())
+}
+
+/// Forces a single already-committed object's data to stable storage.
+///
+/// - **Linux:** `sync_file_range(fd, 0, 0, WAIT_BEFORE | WRITE | WAIT_AFTER)` —
+///   wait for any in-flight writeback, start+finish the rest, then wait. If the
+///   filesystem does not implement `sync_file_range` (`ENOTSUP`/`EINVAL`), fall
+///   back to a full `fsync`.
+/// - **other unix:** `fsync(fd)` (a.k.a. `File::sync_data`'s effect).
+fn barrier_one(file: &File) -> io::Result<()> {
+    #[cfg(target_os = "linux")]
+    {
+        let flags = libc::SYNC_FILE_RANGE_WAIT_BEFORE
+            | libc::SYNC_FILE_RANGE_WRITE
+            | libc::SYNC_FILE_RANGE_WAIT_AFTER;
+        let ret = unsafe { libc::sync_file_range(file.as_raw_fd(), 0, 0, flags) };
+        if ret == 0 {
+            return Ok(());
+        }
+        let err = io::Error::last_os_error();
+        // `sync_file_range` is unsupported on some filesystems; fall back to a
+        // full data sync rather than fail the pack.
+        match err.raw_os_error() {
+            Some(libc::ENOSYS | libc::ENOTSUP | libc::EINVAL) => file.sync_data(),
+            _ => Err(err),
+        }
+    }
+    #[cfg(not(target_os = "linux"))]
+    {
+        // Darwin: `fsync` flushes the file's data to the device (writeout). It
+        // is intentionally NOT `sync_all` (= `F_FULLFSYNC`, a per-object drive
+        // cache-flush barrier) — the manifest commit's directory fsync provides
+        // the single ordering barrier for the whole pack.
+        let ret = unsafe { libc::fsync(file.as_raw_fd()) };
+        if ret == 0 {
+            Ok(())
+        } else {
+            Err(io::Error::last_os_error())
+        }
+    }
+}
+
+/// fsyncs a directory so a rename *into* it (a freshly created or replaced
+/// directory entry) is durable. Opening a directory read-only and `fsync`-ing
+/// the resulting fd is the portable POSIX idiom for this; it is a no-op success
+/// on the platforms where directory fsync is not meaningful.
+///
+/// Used by [`crate::file_store::write_manifest_durable`] for the manifest's
+/// parent shard directory — full sync #2 of the two-sync budget.
+pub fn sync_dir(dir: &Path) -> io::Result<()> {
+    let dir_file = File::open(dir)?;
+    let ret = unsafe { libc::fsync(dir_file.as_raw_fd()) };
+    if ret == 0 {
+        Ok(())
+    } else {
+        let err = io::Error::last_os_error();
+        // Some platforms reject fsync on a directory fd (EINVAL/EBADF) because
+        // directory metadata is journaled regardless; treat that as already
+        // durable rather than an error.
+        match err.raw_os_error() {
+            Some(libc::EINVAL | libc::ENOTSUP) => Ok(()),
+            _ => Err(err),
+        }
+    }
+}
+
+/// fsyncs a single just-written file's data to stable storage (`File::sync_data`
+/// = `fdatasync`). Used by [`crate::file_store::write_manifest_durable`] for the
+/// manifest temp file before it is renamed into place.
+pub fn sync_file_data(file: &File) -> io::Result<()> {
+    file.sync_data()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::path::PathBuf;
+
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn new(tag: &str) -> Self {
+            use std::sync::atomic::{AtomicU64, Ordering};
+            static COUNTER: AtomicU64 = AtomicU64::new(0);
+            let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let path = std::env::temp_dir().join(format!(
+                "snapdir-fsync-test-{}-{tag}-{n}",
+                std::process::id()
+            ));
+            std::fs::create_dir_all(&path).expect("create temp dir");
+            Self { path }
+        }
+        fn path(&self) -> &Path {
+            &self.path
+        }
+    }
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn pack_fsync_writeout_hint_and_barrier_succeed_on_real_files() {
+        let dir = TempDir::new("hint");
+        let mut paths = Vec::new();
+        for i in 0..4u8 {
+            let p = dir.path().join(format!("obj-{i}"));
+            let mut f = File::create(&p).expect("create");
+            f.write_all(&[i; 4096]).expect("write");
+            // Hint is best-effort and must not panic on a real, open fd.
+            writeout_hint(&f);
+            f.sync_all().expect("sync");
+            paths.push(p);
+        }
+        // The whole-batch barrier must succeed over real files.
+        barrier_objects(&paths).expect("barrier over real files");
+    }
+
+    #[test]
+    fn pack_fsync_barrier_tolerates_a_missing_object() {
+        let dir = TempDir::new("missing");
+        let present = dir.path().join("present");
+        File::create(&present).expect("create");
+        let absent = dir.path().join("does-not-exist");
+        // A vanished object (concurrent GC) is tolerated, not an error.
+        barrier_objects(&[present, absent]).expect("missing path tolerated");
+    }
+
+    #[test]
+    fn pack_fsync_sync_dir_and_sync_file_data_succeed() {
+        let dir = TempDir::new("dir");
+        let p = dir.path().join("file");
+        let mut f = File::create(&p).expect("create");
+        f.write_all(b"durable\n").expect("write");
+        sync_file_data(&f).expect("fdatasync the file");
+        // Directory fsync must succeed (or be a tolerated no-op) on a real dir.
+        sync_dir(dir.path()).expect("fsync the directory");
+    }
+}

--- a/crates/snapdir-stores/src/gcs_store.rs
+++ b/crates/snapdir-stores/src/gcs_store.rs
@@ -56,12 +56,13 @@ use google_cloud_gax::retry_policy::NeverRetry;
 use google_cloud_storage::client::{Storage, StorageControl};
 use snapdir_core::manifest::Manifest;
 use snapdir_core::merkle::{Blake3Hasher, Hasher};
-use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
+use snapdir_core::store::{manifest_path, object_path, Store, StoreError, MANIFESTS_DIR};
 use snapdir_core::Meter;
 
 use crate::fetch::fetch_files_concurrent;
 use crate::push::{push_objects_concurrent, upload_object};
 use crate::retry::{parse_retry_after, retry_network, Attempt, DefaultJitter, TokioSleeper};
+use crate::s3_store::manifest_ids_from_keys;
 use crate::stream::StreamStore;
 use crate::transfer::{classify_error, RateLimiter, TransferConfig};
 use tokio::runtime::Runtime;
@@ -388,6 +389,55 @@ impl GcsStore {
         .await
     }
 
+    /// Lists every object name under `prefix` (a leading-slash-free key
+    /// prefix), following the SDK's `list_objects` page-token pagination to
+    /// completion.
+    ///
+    /// Each page's single SDK call is wrapped in [`retry_network`] — the same
+    /// request-rate + transient-retry discipline as
+    /// [`key_exists`](Self::key_exists) — and `next_page_token` drives the page
+    /// loop until it is empty. Returns the full set of object names (the caller
+    /// filters / reconstructs ids).
+    async fn list_keys_under(&self, prefix: &str) -> Result<Vec<String>, StoreError> {
+        let mut keys = Vec::new();
+        let mut page_token = String::new();
+        loop {
+            let token = page_token.clone();
+            let page = retry_network(
+                &self.config.retry,
+                &self.req_limiter,
+                &TokioSleeper,
+                &DefaultJitter::new(),
+                || {
+                    let token = token.clone();
+                    async move {
+                        self.control
+                            .list_objects()
+                            .set_parent(self.location.bucket_resource())
+                            .set_prefix(prefix)
+                            .set_page_token(token)
+                            .send()
+                            .await
+                            .map_err(|err| gcs_attempt_from_err("GCS list_objects failed", err))
+                    }
+                },
+            )
+            .await?;
+
+            for object in &page.objects {
+                keys.push(object.name.clone());
+            }
+
+            // Page on while a non-empty next-token is returned (the SDK signals
+            // end-of-listing with an empty token).
+            if page.next_page_token.is_empty() {
+                break;
+            }
+            page_token = page.next_page_token;
+        }
+        Ok(keys)
+    }
+
     /// Downloads `key`, verifying its BLAKE3 against `expected`, retrying up to
     /// [`MAX_FETCH_RETRIES`] times. Mirrors `_snapdir_gcs_fetch_to_cache`.
     async fn fetch_verified(&self, key: &str, expected: &str) -> Result<Vec<u8>, StoreError> {
@@ -597,6 +647,18 @@ impl StreamStore for GcsStore {
         }
         self.runtime
             .block_on(async { self.put_bytes(&key, text.into_bytes()).await })
+    }
+
+    fn list_manifest_ids(&self) -> Result<Vec<String>, StoreError> {
+        // List every object name under `<prefix>/.manifests/` and reconstruct
+        // the id from the `3/3/3/rest` segments after that prefix, reusing the
+        // SAME key->id logic as `S3Store`. The trailing slash anchors the
+        // listing to the `.manifests/` subtree (never `.objects/`).
+        let list_prefix = format!("{}/", self.location.key_for(MANIFESTS_DIR));
+        let keys = self
+            .runtime
+            .block_on(async { self.list_keys_under(&list_prefix).await })?;
+        Ok(manifest_ids_from_keys(&keys, &list_prefix))
     }
 }
 

--- a/crates/snapdir-stores/src/lib.rs
+++ b/crates/snapdir-stores/src/lib.rs
@@ -41,6 +41,13 @@
 //!   stream through incremental BLAKE3 verification (O(1) memory into a
 //!   [`FileSink`]), the manifest rides last and commits only after the `end`
 //!   trailer, so truncation can never publish a snapshot.
+//! - [`fsync`] ([`barrier_objects`](fsync::barrier_objects),
+//!   [`writeout_hint`](fsync::writeout_hint)) — the batched crash-durability
+//!   primitives behind the receive-pack path: a cheap per-object writeout hint
+//!   while filing, then exactly two full syncs per pack (one object barrier
+//!   before the manifest, one durable manifest commit), so a present manifest
+//!   implies present, on-disk objects even across power loss. cfg-gated over
+//!   `libc` (no new lock crate); env-free.
 //! - [`sync`] ([`sync_snapshot`], [`SyncReport`]) — streaming store-to-store
 //!   snapshot copy: walks a source manifest and copies its raw objects
 //!   source → dest through memory only (no local filesystem staging),
@@ -52,6 +59,7 @@ pub mod adaptive;
 pub mod b2_store;
 pub(crate) mod fetch;
 pub mod file_store;
+pub mod fsync;
 pub mod gcs_store;
 pub mod limits;
 pub mod pack;
@@ -60,6 +68,7 @@ pub mod retry;
 pub mod router;
 pub mod s3_store;
 pub mod shim;
+pub mod split;
 pub mod stream;
 pub mod sync;
 pub mod transfer;
@@ -70,12 +79,14 @@ pub use adaptive::{
     OpResult, OpSample,
 };
 pub use b2_store::B2Store;
-pub use file_store::FileStore;
+pub use file_store::{clonefile_hits, FileStore};
 pub use gcs_store::{GcsLocation, GcsStore};
 pub use limits::{for_scheme, BackendLimits};
 pub use pack::{
-    is_hex64, read_pack, write_pack, FileSink, PackReadReport, PackSink, PackWriteReport,
-    StreamSink, MAX_HEADER_BYTES, MAX_MANIFEST_BYTES, WIRE_CAPS, WIRE_MAGIC, WIRE_VERSION,
+    is_hex64, read_pack, write_pack, write_pack_with_format, Durability, FileSink, PackFormat,
+    PackReadReport, PackSink, PackWriteReport, StreamSink, DEFAULT_ZSTD_LEVEL, MAX_HEADER_BYTES,
+    MAX_MANIFEST_BYTES, MAX_ZSTD_LEVEL, MIN_ZSTD_LEVEL, WIRE_CAPS, WIRE_MAGIC, WIRE_MAGIC_ZSTD,
+    WIRE_VERSION,
 };
 pub use retry::{
     parse_retry_after, retry_async, retry_blocking, retry_network, AsyncSleeper, Attempt,
@@ -84,6 +95,7 @@ pub use retry::{
 pub use router::{resolve_adapter, Adapter, RouteError};
 pub use s3_store::{S3Location, S3Store};
 pub use shim::ExternalStore;
+pub use split::SplitStore;
 pub use stream::StreamStore;
 pub use sync::{sync_snapshot, SyncReport};
 pub use transfer::{

--- a/crates/snapdir-stores/src/pack.rs
+++ b/crates/snapdir-stores/src/pack.rs
@@ -76,11 +76,46 @@ use crate::stream::StreamStore;
 pub const WIRE_VERSION: u32 = 1;
 
 /// The plumbing capabilities this build advertises alongside [`WIRE_VERSION`].
-pub const WIRE_CAPS: &[&str] = &["objects-needed", "send-pack", "receive-pack"];
+///
+/// `snappack-zstd` advertises the additive [`WIRE_MAGIC_ZSTD`] transport
+/// encoding (same record grammar, whole body in one zstd frame). It is a plain
+/// capability token, NOT a version bump — 1.5.0's `_snapdir_caps_ok` ignores
+/// unknown tokens, so an integer [`WIRE_VERSION`] bump would force a dumb
+/// fallback against older peers; appending a token keeps full back/forward
+/// compatibility (a peer that lacks the token simply never gets a 1Z stream,
+/// and every receiver sniffs + accepts BOTH forms forever).
+pub const WIRE_CAPS: &[&str] = &[
+    "objects-needed",
+    "send-pack",
+    "receive-pack",
+    "snappack-zstd",
+];
 
-/// The exact magic line that opens every pack stream (version baked in; a
-/// unit test pins it to [`WIRE_VERSION`]).
+/// The exact magic line that opens every plain (v1) pack stream (version baked
+/// in; a unit test pins it to [`WIRE_VERSION`]).
 pub const WIRE_MAGIC: &str = "SNAPPACK 1\n";
+
+/// The magic line that opens a zstd-compressed pack stream (SNAPPACK 1Z).
+///
+/// The grammar is UNCHANGED: everything after this magic is a single zstd frame
+/// that decompresses to exactly `record* "end\n"` — the verbatim v1 body. The
+/// receiver sniffs the magic and feeds the decompressed bytes to the same
+/// parser, so the incremental BLAKE3 verification is byte-for-byte identical to
+/// v1. The wire version stays [`WIRE_VERSION`] = 1 (the trailing `Z` is a
+/// transport-encoding marker, not a new format version).
+pub const WIRE_MAGIC_ZSTD: &str = "SNAPPACK 1Z\n";
+
+/// Default zstd compression level for [`PackFormat::Zstd`] when the caller does
+/// not specify one. Level 3 is zstd's own default — a good speed/ratio balance
+/// for the typical small-text snapshot payload.
+pub const DEFAULT_ZSTD_LEVEL: i32 = 3;
+
+/// Minimum / maximum zstd level the encoder accepts. The library reads NO
+/// environment; the CLI lane validates a `SNAPDIR_SSH_ZSTD_LEVEL` knob against
+/// this range and threads the result in via [`PackFormat::Zstd`].
+pub const MIN_ZSTD_LEVEL: i32 = 1;
+/// See [`MIN_ZSTD_LEVEL`].
+pub const MAX_ZSTD_LEVEL: i32 = 19;
 
 /// Hard cap on a header line, INCLUDING its terminating `\n`. The reader
 /// rejects a longer line the moment the cap is reached — this bounds reader
@@ -174,6 +209,20 @@ pub trait PackSink {
     /// Commits the manifest under `id`. Called only after the `end` trailer of
     /// a fully verified stream (manifest-last survives truncation).
     fn put_manifest(&mut self, id: &str, manifest: &Manifest) -> Result<(), StoreError>;
+
+    /// Durability barrier: forces every object this pack committed to stable
+    /// storage. [`read_pack`] calls it exactly once, in the `end` arm, BEFORE
+    /// [`put_manifest`](Self::put_manifest) — so a durable manifest provably
+    /// implies durable objects across power loss, not just process crash.
+    ///
+    /// Defaults to a **no-op**: a sink with no crash-durability concern
+    /// (in-memory, network, or a delegating wrapper) keeps the historical
+    /// behavior unchanged. [`FileSink`] overrides it to issue the batched
+    /// object barrier (see [`crate::fsync`]). The default lets the manifest
+    /// commit proceed exactly as before.
+    fn flush_barrier(&mut self) -> Result<(), StoreError> {
+        Ok(())
+    }
 }
 
 /// Generic [`PackSink`] over any [`StreamStore`]: buffers one `obj` payload at
@@ -243,6 +292,28 @@ impl PackSink for StreamSink<'_> {
     }
 }
 
+/// How a [`FileSink`] makes the objects + manifest it files crash-durable.
+///
+/// The library is **env-free**: the CLI lane wires any `SNAPDIR_*` knob and
+/// selects a variant via [`FileSink::with_durability`]. The default
+/// ([`Durability::Off`]) preserves the historical byte-for-byte filing — no
+/// fsync, the existing pinned tests stay green.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum Durability {
+    /// No fsync (historical behavior). A present manifest implies present
+    /// objects after a *clean* run / process crash, but not across power loss.
+    #[default]
+    Off,
+    /// Batched durability (Design A): a cheap writeout hint per committed
+    /// object while filing, then exactly two full syncs per pack — one object
+    /// barrier ([`crate::fsync::barrier_objects`]) in [`FileSink::flush_barrier`]
+    /// right before the manifest, and one durable manifest commit
+    /// ([`crate::file_store::write_manifest_durable`]). So a durable manifest
+    /// implies durable objects even across power loss (see the
+    /// non-journaling-fs caveat in [`crate::fsync`]).
+    Batch,
+}
+
 /// File-backed [`PackSink`] over a [`FileStore`]: `obj` payloads stream
 /// through a fixed-size buffer straight into a unique temp sibling of the
 /// final object path, then an atomic rename commits on hash match — O(1)
@@ -252,9 +323,23 @@ impl PackSink for StreamSink<'_> {
 /// (temp file in the SAME directory so the rename is an atomic,
 /// same-filesystem move; a partially-written object is never visible at its
 /// content-address; a failed record removes its temp file).
+///
+/// Durability is selected by [`with_durability`](Self::with_durability)
+/// ([`Durability::Off`] by default — byte-identical historical filing). Under
+/// [`Durability::Batch`] every committed object path is recorded in `written`
+/// so [`flush_barrier`](PackSink::flush_barrier) can sync them all in one pass
+/// before the manifest commits.
 pub struct FileSink<'a> {
     store: &'a FileStore,
     staged: Option<StagedFile>,
+    /// Selected durability mode (default [`Durability::Off`]).
+    durability: Durability,
+    /// Final paths of objects this pack newly committed, in commit order. Only
+    /// populated (and only used) under [`Durability::Batch`]; the barrier syncs
+    /// exactly this set, then it is cleared. Duplicates / pre-seeded objects
+    /// are NOT recorded — they were made durable by whatever pack first wrote
+    /// them.
+    written: Vec<PathBuf>,
 }
 
 /// A staged-but-uncommitted object payload on disk.
@@ -265,13 +350,25 @@ struct StagedFile {
 }
 
 impl<'a> FileSink<'a> {
-    /// Wraps `store` as a streaming, file-backed pack sink.
+    /// Wraps `store` as a streaming, file-backed pack sink with the default
+    /// (historical, no-fsync) [`Durability::Off`].
     #[must_use]
     pub fn new(store: &'a FileStore) -> Self {
         Self {
             store,
             staged: None,
+            durability: Durability::default(),
+            written: Vec::new(),
         }
+    }
+
+    /// Selects the crash-durability mode for this sink (builder style). The
+    /// library reads NO environment — the CLI lane decides the mode (e.g. from
+    /// a `SNAPDIR_*` knob) and threads it in here.
+    #[must_use]
+    pub fn with_durability(mut self, durability: Durability) -> Self {
+        self.durability = durability;
+        self
     }
 }
 
@@ -310,6 +407,12 @@ impl PackSink for FileSink<'_> {
         // `io::copy` streams through a fixed-size buffer (O(1) memory); the
         // reader-side incremental hasher sees every byte we pull here.
         let copied = io::copy(payload, &mut file);
+        if copied.is_ok() && self.durability == Durability::Batch {
+            // Cheap, non-blocking writeout hint so this object's dirty pages
+            // start heading to disk now — amortizes the later batch barrier.
+            // Best-effort: errors are owned by `flush_barrier`, never here.
+            crate::fsync::writeout_hint(&file);
+        }
         drop(file);
         if let Err(err) = copied {
             // Failed mid-write: remove the temp file, leave nothing behind.
@@ -329,8 +432,16 @@ impl PackSink for FileSink<'_> {
             Some(staged) if staged.checksum == checksum => {
                 // Atomic rename into the final content-addressed location; the
                 // reader has already verified the streamed bytes hash to
-                // `checksum`, so this is the rename-on-match step.
+                // `checksum`, so this is the rename-on-match step. PRESERVES
+                // per-record rename visibility (incremental resume) — the
+                // object is observable at its address immediately, exactly as
+                // before, independent of the durability mode.
                 fs::rename(&staged.tmp, &staged.target)?;
+                // Under Batch, remember the path so the single pre-manifest
+                // barrier can sync every object this pack committed in one pass.
+                if self.durability == Durability::Batch {
+                    self.written.push(staged.target);
+                }
                 Ok(())
             }
             other => {
@@ -350,18 +461,100 @@ impl PackSink for FileSink<'_> {
         }
     }
 
+    fn flush_barrier(&mut self) -> Result<(), StoreError> {
+        // Off keeps the historical behavior (no fsync): the pinned filing tests
+        // and `FileStore::push`/`put_object` are byte-identical and untouched.
+        if self.durability == Durability::Off {
+            return Ok(());
+        }
+        // Batch: full sync #1 — force every object this pack committed to
+        // stable storage in ONE pass, then clear the set (so a later
+        // `put_manifest` is the only remaining sync). Called once by
+        // `read_pack` in the `end` arm, strictly BEFORE `put_manifest`.
+        let written = std::mem::take(&mut self.written);
+        crate::fsync::barrier_objects(&written)
+    }
+
     fn put_manifest(&mut self, id: &str, manifest: &Manifest) -> Result<(), StoreError> {
-        // FileStore::put_manifest re-verifies snapshot_id(manifest) == id and
-        // writes via its own temp+atomic-rename path.
-        self.store.put_manifest(id, manifest)
+        match self.durability {
+            // Historical path: FileStore::put_manifest re-verifies
+            // snapshot_id(manifest) == id and writes via its own
+            // temp+atomic-rename (no fsync).
+            Durability::Off => self.store.put_manifest(id, manifest),
+            // Durable path (full sync #2): fsync temp -> rename -> fsync the
+            // parent shard dir, so the manifest's directory entry survives
+            // power loss. The objects were already barriered in
+            // `flush_barrier`, so a durable manifest implies durable objects.
+            Durability::Batch => {
+                let target = self.store.root().join(manifest_path(id));
+                crate::file_store::write_manifest_durable(
+                    manifest,
+                    &target,
+                    id,
+                    &Blake3Hasher::new(),
+                )
+            }
+        }
     }
 }
 
-/// Emits a SNAPPACK 1 stream: magic, one `obj` record per entry of `ids` IN
-/// INPUT ORDER, then (if `manifest_id` is given) the `manifest` record LAST,
-/// then the `end` trailer.
+/// The on-wire transport encoding [`write_pack_with_format`] emits.
 ///
-/// Fail-closed discipline:
+/// Both forms carry the IDENTICAL record grammar; they differ only in the magic
+/// line and whether the body bytes are wrapped in one zstd frame. The receiver
+/// sniffs the magic and accepts either form — there is no negotiation token on
+/// the wire, so a `Zstd` stream is just as self-describing as a `V1` one.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PackFormat {
+    /// Plain SNAPPACK 1 ([`WIRE_MAGIC`]): the historical byte-for-byte form.
+    V1,
+    /// SNAPPACK 1Z ([`WIRE_MAGIC_ZSTD`]): magic, then the WHOLE v1 body
+    /// (`record* "end\n"`) inside a single zstd frame at the given level
+    /// (clamped to `MIN_ZSTD_LEVEL..=MAX_ZSTD_LEVEL`).
+    Zstd(i32),
+}
+
+impl Default for PackFormat {
+    /// The default is [`PackFormat::V1`] so a caller that does not opt in emits
+    /// the historical byte-identical stream.
+    fn default() -> Self {
+        Self::V1
+    }
+}
+
+impl PackFormat {
+    /// Convenience constructor for the zstd form at the [`DEFAULT_ZSTD_LEVEL`].
+    #[must_use]
+    pub fn zstd_default() -> Self {
+        Self::Zstd(DEFAULT_ZSTD_LEVEL)
+    }
+}
+
+/// Emits a plain SNAPPACK 1 stream — the historical [`PackFormat::V1`] path,
+/// byte-for-byte unchanged. Equivalent to
+/// [`write_pack_with_format`]`(.., PackFormat::V1)`. See that function for the
+/// fail-closed discipline; this thin wrapper keeps every existing caller and
+/// pinned byte-comparison test untouched.
+pub fn write_pack(
+    source: &dyn StreamStore,
+    ids: &[String],
+    manifest_id: Option<&str>,
+    out: impl Write,
+) -> Result<PackWriteReport, StoreError> {
+    write_pack_with_format(source, ids, manifest_id, PackFormat::V1, out)
+}
+
+/// Emits a SNAPPACK stream in the chosen [`PackFormat`]: magic, one `obj`
+/// record per entry of `ids` IN INPUT ORDER, then (if `manifest_id` is given)
+/// the `manifest` record LAST, then the `end` trailer.
+///
+/// For [`PackFormat::Zstd`] the magic is emitted in the clear and everything
+/// after it (`record* "end\n"`) is written through a single
+/// `zstd::stream::write::Encoder`, whose frame is `finish()`ed after the `end`
+/// trailer. The record grammar — and therefore the reader's incremental BLAKE3
+/// verification — is identical to V1; compression is a pure transport wrapper.
+///
+/// Fail-closed discipline (identical for both formats):
 ///
 /// - Every id (and `manifest_id`) is validated against `^[0-9a-f]{64}$` BEFORE
 ///   any byte is written.
@@ -373,14 +566,17 @@ impl PackSink for FileSink<'_> {
 ///   own read verification) before its record is written.
 /// - Any failure — including a missing object — aborts BEFORE the `end`
 ///   trailer is emitted, so a consumer of the partial stream also fails
-///   (no silent partial transfer).
+///   (no silent partial transfer). Under zstd the frame is never `finish()`ed
+///   on the error path, so a truncated/incomplete frame is what the receiver
+///   sees — the receiver's decoder + missing-`end` check both reject it.
 ///
 /// Duplicates in `ids` emit duplicate records (the reader handles them
 /// idempotently); deduplication is the caller's job.
-pub fn write_pack(
+pub fn write_pack_with_format(
     source: &dyn StreamStore,
     ids: &[String],
     manifest_id: Option<&str>,
+    format: PackFormat,
     mut out: impl Write,
 ) -> Result<PackWriteReport, StoreError> {
     // Validate EVERY checksum before emitting anything (fail closed).
@@ -424,7 +620,45 @@ pub fn write_pack(
         None => None,
     };
 
-    out.write_all(WIRE_MAGIC.as_bytes())?;
+    match format {
+        PackFormat::V1 => {
+            out.write_all(WIRE_MAGIC.as_bytes())?;
+            let report = write_pack_body(source, ids, manifest_payload, hasher, &mut out)?;
+            out.flush()?;
+            Ok(report)
+        }
+        PackFormat::Zstd(level) => {
+            // Magic in the clear, then the WHOLE v1 body inside ONE zstd frame.
+            out.write_all(WIRE_MAGIC_ZSTD.as_bytes())?;
+            let level = level.clamp(MIN_ZSTD_LEVEL, MAX_ZSTD_LEVEL);
+            let mut encoder = zstd::stream::write::Encoder::new(&mut out, level)
+                .map_err(|err| backend_io("starting the SNAPPACK 1Z zstd encoder", err))?;
+            // On the fail-closed error paths below, `encoder` is dropped WITHOUT
+            // `finish()`, so the frame is never finalized and the receiver sees
+            // a truncated/incomplete frame (rejected by the decoder AND by the
+            // missing-`end` check). `finish()` is only reached after `end\n`.
+            let report = write_pack_body(source, ids, manifest_payload, hasher, &mut encoder)?;
+            let out = encoder
+                .finish()
+                .map_err(|err| backend_io("finalizing the SNAPPACK 1Z zstd frame", err))?;
+            out.flush()?;
+            Ok(report)
+        }
+    }
+}
+
+/// Emits the format-agnostic SNAPPACK body — `obj` records IN INPUT ORDER, the
+/// optional `manifest` record LAST, then the `end\n` trailer — into `out`
+/// (which is either the raw sink for V1 or the zstd encoder for 1Z). The magic
+/// has already been written by the caller; the byte grammar is identical for
+/// both formats, so the reader's parser/incremental-BLAKE3 path is shared.
+fn write_pack_body(
+    source: &dyn StreamStore,
+    ids: &[String],
+    manifest_payload: Option<(&str, Vec<u8>)>,
+    hasher: Blake3Hasher,
+    out: &mut dyn Write,
+) -> Result<PackWriteReport, StoreError> {
     let mut report = PackWriteReport::default();
 
     for id in ids {
@@ -452,7 +686,6 @@ pub fn write_pack(
     }
 
     out.write_all(b"end\n")?;
-    out.flush()?;
     Ok(report)
 }
 
@@ -471,17 +704,58 @@ pub fn write_pack(
 pub fn read_pack(input: impl Read, sink: &mut dyn PackSink) -> Result<PackReadReport, StoreError> {
     let mut input = BufReader::new(input);
 
-    check_magic(&read_header_line(&mut input)?)?;
+    // Sniff the magic line (read byte-by-byte up to its `\n`, so NOTHING past
+    // the magic is consumed — the body that follows is either plaintext records
+    // or a zstd frame, both left intact on `input`).
+    match classify_magic(&read_header_line(&mut input)?)? {
+        WireForm::V1 => parse_body(&mut input, sink),
+        WireForm::Zstd => {
+            // The whole body after the magic is ONE zstd frame that decompresses
+            // to the verbatim v1 body. Feed the decompressed bytes to the SAME
+            // parser: the incremental BLAKE3 verification is untouched, and the
+            // 128B-header / 64MiB-manifest / lying-len bounds are all enforced on
+            // the DECOMPRESSED bytes (a decompression bomb costs CPU only — every
+            // decompressed byte is still hash-verified).
+            let decoder = zstd::stream::read::Decoder::new(input)
+                .map_err(|err| backend_io("starting the SNAPPACK 1Z zstd decoder", err))?;
+            parse_body(&mut BufReader::new(decoder), sink)
+        }
+    }
+}
 
+/// The transport encoding [`classify_magic`] sniffed.
+enum WireForm {
+    /// Plain SNAPPACK 1: the body is plaintext records.
+    V1,
+    /// SNAPPACK 1Z: the body is a single zstd frame over the v1 record bytes.
+    Zstd,
+}
+
+/// Runs the shared record parse loop over `input` — which is the raw reader for
+/// V1 or the zstd-decompressing reader for 1Z. Identical for both forms: the
+/// grammar, the bounds, and the incremental BLAKE3 verification are all applied
+/// to the (decompressed) record bytes.
+fn parse_body(
+    input: &mut impl BufRead,
+    sink: &mut dyn PackSink,
+) -> Result<PackReadReport, StoreError> {
     let mut report = PackReadReport::default();
     let mut pending_manifest: Option<(String, Manifest)> = None;
 
     loop {
-        let line = read_header_line(&mut input)?;
+        let line = read_header_line(input)?;
         if line == "end" {
             // The `end` trailer is the ONLY place a manifest commits:
             // truncation anywhere above has already errored out, so a
             // committed manifest proves the whole stream verified.
+            //
+            // Durability barrier BEFORE the manifest: force every committed
+            // object to stable storage first, so a durable manifest provably
+            // implies durable objects (Design A). The default `flush_barrier`
+            // is a no-op, so non-durable sinks are byte-identical to before.
+            // It runs unconditionally (even for a manifest-only / empty pack)
+            // so the ordering contract holds regardless of object count.
+            sink.flush_barrier()?;
             if let Some((id, manifest)) = pending_manifest.take() {
                 sink.put_manifest(&id, &manifest)?;
                 report.manifest_committed = true;
@@ -495,9 +769,9 @@ pub fn read_pack(input: impl Read, sink: &mut dyn PackSink) -> Result<PackReadRe
         }
         let (kind, checksum, len) = parse_record_header(&line)?;
         match kind {
-            RecordKind::Obj => read_obj_record(&mut input, sink, &checksum, len, &mut report)?,
+            RecordKind::Obj => read_obj_record(&mut *input, sink, &checksum, len, &mut report)?,
             RecordKind::Manifest => {
-                pending_manifest = Some(read_manifest_record(&mut input, &checksum, len)?);
+                pending_manifest = Some(read_manifest_record(&mut *input, &checksum, len)?);
             }
         }
     }
@@ -637,6 +911,15 @@ fn protocol(message: impl Into<String>) -> StoreError {
     }
 }
 
+/// Wraps an `io::Error` from the zstd encoder/decoder setup or finalization as a
+/// backend error, preserving the underlying cause.
+fn backend_io(context: &str, err: io::Error) -> StoreError {
+    StoreError::Backend {
+        message: format!("SNAPPACK zstd transport error while {context}"),
+        source: Some(Box::new(err)),
+    }
+}
+
 /// Reads one `\n`-terminated header line (returned WITHOUT the `\n`),
 /// enforcing the [`MAX_HEADER_BYTES`] cap while reading — an over-long line is
 /// rejected the moment the cap is hit, without buffering more. EOF at any
@@ -673,22 +956,33 @@ fn read_header_line(input: &mut impl BufRead) -> Result<String, StoreError> {
     })
 }
 
-/// Validates the magic line (already stripped of its `\n`). Negotiation is on
-/// the exact `wire` integer only: a different version — newer OR older — is
-/// rejected, and the caller falls back to the dumb path.
-fn check_magic(line: &str) -> Result<(), StoreError> {
+/// Sniffs the magic line (already stripped of its `\n`) and classifies the
+/// transport encoding. The receiver accepts BOTH the plain `SNAPPACK 1` and the
+/// zstd `SNAPPACK 1Z` forms FOREVER — there is no flag and no negotiation token
+/// here, the magic alone is self-describing. Anything else — a different wire
+/// version (newer OR older, e.g. `SNAPPACK 3`), a non-canonical token, or
+/// garbage — is rejected, and the caller falls back to the dumb path.
+fn classify_magic(line: &str) -> Result<WireForm, StoreError> {
+    // Match against the magics WITHOUT their trailing `\n` (already stripped).
+    if line == WIRE_MAGIC.trim_end_matches('\n') {
+        return Ok(WireForm::V1);
+    }
+    if line == WIRE_MAGIC_ZSTD.trim_end_matches('\n') {
+        return Ok(WireForm::Zstd);
+    }
     let Some(version) = line.strip_prefix("SNAPPACK ") else {
         return Err(protocol(format!(
-            "bad pack magic {line:?} (expected {:?})",
-            WIRE_MAGIC.trim_end()
+            "bad pack magic {line:?} (expected {:?} or {:?})",
+            WIRE_MAGIC.trim_end(),
+            WIRE_MAGIC_ZSTD.trim_end()
         )));
     };
-    if version != WIRE_VERSION.to_string() {
-        return Err(protocol(format!(
-            "unsupported pack wire version {version:?}: this build speaks wire={WIRE_VERSION}"
-        )));
-    }
-    Ok(())
+    Err(protocol(format!(
+        "unsupported pack wire version {version:?}: this build speaks wire={WIRE_VERSION} \
+         (magic {:?} or {:?})",
+        WIRE_MAGIC.trim_end(),
+        WIRE_MAGIC_ZSTD.trim_end()
+    )))
 }
 
 /// Parses a record header line into `(kind, hex64, len)`, enforcing the exact
@@ -942,13 +1236,50 @@ mod tests {
         Blake3Hasher::new().hash_hex(bytes)
     }
 
+    /// Hand-builds a SNAPPACK 1Z stream: the `SNAPPACK 1Z\n` magic in the clear,
+    /// then `body` (the verbatim v1 record bytes, `record* "end\n"`) inside ONE
+    /// zstd frame. `body` is whatever the caller wants the receiver's parser to
+    /// see after decompression — used to forge unsolicited / lying-len / bad
+    /// inner streams the writer would never emit.
+    fn zstd_stream_from_body(body: &[u8]) -> Vec<u8> {
+        let mut out = WIRE_MAGIC_ZSTD.as_bytes().to_vec();
+        let frame = zstd::stream::encode_all(body, DEFAULT_ZSTD_LEVEL).expect("zstd encode body");
+        out.extend_from_slice(&frame);
+        out
+    }
+
+    /// The verbatim v1 body (no magic): `records` concatenated + `end\n`.
+    fn v1_body(records: &[Vec<u8>]) -> Vec<u8> {
+        let mut out = Vec::new();
+        for record in records {
+            out.extend_from_slice(record);
+        }
+        out.extend_from_slice(b"end\n");
+        out
+    }
+
     // --- wire constants ----------------------------------------------------
 
     #[test]
     fn pack_wire_constants_are_consistent() {
         assert_eq!(WIRE_MAGIC, format!("SNAPPACK {WIRE_VERSION}\n"));
         assert_eq!(WIRE_VERSION, 1);
-        assert_eq!(WIRE_CAPS, &["objects-needed", "send-pack", "receive-pack"]);
+        // WIRE_VERSION STAYS 1 even though the zstd transport encoding was added:
+        // `snappack-zstd` is an additive capability TOKEN, not a version bump.
+        assert_eq!(
+            WIRE_CAPS,
+            &[
+                "objects-needed",
+                "send-pack",
+                "receive-pack",
+                "snappack-zstd"
+            ]
+        );
+        // The 1Z magic shares the wire version with v1 (the `Z` is a transport
+        // marker, not a format version).
+        assert_eq!(WIRE_MAGIC_ZSTD, format!("SNAPPACK {WIRE_VERSION}Z\n"));
+        assert_eq!(DEFAULT_ZSTD_LEVEL, 3);
+        assert_eq!((MIN_ZSTD_LEVEL, MAX_ZSTD_LEVEL), (1, 19));
     }
 
     #[test]
@@ -1508,5 +1839,699 @@ mod tests {
                 "checksum {bad:?}: got {err}"
             );
         }
+    }
+
+    // --- receiver durability (Design A) --------------------------------------
+
+    /// Recursively snapshots `(relative-path, bytes)` for every regular file
+    /// under `dir`, sorted — the canonical "filing" of a store, used to prove
+    /// Off and Batch produce IDENTICAL on-disk results.
+    fn filing_of(dir: &Path) -> Vec<(String, Vec<u8>)> {
+        let mut out: Vec<(String, Vec<u8>)> = files_under(dir)
+            .into_iter()
+            .map(|p| {
+                let rel = p.strip_prefix(dir).unwrap().to_string_lossy().into_owned();
+                (rel, fs::read(&p).expect("read filed bytes"))
+            })
+            .collect();
+        out.sort_by(|a, b| a.0.cmp(&b.0));
+        out
+    }
+
+    #[test]
+    fn pack_durability_off_vs_batch_produce_identical_filing() {
+        // A representative pack: a 0-byte object, a small one, a multi-MB one
+        // (streaming path), a duplicate, plus the manifest.
+        let payloads = vec![
+            Vec::new(),
+            b"durable hello\n".to_vec(),
+            big_payload(2 * 1024 * 1024 + 11),
+        ];
+        let (_a_dir, a, mut ids) = seed_store("dura-a", &payloads);
+        ids.push(ids[1].clone()); // duplicate record
+        let (manifest, man_id) = manifest_for(&payloads);
+        a.put_manifest(&man_id, &manifest).expect("seed manifest");
+
+        let mut pack = Vec::new();
+        write_pack(&a, &ids, Some(&man_id), &mut pack).expect("write_pack");
+
+        // Off (historical, no fsync).
+        let off_dir = TempDir::new("dura-off");
+        let off = FileStore::from_root(off_dir.path());
+        let mut off_sink = FileSink::new(&off).with_durability(Durability::Off);
+        let off_report = read_pack(pack.as_slice(), &mut off_sink).expect("off read");
+
+        // Batch (fsync barrier + durable manifest).
+        let batch_dir = TempDir::new("dura-batch");
+        let batch = FileStore::from_root(batch_dir.path());
+        let mut batch_sink = FileSink::new(&batch).with_durability(Durability::Batch);
+        let batch_report = read_pack(pack.as_slice(), &mut batch_sink).expect("batch read");
+
+        // Identical reports AND identical on-disk filing (objects + manifest,
+        // same sharded keys, same bytes) — durability is invisible to output.
+        assert_eq!(off_report, batch_report);
+        assert!(batch_report.manifest_committed);
+        assert_eq!(batch_report.objects_written, 3);
+        assert_eq!(batch_report.objects_skipped, 1, "duplicate skipped");
+        assert_eq!(
+            filing_of(off_dir.path()),
+            filing_of(batch_dir.path()),
+            "Off and Batch must file byte-identical trees"
+        );
+        // No stray temp litter in either.
+        for d in [off_dir.path(), batch_dir.path()] {
+            assert!(
+                !files_under(d)
+                    .iter()
+                    .any(|p| p.to_string_lossy().ends_with(".tmp")),
+                "no stray temp files"
+            );
+        }
+    }
+
+    /// A spy [`PackSink`] that records the ORDER of lifecycle calls so a test
+    /// can prove `flush_barrier` happens-before `put_manifest`. It also files
+    /// objects into a real [`FileStore`] (delegating) so the rest of the read
+    /// path behaves normally.
+    struct OrderSpy<'a> {
+        inner: FileSink<'a>,
+        events: Vec<&'static str>,
+    }
+
+    impl PackSink for OrderSpy<'_> {
+        fn has_object(&mut self, checksum: &str) -> Result<bool, StoreError> {
+            self.inner.has_object(checksum)
+        }
+        fn stage_object(
+            &mut self,
+            checksum: &str,
+            len: u64,
+            payload: &mut dyn Read,
+        ) -> Result<(), StoreError> {
+            self.events.push("stage");
+            self.inner.stage_object(checksum, len, payload)
+        }
+        fn commit_object(&mut self, checksum: &str) -> Result<(), StoreError> {
+            self.events.push("commit");
+            self.inner.commit_object(checksum)
+        }
+        fn abort_object(&mut self, checksum: &str) {
+            self.events.push("abort");
+            self.inner.abort_object(checksum);
+        }
+        fn flush_barrier(&mut self) -> Result<(), StoreError> {
+            self.events.push("barrier");
+            self.inner.flush_barrier()
+        }
+        fn put_manifest(&mut self, id: &str, manifest: &Manifest) -> Result<(), StoreError> {
+            self.events.push("manifest");
+            self.inner.put_manifest(id, manifest)
+        }
+    }
+
+    #[test]
+    fn pack_barrier_happens_before_manifest_via_spy_sink() {
+        let payloads = vec![b"o1\n".to_vec(), b"o2\n".to_vec()];
+        let (_a_dir, a, ids) = seed_store("spy-a", &payloads);
+        let (manifest, man_id) = manifest_for(&payloads);
+        a.put_manifest(&man_id, &manifest).expect("seed manifest");
+
+        let mut pack = Vec::new();
+        write_pack(&a, &ids, Some(&man_id), &mut pack).expect("write_pack");
+
+        let b_dir = TempDir::new("spy-b");
+        let b = FileStore::from_root(b_dir.path());
+        let mut spy = OrderSpy {
+            inner: FileSink::new(&b).with_durability(Durability::Batch),
+            events: Vec::new(),
+        };
+        let report = read_pack(pack.as_slice(), &mut spy).expect("read_pack");
+        assert!(report.manifest_committed);
+
+        // The barrier must appear exactly once, AFTER all commits and strictly
+        // BEFORE the manifest (the core ordering guarantee of Design A).
+        let barrier = spy
+            .events
+            .iter()
+            .position(|e| *e == "barrier")
+            .expect("barrier was called");
+        let manifest_at = spy
+            .events
+            .iter()
+            .position(|e| *e == "manifest")
+            .expect("manifest was committed");
+        assert!(
+            barrier < manifest_at,
+            "flush_barrier must happen-before put_manifest: {:?}",
+            spy.events
+        );
+        let last_commit = spy
+            .events
+            .iter()
+            .rposition(|e| *e == "commit")
+            .expect("at least one commit");
+        assert!(
+            last_commit < barrier,
+            "barrier must follow every object commit: {:?}",
+            spy.events
+        );
+        assert_eq!(
+            spy.events.iter().filter(|e| **e == "barrier").count(),
+            1,
+            "exactly one barrier per pack: {:?}",
+            spy.events
+        );
+    }
+
+    #[test]
+    fn pack_barrier_runs_even_for_empty_and_manifest_only_packs() {
+        // Empty pack: barrier still runs exactly once (no manifest, no objects).
+        let payloads_empty: Vec<Vec<u8>> = Vec::new();
+        let (_a0, a0, ids0) = seed_store("empty-bar-a", &payloads_empty);
+        let mut pack = Vec::new();
+        write_pack(&a0, &ids0, None, &mut pack).expect("write_pack");
+        let b0 = TempDir::new("empty-bar-b");
+        let store0 = FileStore::from_root(b0.path());
+        let mut spy = OrderSpy {
+            inner: FileSink::new(&store0).with_durability(Durability::Batch),
+            events: Vec::new(),
+        };
+        read_pack(pack.as_slice(), &mut spy).expect("read empty");
+        assert_eq!(spy.events, vec!["barrier"]);
+
+        // Manifest-only pack (objects already present): barrier-then-manifest.
+        let payloads = vec![b"present\n".to_vec()];
+        let (_a1, a1, _ids1) = seed_store("mo-bar-a", &payloads);
+        let (manifest, man_id) = manifest_for(&payloads);
+        a1.put_manifest(&man_id, &manifest).expect("seed manifest");
+        let mut pack = Vec::new();
+        write_pack(&a1, &[], Some(&man_id), &mut pack).expect("write_pack");
+        let b1 = TempDir::new("mo-bar-b");
+        let store1 = FileStore::from_root(b1.path());
+        let mut spy = OrderSpy {
+            inner: FileSink::new(&store1).with_durability(Durability::Batch),
+            events: Vec::new(),
+        };
+        let report = read_pack(pack.as_slice(), &mut spy).expect("read manifest-only");
+        assert!(report.manifest_committed);
+        assert_eq!(spy.events, vec!["barrier", "manifest"]);
+        assert_eq!(store1.get_manifest(&man_id).expect("manifest"), manifest);
+    }
+
+    #[test]
+    fn pack_batch_truncated_before_end_files_objects_never_manifest() {
+        // Re-pin the manifest-last / incremental-resume invariant under Batch:
+        // a stream cut before `end` files the verified objects (resume can pick
+        // them up) but NEVER the manifest, and leaves no temp litter — even
+        // though the durable path is selected.
+        let payloads = vec![b"one\n".to_vec(), b"two\n".to_vec()];
+        let (_a_dir, a, ids) = seed_store("btrunc-a", &payloads);
+        let (manifest, man_id) = manifest_for(&payloads);
+        a.put_manifest(&man_id, &manifest).expect("seed manifest");
+
+        let mut pack = Vec::new();
+        write_pack(&a, &ids, Some(&man_id), &mut pack).expect("write_pack");
+        assert!(pack.ends_with(b"end\n"));
+        let cut = &pack[..pack.len() - b"end\n".len()];
+
+        let b_dir = TempDir::new("btrunc-b");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b).with_durability(Durability::Batch);
+        let err = read_pack(cut, &mut sink).expect_err("truncation is a hard error");
+        assert!(err.to_string().contains("truncated"), "got: {err}");
+        drop(sink);
+
+        // Verified objects ARE filed (per-record rename visibility preserved for
+        // incremental resume)...
+        for (id, payload) in ids.iter().zip(&payloads) {
+            assert_eq!(b.get_object(id).unwrap(), *payload);
+        }
+        // ...but the manifest must NEVER be committed (barrier never reached).
+        assert!(matches!(
+            b.get_manifest(&man_id),
+            Err(StoreError::ManifestNotFound { .. })
+        ));
+        assert!(
+            !files_under(b_dir.path())
+                .iter()
+                .any(|p| p.to_string_lossy().ends_with(".tmp")),
+            "no stray temp files"
+        );
+    }
+
+    #[test]
+    fn pack_batch_resume_after_truncation_completes_via_second_pack() {
+        // Full incremental-resume cycle under Batch: a truncated first pack
+        // files some objects; a complete second pack verified-skips those and
+        // commits the manifest durably.
+        // First (small) object lands; the SECOND (large) object is the one the
+        // truncation cuts through, so it must NOT survive the first attempt.
+        let payloads = vec![b"head\n".to_vec(), big_payload(300 * 1024)];
+        let (_a_dir, a, ids) = seed_store("bresume-a", &payloads);
+        let (manifest, man_id) = manifest_for(&payloads);
+        a.put_manifest(&man_id, &manifest).expect("seed manifest");
+
+        let mut pack = Vec::new();
+        write_pack(&a, &ids, Some(&man_id), &mut pack).expect("write_pack");
+
+        let b_dir = TempDir::new("bresume-b");
+        let b = FileStore::from_root(b_dir.path());
+
+        // First attempt: cut deep inside the SECOND object's payload.
+        let cut = &pack[..pack.len() - 100_000];
+        {
+            let mut sink = FileSink::new(&b).with_durability(Durability::Batch);
+            assert!(read_pack(cut, &mut sink).is_err(), "truncated first pack");
+        }
+        // Object 1 landed; object 2 + manifest did not.
+        assert_eq!(b.get_object(&ids[0]).unwrap(), payloads[0]);
+        assert!(!StreamStore::has_object(&b, &ids[1]).unwrap());
+        assert!(matches!(
+            b.get_manifest(&man_id),
+            Err(StoreError::ManifestNotFound { .. })
+        ));
+
+        // Second, complete attempt resumes: obj 1 verified-skipped, obj 2
+        // written, manifest committed durably.
+        let mut sink = FileSink::new(&b).with_durability(Durability::Batch);
+        let report = read_pack(pack.as_slice(), &mut sink).expect("resume read");
+        assert_eq!(report.objects_skipped, 1, "already-present obj 1 skipped");
+        assert_eq!(report.objects_written, 1, "obj 2 written on resume");
+        assert!(report.manifest_committed);
+        assert_eq!(b.get_object(&ids[1]).unwrap(), payloads[1]);
+        assert_eq!(b.get_manifest(&man_id).expect("manifest"), manifest);
+    }
+
+    #[test]
+    fn pack_batch_roundtrip_streams_objects_and_manifest_durably() {
+        // End-to-end Batch round-trip incl. a multi-MB streaming object: the
+        // durable path produces a correct, complete store.
+        let payloads = vec![
+            b"alpha\n".to_vec(),
+            big_payload(4 * 1024 * 1024 + 3),
+            b"omega\n".to_vec(),
+        ];
+        let (a_dir, a, ids) = seed_store("brt-a", &payloads);
+        let (manifest, man_id) = manifest_for(&payloads);
+        a.put_manifest(&man_id, &manifest).expect("seed manifest");
+
+        let mut pack = Vec::new();
+        write_pack(&a, &ids, Some(&man_id), &mut pack).expect("write_pack");
+
+        let b_dir = TempDir::new("brt-b");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b).with_durability(Durability::Batch);
+        let read = read_pack(pack.as_slice(), &mut sink).expect("read_pack");
+        assert_eq!(read.objects_written, 3);
+        assert!(read.manifest_committed);
+
+        for id in &ids {
+            let key = object_path(id);
+            assert_eq!(
+                fs::read(b_dir.path().join(&key)).expect("b object"),
+                fs::read(a_dir.path().join(&key)).expect("a object"),
+            );
+        }
+        assert_eq!(b.get_manifest(&man_id).expect("manifest"), manifest);
+        assert_eq!(
+            snapshot_id(&b.get_manifest(&man_id).unwrap(), &Blake3Hasher::new()),
+            man_id
+        );
+    }
+
+    // --- SNAPPACK 1Z (zstd transport encoding) -------------------------------
+
+    /// A highly compressible fixture: a large run of a single repeated line, so
+    /// the 1Z frame is provably smaller than the v1 stream.
+    fn compressible_payload(reps: usize) -> Vec<u8> {
+        b"the quick brown fox jumps over the lazy dog\n".repeat(reps)
+    }
+
+    #[test]
+    fn pack_zstd_roundtrip_magic_and_smaller_than_v1() {
+        // A compressible object + manifest. The 1Z stream must (a) open with the
+        // 1Z magic, (b) decode + verify byte-identically into the sink, and
+        // (c) be strictly smaller than the equivalent v1 stream.
+        let payloads = vec![compressible_payload(4096), b"tail\n".to_vec()];
+        let (a_dir, a, ids) = seed_store("zrt-a", &payloads);
+        let (manifest, man_id) = manifest_for(&payloads);
+        a.put_manifest(&man_id, &manifest).expect("seed manifest");
+
+        // v1 reference stream.
+        let mut v1 = Vec::new();
+        write_pack(&a, &ids, Some(&man_id), &mut v1).expect("write v1");
+        assert!(v1.starts_with(WIRE_MAGIC.as_bytes()));
+
+        // 1Z stream.
+        let mut zpack = Vec::new();
+        let wrote = write_pack_with_format(
+            &a,
+            &ids,
+            Some(&man_id),
+            PackFormat::zstd_default(),
+            &mut zpack,
+        )
+        .expect("write 1Z");
+        assert_eq!(wrote.objects_written, 2);
+        assert!(wrote.manifest_written);
+        assert!(
+            zpack.starts_with(WIRE_MAGIC_ZSTD.as_bytes()),
+            "1Z stream must open with the 1Z magic"
+        );
+        assert!(
+            zpack.len() < v1.len(),
+            "1Z stream ({} bytes) must be smaller than v1 ({} bytes) on a compressible fixture",
+            zpack.len(),
+            v1.len()
+        );
+
+        // The receiver sniffs the 1Z magic, decompresses, and files byte-equal
+        // objects at the identical sharded keys (incremental BLAKE3 untouched).
+        let b_dir = TempDir::new("zrt-b");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        let read = read_pack(zpack.as_slice(), &mut sink).expect("read 1Z");
+        assert_eq!(read.objects_written, 2);
+        assert_eq!(read.objects_skipped, 0);
+        assert!(read.manifest_committed);
+
+        for (id, payload) in ids.iter().zip(&payloads) {
+            let key = object_path(id);
+            assert_eq!(
+                fs::read(b_dir.path().join(&key)).expect("b object"),
+                *payload
+            );
+            assert_eq!(
+                fs::read(a_dir.path().join(&key)).expect("a object"),
+                fs::read(b_dir.path().join(&key)).expect("b object"),
+            );
+        }
+        assert_eq!(b.get_manifest(&man_id).expect("manifest in B"), manifest);
+        assert!(
+            !files_under(b_dir.path())
+                .iter()
+                .any(|p| p.to_string_lossy().ends_with(".tmp")),
+            "no stray temp files after a clean 1Z stream"
+        );
+    }
+
+    #[test]
+    fn pack_zstd_batch_durability_roundtrips() {
+        // The 1Z decode path feeds the SAME sink, so Batch durability works over
+        // a compressed stream exactly as over v1.
+        let payloads = vec![compressible_payload(2048), big_payload(512 * 1024)];
+        let (_a_dir, a, ids) = seed_store("zbatch-a", &payloads);
+        let (manifest, man_id) = manifest_for(&payloads);
+        a.put_manifest(&man_id, &manifest).expect("seed manifest");
+
+        let mut zpack = Vec::new();
+        write_pack_with_format(
+            &a,
+            &ids,
+            Some(&man_id),
+            PackFormat::zstd_default(),
+            &mut zpack,
+        )
+        .expect("write 1Z");
+
+        let b_dir = TempDir::new("zbatch-b");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b).with_durability(Durability::Batch);
+        let read = read_pack(zpack.as_slice(), &mut sink).expect("read 1Z batch");
+        assert_eq!(read.objects_written, 2);
+        assert!(read.manifest_committed);
+        for (id, payload) in ids.iter().zip(&payloads) {
+            assert_eq!(b.get_object(id).unwrap(), *payload);
+        }
+        assert_eq!(b.get_manifest(&man_id).expect("manifest"), manifest);
+    }
+
+    #[test]
+    fn pack_zstd_unsolicited_stream_is_accepted_and_verified() {
+        // A 1Z stream arrives with NO prior flag/negotiation — the receiver
+        // sniffs the magic and accepts it, verifying every record.
+        let payload = b"unsolicited compressed object\n".to_vec();
+        let checksum = hex_of(&payload);
+        let body = v1_body(&[raw_record("obj", &checksum, &payload)]);
+        let stream = zstd_stream_from_body(&body);
+
+        let b_dir = TempDir::new("zunsol");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        let read = read_pack(stream.as_slice(), &mut sink).expect("unsolicited 1Z accepted");
+        assert_eq!(read.objects_written, 1);
+        assert_eq!(b.get_object(&checksum).unwrap(), payload);
+    }
+
+    #[test]
+    fn pack_zstd_level_clamped_and_levels_roundtrip() {
+        // Out-of-range levels are clamped (not rejected) and every in-range
+        // level produces a valid, verifiable 1Z stream.
+        let payloads = vec![compressible_payload(1024)];
+        let (_a_dir, a, ids) = seed_store("zlevel-a", &payloads);
+
+        for level in [
+            MIN_ZSTD_LEVEL - 5,
+            MIN_ZSTD_LEVEL,
+            9,
+            MAX_ZSTD_LEVEL,
+            MAX_ZSTD_LEVEL + 50,
+        ] {
+            let mut zpack = Vec::new();
+            write_pack_with_format(&a, &ids, None, PackFormat::Zstd(level), &mut zpack)
+                .unwrap_or_else(|e| panic!("write 1Z at level {level}: {e}"));
+            assert!(zpack.starts_with(WIRE_MAGIC_ZSTD.as_bytes()));
+
+            let b_dir = TempDir::new("zlevel-b");
+            let b = FileStore::from_root(b_dir.path());
+            let mut sink = FileSink::new(&b);
+            let read = read_pack(zpack.as_slice(), &mut sink)
+                .unwrap_or_else(|e| panic!("read 1Z at level {level}: {e}"));
+            assert_eq!(read.objects_written, 1);
+            assert_eq!(b.get_object(&ids[0]).unwrap(), payloads[0]);
+        }
+    }
+
+    #[test]
+    fn pack_zstd_truncated_files_objects_but_never_manifest_and_no_litter() {
+        // Build a full 1Z stream, then cut the zstd frame short. The verified
+        // objects that fully decoded are filed (incremental resume), but the
+        // manifest is NEVER committed and no temp litter survives.
+        let payloads = vec![b"one\n".to_vec(), b"two\n".to_vec()];
+        let (_a_dir, a, ids) = seed_store("ztrunc-a", &payloads);
+        let (manifest, man_id) = manifest_for(&payloads);
+        a.put_manifest(&man_id, &manifest).expect("seed manifest");
+
+        // Forge the body so the manifest record is LAST, then truncate the frame
+        // hard (drop its tail) so the `end` trailer never decodes.
+        let body = v1_body(&[
+            raw_record("obj", &ids[0], &payloads[0]),
+            raw_record("obj", &ids[1], &payloads[1]),
+            raw_record("manifest", &man_id, &manifest_bytes(&manifest)),
+        ]);
+        let full = zstd_stream_from_body(&body);
+        // Keep the magic + a prefix of the frame only.
+        let magic_len = WIRE_MAGIC_ZSTD.len();
+        let frame_len = full.len() - magic_len;
+        let cut = &full[..magic_len + frame_len / 2];
+
+        let b_dir = TempDir::new("ztrunc-b");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        let err = read_pack(cut, &mut sink).expect_err("truncated 1Z is a hard error");
+        // Either a zstd decode error or the missing-`end` truncation error — both
+        // are hard failures that never commit the manifest.
+        let _ = err;
+        drop(sink);
+
+        // The manifest must NEVER be committed (manifest-last survives a cut).
+        assert!(matches!(
+            b.get_manifest(&man_id),
+            Err(StoreError::ManifestNotFound { .. })
+        ));
+        // No temp litter regardless of how many objects decoded before the cut.
+        assert!(
+            !files_under(b_dir.path())
+                .iter()
+                .any(|p| p.to_string_lossy().ends_with(".tmp")),
+            "no stray temp files after a truncated 1Z stream"
+        );
+    }
+
+    #[test]
+    fn pack_zstd_lying_len_inside_frame_stays_bounded() {
+        // A header INSIDE the 1Z frame LIES about a huge payload length while
+        // sending few bytes. Bounds are enforced on the DECOMPRESSED bytes: the
+        // manifest cap fires on the header alone, and an obj record that under-
+        // delivers its claimed length is a truncation error — neither allocates
+        // gigabytes nor hangs.
+        let claimed = hex_of(b"irrelevant");
+
+        // (a) Manifest record claiming > 64MiB: the cap check fires on the header.
+        let big_len: u64 = MAX_MANIFEST_BYTES + 1;
+        let mut body = format!("manifest {claimed} {big_len}\n").into_bytes();
+        body.extend_from_slice(b"end\n");
+        let stream = zstd_stream_from_body(&body);
+        let b_dir = TempDir::new("zlie-man");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        let err = read_pack(stream.as_slice(), &mut sink).expect_err("lying manifest len");
+        assert!(err.to_string().contains("cap"), "got: {err}");
+
+        // (b) Obj record claiming a giant length but sending only a few bytes:
+        // truncation error, bounded — the prealloc guard never honors the lie.
+        let body = {
+            let mut out = format!("obj {claimed} 4000000000\n").into_bytes();
+            out.extend_from_slice(b"tiny"); // 4 bytes, not 4e9
+            out.extend_from_slice(b"end\n");
+            out
+        };
+        let stream = zstd_stream_from_body(&body);
+        let mut sink = FileSink::new(&b);
+        let err = read_pack(stream.as_slice(), &mut sink).expect_err("lying obj len");
+        assert!(err.to_string().contains("truncated"), "got: {err}");
+        assert!(
+            !files_under(b_dir.path())
+                .iter()
+                .any(|p| p.to_string_lossy().ends_with(".tmp")),
+            "no temp litter after a lying-len 1Z stream"
+        );
+    }
+
+    #[test]
+    fn pack_zstd_oversized_header_inside_frame_is_bounded() {
+        // The 128-byte header cap is enforced on DECOMPRESSED bytes too: a long
+        // garbage header line inside the frame is rejected before buffering more.
+        let mut body = "o".repeat(200).into_bytes();
+        body.extend_from_slice(b"\nend\n");
+        let stream = zstd_stream_from_body(&body);
+        let b_dir = TempDir::new("zhdr-cap");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        let err = read_pack(stream.as_slice(), &mut sink).expect_err("must reject");
+        assert!(err.to_string().contains("128-byte cap"), "got: {err}");
+    }
+
+    #[test]
+    fn pack_zstd_mismatch_inside_frame_fails_closed() {
+        // A record inside the 1Z frame CLAIMS checksum X but its decompressed
+        // bytes hash to Y: hard Integrity error, nothing filed, no litter.
+        let claimed = hex_of(b"good bytes");
+        let evil = b"evil bytes";
+        let body = v1_body(&[raw_record("obj", &claimed, evil)]);
+        let stream = zstd_stream_from_body(&body);
+
+        let b_dir = TempDir::new("zmismatch");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = FileSink::new(&b);
+        let err = read_pack(stream.as_slice(), &mut sink).expect_err("must abort");
+        assert!(matches!(err, StoreError::Integrity { .. }), "got: {err}");
+        drop(sink);
+        assert!(!StreamStore::has_object(&b, &claimed).unwrap());
+        assert_eq!(
+            files_under(b_dir.path()),
+            Vec::<PathBuf>::new(),
+            "no file may survive a mismatch inside the 1Z frame"
+        );
+    }
+
+    #[test]
+    fn pack_zstd_bad_magic_is_a_clean_error() {
+        // Garbage / wrong-version magics — including ones that merely resemble
+        // the 1Z magic — are rejected cleanly (no panic, no decode attempt).
+        let b_dir = TempDir::new("zmagic");
+        let b = FileStore::from_root(b_dir.path());
+        for stream in [
+            &b"SNAPPACK 3\nend\n"[..],             // wrong version
+            &b"SNAPPACK 1z\nGARBAGE"[..],          // lowercase z is NOT the 1Z magic
+            &b"SNAPPACK 2Z\nGARBAGE"[..],          // wrong version + Z
+            &b"SNAPPACK 1ZZ\nGARBAGE"[..],         // trailing junk
+            &b"GARBAGE\nend\n"[..],                // not SNAPPACK at all
+            &b"SNAPPACK 1Z\nnot a zstd frame"[..], // right magic, garbage frame
+        ] {
+            let mut sink = FileSink::new(&b);
+            assert!(
+                read_pack(stream, &mut sink).is_err(),
+                "stream {:?} must be rejected cleanly",
+                String::from_utf8_lossy(stream)
+            );
+        }
+    }
+
+    #[test]
+    fn pack_zstd_stream_sink_generic_roundtrips() {
+        // The generic StreamSink also decodes a 1Z stream correctly.
+        let payloads = vec![compressible_payload(512), b"z\n".to_vec()];
+        let (_a_dir, a, ids) = seed_store("zss-a", &payloads);
+        let (manifest, man_id) = manifest_for(&payloads);
+        a.put_manifest(&man_id, &manifest).expect("seed manifest");
+
+        let mut zpack = Vec::new();
+        write_pack_with_format(
+            &a,
+            &ids,
+            Some(&man_id),
+            PackFormat::zstd_default(),
+            &mut zpack,
+        )
+        .expect("write 1Z");
+
+        let b_dir = TempDir::new("zss-b");
+        let b = FileStore::from_root(b_dir.path());
+        let mut sink = StreamSink::new(&b);
+        let read = read_pack(zpack.as_slice(), &mut sink).expect("read 1Z");
+        assert_eq!(read.objects_written, 2);
+        assert!(read.manifest_committed);
+        for (id, payload) in ids.iter().zip(&payloads) {
+            assert_eq!(b.get_object(id).expect("object"), *payload);
+        }
+        assert_eq!(b.get_manifest(&man_id).expect("manifest"), manifest);
+    }
+
+    #[test]
+    fn pack_v1_default_unchanged_and_both_forms_file_identically() {
+        // `write_pack` (the default) is byte-identical to V1, and the v1 + 1Z
+        // forms of the SAME content file the SAME on-disk tree.
+        let payloads = vec![compressible_payload(256), b"k\n".to_vec()];
+        let (_a_dir, a, ids) = seed_store("zboth-a", &payloads);
+        let (manifest, man_id) = manifest_for(&payloads);
+        a.put_manifest(&man_id, &manifest).expect("seed manifest");
+
+        let mut default_pack = Vec::new();
+        write_pack(&a, &ids, Some(&man_id), &mut default_pack).expect("default");
+        let mut v1_pack = Vec::new();
+        write_pack_with_format(&a, &ids, Some(&man_id), PackFormat::V1, &mut v1_pack)
+            .expect("explicit v1");
+        assert_eq!(
+            default_pack, v1_pack,
+            "default == explicit V1, byte-for-byte"
+        );
+        assert!(default_pack.starts_with(WIRE_MAGIC.as_bytes()));
+
+        let mut z_pack = Vec::new();
+        write_pack_with_format(
+            &a,
+            &ids,
+            Some(&man_id),
+            PackFormat::zstd_default(),
+            &mut z_pack,
+        )
+        .expect("1Z");
+
+        let v1_dir = TempDir::new("zboth-v1");
+        let v1_store = FileStore::from_root(v1_dir.path());
+        let mut v1_sink = FileSink::new(&v1_store);
+        read_pack(v1_pack.as_slice(), &mut v1_sink).expect("read v1");
+
+        let z_dir = TempDir::new("zboth-z");
+        let z_store = FileStore::from_root(z_dir.path());
+        let mut z_sink = FileSink::new(&z_store);
+        read_pack(z_pack.as_slice(), &mut z_sink).expect("read 1Z");
+
+        assert_eq!(
+            filing_of(v1_dir.path()),
+            filing_of(z_dir.path()),
+            "v1 and 1Z must file byte-identical trees"
+        );
     }
 }

--- a/crates/snapdir-stores/src/s3_store.rs
+++ b/crates/snapdir-stores/src/s3_store.rs
@@ -50,13 +50,13 @@ use aws_smithy_http_client::Builder as HttpClientBuilder;
 use aws_smithy_runtime_api::client::orchestrator::HttpResponse;
 use snapdir_core::manifest::Manifest;
 use snapdir_core::merkle::{Blake3Hasher, Hasher};
-use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
+use snapdir_core::store::{manifest_path, object_path, Store, StoreError, MANIFESTS_DIR};
 use snapdir_core::Meter;
 
 use crate::fetch::fetch_files_concurrent;
 use crate::push::{push_objects_concurrent, upload_object};
 use crate::retry::{parse_retry_after, retry_network, Attempt, DefaultJitter, TokioSleeper};
-use crate::stream::StreamStore;
+use crate::stream::{manifest_id_from_shard_segments, StreamStore};
 use crate::transfer::{classify_error, RateLimiter, TransferConfig};
 
 use std::error::Error as StdError;
@@ -385,6 +385,59 @@ impl S3Store {
         .await
     }
 
+    /// Lists every object key under `prefix` (a leading-slash-free key prefix),
+    /// following `list_objects_v2` pagination to completion.
+    ///
+    /// Each page's single SDK call is wrapped in [`retry_network`] — the same
+    /// request-rate + transient-retry discipline as
+    /// [`key_exists`](Self::key_exists) / [`get_bytes`](Self::get_bytes) — and
+    /// the `continuation_token` drives the page loop until the response is no
+    /// longer truncated. Returns the full set of keys (the caller filters /
+    /// reconstructs ids).
+    async fn list_keys_under(&self, prefix: &str) -> Result<Vec<String>, StoreError> {
+        let mut keys = Vec::new();
+        let mut continuation: Option<String> = None;
+        loop {
+            let token = continuation.clone();
+            let page = retry_network(
+                &self.config.retry,
+                &self.req_limiter,
+                &TokioSleeper,
+                &DefaultJitter::new(),
+                || {
+                    let token = token.clone();
+                    async move {
+                        self.client
+                            .list_objects_v2()
+                            .bucket(&self.location.bucket)
+                            .prefix(prefix)
+                            .set_continuation_token(token)
+                            .send()
+                            .await
+                            .map_err(|err| s3_attempt_from_err("S3 list objects failed", err))
+                    }
+                },
+            )
+            .await?;
+
+            for object in page.contents() {
+                if let Some(key) = object.key() {
+                    keys.push(key.to_owned());
+                }
+            }
+
+            // Page on while the listing is truncated; the next-token is the
+            // SDK's resumption cursor.
+            match page.next_continuation_token() {
+                Some(next) if page.is_truncated().unwrap_or(false) => {
+                    continuation = Some(next.to_owned());
+                }
+                _ => break,
+            }
+        }
+        Ok(keys)
+    }
+
     /// Downloads `key`, verifying its BLAKE3 against `expected`, retrying up to
     /// [`MAX_FETCH_RETRIES`] times. Mirrors `_snapdir_s3_fetch_to_cache`.
     async fn fetch_verified(&self, key: &str, expected: &str) -> Result<Vec<u8>, StoreError> {
@@ -595,6 +648,41 @@ impl StreamStore for S3Store {
         self.runtime
             .block_on(async { self.put_bytes(&key, text.into_bytes()).await })
     }
+
+    fn list_manifest_ids(&self) -> Result<Vec<String>, StoreError> {
+        // List every key under `<prefix>/.manifests/` and reconstruct the id
+        // from the `3/3/3/rest` segments after that prefix, mirroring the
+        // FileStore walk but over S3 keys. The trailing slash anchors the
+        // listing to the `.manifests/` subtree (never `.objects/`).
+        let list_prefix = format!("{}/", self.location.key_for(MANIFESTS_DIR));
+        let keys = self
+            .runtime
+            .block_on(async { self.list_keys_under(&list_prefix).await })?;
+        Ok(manifest_ids_from_keys(&keys, &list_prefix))
+    }
+}
+
+/// Reconstructs the deduplicated, validated set of 64-hex manifest ids from a
+/// flat list of store keys produced by listing under `list_prefix` (the
+/// leading-slash-free `<prefix>/.manifests/` key prefix WITH a trailing slash).
+///
+/// Each key has `list_prefix` stripped, the remainder is split on `/` into the
+/// `3/3/3/rest` shard segments, and
+/// [`manifest_id_from_shard_segments`](crate::stream::manifest_id_from_shard_segments)
+/// validates + reconstructs the id (a stray / malformed key yields `None` and is
+/// skipped). The `HashSet` dedups. Shared by `S3Store` and `GcsStore`.
+pub(crate) fn manifest_ids_from_keys(keys: &[String], list_prefix: &str) -> Vec<String> {
+    let mut ids = std::collections::HashSet::new();
+    for key in keys {
+        let Some(rel) = key.strip_prefix(list_prefix) else {
+            continue;
+        };
+        let segments: Vec<&str> = rel.split('/').collect();
+        if let Some(id) = manifest_id_from_shard_segments(&segments) {
+            ids.insert(id);
+        }
+    }
+    ids.into_iter().collect()
 }
 
 /// Builds the multi-thread tokio runtime that backs the sync bridge.

--- a/crates/snapdir-stores/src/split.rs
+++ b/crates/snapdir-stores/src/split.rs
@@ -1,0 +1,191 @@
+//! `SplitStore`: a composite store that serves objects from one pool and
+//! manifests from a separate location.
+//!
+//! A [`SplitStore`] wraps TWO underlying [`StreamStore`]s:
+//!
+//! - an **objects** pool — only its `.objects/` content-addressed blobs are
+//!   used;
+//! - a **manifests** location — only its `.manifests/<id>` slots are used.
+//!
+//! Object-level operations
+//! ([`has_object`](StreamStore::has_object) / [`get_object`](StreamStore::get_object)
+//! / [`put_object`](StreamStore::put_object) / [`objects_needed`](StreamStore::objects_needed))
+//! route to the objects pool; manifest operations
+//! ([`get_manifest`](Store::get_manifest) / [`put_manifest`](StreamStore::put_manifest))
+//! route to the manifests location. It implements both [`Store`] and
+//! [`StreamStore`], so it is a drop-in for `push`/`fetch`/`pull`/`sync`.
+//!
+//! # Why split?
+//!
+//! One content-addressed objects pool can back many independent manifest
+//! prefixes: pushing the same tree under two different manifest locations
+//! re-uploads ZERO objects the second time, because the per-object skip probe is
+//! the SHARED pool's [`has_object`](StreamStore::has_object). The objects bytes a
+//! split push writes are byte-for-byte identical to a colocated [`FileStore`]
+//! push of the same tree (frozen sharded-layout interop), so a split pool and a
+//! colocated store are interchangeable.
+//!
+//! # Reuse, not reinvention
+//!
+//! [`SplitStore`] does NOT duplicate the materialization or upload machinery the
+//! backends already ship:
+//!
+//! - [`fetch_files`](Store::fetch_files) delegates straight to the objects
+//!   side's [`Store::fetch_files`], so per-entry directory/perms/skip-present
+//!   materialization and the `ObjectNotFound` / `Integrity` discipline come from
+//!   the backend verbatim.
+//! - [`push`](Store::push) reuses the [`StreamStore`] object primitives
+//!   ([`has_object`](StreamStore::has_object) +
+//!   [`put_object`](StreamStore::put_object), each BLAKE3-verified before it
+//!   writes) and the manifests side's [`put_manifest`](StreamStore::put_manifest),
+//!   preserving the objects-before-manifest + manifest-last + all-or-nothing
+//!   invariants. The only new code is the small "read+verify local file objects
+//!   into the pool, then write the manifest last" glue — the same shape
+//!   `file_store.rs` / `push.rs` already use, but with the manifest landing in a
+//!   DIFFERENT store.
+
+use std::path::Path;
+
+use snapdir_core::manifest::{Manifest, PathType};
+use snapdir_core::merkle::{snapshot_id, Blake3Hasher};
+use snapdir_core::store::{Store, StoreError};
+
+use crate::stream::StreamStore;
+
+/// Strips a leading `./` (relative-mode manifest paths) and a trailing `/`
+/// (directory entries) so the remainder can be joined onto a source root.
+///
+/// Mirrors the identical helper in `file_store.rs` / `push.rs`; kept local so
+/// the split push glue never reaches into a sibling module's privates.
+fn strip_leading_dot_slash(path: &str) -> &str {
+    let trimmed = path.strip_prefix("./").unwrap_or(path);
+    trimmed.strip_suffix('/').unwrap_or(trimmed)
+}
+
+/// A composite [`Store`]/[`StreamStore`] that serves content objects from one
+/// pool and manifests from a separate location.
+///
+/// See the [module docs](crate::split) for the routing and reuse model.
+/// Construct one with [`SplitStore::new`].
+pub struct SplitStore {
+    /// The objects pool: only its `.objects/` content-addressed blobs are used.
+    objects: Box<dyn StreamStore + Sync>,
+    /// The manifests location: only its `.manifests/<id>` slots are used.
+    manifests: Box<dyn StreamStore + Sync>,
+}
+
+impl SplitStore {
+    /// Builds a [`SplitStore`] over an `objects` pool and a `manifests`
+    /// location.
+    ///
+    /// Object ops route to `objects`; manifest ops route to `manifests`. Either
+    /// side may be any [`StreamStore`] (a [`FileStore`](crate::FileStore), an
+    /// `S3Store`, etc.).
+    pub fn new(
+        objects: impl StreamStore + Sync + 'static,
+        manifests: impl StreamStore + Sync + 'static,
+    ) -> Self {
+        Self {
+            objects: Box::new(objects),
+            manifests: Box::new(manifests),
+        }
+    }
+
+    /// Builds a [`SplitStore`] from two already-boxed stores (e.g. when the two
+    /// sides are different concrete types resolved at the CLI seam).
+    #[must_use]
+    pub fn from_boxed(
+        objects: Box<dyn StreamStore + Sync>,
+        manifests: Box<dyn StreamStore + Sync>,
+    ) -> Self {
+        Self { objects, manifests }
+    }
+}
+
+impl Store for SplitStore {
+    fn get_manifest(&self, id: &str) -> Result<Manifest, StoreError> {
+        // Manifest ops route to the manifests location.
+        self.manifests.get_manifest(id)
+    }
+
+    fn fetch_files(&self, manifest: &Manifest, dest: &Path) -> Result<(), StoreError> {
+        // The objects side already materializes file objects from its own
+        // `.objects/` pool into `dest`, reusing the backend's per-entry
+        // directory/perms/symlink + skip-present + `ObjectNotFound`/`Integrity`
+        // discipline. No duplication here.
+        self.objects.fetch_files(manifest, dest)
+    }
+
+    fn push(&self, manifest: &Manifest, source: &Path) -> Result<(), StoreError> {
+        let hasher = Blake3Hasher::new();
+        let id = snapshot_id(manifest, &hasher);
+
+        // Skip-if-present probed on the MANIFESTS side: a present manifest there
+        // implies all of its objects already landed in the pool (we maintain
+        // that by writing the manifest LAST). The fast path must not touch the
+        // pool, so we never probe `objects` here.
+        if self.manifests.get_manifest(&id).is_ok() {
+            return Ok(());
+        }
+
+        // Objects-before-manifest: read+verify every absent local file object
+        // and upload it into the objects pool. Per-object skip is probed on the
+        // pool's `has_object` (content-addressed: a present object is already
+        // the right bytes). Any failure returns early WITHOUT writing the
+        // manifest (all-or-nothing).
+        for entry in manifest.entries() {
+            if entry.path_type != PathType::File {
+                continue;
+            }
+            if self.objects.has_object(&entry.checksum)? {
+                continue;
+            }
+            let rel = strip_leading_dot_slash(&entry.path);
+            let object_source = source.join(rel);
+            // A missing/unreadable source aborts the push (interrupted push ->
+            // no manifest). `put_object` re-verifies the bytes against the
+            // content-address before storing, so a corrupt source can never
+            // land at the wrong key.
+            let bytes = std::fs::read(&object_source)?;
+            self.objects.put_object(&entry.checksum, bytes)?;
+        }
+
+        // Manifest-last: only after every object landed in the pool do we write
+        // the manifest to the manifests location.
+        self.manifests.put_manifest(&id, manifest)
+    }
+}
+
+impl StreamStore for SplitStore {
+    fn has_object(&self, checksum: &str) -> Result<bool, StoreError> {
+        self.objects.has_object(checksum)
+    }
+
+    fn get_object(&self, checksum: &str) -> Result<Vec<u8>, StoreError> {
+        self.objects.get_object(checksum)
+    }
+
+    fn put_object(&self, checksum: &str, bytes: Vec<u8>) -> Result<(), StoreError> {
+        self.objects.put_object(checksum, bytes)
+    }
+
+    fn put_manifest(&self, id: &str, manifest: &Manifest) -> Result<(), StoreError> {
+        // Manifest ops route to the manifests location; the objects pool is
+        // never written.
+        self.manifests.put_manifest(id, manifest)
+    }
+
+    fn objects_needed(&self, checksums: &[String]) -> Result<Vec<String>, StoreError> {
+        // Delegate so the pool's own (possibly batched) override is used, and
+        // the fail-closed checksum validation is the pool's.
+        self.objects.objects_needed(checksums)
+    }
+
+    fn list_manifest_ids(&self) -> Result<Vec<String>, StoreError> {
+        // `list_manifest_ids` is a MANIFEST op: it enumerates the `.manifests/`
+        // ids of the manifests location, NEVER the shared objects pool. Two
+        // split stores sharing one pool therefore each list only their own
+        // manifests (shared-pool isolation).
+        self.manifests.list_manifest_ids()
+    }
+}

--- a/crates/snapdir-stores/src/stream.rs
+++ b/crates/snapdir-stores/src/stream.rs
@@ -143,4 +143,61 @@ pub trait StreamStore: Store {
         }
         Ok(needed)
     }
+
+    /// Enumerates the snapshot ids present under this store's `.manifests/`
+    /// tree.
+    ///
+    /// Each id is a 64-lowercase-hex snapshot id reconstructed from the frozen
+    /// `3/3/3/rest` shard layout (the same layout
+    /// [`manifest_path`](snapdir_core::store::manifest_path) writes). The
+    /// returned ids are:
+    ///
+    /// - **deduplicated** — each id appears AT MOST once;
+    /// - **validated** — only ids matching `^[0-9a-f]{64}$` are returned; a
+    ///   stray / non-manifest key under `.manifests/` is IGNORED, not an error;
+    /// - **unordered** — the caller sorts; no order is promised.
+    ///
+    /// # Default: fail closed
+    ///
+    /// The default implementation returns a [`StoreError::Backend`] ("listing
+    /// unsupported"): a backend that cannot enumerate its manifests must NOT
+    /// silently claim it has zero snapshots. Backends that can list
+    /// ([`FileStore`](crate::FileStore), `S3Store`, `GcsStore`, `B2Store`, and
+    /// [`SplitStore`](crate::SplitStore) via its manifests side) override this.
+    ///
+    /// # Errors
+    ///
+    /// - [`StoreError::Backend`] from the default impl (listing unsupported).
+    /// - [`StoreError::Io`] / [`StoreError::Backend`] on transport failure for
+    ///   the listing backends.
+    fn list_manifest_ids(&self) -> Result<Vec<String>, StoreError> {
+        Err(StoreError::Backend {
+            message: "listing unsupported: this store cannot enumerate manifest ids".to_owned(),
+            source: None,
+        })
+    }
+}
+
+/// Reconstructs a candidate 64-hex snapshot id from the shard segments of a
+/// store key under `.manifests/` and keeps it only if it is a valid id.
+///
+/// `segments` are the path components AFTER the `.manifests/` prefix (e.g.
+/// `["49d", "c87", "0df", "1de7…db92"]`). They are concatenated verbatim — the
+/// inverse of the frozen `3/3/3/rest` [`sharded_path`] split — and the result
+/// is accepted only when it matches `^[0-9a-f]{64}$` ([`crate::pack::is_hex64`]).
+/// A key with the wrong shard depth, a short/non-hex/uppercase id, or any other
+/// out-of-spec shape yields `None` (the caller skips it WITHOUT erroring).
+pub(crate) fn manifest_id_from_shard_segments(segments: &[&str]) -> Option<String> {
+    // A well-formed manifest key is exactly four segments under `.manifests/`:
+    // the `3 / 3 / 3 / rest` shard split. Anything else (too shallow, an extra
+    // nested level, …) cannot be a clean reconstruction and is skipped.
+    if segments.len() != 4 {
+        return None;
+    }
+    let id: String = segments.concat();
+    if crate::pack::is_hex64(&id) {
+        Some(id)
+    } else {
+        None
+    }
 }

--- a/crates/snapdir-stores/tests/apfs_clone.rs
+++ b/crates/snapdir-stores/tests/apfs_clone.rs
@@ -1,0 +1,1074 @@
+//! Adversarial integration suite for the macOS APFS `clonefile` copy-on-write
+//! fast-path in the `FileStore` file-copy primitive (phase 29, gate
+//! `apfs-clone-spec-tests`).
+//!
+//! BLACK-BOX: authored from the gate SPEC alone, with NO visibility into the
+//! `copy_file` / `persist` internals being tested (there is no clone path yet).
+//! It will NOT compile/pass until the stores-impl teammate moves this file into
+//! `crates/snapdir-stores/tests/apfs_clone.rs` and lands the feature. Do NOT
+//! weaken any assertion to make it green — if a behavior here fails against the
+//! landed impl, that is a real bug in the impl, not in this test.
+//!
+//! SPEC under test: on macOS, when the copy source and the store destination are
+//! on the same APFS volume, `FileStore`'s internal copy primitive (used by
+//! `push` (source → object) AND `fetch_files` (object → working file)) uses
+//! `clonefile()` (copy-on-write) instead of a byte-copy; on non-APFS /
+//! cross-volume / non-macOS it falls back to `std::fs::copy`. KEYSTONE: the
+//! clone path must be OBSERVABLY IDENTICAL to the `fs::copy` path — same object
+//! bytes, same sharded object filenames (checksums), same restored content and
+//! permissions.
+//!
+//! ## Contracted new symbols (impl lane MUST match these names)
+//!
+//! - Env knob **`SNAPDIR_CLONEFILE=0`** forces the plain `fs::copy` path
+//!   (disables the fast-path). `1` / unset = fast-path enabled where supported.
+//! - A **public, test-visible clone-hit counter**:
+//!   **`snapdir_stores::clonefile_hits() -> u64`** — a process-global
+//!   `AtomicU64` incremented each time the clone fast-path actually fires. It
+//!   MUST be `pub` (callable from this integration test); a `pub(crate)` hook is
+//!   NOT visible from `tests/`.
+//!
+//! ## Env / parallelism note (read before touching the env knob)
+//!
+//! `SNAPDIR_CLONEFILE` is process-global, and Rust runs the `#[test]`s in one
+//! binary across multiple threads. Tests that toggle the knob therefore take a
+//! single process-wide mutex (`ENV_LOCK`) and RESTORE the prior value before
+//! releasing it, so a parallel test never observes a half-set knob. The
+//! clone-hit-counter delta cases additionally serialize under that lock because
+//! `clonefile_hits()` is process-global. Cross-volume (case 4) is
+//! skip-if-unavailable (detected at runtime, `return`s with an eprintln note)
+//! because CI may have only one filesystem.
+
+// Wiring (shape only, no assertion change): silence workspace `-D warnings`
+// clippy lints on this adversary-authored suite. `StreamStore` is imported as a
+// contracted-symbol presence check; the round-trip return tuple and the
+// skip-if-unavailable match are intentional in the adversary's style.
+#![allow(
+    unused_imports,
+    clippy::type_complexity,
+    clippy::single_match_else,
+    clippy::single_match,
+    clippy::manual_let_else
+)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
+use snapdir_core::merkle::{directory_checksum, Blake3Hasher, Hasher};
+use snapdir_core::snapshot_id;
+use snapdir_core::store::{manifest_path, object_path, Store};
+
+use snapdir_stores::{FileStore, StreamStore};
+
+// ---------------------------------------------------------------------------
+// Test scaffolding (no dev-dependencies; mirrors the existing split/shim tests).
+// ---------------------------------------------------------------------------
+
+/// A unique temp dir removed on drop.
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "snapdir-clone-test-{}-{tag}-{n}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).expect("create temp dir");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        // Best-effort: clear any immutable flag a case set so the dir can be
+        // removed, then remove. (chflags on the file is cleared by the case
+        // itself; this is belt-and-suspenders for the temp root.)
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+/// Process-global lock guarding the `SNAPDIR_CLONEFILE` env var + the
+/// process-global `clonefile_hits()` counter. Any test that reads/sets the knob
+/// or compares counter deltas MUST hold this for its whole body.
+fn env_lock() -> MutexGuard<'static, ()> {
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// RAII guard that sets `SNAPDIR_CLONEFILE` to `value` and restores the prior
+/// value (or unsets it) on drop. The caller must already hold `env_lock()`.
+struct CloneEnv {
+    prev: Option<String>,
+}
+
+impl CloneEnv {
+    /// `Some("0")` disables the fast-path; `None` removes the var (default =
+    /// fast-path enabled where supported).
+    fn set(value: Option<&str>) -> Self {
+        let prev = std::env::var("SNAPDIR_CLONEFILE").ok();
+        match value {
+            Some(v) => std::env::set_var("SNAPDIR_CLONEFILE", v),
+            None => std::env::remove_var("SNAPDIR_CLONEFILE"),
+        }
+        Self { prev }
+    }
+}
+
+impl Drop for CloneEnv {
+    fn drop(&mut self) {
+        match &self.prev {
+            Some(v) => std::env::set_var("SNAPDIR_CLONEFILE", v),
+            None => std::env::remove_var("SNAPDIR_CLONEFILE"),
+        }
+    }
+}
+
+/// Writes a real source tree under `src` and returns the matching `Manifest`
+/// plus its snapshot id. `files` is `(relative path, content, octal-mode-str)`.
+/// A `D ./` root entry is synthesized so the manifest is a valid snapshot.
+/// Object addressing uses the NON-keyed `Blake3Hasher` (the content-address
+/// hasher the file store files objects under), exactly as the shipped
+/// shim/file-store/split tests do.
+fn build_tree(src: &Path, files: &[(&str, &[u8], &str)]) -> (Manifest, String) {
+    let hasher = Blake3Hasher::new();
+    let mut manifest = Manifest::new();
+
+    let mut file_sums: Vec<String> = Vec::new();
+    for (rel, content, mode) in files {
+        let target = src.join(rel);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&target, content).unwrap();
+        #[cfg(unix)]
+        {
+            let perms = fs::Permissions::from_mode(u32::from_str_radix(mode, 8).unwrap());
+            fs::set_permissions(&target, perms).unwrap();
+        }
+        let sum = hasher.hash_hex(content);
+        file_sums.push(sum.clone());
+        manifest.push(ManifestEntry::new(
+            PathType::File,
+            *mode,
+            sum,
+            content.len() as u64,
+            format!("./{rel}"),
+        ));
+    }
+
+    let root_sum = directory_checksum(file_sums.iter().map(String::as_str), &hasher);
+    let root_size: u64 = files.iter().map(|(_, c, _)| c.len() as u64).sum();
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        root_size,
+        "./",
+    ));
+
+    manifest.sort();
+    let id = snapshot_id(&manifest, &hasher);
+    (manifest, id)
+}
+
+/// Counts the regular files under `<root>/.objects`.
+fn count_objects(root: &Path) -> usize {
+    fn walk(dir: &Path, acc: &mut usize) {
+        if let Ok(rd) = fs::read_dir(dir) {
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    walk(&p, acc);
+                } else if p.is_file() {
+                    *acc += 1;
+                }
+            }
+        }
+    }
+    let mut n = 0;
+    walk(&root.join(".objects"), &mut n);
+    n
+}
+
+/// Collects every `.objects` blob under `root` as `(sharded relative path,
+/// bytes)`, sorted by path — the structure case 1 compares between the clone
+/// and `fs::copy` pools (identical sharded filenames AND identical bytes).
+fn object_inventory(root: &Path) -> Vec<(String, Vec<u8>)> {
+    fn walk(base: &Path, dir: &Path, acc: &mut Vec<(String, Vec<u8>)>) {
+        if let Ok(rd) = fs::read_dir(dir) {
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    walk(base, &p, acc);
+                } else if p.is_file() {
+                    let rel = p.strip_prefix(base).unwrap().to_string_lossy().into_owned();
+                    acc.push((rel, fs::read(&p).unwrap()));
+                }
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(root, &root.join(".objects"), &mut out);
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}
+
+/// On-disk sharded path of an object blob under `root`.
+fn object_disk(root: &Path, checksum: &str) -> PathBuf {
+    root.join(object_path(checksum))
+}
+
+/// On-disk sharded path of a manifest under `root`.
+fn manifest_disk(root: &Path, id: &str) -> PathBuf {
+    root.join(manifest_path(id))
+}
+
+/// The unix mode bits (permission portion) of `path`, or `None` off-unix.
+#[cfg(unix)]
+fn mode_bits(path: &Path) -> Option<u32> {
+    Some(fs::metadata(path).ok()?.permissions().mode() & 0o7777)
+}
+#[cfg(not(unix))]
+fn mode_bits(_path: &Path) -> Option<u32> {
+    None
+}
+
+/// A representative tree exercising the boundary sizes the SPEC calls out: a
+/// file LARGER than 256 KiB (the mmap/clone-relevant size), a tiny file, and a
+/// 0-byte file. Contents are deterministic so checksums are stable.
+fn mixed_size_files() -> Vec<(&'static str, Vec<u8>, &'static str)> {
+    // >256 KiB so it straddles any size-based clone/byte-copy branch.
+    let big: Vec<u8> = (0..(300 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    vec![
+        ("big.bin", big, "644"),
+        ("tiny.txt", b"x".to_vec(), "644"),
+        ("empty", Vec::new(), "644"),
+        (
+            "nested/deep/leaf.bin",
+            vec![0u8, 1, 2, 3, 255, 254, 0],
+            "600",
+        ),
+    ]
+}
+
+// ===========================================================================
+// CASE 1 — Round-trip equivalence, clone ON (default) vs OFF (SNAPDIR_CLONEFILE=0).
+// Spec: "the clone path must be OBSERVABLY IDENTICAL to the fs::copy path —
+// same object bytes, same sharded object filenames, same restored content."
+// ===========================================================================
+
+/// Runs a full stage→object→checkout cycle for `files` against a fresh store,
+/// returning (object-pool inventory, restored-content map, restored-mode map,
+/// snapshot id). Holds NOTHING about the env — the caller sets the knob.
+fn roundtrip_once(
+    tag: &str,
+    files: &[(&str, &[u8], &str)],
+) -> (
+    Vec<(String, Vec<u8>)>,
+    Vec<(String, Vec<u8>)>,
+    Vec<(String, Option<u32>)>,
+    String,
+) {
+    let store_dir = TempDir::new(&format!("rt-store-{tag}"));
+    let src = TempDir::new(&format!("rt-src-{tag}"));
+    let dest = TempDir::new(&format!("rt-dest-{tag}"));
+
+    let (manifest, id) = build_tree(src.path(), files);
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    store.push(&manifest, src.path()).expect("push");
+    store
+        .fetch_files(&manifest, dest.path())
+        .expect("fetch_files");
+
+    let inv = object_inventory(store_dir.path());
+
+    let mut restored: Vec<(String, Vec<u8>)> = Vec::new();
+    let mut modes: Vec<(String, Option<u32>)> = Vec::new();
+    for (rel, _, _) in files {
+        let p = dest.path().join(rel);
+        restored.push(((*rel).to_string(), fs::read(&p).expect("restored file")));
+        modes.push(((*rel).to_string(), mode_bits(&p)));
+    }
+    restored.sort_by(|a, b| a.0.cmp(&b.0));
+    modes.sort_by(|a, b| a.0.cmp(&b.0));
+
+    // The store_dir / src / dest TempDirs drop here; we already snapshotted
+    // every byte we need above.
+    (inv, restored, modes, id)
+}
+
+#[test]
+fn clone_on_and_off_produce_identical_objects_filenames_and_restored_content() {
+    // Spec clause: clone path OBSERVABLY IDENTICAL to fs::copy — identical
+    // object bytes AND identical sharded filenames AND identical restored
+    // content; snapshot id round-trips unchanged across both paths.
+    let files_owned = mixed_size_files();
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let _g = env_lock();
+
+    // Fast-path enabled (default / unset).
+    let on = {
+        let _e = CloneEnv::set(None);
+        roundtrip_once("on", &files)
+    };
+    // Fast-path force-disabled.
+    let off = {
+        let _e = CloneEnv::set(Some("0"));
+        roundtrip_once("off", &files)
+    };
+
+    assert_eq!(
+        on.0, off.0,
+        "object pool inventory (sharded filenames + bytes) must be byte-identical \
+         between the clone fast-path and the fs::copy path"
+    );
+    assert_eq!(
+        on.1, off.1,
+        "restored file content must be identical between clone and fs::copy"
+    );
+    assert_eq!(
+        on.3, off.3,
+        "snapshot id must round-trip identically regardless of the copy path"
+    );
+
+    // Sanity: the >256 KiB file actually produced a distinct large blob, so the
+    // equivalence above is not vacuously over only tiny inputs.
+    let big_sum = Blake3Hasher::new().hash_hex(&files_owned[0].1);
+    // The inventory `rel` is the object's sharded relative path under the store
+    // root (`object_path` inserts `/` separators between the shard segments), so
+    // match the full sharded path rather than a raw checksum substring (wiring).
+    let big_rel = object_path(&big_sum);
+    assert!(
+        on.0.iter()
+            .any(|(rel, bytes)| *rel == big_rel && bytes.len() == files_owned[0].1.len()),
+        "the >256 KiB object must be present in the pool with its full length"
+    );
+}
+
+// ===========================================================================
+// CASE 2 — Permissions parity (clone copies all metadata; impl must match
+// fs::copy's perms-only semantics).
+// Spec clause: "A source file with an unusual mode yields the SAME
+// object/restored permissions under clone vs fs::copy."
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn clone_and_fscopy_yield_identical_restored_permissions() {
+    // Spec clause: identical resulting restored-file mode between the clone path
+    // and the fs::copy path for unusual source modes (0o600, 0o755).
+    // Sorted by path so this vec lines up with `on.2`/`off.2` (which
+    // `roundtrip_once` sorts by rel) when zipped below — wiring only; every
+    // file's recorded mode is still asserted against its own restored mode.
+    let mut files_owned: Vec<(&str, Vec<u8>, &str)> = vec![
+        ("secret", b"private\n".to_vec(), "600"),
+        ("script.sh", b"#!/bin/sh\necho hi\n".to_vec(), "755"),
+    ];
+    files_owned.sort_by(|a, b| a.0.cmp(b.0));
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let _g = env_lock();
+
+    let on = {
+        let _e = CloneEnv::set(None);
+        roundtrip_once("perm-on", &files)
+    };
+    let off = {
+        let _e = CloneEnv::set(Some("0"));
+        roundtrip_once("perm-off", &files)
+    };
+
+    assert_eq!(
+        on.2, off.2,
+        "restored-file permission bits must be identical between clone and fs::copy"
+    );
+    // And both must honor the manifest's recorded mode (the restored file's
+    // perm bits equal the manifest mode), so neither path silently widens perms.
+    for ((rel, mode), (_, _, want)) in on.2.iter().zip(files_owned.iter()) {
+        let want_bits = u32::from_str_radix(want, 8).unwrap();
+        assert_eq!(
+            *mode,
+            Some(want_bits),
+            "restored {rel} must carry the manifest-recorded mode {want}"
+        );
+    }
+}
+
+// ===========================================================================
+// CASE 3 — BSD-flags safety (the dangerous one): a `uchg` (UF_IMMUTABLE)
+// source must NOT yield an immutable object — the impl must clear cloned BSD
+// flags so the object stays removable/GC-able.
+// Spec clause: "the resulting object file is removable (can be fs::remove_file'd
+// / GC'd)."
+// ===========================================================================
+
+#[cfg(target_os = "macos")]
+#[test]
+fn immutable_uchg_source_does_not_produce_an_immutable_object() {
+    // Spec clause: clone must clear cloned BSD flags; the object must be GC-able.
+    let store_dir = TempDir::new("uchg-store");
+    let src = TempDir::new("uchg-src");
+
+    let content = b"immutable-source-bytes\n".to_vec();
+    let rel = "locked.bin";
+    let target = src.path().join(rel);
+    fs::write(&target, &content).unwrap();
+
+    // Set the user-immutable flag on the SOURCE via `chflags uchg`.
+    let set = std::process::Command::new("chflags")
+        .arg("uchg")
+        .arg(&target)
+        .status()
+        .expect("spawn chflags");
+    assert!(set.success(), "chflags uchg must succeed on the source");
+
+    // Build the manifest AFTER setting the flag (the file content is unchanged).
+    let hasher = Blake3Hasher::new();
+    let sum = hasher.hash_hex(&content);
+    let mut manifest = Manifest::new();
+    manifest.push(ManifestEntry::new(
+        PathType::File,
+        "644",
+        sum.clone(),
+        content.len() as u64,
+        format!("./{rel}"),
+    ));
+    let root_sum = directory_checksum(std::iter::once(sum.as_str()), &hasher);
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        content.len() as u64,
+        "./",
+    ));
+    manifest.sort();
+
+    let _g = env_lock();
+    let _e = CloneEnv::set(None); // fast-path on, so a clone really fires
+
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    let push_res = store.push(&manifest, src.path());
+
+    // Clear the source flag now so the src TempDir can be cleaned up regardless
+    // of the assertion outcome below.
+    let _ = std::process::Command::new("chflags")
+        .arg("nouchg")
+        .arg(&target)
+        .status();
+
+    push_res.expect("push of a uchg source must succeed");
+
+    // The KEYSTONE assertion: the resulting object blob must be REMOVABLE — the
+    // immutable flag must NOT have been cloned onto it.
+    let obj = object_disk(store_dir.path(), &sum);
+    assert!(obj.is_file(), "object must have landed");
+    fs::remove_file(&obj)
+        .expect("the cloned object must NOT be immutable — it must be removable/GC-able");
+    assert!(!obj.exists(), "object must be gone after removal");
+}
+
+// ===========================================================================
+// CASE 4 — Cross-volume fallback: when source and store are on DIFFERENT
+// filesystems, clonefile returns EXDEV/ENOTSUP and the impl must fall back to
+// fs::copy — the copy still succeeds with correct bytes. Skip-if-unavailable.
+// Spec clause: "the clone path must fall back to fs::copy on EXDEV/ENOTSUP."
+// ===========================================================================
+
+/// Finds a writable directory on a DIFFERENT device than `same_dev_path`, or
+/// `None` if no distinct volume is exercisable (CI single-FS → skip).
+#[cfg(unix)]
+fn other_volume_dir(same_dev_path: &Path) -> Option<PathBuf> {
+    use std::os::unix::fs::MetadataExt;
+    let base_dev = fs::metadata(same_dev_path).ok()?.dev();
+    // Common candidates for a second filesystem (macOS RAM disk / Linux tmpfs).
+    for cand in ["/dev/shm", "/tmp", "/private/tmp", "/var/tmp"] {
+        let p = Path::new(cand);
+        if let Ok(md) = fs::metadata(p) {
+            if md.dev() != base_dev {
+                // Confirm it is actually writable by creating a scratch subdir.
+                let scratch = p.join(format!("snapdir-xdev-{}", std::process::id()));
+                if fs::create_dir_all(&scratch).is_ok() {
+                    return Some(scratch);
+                }
+            }
+        }
+    }
+    None
+}
+
+#[cfg(unix)]
+#[test]
+fn cross_volume_source_falls_back_to_fscopy_with_correct_bytes() {
+    // Spec clause: cross-volume must fall back to fs::copy (EXDEV/ENOTSUP) and
+    // still produce correct bytes. Skip-if-unavailable on single-FS CI.
+    let store_dir = TempDir::new("xdev-store");
+
+    let other = match other_volume_dir(store_dir.path()) {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "SKIP cross_volume_source_falls_back_to_fscopy_with_correct_bytes: \
+                 no second writable volume detected on this host"
+            );
+            return;
+        }
+    };
+
+    // Put the SOURCE tree on the other volume; the store stays on `store_dir`'s
+    // volume — so source→object crosses a device boundary.
+    let src = other.join(format!("src-{}", std::process::id()));
+    fs::create_dir_all(&src).unwrap();
+
+    let content: Vec<u8> = (0..(280 * 1024u32)).map(|i| (i % 197) as u8).collect();
+    let files: Vec<(&str, &[u8], &str)> = vec![("payload.bin", content.as_slice(), "644")];
+    let (manifest, id) = build_tree(&src, &files);
+
+    let _g = env_lock();
+    let _e = CloneEnv::set(None); // fast-path on; impl must fall back on EXDEV
+
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    let res = store.push(&manifest, &src);
+
+    // Clean the cross-volume scratch regardless.
+    let cleanup = |p: &Path| {
+        let _ = fs::remove_dir_all(p);
+    };
+
+    match res {
+        Ok(()) => {
+            let sum = Blake3Hasher::new().hash_hex(&content);
+            let blob = fs::read(object_disk(store_dir.path(), &sum));
+            cleanup(&other);
+            let blob = blob.expect("object blob must exist after cross-volume push");
+            assert_eq!(
+                blob, content,
+                "cross-volume fallback must still file byte-correct object content"
+            );
+            assert!(
+                manifest_disk(store_dir.path(), &id).is_file(),
+                "manifest must commit after the fallback copy"
+            );
+        }
+        Err(e) => {
+            cleanup(&other);
+            panic!("cross-volume push must succeed via fs::copy fallback, got {e}");
+        }
+    }
+}
+
+// ===========================================================================
+// CASE 5 — Clone actually fires (anti-silent-fallback) + the OFF knob really
+// disables it.
+// Spec clause: on a same-volume APFS stage clonefile_hits() INCREASES;
+// under SNAPDIR_CLONEFILE=0 the counter does NOT increase.
+// ===========================================================================
+
+#[cfg(target_os = "macos")]
+#[test]
+fn clone_fast_path_actually_fires_on_same_volume_and_off_knob_disables_it() {
+    // Spec clause: anti-silent-fallback — the counter must increase on a
+    // same-volume push with the fast-path on, and stay flat when forced off.
+    let files_owned = mixed_size_files();
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let _g = env_lock();
+
+    // (a) Fast-path ON: the counter must strictly increase.
+    let before_on = snapdir_stores::clonefile_hits();
+    {
+        let _e = CloneEnv::set(None);
+        // src + store on the SAME temp volume (both under std::env::temp_dir()).
+        let store_dir = TempDir::new("fires-store");
+        let src = TempDir::new("fires-src");
+        let dest = TempDir::new("fires-dest");
+        let (manifest, _id) = build_tree(src.path(), &files);
+        let store = FileStore::from_root(store_dir.path().to_path_buf());
+        store.push(&manifest, src.path()).expect("push");
+        // checkout too, so BOTH copy directions (push + fetch) exercise clone.
+        store
+            .fetch_files(&manifest, dest.path())
+            .expect("fetch_files");
+    }
+    let after_on = snapdir_stores::clonefile_hits();
+    assert!(
+        after_on > before_on,
+        "clonefile_hits() must INCREASE on a same-volume APFS stage \
+         (impl must not be silently always-falling-back): {before_on} -> {after_on}"
+    );
+
+    // (b) Fast-path forced OFF: the counter must NOT move.
+    let before_off = snapdir_stores::clonefile_hits();
+    {
+        let _e = CloneEnv::set(Some("0"));
+        let store_dir = TempDir::new("off-store");
+        let src = TempDir::new("off-src");
+        let dest = TempDir::new("off-dest");
+        let (manifest, _id) = build_tree(src.path(), &files);
+        let store = FileStore::from_root(store_dir.path().to_path_buf());
+        store.push(&manifest, src.path()).expect("push");
+        store
+            .fetch_files(&manifest, dest.path())
+            .expect("fetch_files");
+    }
+    let after_off = snapdir_stores::clonefile_hits();
+    assert_eq!(
+        after_off, before_off,
+        "with SNAPDIR_CLONEFILE=0 the clone fast-path must NOT fire: {before_off} -> {after_off}"
+    );
+}
+
+// ===========================================================================
+// CASE 6 — Degenerate inputs: a 0-byte file clones correctly, and a read-only
+// source still produces a correct, usable object.
+// Spec clause: "0-byte file clones correctly; a read-only source still produces
+// a correct, writable-enough object."
+// ===========================================================================
+
+#[test]
+fn zero_byte_file_clones_correctly() {
+    // Spec clause: 0-byte file clones/copies correctly (no empty-file choke).
+    let files: Vec<(&str, &[u8], &str)> = vec![("empty", b"".as_slice(), "644")];
+
+    let _g = env_lock();
+    let _e = CloneEnv::set(None); // fast-path on
+
+    let store_dir = TempDir::new("zero-store");
+    let src = TempDir::new("zero-src");
+    let dest = TempDir::new("zero-dest");
+    let (manifest, id) = build_tree(src.path(), &files);
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    store.push(&manifest, src.path()).expect("push 0-byte");
+    store
+        .fetch_files(&manifest, dest.path())
+        .expect("fetch 0-byte");
+
+    // The empty object's checksum is the BLAKE3 of the empty input.
+    let sum = Blake3Hasher::new().hash_hex(b"");
+    let obj = object_disk(store_dir.path(), &sum);
+    assert!(obj.is_file(), "0-byte object must exist");
+    assert_eq!(
+        fs::metadata(&obj).unwrap().len(),
+        0,
+        "0-byte object must be exactly empty"
+    );
+    let restored = fs::read(dest.path().join("empty")).expect("restored empty file");
+    assert!(restored.is_empty(), "restored 0-byte file must be empty");
+    // And the snapshot round-trips.
+    assert_eq!(
+        store.get_manifest(&id).expect("get_manifest").to_string(),
+        manifest.to_string()
+    );
+}
+
+#[test]
+fn read_only_source_still_produces_a_correct_object() {
+    // Spec clause: a read-only (0o444) source still produces a correct object
+    // (the clone/copy must not require write perms on the source).
+    let content = b"read-only source content\n".to_vec();
+    let files: Vec<(&str, &[u8], &str)> = vec![("ro.txt", content.as_slice(), "444")];
+
+    let _g = env_lock();
+    let _e = CloneEnv::set(None); // fast-path on
+
+    let store_dir = TempDir::new("ro-store");
+    let src = TempDir::new("ro-src");
+    let dest = TempDir::new("ro-dest");
+    let (manifest, _id) = build_tree(src.path(), &files);
+
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    store
+        .push(&manifest, src.path())
+        .expect("push read-only source");
+    store
+        .fetch_files(&manifest, dest.path())
+        .expect("fetch read-only source");
+
+    let sum = Blake3Hasher::new().hash_hex(&content);
+    // The object exists, has the right bytes, AND is removable (GC-able) — i.e.
+    // the read-only source mode did not leave the object un-deletable.
+    let obj = object_disk(store_dir.path(), &sum);
+    assert_eq!(fs::read(&obj).expect("object bytes"), content);
+    assert_eq!(count_objects(store_dir.path()), 1);
+    fs::remove_file(&obj).expect("object from a read-only source must be removable/GC-able");
+
+    // Restored content is correct.
+    let restored = fs::read(dest.path().join("ro.txt")).expect("restored file");
+    assert_eq!(restored, content);
+}
+
+// ===========================================================================
+// CASE 7 — Object/restored object COUNT + dedup parity between clone and
+// fs::copy on a duplicate-content tree (clone path must not alter dedup: two
+// files with identical content → ONE object under both paths).
+// Spec clause: clone path OBSERVABLY IDENTICAL — same object SET (dedup intact).
+// ===========================================================================
+
+#[test]
+fn duplicate_content_dedups_to_one_object_under_both_paths() {
+    // Spec clause: identical object set/dedup between clone and fs::copy.
+    let dup = b"identical-content-deduped\n";
+    let files: Vec<(&str, &[u8], &str)> = vec![
+        ("a/first", dup.as_slice(), "644"),
+        ("b/second", dup.as_slice(), "644"),
+        ("c/third", dup.as_slice(), "644"),
+    ];
+
+    let _g = env_lock();
+
+    let on_count = {
+        let _e = CloneEnv::set(None);
+        let store_dir = TempDir::new("dedup-on-store");
+        let src = TempDir::new("dedup-on-src");
+        let (manifest, _id) = build_tree(src.path(), &files);
+        FileStore::from_root(store_dir.path().to_path_buf())
+            .push(&manifest, src.path())
+            .expect("push on");
+        count_objects(store_dir.path())
+    };
+    let off_count = {
+        let _e = CloneEnv::set(Some("0"));
+        let store_dir = TempDir::new("dedup-off-store");
+        let src = TempDir::new("dedup-off-src");
+        let (manifest, _id) = build_tree(src.path(), &files);
+        FileStore::from_root(store_dir.path().to_path_buf())
+            .push(&manifest, src.path())
+            .expect("push off");
+        count_objects(store_dir.path())
+    };
+
+    assert_eq!(
+        on_count, 1,
+        "three identical-content files must dedup to ONE object"
+    );
+    assert_eq!(
+        on_count, off_count,
+        "dedup behavior must be identical between the clone and fs::copy paths"
+    );
+}
+
+// ===========================================================================
+// CASE 8 (review/impl-revealed) — Clone-path Copy-on-Write determinism for a
+// >256 KiB object: with the fast-path ON the clone branch ACTUALLY fires for
+// the large blob, and the on-disk sharded path AND the on-disk bytes are
+// byte-for-byte identical to the SNAPDIR_CLONEFILE=0 (plain fs::copy) path.
+// This is the branch where an APFS CoW divergence (a stale/aliased extent,
+// truncated clone, sparse-hole mishandling) would hide. The landed impl files
+// the object via copy_file(source -> temp -> rename), so a CoW bug surfaces as
+// wrong object bytes here even though the small-file equivalence (case 1) would
+// not catch a size-dependent fault.
+// ===========================================================================
+
+#[cfg(target_os = "macos")]
+#[test]
+fn large_file_clone_path_is_byte_identical_to_fscopy_path() {
+    // Spec/impl clause: the >256 KiB clone branch produces an object whose
+    // sharded path and bytes equal the fs::copy path's, AND the clone really
+    // fired (not a silent fallback that would make the comparison vacuous).
+    // 1 MiB so it spans many APFS extents; deterministic so the checksum is
+    // stable across both runs.
+    let big: Vec<u8> = (0..(1024 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    let files: Vec<(&str, &[u8], &str)> = vec![("big/cow.bin", big.as_slice(), "640")];
+    let sum = Blake3Hasher::new().hash_hex(&big);
+
+    let _g = env_lock();
+
+    // Clone ON: capture the object's sharded path + bytes, and prove the clone
+    // fast-path fired for THIS push (delta >= 1 covers the single object).
+    let (on_rel, on_bytes) = {
+        let before = snapdir_stores::clonefile_hits();
+        let _e = CloneEnv::set(None);
+        let store_dir = TempDir::new("cow-on-store");
+        let src = TempDir::new("cow-on-src");
+        let (manifest, _id) = build_tree(src.path(), &files);
+        FileStore::from_root(store_dir.path().to_path_buf())
+            .push(&manifest, src.path())
+            .expect("push clone-on");
+        let after = snapdir_stores::clonefile_hits();
+        assert!(
+            after > before,
+            "the >256 KiB object must travel the clone fast-path (so the byte \
+             comparison below is not vacuously over a silent fs::copy fallback): \
+             {before} -> {after}"
+        );
+        let obj = object_disk(store_dir.path(), &sum);
+        let rel = obj.strip_prefix(store_dir.path()).unwrap().to_path_buf();
+        (rel, fs::read(&obj).expect("clone-on object bytes"))
+    };
+
+    // Clone OFF: same object via plain fs::copy.
+    let (off_rel, off_bytes) = {
+        let _e = CloneEnv::set(Some("0"));
+        let store_dir = TempDir::new("cow-off-store");
+        let src = TempDir::new("cow-off-src");
+        let (manifest, _id) = build_tree(src.path(), &files);
+        FileStore::from_root(store_dir.path().to_path_buf())
+            .push(&manifest, src.path())
+            .expect("push clone-off");
+        let obj = object_disk(store_dir.path(), &sum);
+        let rel = obj.strip_prefix(store_dir.path()).unwrap().to_path_buf();
+        (rel, fs::read(&obj).expect("clone-off object bytes"))
+    };
+
+    assert_eq!(
+        on_rel, off_rel,
+        "the large object's sharded path must be identical under clone vs fs::copy"
+    );
+    assert_eq!(
+        on_bytes.len(),
+        big.len(),
+        "cloned large object must have the full source length (no truncated CoW)"
+    );
+    assert_eq!(
+        on_bytes, off_bytes,
+        "cloned >256 KiB object bytes must be byte-for-byte identical to the \
+         fs::copy path (a CoW extent-aliasing/truncation bug would diverge here)"
+    );
+    assert_eq!(
+        on_bytes, big,
+        "cloned large object must equal the original source content"
+    );
+}
+
+// ===========================================================================
+// CASE 9 (review/impl-revealed) — Counter PRECISION: N distinct objects staged
+// on the same APFS volume bump clonefile_hits() by EXACTLY N (the fast-path is
+// fired once per object, never double-counted and never bumped on a fallback).
+// Under SNAPDIR_CLONEFILE=0 the same stage bumps the counter by EXACTLY 0.
+// (Push copies each distinct object once; dedup means N distinct contents.)
+// ===========================================================================
+
+#[cfg(target_os = "macos")]
+#[test]
+fn clonefile_hits_counts_exactly_one_per_distinct_object() {
+    // Impl clause: CLONEFILE_HITS.fetch_add(1) fires once per genuine clone
+    // success and never on the fallback path. Five DISTINCT contents => five
+    // objects => exactly five hits with the fast-path on, zero with it off.
+    let n: usize = 5;
+    let owned: Vec<(String, Vec<u8>)> = (0u32..5)
+        .map(|i| {
+            (
+                format!("d{i}/obj{i}.bin"),
+                // Distinct content per file so each is its own object (no dedup),
+                // each > a trivial size so it is a real copy. The `+ i` byte
+                // offset makes every file's bytes unique while staying bounded.
+                (0..(4096u32 + i)).map(|b| ((b + i) % 251) as u8).collect(),
+            )
+        })
+        .collect();
+    let files: Vec<(&str, &[u8], &str)> = owned
+        .iter()
+        .map(|(p, c)| (p.as_str(), c.as_slice(), "644"))
+        .collect();
+
+    let _g = env_lock();
+
+    // Fast-path ON: exactly N hits for N distinct objects (push only — fetch
+    // would add another N, so we deliberately do NOT checkout here).
+    let on_delta = {
+        let _e = CloneEnv::set(None);
+        let store_dir = TempDir::new("count-on-store");
+        let src = TempDir::new("count-on-src");
+        let (manifest, _id) = build_tree(src.path(), &files);
+        let before = snapdir_stores::clonefile_hits();
+        FileStore::from_root(store_dir.path().to_path_buf())
+            .push(&manifest, src.path())
+            .expect("push count-on");
+        // Sanity: exactly N objects landed (no dedup collapse, no extras).
+        assert_eq!(
+            count_objects(store_dir.path()),
+            n,
+            "expected N distinct objects"
+        );
+        snapdir_stores::clonefile_hits() - before
+    };
+    assert_eq!(
+        on_delta, n as u64,
+        "clonefile_hits() must increase by EXACTLY N for N distinct objects \
+         (not over-counted, not bumped on any fallback): got {on_delta}, want {n}"
+    );
+
+    // Fast-path OFF: zero hits.
+    let off_delta = {
+        let _e = CloneEnv::set(Some("0"));
+        let store_dir = TempDir::new("count-off-store");
+        let src = TempDir::new("count-off-src");
+        let (manifest, _id) = build_tree(src.path(), &files);
+        let before = snapdir_stores::clonefile_hits();
+        FileStore::from_root(store_dir.path().to_path_buf())
+            .push(&manifest, src.path())
+            .expect("push count-off");
+        snapdir_stores::clonefile_hits() - before
+    };
+    assert_eq!(
+        off_delta, 0,
+        "with SNAPDIR_CLONEFILE=0 no clone may fire: counter moved by {off_delta}"
+    );
+}
+
+// ===========================================================================
+// CASE 10 (review/impl-revealed) — FETCH direction uses the clone path too
+// (object -> working file via copy_file/persist). A checkout with the
+// fast-path ON must restore byte-identical content AND the manifest-recorded
+// permission bits, and the fetch must itself fire the clone fast-path (the
+// counter advances ACROSS the checkout, isolated from the push).
+// ===========================================================================
+
+#[cfg(target_os = "macos")]
+#[test]
+fn fetch_direction_clones_and_restores_identical_content_and_perms() {
+    // Impl clause: copy_file is shared by fetch_files; a clone-ON checkout
+    // restores correct bytes + perms and bumps the counter on the fetch side.
+    let content: Vec<u8> = (0..(300 * 1024u32)).map(|i| (i % 241) as u8).collect();
+    let files: Vec<(&str, &[u8], &str)> = vec![("restore/me.bin", content.as_slice(), "640")];
+
+    let _g = env_lock();
+    let _e = CloneEnv::set(None); // fast-path on for both push and fetch
+
+    let store_dir = TempDir::new("fetch-store");
+    let src = TempDir::new("fetch-src");
+    let dest = TempDir::new("fetch-dest");
+    let (manifest, _id) = build_tree(src.path(), &files);
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+
+    store.push(&manifest, src.path()).expect("push for fetch");
+
+    // Isolate the FETCH side: measure the counter delta across only fetch_files.
+    let before_fetch = snapdir_stores::clonefile_hits();
+    store
+        .fetch_files(&manifest, dest.path())
+        .expect("fetch_files clone-on");
+    let fetch_delta = snapdir_stores::clonefile_hits() - before_fetch;
+    assert!(
+        fetch_delta >= 1,
+        "the object -> working-file checkout must also travel the clone \
+         fast-path (copy_file is shared by fetch_files): delta={fetch_delta}"
+    );
+
+    let restored_path = dest.path().join("restore/me.bin");
+    let restored = fs::read(&restored_path).expect("restored file");
+    assert_eq!(
+        restored, content,
+        "clone-restored working file must be byte-identical to the source"
+    );
+    assert_eq!(
+        mode_bits(&restored_path),
+        Some(0o640),
+        "clone-restored working file must carry the manifest-recorded mode 0o640"
+    );
+}
+
+// ===========================================================================
+// CASE 11 (review/impl-revealed) — xattr non-leak / content-addressing
+// invariant. clonefile(2) copies xattrs from the source; objects are content-
+// addressed, so a user xattr on the SOURCE must NOT change the object's
+// checksum or its stored bytes (it files under the SAME sharded path with the
+// SAME content as an xattr-free source). Skip-if-the-fs-rejects-xattrs.
+// ===========================================================================
+
+#[cfg(target_os = "macos")]
+#[test]
+fn source_xattr_does_not_affect_object_checksum_or_bytes() {
+    // Impl/spec clause: content addressing is over file BYTES only; a cloned
+    // xattr must not perturb the object's address or content.
+    let content = b"xattr-bearing-source-but-content-addressed\n".to_vec();
+    let rel = "tagged.bin";
+    let sum = Blake3Hasher::new().hash_hex(&content);
+
+    let _g = env_lock();
+    let _e = CloneEnv::set(None); // fast-path on so clonefile copies the xattr
+
+    let store_dir = TempDir::new("xattr-store");
+    let src = TempDir::new("xattr-src");
+    let target = src.path().join(rel);
+    fs::write(&target, &content).unwrap();
+
+    // Tag the SOURCE with a user xattr via the `xattr` CLI (test harness only).
+    let set = std::process::Command::new("xattr")
+        .arg("-w")
+        .arg("com.snapdir.test.flavor")
+        .arg("vanilla")
+        .arg(&target)
+        .status();
+    match set {
+        Ok(s) if s.success() => {}
+        _ => {
+            eprintln!(
+                "SKIP source_xattr_does_not_affect_object_checksum_or_bytes: \
+                 could not set a user xattr on this filesystem"
+            );
+            return;
+        }
+    }
+
+    let hasher = Blake3Hasher::new();
+    let mut manifest = Manifest::new();
+    manifest.push(ManifestEntry::new(
+        PathType::File,
+        "644",
+        sum.clone(),
+        content.len() as u64,
+        format!("./{rel}"),
+    ));
+    let root_sum = directory_checksum(std::iter::once(sum.as_str()), &hasher);
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        content.len() as u64,
+        "./",
+    ));
+    manifest.sort();
+
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    store
+        .push(&manifest, src.path())
+        .expect("push xattr-bearing source");
+
+    // The object files under the BYTES' checksum (unaffected by the xattr) and
+    // its stored bytes are exactly the source content.
+    let obj = object_disk(store_dir.path(), &sum);
+    assert!(
+        obj.is_file(),
+        "object must file under the content checksum regardless of source xattrs"
+    );
+    assert_eq!(
+        fs::read(&obj).expect("object bytes"),
+        content,
+        "object bytes must equal the source content (xattrs are not part of the blob)"
+    );
+    assert_eq!(
+        count_objects(store_dir.path()),
+        1,
+        "exactly one object — the xattr must not split or duplicate the address"
+    );
+    // And it remains removable (chflags(0) parity also leaves it GC-able).
+    fs::remove_file(&obj).expect("xattr-tagged-source object must be GC-able");
+}

--- a/crates/snapdir-stores/tests/clone_skip.rs
+++ b/crates/snapdir-stores/tests/clone_skip.rs
@@ -1,0 +1,1425 @@
+//! Adversarial integration suite for the "skip the redundant post-copy
+//! re-hash on the clone path" optimization (phase 29, gate
+//! `clone-skip-spec-tests`).
+//!
+//! BLACK-BOX: authored from the gate SPEC alone, with NO visibility into the
+//! private `copy_file` / `persist` internals being changed (the skip path does
+//! not exist yet). It will NOT compile/pass until the stores-impl teammate
+//! moves this file into `crates/snapdir-stores/tests/clone_skip.rs`, adds the
+//! `CopyGuard` walk side-channel + `CopyMethod` trust-enum + the
+//! `SNAPDIR_VERIFY_COPIES` knob, and lands the feature. Do NOT weaken any
+//! assertion to make it green — if a behavior here fails against the landed
+//! impl, that is a real bug in the impl, not in this test.
+//!
+//! ## SPEC under test
+//!
+//! Today `persist()` ALWAYS re-hashes the temp after `copy_file`, so the macOS
+//! APFS `clonefile` fast-path buys ~0 wall-clock. The impl SKIPS that re-hash
+//! when the copy was a CoW clone:
+//!   * FETCH/checkout (source = an immutable, read-verified store object): skip
+//!     whenever cloned — provably safe.
+//!   * STAGE/push (source = a mutable user file): skip only under
+//!     "stat-validated trust" — the walk records each file's
+//!     `(size, mtime, ctime, ino)` into a `CopyGuard`; `persist` re-stats the
+//!     source at clone time and skips the re-hash IFF unchanged, else falls
+//!     back to the re-hash (-> Integrity error if the changed source != the
+//!     expected checksum).
+//!   * The `fs::copy` (non-clone) path ALWAYS re-hashes — unchanged.
+//!
+//! The skip MUST NOT introduce a silently mis-addressed object: an object
+//! filed under checksum(A) that actually contains bytes(B) and is ACCEPTED on
+//! read is the single forbidden outcome.
+//!
+//! ## Contracted symbols / env knobs (impl lane MUST match these names)
+//!
+//! - **`SNAPDIR_CLONEFILE=0`** (EXISTS) — disables clone entirely -> the
+//!   `fs::copy` path, which always re-hashes. Used as the "always-rehash"
+//!   control arm.
+//! - **`SNAPDIR_VERIFY_COPIES=1`** (NEW) — forces the write-time re-hash even
+//!   on the clone path (strict mode). Unset / `0` = the optimization is live
+//!   (skip the re-hash on a trusted clone). When set to `1`, a clone still
+//!   FIRES (so `clonefile_hits()` still advances) but `persist` re-hashes the
+//!   cloned temp exactly as the `fs::copy` path does — proving the override is
+//!   write-time strict, not a clone-disable.
+//! - **`snapdir_stores::clonefile_hits() -> u64`** (EXISTS) — process-global
+//!   clone-fire counter; used only to prove the clone still fired under the
+//!   skip + under VERIFY_COPIES (cfg macos).
+//!
+//! The internal `CopyMethod` / trust-enum / `CopyGuard` are impl details; this
+//! suite pins their EFFECT through the public `FileStore` API + env only (it
+//! does not import them — they may be `pub(crate)`).
+//!
+//! ## How the RACE KEYSTONE is asserted (never silent)
+//!
+//! `push` reads its object bytes from the live source files; `fetch_files` /
+//! `get_object` BLAKE3-verify on read. So to force the dangerous case through
+//! the PUBLIC API we build a manifest whose entry records checksum(A) while the
+//! on-disk source file actually holds bytes(B) at `push` time. Whichever way
+//! the impl's stat-guard goes, the safe outcomes are EXACTLY:
+//!   (1) `push` returns `StoreError::Integrity` (guard re-stats, sees the
+//!       change vs the recorded `(size,mtime,ctime,ino)` -> re-hashes -> the B
+//!       bytes != checksum(A)), OR
+//!   (2) `push` succeeds BUT a later `get_object(checksum(A))` /
+//!       `fetch_files` rejects with `StoreError::Integrity` (read-time BLAKE3
+//!       verify is the backstop).
+//! The FORBIDDEN outcome the test fails on: an object readable at
+//! checksum(A) whose bytes are B. The assertion holds whether or not the
+//! stat-guard fires, so it is robust to the impl's trust decision.
+//!
+//! ## Env / parallelism note
+//!
+//! `SNAPDIR_CLONEFILE` and `SNAPDIR_VERIFY_COPIES` are process-global and Rust
+//! runs `#[test]`s multithreaded in one binary, so every test that touches a
+//! knob (or compares a `clonefile_hits()` delta) holds a single process-wide
+//! `ENV_LOCK` for its whole body and RESTORES the prior values on drop, so a
+//! parallel test never observes a half-set knob.
+
+// Wiring (shape only, no assertion change): silence workspace `-D warnings`
+// clippy lints on this adversary-authored suite.
+#![allow(
+    unused_imports,
+    clippy::type_complexity,
+    clippy::single_match_else,
+    clippy::single_match,
+    clippy::manual_let_else,
+    clippy::too_many_lines,
+    clippy::doc_markdown,
+    clippy::similar_names,
+    dead_code
+)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
+use snapdir_core::merkle::{directory_checksum, Blake3Hasher, Hasher};
+use snapdir_core::snapshot_id;
+use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
+use snapdir_core::CopyGuard;
+
+use std::collections::HashMap;
+
+use snapdir_stores::{FileStore, StreamStore};
+
+// ---------------------------------------------------------------------------
+// Test scaffolding (no dev-dependencies; mirrors apfs_clone.rs).
+// ---------------------------------------------------------------------------
+
+/// A unique temp dir removed on drop.
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "snapdir-clone-skip-test-{}-{tag}-{n}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).expect("create temp dir");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+/// Process-global lock guarding `SNAPDIR_CLONEFILE` + `SNAPDIR_VERIFY_COPIES`
+/// (both process-global) and the process-global `clonefile_hits()` counter.
+fn env_lock() -> MutexGuard<'static, ()> {
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// RAII guard that sets/clears `SNAPDIR_CLONEFILE` and `SNAPDIR_VERIFY_COPIES`
+/// and restores the prior values on drop. Caller must already hold `env_lock()`.
+struct CopyModeEnv {
+    prev_clone: Option<String>,
+    prev_verify: Option<String>,
+}
+
+impl CopyModeEnv {
+    /// `clonefile`: `Some("0")` disables the clone fast-path entirely (forces
+    /// `fs::copy` + always-rehash); `None` leaves it default-enabled.
+    /// `verify`: `Some("1")` forces the write-time re-hash even on the clone
+    /// path (strict); `None` leaves the skip optimization live.
+    fn set(clonefile: Option<&str>, verify: Option<&str>) -> Self {
+        let prev_clone = std::env::var("SNAPDIR_CLONEFILE").ok();
+        let prev_verify = std::env::var("SNAPDIR_VERIFY_COPIES").ok();
+        match clonefile {
+            Some(v) => std::env::set_var("SNAPDIR_CLONEFILE", v),
+            None => std::env::remove_var("SNAPDIR_CLONEFILE"),
+        }
+        match verify {
+            Some(v) => std::env::set_var("SNAPDIR_VERIFY_COPIES", v),
+            None => std::env::remove_var("SNAPDIR_VERIFY_COPIES"),
+        }
+        Self {
+            prev_clone,
+            prev_verify,
+        }
+    }
+}
+
+impl Drop for CopyModeEnv {
+    fn drop(&mut self) {
+        match &self.prev_clone {
+            Some(v) => std::env::set_var("SNAPDIR_CLONEFILE", v),
+            None => std::env::remove_var("SNAPDIR_CLONEFILE"),
+        }
+        match &self.prev_verify {
+            Some(v) => std::env::set_var("SNAPDIR_VERIFY_COPIES", v),
+            None => std::env::remove_var("SNAPDIR_VERIFY_COPIES"),
+        }
+    }
+}
+
+/// The three observable copy modes the SPEC compares. All three MUST produce
+/// identical object pools + restored content + snapshot id for honest input.
+#[derive(Clone, Copy)]
+enum Mode {
+    /// Default: clone fast-path enabled, skip optimization live.
+    Default,
+    /// `SNAPDIR_CLONEFILE=0`: `fs::copy` + always re-hash.
+    CloneOff,
+    /// `SNAPDIR_VERIFY_COPIES=1`: clone fires but the re-hash is forced.
+    VerifyCopies,
+}
+
+impl Mode {
+    fn env(self) -> CopyModeEnv {
+        match self {
+            Mode::Default => CopyModeEnv::set(None, None),
+            Mode::CloneOff => CopyModeEnv::set(Some("0"), None),
+            Mode::VerifyCopies => CopyModeEnv::set(None, Some("1")),
+        }
+    }
+
+    fn tag(self) -> &'static str {
+        match self {
+            Mode::Default => "default",
+            Mode::CloneOff => "cloneoff",
+            Mode::VerifyCopies => "verify",
+        }
+    }
+}
+
+const ALL_MODES: [Mode; 3] = [Mode::Default, Mode::CloneOff, Mode::VerifyCopies];
+
+/// Writes a real source tree under `src` and returns the matching `Manifest`
+/// plus its snapshot id. `files` is `(relative path, content, octal-mode-str)`.
+/// Object addressing uses the NON-keyed `Blake3Hasher` (the content-address
+/// hasher the file store files objects under), as the shipped tests do.
+fn build_tree(src: &Path, files: &[(&str, &[u8], &str)]) -> (Manifest, String) {
+    let hasher = Blake3Hasher::new();
+    let mut manifest = Manifest::new();
+
+    let mut file_sums: Vec<String> = Vec::new();
+    for (rel, content, mode) in files {
+        let target = src.join(rel);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&target, content).unwrap();
+        #[cfg(unix)]
+        {
+            let perms = fs::Permissions::from_mode(u32::from_str_radix(mode, 8).unwrap());
+            fs::set_permissions(&target, perms).unwrap();
+        }
+        let sum = hasher.hash_hex(content);
+        file_sums.push(sum.clone());
+        manifest.push(ManifestEntry::new(
+            PathType::File,
+            *mode,
+            sum,
+            content.len() as u64,
+            format!("./{rel}"),
+        ));
+    }
+
+    let root_sum = directory_checksum(file_sums.iter().map(String::as_str), &hasher);
+    let root_size: u64 = files.iter().map(|(_, c, _)| c.len() as u64).sum();
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        root_size,
+        "./",
+    ));
+
+    manifest.sort();
+    let id = snapshot_id(&manifest, &hasher);
+    (manifest, id)
+}
+
+/// Counts the regular files under `<root>/.objects`.
+fn count_objects(root: &Path) -> usize {
+    fn walk(dir: &Path, acc: &mut usize) {
+        if let Ok(rd) = fs::read_dir(dir) {
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    walk(&p, acc);
+                } else if p.is_file() {
+                    *acc += 1;
+                }
+            }
+        }
+    }
+    let mut n = 0;
+    walk(&root.join(".objects"), &mut n);
+    n
+}
+
+/// Collects every `.objects` blob under `root` as `(sharded relative path,
+/// bytes)`, sorted by path.
+fn object_inventory(root: &Path) -> Vec<(String, Vec<u8>)> {
+    fn walk(base: &Path, dir: &Path, acc: &mut Vec<(String, Vec<u8>)>) {
+        if let Ok(rd) = fs::read_dir(dir) {
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    walk(base, &p, acc);
+                } else if p.is_file() {
+                    let rel = p.strip_prefix(base).unwrap().to_string_lossy().into_owned();
+                    acc.push((rel, fs::read(&p).unwrap()));
+                }
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(root, &root.join(".objects"), &mut out);
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}
+
+/// On-disk sharded path of an object blob under `root`.
+fn object_disk(root: &Path, checksum: &str) -> PathBuf {
+    root.join(object_path(checksum))
+}
+
+/// On-disk sharded path of a manifest under `root`.
+fn manifest_disk(root: &Path, id: &str) -> PathBuf {
+    root.join(manifest_path(id))
+}
+
+/// The unix mode bits (permission portion) of `path`, or `None` off-unix.
+#[cfg(unix)]
+fn mode_bits(path: &Path) -> Option<u32> {
+    Some(fs::metadata(path).ok()?.permissions().mode() & 0o7777)
+}
+#[cfg(not(unix))]
+fn mode_bits(_path: &Path) -> Option<u32> {
+    None
+}
+
+/// `true` iff `e` is a `StoreError::Integrity`.
+fn is_integrity(e: &StoreError) -> bool {
+    matches!(e, StoreError::Integrity { .. })
+}
+
+/// A representative tree exercising the boundary sizes the SPEC calls out: a
+/// file LARGER than 256 KiB, a tiny file, a 0-byte file, a nested deep path,
+/// and a unicode/space path. Contents are deterministic so checksums are stable.
+fn mixed_size_files() -> Vec<(&'static str, Vec<u8>, &'static str)> {
+    let big: Vec<u8> = (0..(300 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    vec![
+        ("big.bin", big, "644"),
+        ("tiny.txt", b"x".to_vec(), "644"),
+        ("empty", Vec::new(), "644"),
+        (
+            "nested/deep/leaf.bin",
+            vec![0u8, 1, 2, 3, 255, 254, 0],
+            "600",
+        ),
+        (
+            "uni \u{2728}/space name.txt",
+            "snowman \u{2603}\n".as_bytes().to_vec(),
+            "644",
+        ),
+    ]
+}
+
+// ===========================================================================
+// CASE 1 — FETCH skip: observable identity across the three modes.
+// Spec clause: "FETCH/checkout skip whenever cloned — provably safe. Assert all
+// three produce IDENTICAL restored content and the SAME object pool + SAME
+// snapshot id."
+// ===========================================================================
+
+/// One full stage->object->checkout cycle under `mode`, returning
+/// (object-pool inventory, restored-content map, restored-mode map, id).
+fn roundtrip_once(
+    mode: Mode,
+    files: &[(&str, &[u8], &str)],
+) -> (
+    Vec<(String, Vec<u8>)>,
+    Vec<(String, Vec<u8>)>,
+    Vec<(String, Option<u32>)>,
+    String,
+) {
+    let store_dir = TempDir::new(&format!("rt-store-{}", mode.tag()));
+    let src = TempDir::new(&format!("rt-src-{}", mode.tag()));
+    let dest = TempDir::new(&format!("rt-dest-{}", mode.tag()));
+
+    let (manifest, id) = build_tree(src.path(), files);
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    store.push(&manifest, src.path()).expect("push");
+    store
+        .fetch_files(&manifest, dest.path())
+        .expect("fetch_files");
+
+    let inv = object_inventory(store_dir.path());
+
+    let mut restored: Vec<(String, Vec<u8>)> = Vec::new();
+    let mut modes: Vec<(String, Option<u32>)> = Vec::new();
+    for (rel, _, _) in files {
+        let p = dest.path().join(rel);
+        restored.push(((*rel).to_string(), fs::read(&p).expect("restored file")));
+        modes.push(((*rel).to_string(), mode_bits(&p)));
+    }
+    restored.sort_by(|a, b| a.0.cmp(&b.0));
+    modes.sort_by(|a, b| a.0.cmp(&b.0));
+
+    (inv, restored, modes, id)
+}
+
+#[test]
+fn fetch_skip_identical_objects_content_and_id_across_three_modes() {
+    // Spec clause (FETCH skip — observable identity): default (clone+skip),
+    // SNAPDIR_CLONEFILE=0 (fs::copy+rehash), and SNAPDIR_VERIFY_COPIES=1
+    // (clone+forced rehash) must produce IDENTICAL restored content, the SAME
+    // object pool (sharded filenames + bytes), and the SAME snapshot id.
+    let files_owned = mixed_size_files();
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let _g = env_lock();
+
+    let runs: Vec<_> = ALL_MODES
+        .iter()
+        .map(|m| {
+            let _e = m.env();
+            roundtrip_once(*m, &files)
+        })
+        .collect();
+
+    let base = &runs[0];
+    for (i, run) in runs.iter().enumerate().skip(1) {
+        assert_eq!(
+            run.0, base.0,
+            "mode {i}: object pool (sharded filenames + bytes) must be byte-identical \
+             to the default/skip mode across all three copy modes"
+        );
+        assert_eq!(
+            run.1, base.1,
+            "mode {i}: restored file content must be identical across all three modes"
+        );
+        assert_eq!(
+            run.2, base.2,
+            "mode {i}: restored permission bits must be identical across all three modes"
+        );
+        assert_eq!(
+            run.3, base.3,
+            "mode {i}: snapshot id must round-trip identically across all three modes"
+        );
+    }
+
+    // Sanity: the >256 KiB object is really present full-length (so identity is
+    // not vacuously over only tiny inputs).
+    let big_sum = Blake3Hasher::new().hash_hex(&files_owned[0].1);
+    let big_rel = object_path(&big_sum);
+    assert!(
+        base.0
+            .iter()
+            .any(|(rel, bytes)| *rel == big_rel && bytes.len() == files_owned[0].1.len()),
+        "the >256 KiB object must be present in the pool at full length"
+    );
+}
+
+// ===========================================================================
+// CASE 2 — STAGE skip: observable identity of the PUSH object pool across the
+// three modes (no fetch — isolates the stage/push copy path the skip changes).
+// Spec clause: "STAGE skip — same three-way comparison for the object pool
+// produced by push/stage: identical sharded object files + bytes + id."
+// ===========================================================================
+
+#[test]
+fn stage_skip_identical_object_pool_and_id_across_three_modes() {
+    // Spec clause (STAGE skip — observable identity): the object pool produced
+    // by push (stage) must be byte-identical (sharded filenames + bytes) and
+    // carry the same snapshot id across default / CLONEFILE=0 / VERIFY_COPIES=1.
+    let files_owned = mixed_size_files();
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let _g = env_lock();
+
+    let runs: Vec<(Vec<(String, Vec<u8>)>, String, bool)> = ALL_MODES
+        .iter()
+        .map(|m| {
+            let _e = m.env();
+            let store_dir = TempDir::new(&format!("stage-store-{}", m.tag()));
+            let src = TempDir::new(&format!("stage-src-{}", m.tag()));
+            let (manifest, id) = build_tree(src.path(), &files);
+            let store = FileStore::from_root(store_dir.path().to_path_buf());
+            store.push(&manifest, src.path()).expect("push");
+            let inv = object_inventory(store_dir.path());
+            let manifest_committed = manifest_disk(store_dir.path(), &id).is_file();
+            (inv, id, manifest_committed)
+        })
+        .collect();
+
+    let base = &runs[0];
+    for (i, run) in runs.iter().enumerate().skip(1) {
+        assert_eq!(
+            run.0, base.0,
+            "mode {i}: stage object pool must be byte-identical across all three copy modes"
+        );
+        assert_eq!(
+            run.1, base.1,
+            "mode {i}: stage snapshot id must be identical across all three copy modes"
+        );
+    }
+    for (i, run) in runs.iter().enumerate() {
+        assert!(
+            run.2,
+            "mode {i}: the manifest must be committed (manifest-last) after a clean stage"
+        );
+    }
+}
+
+// ===========================================================================
+// CASE 3 — RACE KEYSTONE (the dangerous one). A manifest entry records
+// checksum(A); the on-disk source actually holds bytes(B) at push time. The
+// skip must NEVER yield an object readable at checksum(A) whose bytes are B.
+// Spec clause: "Assert NO silently mis-addressed object is ever accepted:
+// EITHER push fails with StoreError::Integrity, OR if an object lands a
+// subsequent get_object(checksum_of_A)/fetch REJECTS it with Integrity."
+// ===========================================================================
+
+/// Drives the keystone for a given (B-size-vs-A) shape under `mode`, asserting
+/// the never-silent invariant. `content_b_len_differs` toggles whether B has a
+/// different length than A (size-changes are the easiest for a stat-guard to
+/// catch; equal-length B is the harder forge this test deliberately includes).
+fn assert_no_silent_misaddress(mode: Mode, content_b_len_differs: bool) {
+    let store_dir = TempDir::new(&format!("race-store-{}", mode.tag()));
+    let src = TempDir::new(&format!("race-src-{}", mode.tag()));
+
+    let content_a: Vec<u8> = (0..(64 * 1024u32)).map(|i| (i % 211) as u8).collect();
+    let content_b: Vec<u8> = if content_b_len_differs {
+        (0..(96 * 1024u32))
+            .map(|i| (i % 199) as u8 ^ 0x5a)
+            .collect()
+    } else {
+        // Same length as A, different bytes (the hard case for a size-only guard).
+        content_a.iter().map(|b| b ^ 0xff).collect()
+    };
+    assert_ne!(content_a, content_b, "A and B must differ");
+
+    let hasher = Blake3Hasher::new();
+    let sum_a = hasher.hash_hex(&content_a);
+    let sum_b = hasher.hash_hex(&content_b);
+    assert_ne!(sum_a, sum_b, "checksum(A) must differ from checksum(B)");
+
+    let rel = "racey.bin";
+    let target = src.path().join(rel);
+
+    // Build the manifest entry over content A (records checksum(A) + len(A))...
+    fs::write(&target, &content_a).unwrap();
+    let mut manifest = Manifest::new();
+    manifest.push(ManifestEntry::new(
+        PathType::File,
+        "644",
+        sum_a.clone(),
+        content_a.len() as u64,
+        format!("./{rel}"),
+    ));
+    let root_sum = directory_checksum(std::iter::once(sum_a.as_str()), &hasher);
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        content_a.len() as u64,
+        "./",
+    ));
+    manifest.sort();
+
+    // ...then, BEFORE the store copy, overwrite the source with bytes B (the
+    // mid-stage race the stat-guard is supposed to defend against).
+    fs::write(&target, &content_b).unwrap();
+
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    let push_res = store.push(&manifest, src.path());
+
+    match push_res {
+        Err(ref e) => {
+            // Outcome (1): the guard saw the change -> re-hashed -> Integrity.
+            assert!(
+                is_integrity(e),
+                "a mid-stage source change must surface as StoreError::Integrity, got {e:?}"
+            );
+            // And no usable object may be readable at checksum(A) holding B.
+            match store.get_object(&sum_a) {
+                Ok(bytes) => assert_ne!(
+                    bytes, content_b,
+                    "FORBIDDEN: object readable at checksum(A) but holding bytes(B) \
+                     after a push that reported Integrity"
+                ),
+                Err(_) => {} // absent / integrity-rejected on read — both fine.
+            }
+        }
+        Ok(()) => {
+            // Outcome (2): an object landed; the read-time BLAKE3 backstop MUST
+            // reject any attempt to read it as checksum(A) when it holds B.
+            let read = store.get_object(&sum_a);
+            match read {
+                Ok(bytes) => {
+                    assert_ne!(
+                        bytes, content_b,
+                        "FORBIDDEN: get_object(checksum(A)) returned bytes(B) — a silently \
+                         mis-addressed object was accepted (the whole point of the test)"
+                    );
+                    // If it returned bytes at all they MUST hash to checksum(A).
+                    assert_eq!(
+                        Blake3Hasher::new().hash_hex(&bytes),
+                        sum_a,
+                        "an object returned at checksum(A) must actually hash to checksum(A)"
+                    );
+                }
+                Err(e) => assert!(
+                    is_integrity(&e) || matches!(e, StoreError::ObjectNotFound { .. }),
+                    "reading checksum(A) of a raced stage must be Integrity-rejected or absent, \
+                     got {e:?}"
+                ),
+            }
+            // The backstop must also fire through fetch_files (the checkout path).
+            let dest = TempDir::new(&format!("race-dest-{}", mode.tag()));
+            if let Ok(()) = store.fetch_files(&manifest, dest.path()) {
+                // If the checkout "succeeded", the restored file MUST be A, never B.
+                let restored = fs::read(dest.path().join(rel)).unwrap_or_default();
+                assert_ne!(
+                    restored, content_b,
+                    "FORBIDDEN: checkout restored bytes(B) under an entry addressed as A"
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn race_keystone_no_silent_misaddress_size_change_default() {
+    // Spec clause (RACE KEYSTONE): mid-stage source overwrite (B has a
+    // DIFFERENT size than A) under the default skip mode must never yield a
+    // silently mis-addressed object.
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None);
+    assert_no_silent_misaddress(Mode::Default, true);
+}
+
+#[test]
+fn race_keystone_no_silent_misaddress_same_size_default() {
+    // Spec clause (RACE KEYSTONE, hard case): mid-stage overwrite where B has
+    // the SAME size as A (a size-only guard cannot catch this) must still never
+    // yield a silently mis-addressed object — the read-time BLAKE3 backstop
+    // covers it.
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None);
+    assert_no_silent_misaddress(Mode::Default, false);
+}
+
+#[test]
+fn race_keystone_no_silent_misaddress_under_clone_off() {
+    // Spec clause (RACE KEYSTONE): the fs::copy path ALWAYS re-hashes, so the
+    // raced push MUST fail at write time with Integrity (no object lands).
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(Some("0"), None);
+    // CLONEFILE=0 forces fs::copy + re-hash on every object, so a same-size or
+    // different-size B is caught at write time. Exercise both shapes.
+    assert_no_silent_misaddress(Mode::CloneOff, true);
+    assert_no_silent_misaddress(Mode::CloneOff, false);
+}
+
+// ===========================================================================
+// CASE 4 — VERIFY_COPIES strict catches at WRITE time. With
+// SNAPDIR_VERIFY_COPIES=1, the raced/mutated source stage MUST fail at write
+// time with Integrity (the strict override re-hashes on the clone path).
+// Spec clause: "With SNAPDIR_VERIFY_COPIES=1, the case-3 mutated-source stage
+// MUST fail at write time (Integrity) — proving the strict override re-hashes
+// on the clone path."
+// ===========================================================================
+
+#[test]
+fn verify_copies_strict_catches_mutated_source_at_write_time() {
+    // Spec clause (VERIFY_COPIES strict): a clone-path stage of a source that no
+    // longer matches its recorded checksum MUST be rejected at WRITE time with
+    // StoreError::Integrity when SNAPDIR_VERIFY_COPIES=1 — not deferred to read.
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, Some("1"));
+
+    let store_dir = TempDir::new("verify-store");
+    let src = TempDir::new("verify-src");
+
+    let content_a: Vec<u8> = (0..(80 * 1024u32)).map(|i| (i % 223) as u8).collect();
+    // Same length as A, different bytes — proves the strict re-hash is a true
+    // content re-hash, not a size check.
+    let content_b: Vec<u8> = content_a.iter().map(|b| b ^ 0xa5).collect();
+
+    let hasher = Blake3Hasher::new();
+    let sum_a = hasher.hash_hex(&content_a);
+
+    let rel = "strict.bin";
+    let target = src.path().join(rel);
+    fs::write(&target, &content_a).unwrap();
+    let mut manifest = Manifest::new();
+    manifest.push(ManifestEntry::new(
+        PathType::File,
+        "644",
+        sum_a.clone(),
+        content_a.len() as u64,
+        format!("./{rel}"),
+    ));
+    let root_sum = directory_checksum(std::iter::once(sum_a.as_str()), &hasher);
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        content_a.len() as u64,
+        "./",
+    ));
+    manifest.sort();
+
+    // Mutate the source before the copy.
+    fs::write(&target, &content_b).unwrap();
+
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    let res = store.push(&manifest, src.path());
+
+    let err =
+        res.expect_err("SNAPDIR_VERIFY_COPIES=1 must reject a mutated-source stage at write time");
+    assert!(
+        is_integrity(&err),
+        "VERIFY_COPIES strict must fail with StoreError::Integrity, got {err:?}"
+    );
+    // No object addressed as A may be readable holding B.
+    match store.get_object(&sum_a) {
+        Ok(bytes) => assert_ne!(
+            bytes, content_b,
+            "FORBIDDEN: strict mode left a mis-addressed object readable at checksum(A)"
+        ),
+        Err(_) => {}
+    }
+}
+
+// ===========================================================================
+// CASE 5 — clonefile_hits still fires (cfg macos). The skip optimization must
+// NOT disable cloning: a default stage AND a fetch on APFS still increment
+// clonefile_hits(); VERIFY_COPIES=1 still clones (only the re-hash is forced).
+// Spec clause: "clonefile_hits still fires: default stage on APFS still
+// increments clonefile_hits() (skip doesn't disable cloning); a fetch likewise."
+// ===========================================================================
+
+#[cfg(target_os = "macos")]
+#[test]
+fn clonefile_still_fires_under_skip_and_under_verify_copies() {
+    // Spec clause (clonefile_hits still fires): the skip + the strict override
+    // must both leave the clone fast-path firing; only CLONEFILE=0 stops it.
+    let files_owned = mixed_size_files();
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let _g = env_lock();
+
+    // Helper: push + fetch under `mode`, return the clone-hit delta.
+    let run_delta = |mode: Mode| -> u64 {
+        let _e = mode.env();
+        let store_dir = TempDir::new(&format!("hits-store-{}", mode.tag()));
+        let src = TempDir::new(&format!("hits-src-{}", mode.tag()));
+        let dest = TempDir::new(&format!("hits-dest-{}", mode.tag()));
+        let (manifest, _id) = build_tree(src.path(), &files);
+        let store = FileStore::from_root(store_dir.path().to_path_buf());
+        let before = snapdir_stores::clonefile_hits();
+        store.push(&manifest, src.path()).expect("push");
+        store
+            .fetch_files(&manifest, dest.path())
+            .expect("fetch_files");
+        snapdir_stores::clonefile_hits() - before
+    };
+
+    // Default (skip live): clone still fires across push + fetch.
+    let default_delta = run_delta(Mode::Default);
+    assert!(
+        default_delta >= 2,
+        "default skip mode must STILL clone on both push and fetch \
+         (skip does not disable cloning): delta={default_delta}"
+    );
+
+    // VERIFY_COPIES=1: clone still fires (only the re-hash is forced on).
+    let verify_delta = run_delta(Mode::VerifyCopies);
+    assert!(
+        verify_delta >= 2,
+        "SNAPDIR_VERIFY_COPIES=1 must still clone (it forces a re-hash, it does \
+         NOT disable cloning): delta={verify_delta}"
+    );
+
+    // CLONEFILE=0: no clone fires (control arm).
+    let off_delta = run_delta(Mode::CloneOff);
+    assert_eq!(
+        off_delta, 0,
+        "SNAPDIR_CLONEFILE=0 must fire no clone: delta={off_delta}"
+    );
+}
+
+// ===========================================================================
+// CASE 6a — Degenerate: 0-byte file on the skip path. The skip branch must
+// handle an empty source (no empty-file choke) and round-trip byte-correct
+// under all three modes.
+// Spec clause: "Degenerate: 0-byte file (skip path must handle it)."
+// ===========================================================================
+
+#[test]
+fn zero_byte_file_skip_path_roundtrips_under_all_modes() {
+    // Spec clause (degenerate 0-byte): the skip path must handle an empty
+    // source; restored content + object pool + id identical across modes.
+    let files: Vec<(&str, &[u8], &str)> = vec![("empty", b"".as_slice(), "644")];
+
+    let _g = env_lock();
+
+    let runs: Vec<_> = ALL_MODES
+        .iter()
+        .map(|m| {
+            let _e = m.env();
+            roundtrip_once(*m, &files)
+        })
+        .collect();
+
+    let sum = Blake3Hasher::new().hash_hex(b"");
+    let base = &runs[0];
+    for (i, run) in runs.iter().enumerate() {
+        assert_eq!(run.0, base.0, "mode {i}: 0-byte object pool must match");
+        assert_eq!(
+            run.1, base.1,
+            "mode {i}: restored 0-byte content must match"
+        );
+        assert_eq!(run.3, base.3, "mode {i}: 0-byte snapshot id must match");
+        // The empty object exists and is exactly empty.
+        let empty_rel = object_path(&sum);
+        assert!(
+            run.0.iter().any(|(r, b)| *r == empty_rel && b.is_empty()),
+            "mode {i}: the 0-byte object must be present and empty"
+        );
+        // Restored empty file is empty.
+        assert!(
+            run.1.iter().any(|(r, b)| r == "empty" && b.is_empty()),
+            "mode {i}: restored 0-byte file must be empty"
+        );
+    }
+}
+
+// ===========================================================================
+// CASE 6b — Degenerate: same-mtime, different-content. Two source files written
+// "back to back" can share an mtime at coarse filesystem granularity. If the
+// stage stat-guard trusts (size, mtime, ctime, ino) and skips the re-hash, an
+// equal-size + same-mtime forge could in principle slip the guard — but the
+// read-time BLAKE3 backstop must STILL prevent any silently mis-addressed
+// object. (Deep TOCTOU/inode-reuse/`touch -t` fuzz is deferred to the later
+// clone-skip-race-verify gate; this is the basic same-mtime case.)
+// Spec clause: "a file whose mtime is ... equal across two writes
+// (mtime-granularity) — assert no silent mis-address ... include a basic
+// same-mtime-different-content case here."
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn same_mtime_different_content_never_silently_misaddresses() {
+    // Spec clause (degenerate same-mtime forge): record checksum(A) for a
+    // source, then rewrite it with equal-length bytes(B) and FORCE the mtime
+    // (and atime) back to A's recorded value, so a (size,mtime)-only guard would
+    // be fooled. The push must still never produce an object readable at
+    // checksum(A) holding B — caught at write time (full guard incl. ctime/ino)
+    // OR at read time (BLAKE3 backstop).
+    use std::os::unix::fs::MetadataExt;
+
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None); // default skip mode — the risky one
+
+    let store_dir = TempDir::new("mtime-store");
+    let src = TempDir::new("mtime-src");
+
+    let content_a: Vec<u8> = (0..(40 * 1024u32)).map(|i| (i % 181) as u8).collect();
+    let content_b: Vec<u8> = content_a.iter().map(|b| b ^ 0x3c).collect(); // same length
+    assert_eq!(content_a.len(), content_b.len());
+
+    let hasher = Blake3Hasher::new();
+    let sum_a = hasher.hash_hex(&content_a);
+
+    let rel = "twin.bin";
+    let target = src.path().join(rel);
+
+    // Write A, capture its mtime/atime, build the manifest over A.
+    fs::write(&target, &content_a).unwrap();
+    let md_a = fs::metadata(&target).unwrap();
+    let a_mtime = filetime_pair(
+        md_a.atime(),
+        md_a.atime_nsec(),
+        md_a.mtime(),
+        md_a.mtime_nsec(),
+    );
+
+    let mut manifest = Manifest::new();
+    manifest.push(ManifestEntry::new(
+        PathType::File,
+        "644",
+        sum_a.clone(),
+        content_a.len() as u64,
+        format!("./{rel}"),
+    ));
+    let root_sum = directory_checksum(std::iter::once(sum_a.as_str()), &hasher);
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        content_a.len() as u64,
+        "./",
+    ));
+    manifest.sort();
+
+    // Overwrite with B (same length) and force the mtime/atime back to A's, so a
+    // size+mtime-only check sees "unchanged".
+    fs::write(&target, &content_b).unwrap();
+    set_file_times(&target, a_mtime);
+
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    let push_res = store.push(&manifest, src.path());
+
+    // Never-silent invariant (same shape as the keystone): write-time Integrity,
+    // or read-time rejection — never an object at checksum(A) holding B.
+    match push_res {
+        Err(ref e) => assert!(
+            is_integrity(e),
+            "a same-mtime same-size content forge that the full guard catches must \
+             surface as Integrity, got {e:?}"
+        ),
+        Ok(()) => match store.get_object(&sum_a) {
+            Ok(bytes) => {
+                assert_ne!(
+                    bytes, content_b,
+                    "FORBIDDEN: get_object(checksum(A)) returned bytes(B) for a same-mtime forge"
+                );
+                assert_eq!(
+                    Blake3Hasher::new().hash_hex(&bytes),
+                    sum_a,
+                    "any object returned at checksum(A) must hash to checksum(A)"
+                );
+            }
+            Err(e) => assert!(
+                is_integrity(&e) || matches!(e, StoreError::ObjectNotFound { .. }),
+                "reading checksum(A) of a same-mtime forge must be Integrity-rejected or \
+                 absent, got {e:?}"
+            ),
+        },
+    }
+}
+
+// --- tiny in-test filetime helpers (no dev-dep; uses libc via raw syscall) ---
+// We avoid pulling the `filetime` crate (the stores crate has no such dev-dep);
+// the times are set via the libc `utimensat` syscall directly in the harness.
+#[cfg(unix)]
+#[derive(Clone, Copy)]
+struct FileTimes {
+    atime_sec: i64,
+    atime_nsec: i64,
+    mtime_sec: i64,
+    mtime_nsec: i64,
+}
+
+#[cfg(unix)]
+fn filetime_pair(atime_sec: i64, atime_nsec: i64, mtime_sec: i64, mtime_nsec: i64) -> FileTimes {
+    FileTimes {
+        atime_sec,
+        atime_nsec,
+        mtime_sec,
+        mtime_nsec,
+    }
+}
+
+#[cfg(unix)]
+fn set_file_times(path: &Path, t: FileTimes) {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let c = CString::new(path.as_os_str().as_bytes()).expect("path has no NUL");
+    let times = [
+        libc::timespec {
+            tv_sec: t.atime_sec as libc::time_t,
+            tv_nsec: t.atime_nsec as _,
+        },
+        libc::timespec {
+            tv_sec: t.mtime_sec as libc::time_t,
+            tv_nsec: t.mtime_nsec as _,
+        },
+    ];
+    // AT_FDCWD = use the path relative to cwd (the path is absolute here anyway).
+    let rc = unsafe { libc::utimensat(libc::AT_FDCWD, c.as_ptr(), times.as_ptr(), 0) };
+    assert_eq!(rc, 0, "utimensat must succeed to forge the mtime");
+}
+
+// ===========================================================================
+// REVIEW-MODE ADDITIONS (gate `clone-skip-tests-review`). The StatGuarded skip
+// is now live and `FileStore::with_copy_guards` is a public API; these cases
+// exercise the now-visible branches the black-box authoring gate could not
+// reach (it could not populate the guard map directly).
+//
+// Builds a `HashMap<PathBuf, CopyGuard>` from the LIVE metadata of each source
+// file, keyed by the same absolute path `push` joins (`source.join(rel)`), so
+// the StatGuarded SKIP genuinely engages.
+// ===========================================================================
+
+/// Builds the guard map `push` consumes (`source.join(rel)` keys) from the
+/// CURRENT on-disk metadata of every regular file the manifest references.
+#[cfg(unix)]
+fn guards_from_sources(manifest: &Manifest, source: &Path) -> HashMap<PathBuf, CopyGuard> {
+    let mut map = HashMap::new();
+    for entry in manifest.entries() {
+        if entry.path_type != PathType::File {
+            continue;
+        }
+        let rel = entry.path.strip_prefix("./").unwrap_or(entry.path.as_str());
+        let abs = source.join(rel);
+        let meta = fs::metadata(&abs).expect("source file metadata");
+        if let Some(g) = CopyGuard::from_metadata(&meta) {
+            map.insert(abs, g);
+        }
+    }
+    map
+}
+
+// ---------------------------------------------------------------------------
+// REVIEW CASE A — TrustedObject DEVIATION ADJUDICATION: a CORRUPT store object
+// must STILL be detected on the FETCH/checkout path on a clone-capable host.
+//
+// The stores coder did NOT implement the literal "zero-read fetch skip" the
+// plan first described; instead `TrustedObject` re-hashes the SOURCE object
+// once (catching on-disk corruption) and only skips the redundant TEMP re-hash.
+// This case independently CONFIRMS that choice is *safer, not weaker*: it
+// corrupts a committed store object in place, then fetches it on THIS APFS host
+// (clone fast-path live, skip optimization on) and asserts the corruption is
+// STILL rejected (Integrity) — i.e. clone-skip did NOT open a silent
+// corrupt-checkout hole. If this ever FAILS, clone-skip opened a real hole and
+// the impl gate `clone-skip-stores` must reopen.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fetch_of_corrupted_store_object_still_detected_on_clone_path() {
+    // Spec/adjudication clause: clone-skip's TrustedObject path must preserve
+    // the store's verify-on-fetch corruption discipline. A store object whose
+    // on-disk bytes no longer hash to its content address must NEVER be cloned
+    // (skip) into a checkout — the source-verify must surface Integrity.
+    let _g = env_lock();
+    // Default mode: clone fast-path enabled + skip optimization LIVE (the
+    // exact configuration under which a "zero-read fetch skip" would have been
+    // dangerous).
+    let _e = CopyModeEnv::set(None, None);
+
+    let store_dir = TempDir::new("corrupt-fetch-store");
+    let src = TempDir::new("corrupt-fetch-src");
+    let dest = TempDir::new("corrupt-fetch-dest");
+
+    // A >256 KiB file so the clone fast-path is firmly in play on APFS.
+    let content: Vec<u8> = (0..(300 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    let files: Vec<(&str, &[u8], &str)> = vec![("payload.bin", content.as_slice(), "644")];
+    let (manifest, _id) = build_tree(src.path(), &files);
+
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    store
+        .push(&manifest, src.path())
+        .expect("push clean object");
+
+    // Corrupt the committed store object IN PLACE (out-of-band on-disk rot):
+    // same byte length, different content, so a size check alone cannot catch
+    // it — only a real content re-hash can.
+    let checksum = Blake3Hasher::new().hash_hex(&content);
+    let obj = object_disk(store_dir.path(), &checksum);
+    assert!(
+        obj.is_file(),
+        "the store object must exist before corruption"
+    );
+    let mut corrupt = content.clone();
+    corrupt[0] ^= 0xff;
+    corrupt[content.len() - 1] ^= 0xff;
+    assert_eq!(corrupt.len(), content.len(), "corruption preserves length");
+    assert_ne!(corrupt, content, "corruption changes content");
+    fs::write(&obj, &corrupt).expect("corrupt the store object in place");
+
+    // Fetch/checkout on the clone-capable host. The corruption MUST be detected
+    // (Integrity), NOT silently cloned into the destination.
+    let res = store.fetch_files(&manifest, dest.path());
+    let err = res.expect_err(
+        "fetching a corrupted store object on the clone path must be REJECTED, \
+         not silently cloned — clone-skip must not open a silent-corrupt-checkout hole",
+    );
+    assert!(
+        is_integrity(&err),
+        "a corrupt store object must surface as StoreError::Integrity on the clone \
+         fetch path, got {err:?}"
+    );
+
+    // And the destination must NOT hold the corrupt bytes (no partial silent
+    // materialization of a mis-addressed object).
+    let restored = fs::read(dest.path().join("payload.bin")).unwrap_or_default();
+    assert_ne!(
+        restored, corrupt,
+        "FORBIDDEN: the corrupt store bytes were cloned into the checkout"
+    );
+
+    // Read-time backstop is also intact (get_object rejects the corrupt blob).
+    match store.get_object(&checksum) {
+        Err(e) => assert!(
+            is_integrity(&e),
+            "get_object of the corrupt blob must be Integrity-rejected, got {e:?}"
+        ),
+        Ok(_) => panic!("FORBIDDEN: get_object returned the corrupt blob as valid"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// REVIEW CASE B — StatGuarded SKIP genuinely TAKEN. With a guard map populated
+// from the source files' real metadata, the stage clone-skip engages: the
+// object pool + id must be correct, equal to the SNAPDIR_VERIFY_COPIES=1 run
+// (skip ≡ verify for honest input), and (cfg macos) the clone fast-path must
+// have fired (clonefile_hits advanced) — proving the skip rode the clone path,
+// not a silent fs::copy fallback.
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+#[test]
+fn stage_statguarded_skip_taken_equals_verify_and_correct_pool() {
+    // Spec clause (StatGuarded skip taken): a matching guard makes `persist`
+    // skip the temp re-hash with NO read; the result must equal the strict
+    // (VERIFY_COPIES=1, full re-hash) run object-for-object and id-for-id.
+    let files_owned = mixed_size_files();
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let _g = env_lock();
+
+    // Strict reference run (forced re-hash, no skip) WITHOUT guards.
+    let (verify_inv, verify_id) = {
+        let _e = CopyModeEnv::set(None, Some("1"));
+        let store_dir = TempDir::new("sg-verify-store");
+        let src = TempDir::new("sg-verify-src");
+        let (manifest, id) = build_tree(src.path(), &files);
+        let store = FileStore::from_root(store_dir.path().to_path_buf());
+        store.push(&manifest, src.path()).expect("strict push");
+        (object_inventory(store_dir.path()), id)
+    };
+
+    // Skip run: guards captured from the live sources => StatGuarded SKIP.
+    let (skip_inv, skip_id, clone_delta) = {
+        let _e = CopyModeEnv::set(None, None);
+        let store_dir = TempDir::new("sg-skip-store");
+        let src = TempDir::new("sg-skip-src");
+        let (manifest, id) = build_tree(src.path(), &files);
+        let guards = guards_from_sources(&manifest, src.path());
+        assert!(
+            !guards.is_empty(),
+            "the guard map must be populated so the StatGuarded skip can engage"
+        );
+        let store = FileStore::from_root(store_dir.path().to_path_buf()).with_copy_guards(guards);
+        let before = snapdir_stores::clonefile_hits();
+        store.push(&manifest, src.path()).expect("skip push");
+        let delta = snapdir_stores::clonefile_hits() - before;
+        (object_inventory(store_dir.path()), id, delta)
+    };
+
+    assert_eq!(
+        skip_inv, verify_inv,
+        "StatGuarded skip object pool must be byte-identical to the strict verify run"
+    );
+    assert_eq!(
+        skip_id, verify_id,
+        "StatGuarded skip snapshot id must equal the strict verify run"
+    );
+
+    // The >256 KiB object is present at full length (skip is not vacuous).
+    let big_sum = Blake3Hasher::new().hash_hex(&files_owned[0].1);
+    let big_rel = object_path(&big_sum);
+    assert!(
+        skip_inv
+            .iter()
+            .any(|(rel, bytes)| *rel == big_rel && bytes.len() == files_owned[0].1.len()),
+        "the >256 KiB object must be present at full length under the skip path"
+    );
+
+    // On macOS/APFS the skip must have RIDDEN the clone fast-path (>=1 regular
+    // file cloned), not silently fallen back to fs::copy.
+    #[cfg(target_os = "macos")]
+    assert!(
+        clone_delta >= 1,
+        "StatGuarded skip must ride the clone fast-path on APFS (clonefile_hits \
+         must advance): delta={clone_delta}"
+    );
+    #[cfg(not(target_os = "macos"))]
+    let _ = clone_delta;
+}
+
+// ---------------------------------------------------------------------------
+// REVIEW CASE C — StatGuarded MISMATCH falls back to the re-hash. A guard whose
+// (size/mtime/ctime/ino) no longer matches the source (because the source was
+// mutated after the guard was captured) must NOT skip: it falls through to the
+// temp re-hash, which surfaces a true content change as Integrity. A stale
+// guard must NEVER cause a silent mis-addressed object.
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+#[test]
+fn stage_statguarded_stale_guard_never_silently_misaddresses() {
+    // Spec clause (StatGuarded mismatch -> re-hash): a guard captured for
+    // content A, with the source then overwritten by content B (records A's
+    // checksum but holds B), must fall back to the re-hash and reject the
+    // mismatch — never file B under checksum(A).
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None); // default skip mode
+
+    let store_dir = TempDir::new("sg-stale-store");
+    let src = TempDir::new("sg-stale-src");
+
+    let content_a: Vec<u8> = (0..(64 * 1024u32)).map(|i| (i % 211) as u8).collect();
+    // Same length, different bytes (size-only guard cannot catch this).
+    let content_b: Vec<u8> = content_a.iter().map(|b| b ^ 0xff).collect();
+    let hasher = Blake3Hasher::new();
+    let sum_a = hasher.hash_hex(&content_a);
+
+    let rel = "stale.bin";
+    let target = src.path().join(rel);
+    fs::write(&target, &content_a).unwrap();
+
+    // Capture the guard for A (this is what the walk would have recorded).
+    let guard_a = CopyGuard::from_metadata(&fs::metadata(&target).unwrap()).expect("guard for A");
+
+    let mut manifest = Manifest::new();
+    manifest.push(ManifestEntry::new(
+        PathType::File,
+        "644",
+        sum_a.clone(),
+        content_a.len() as u64,
+        format!("./{rel}"),
+    ));
+    let root_sum = directory_checksum(std::iter::once(sum_a.as_str()), &hasher);
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        content_a.len() as u64,
+        "./",
+    ));
+    manifest.sort();
+
+    // Overwrite with B. The guard is now STALE (the live metadata no longer
+    // matches guard_a: at minimum ctime advances on the rewrite).
+    fs::write(&target, &content_b).unwrap();
+
+    let mut guards = HashMap::new();
+    guards.insert(target.clone(), guard_a);
+    let store = FileStore::from_root(store_dir.path().to_path_buf()).with_copy_guards(guards);
+
+    let res = store.push(&manifest, src.path());
+
+    // The stale guard must NOT cause a silent mis-address. Either the guard
+    // mismatch is detected and the re-hash surfaces Integrity (the expected
+    // outcome), or — never — an object readable at checksum(A) holding B.
+    match res {
+        Err(ref e) => assert!(
+            is_integrity(e),
+            "a stale guard must fall back to the re-hash and reject the mutated \
+             source with Integrity, got {e:?}"
+        ),
+        Ok(()) => match store.get_object(&sum_a) {
+            Ok(bytes) => {
+                assert_ne!(
+                    bytes, content_b,
+                    "FORBIDDEN: a stale guard let bytes(B) be filed under checksum(A)"
+                );
+                assert_eq!(
+                    Blake3Hasher::new().hash_hex(&bytes),
+                    sum_a,
+                    "any object readable at checksum(A) must hash to checksum(A)"
+                );
+            }
+            Err(e) => assert!(
+                is_integrity(&e) || matches!(e, StoreError::ObjectNotFound { .. }),
+                "reading checksum(A) after a stale-guard stage must be rejected or \
+                 absent, got {e:?}"
+            ),
+        },
+    }
+}
+
+// ---------------------------------------------------------------------------
+// REVIEW CASE D — SNAPDIR_VERIFY_COPIES=1 OVERRIDES a MATCHING guard. Even when
+// the guard still matches the source's current metadata, strict mode must
+// re-hash (and therefore catch a mutated source whose metadata was forged back
+// to match). This proves the strict override is a true write-time re-hash, not
+// a guard-driven skip. Contrast with the same setup under default mode, where
+// the matching guard would skip (the read-time backstop is the safety net there
+// — covered by case B's race-keystone family).
+// ---------------------------------------------------------------------------
+
+#[cfg(unix)]
+#[test]
+fn verify_copies_overrides_a_matching_guard() {
+    // Spec clause (strict overrides guard): build a guard that MATCHES the
+    // current source metadata, but whose content no longer matches the recorded
+    // checksum (metadata forged back via utimensat); under VERIFY_COPIES=1 the
+    // strict re-hash must catch it (Integrity) regardless of the matching guard.
+    use std::os::unix::fs::MetadataExt;
+
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, Some("1")); // STRICT
+
+    let store_dir = TempDir::new("strict-guard-store");
+    let src = TempDir::new("strict-guard-src");
+
+    let content_a: Vec<u8> = (0..(72 * 1024u32)).map(|i| (i % 197) as u8).collect();
+    let content_b: Vec<u8> = content_a.iter().map(|b| b ^ 0x6b).collect(); // same length
+    let hasher = Blake3Hasher::new();
+    let sum_a = hasher.hash_hex(&content_a);
+
+    let rel = "forged.bin";
+    let target = src.path().join(rel);
+
+    // Write A, capture A's mtime/atime for later forgery.
+    fs::write(&target, &content_a).unwrap();
+    let md_a = fs::metadata(&target).unwrap();
+    let a_times = filetime_pair(
+        md_a.atime(),
+        md_a.atime_nsec(),
+        md_a.mtime(),
+        md_a.mtime_nsec(),
+    );
+
+    let mut manifest = Manifest::new();
+    manifest.push(ManifestEntry::new(
+        PathType::File,
+        "644",
+        sum_a.clone(),
+        content_a.len() as u64,
+        format!("./{rel}"),
+    ));
+    let root_sum = directory_checksum(std::iter::once(sum_a.as_str()), &hasher);
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        content_a.len() as u64,
+        "./",
+    ));
+    manifest.sort();
+
+    // Overwrite with B (same length) and force mtime/atime back to A's.
+    fs::write(&target, &content_b).unwrap();
+    set_file_times(&target, a_times);
+
+    // Build a guard from the CURRENT (post-forge) metadata so it MATCHES what
+    // `persist` will re-stat — proving strict mode ignores the matching guard.
+    let matching_guard =
+        CopyGuard::from_metadata(&fs::metadata(&target).unwrap()).expect("guard for forged");
+    let mut guards = HashMap::new();
+    guards.insert(target.clone(), matching_guard);
+
+    let store = FileStore::from_root(store_dir.path().to_path_buf()).with_copy_guards(guards);
+    let res = store.push(&manifest, src.path());
+
+    let err = res
+        .expect_err("SNAPDIR_VERIFY_COPIES=1 must re-hash and reject even with a MATCHING guard");
+    assert!(
+        is_integrity(&err),
+        "strict mode must surface Integrity despite the matching guard, got {err:?}"
+    );
+    match store.get_object(&sum_a) {
+        Ok(bytes) => assert_ne!(
+            bytes, content_b,
+            "FORBIDDEN: strict mode with a matching guard left a mis-addressed object"
+        ),
+        Err(_) => {}
+    }
+}
+
+// ---------------------------------------------------------------------------
+// REVIEW CASE E — Untrusted (EMPTY guard map) is byte-for-byte today's
+// behavior. A FileStore with no guards (the default) must produce an object
+// pool + id identical to a CLONEFILE=0 (always-fs::copy+rehash) run for the
+// SAME input — i.e. the optimization is inert without guards.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn stage_untrusted_empty_guards_equals_clone_off() {
+    // Spec clause (Untrusted == today): empty `copy_guards` reproduces today's
+    // always-rehash behavior; its object pool + id must equal the CLONEFILE=0
+    // (fs::copy + rehash) reference run.
+    let files_owned = mixed_size_files();
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let _g = env_lock();
+
+    // Reference: CLONEFILE=0, no guards.
+    let (off_inv, off_id) = {
+        let _e = CopyModeEnv::set(Some("0"), None);
+        let store_dir = TempDir::new("untrusted-off-store");
+        let src = TempDir::new("untrusted-off-src");
+        let (manifest, id) = build_tree(src.path(), &files);
+        let store = FileStore::from_root(store_dir.path().to_path_buf());
+        store.push(&manifest, src.path()).expect("off push");
+        (object_inventory(store_dir.path()), id)
+    };
+
+    // Default mode but an EXPLICIT empty guard map => every source Untrusted.
+    let (untrusted_inv, untrusted_id) = {
+        let _e = CopyModeEnv::set(None, None);
+        let store_dir = TempDir::new("untrusted-def-store");
+        let src = TempDir::new("untrusted-def-src");
+        let (manifest, id) = build_tree(src.path(), &files);
+        let store =
+            FileStore::from_root(store_dir.path().to_path_buf()).with_copy_guards(HashMap::new());
+        store.push(&manifest, src.path()).expect("untrusted push");
+        (object_inventory(store_dir.path()), id)
+    };
+
+    assert_eq!(
+        untrusted_inv, off_inv,
+        "Untrusted (empty guards) object pool must equal the CLONEFILE=0 reference"
+    );
+    assert_eq!(
+        untrusted_id, off_id,
+        "Untrusted (empty guards) snapshot id must equal the CLONEFILE=0 reference"
+    );
+}

--- a/crates/snapdir-stores/tests/clone_skip_race.rs
+++ b/crates/snapdir-stores/tests/clone_skip_race.rs
@@ -1,0 +1,1219 @@
+//! INDEPENDENT VERIFICATION suite (gate `clone-skip-race-verify`, phase 29) —
+//! TOCTOU / concurrency / property fuzz proving the clone-skip optimization
+//! NEVER yields a *silently mis-addressed object* (an object readable at
+//! checksum(A) whose bytes are actually B).
+//!
+//! This is the dedicated verification gate, so authoring a NET-NEW test file
+//! here is explicitly allowed. The impl is visible and was read to ground these
+//! cases (`file_store.rs`: `persist`, `CopyTrust`, `StatGuarded`, `copy_file`,
+//! `get_object`, `with_copy_guards`; `snapdir_core::CopyGuard`).
+//!
+//! ## The two-layer safety model under test
+//!
+//! Layer 1 (WRITE-time stat-guard). On the `CopyTrust::StatGuarded` stage path
+//! `persist` re-`stat`s the source at clone time and SKIPS the temp re-hash IFF
+//! the fresh `CopyGuard{size,mtime_ns,ctime_ns,ino}` still equals the recorded
+//! one. A benign mid-stage race is caught here because `ctime` advances on ANY
+//! inode change (a write, a `utimensat`) and cannot be moved backwards via
+//! `utimensat` (which only sets atime/mtime) — so a content+mtime+size spoof
+//! still flips `ctime_ns` and forces the re-hash, which then surfaces the true
+//! content change as `StoreError::Integrity`.
+//!
+//! Layer 2 (READ-time BLAKE3 backstop). Even if the write-time guard were FULLY
+//! defeated (a guard that exactly matches the post-mutation stat) so that B is
+//! cloned into the object filed under checksum(A), `get_object(checksum(A))` and
+//! `fetch_files` re-hash on read and reject the mis-addressed blob with
+//! `StoreError::Integrity`. This is the load-bearing proof that skip is
+//! safe-by-backstop.
+//!
+//! The FORBIDDEN outcome every case fails on: an object readable at checksum(A)
+//! whose bytes are B (i.e. `get_object`/`fetch` hands back bytes that do not
+//! hash to the address requested).
+//!
+//! ## Env / parallelism
+//!
+//! `SNAPDIR_CLONEFILE` / `SNAPDIR_VERIFY_COPIES` are process-global and Rust
+//! runs `#[test]`s multithreaded in one binary, so every test that touches a
+//! knob (or reads a `clonefile_hits()` delta) holds a single process-wide
+//! `ENV_LOCK` for its whole body and RESTORES prior values on drop (mirrors
+//! `apfs_clone.rs` / `clone_skip.rs`). Spawned threads are always joined.
+
+// Style-only lint allows (no assertion is affected): the deterministic
+// schedule generators do arithmetic-mod-256 byte fills (cast truncation is the
+// intent), use large multiplier literals, and define small walk helpers after
+// statements — none of which bear on what the suite proves.
+//
+// The last two only ever fire on the LINUX target (`cfg(target_os="linux")`
+// cases / the musl `libc::time_t` alias), so they are invisible to the macOS
+// dev host's clippy but fail CI's ubuntu `clippy --all-targets -D warnings`
+// (process note in `.gatesmith/state.md` — `reflink-tests-review` caught the
+// same class). Pure shape; no assertion or test logic is affected:
+//   * `map_unwrap_or` — the env-contract gate `reflink_root_or_skip` (mirrors
+//     `reflink.rs`'s allow),
+//   * `deprecated` — `set_mtime_atime`'s `libc::time_t` (musl 1.2 64-bit
+//     migration warning; the existing helper, unchanged).
+#![allow(
+    clippy::type_complexity,
+    clippy::too_many_lines,
+    clippy::doc_markdown,
+    clippy::similar_names,
+    clippy::single_match,
+    clippy::single_match_else,
+    clippy::cast_possible_truncation,
+    clippy::unreadable_literal,
+    clippy::items_after_statements,
+    clippy::map_unwrap_or,
+    deprecated
+)]
+
+use std::collections::HashMap;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Barrier, Mutex, MutexGuard, OnceLock};
+
+#[cfg(unix)]
+use std::os::unix::fs::MetadataExt;
+
+use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
+use snapdir_core::merkle::{directory_checksum, Blake3Hasher, Hasher};
+use snapdir_core::store::{Store, StoreError};
+use snapdir_core::CopyGuard;
+
+use snapdir_stores::{FileStore, StreamStore};
+
+// ---------------------------------------------------------------------------
+// Scaffolding (no NEW dev-dependency; libc is a direct dep of this crate).
+// ---------------------------------------------------------------------------
+
+/// A unique temp dir removed on drop.
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "snapdir-clone-skip-race-{}-{tag}-{n}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).expect("create temp dir");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+/// Process-global lock guarding `SNAPDIR_CLONEFILE` + `SNAPDIR_VERIFY_COPIES`
+/// (both process-global) and the process-global `clonefile_hits()` counter.
+fn env_lock() -> MutexGuard<'static, ()> {
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// RAII guard that sets/clears the two copy knobs and restores prior values on
+/// drop. Caller must already hold `env_lock()`.
+struct CopyModeEnv {
+    prev_clone: Option<String>,
+    prev_verify: Option<String>,
+}
+
+impl CopyModeEnv {
+    fn set(clonefile: Option<&str>, verify: Option<&str>) -> Self {
+        let prev_clone = std::env::var("SNAPDIR_CLONEFILE").ok();
+        let prev_verify = std::env::var("SNAPDIR_VERIFY_COPIES").ok();
+        match clonefile {
+            Some(v) => std::env::set_var("SNAPDIR_CLONEFILE", v),
+            None => std::env::remove_var("SNAPDIR_CLONEFILE"),
+        }
+        match verify {
+            Some(v) => std::env::set_var("SNAPDIR_VERIFY_COPIES", v),
+            None => std::env::remove_var("SNAPDIR_VERIFY_COPIES"),
+        }
+        Self {
+            prev_clone,
+            prev_verify,
+        }
+    }
+}
+
+impl Drop for CopyModeEnv {
+    fn drop(&mut self) {
+        match &self.prev_clone {
+            Some(v) => std::env::set_var("SNAPDIR_CLONEFILE", v),
+            None => std::env::remove_var("SNAPDIR_CLONEFILE"),
+        }
+        match &self.prev_verify {
+            Some(v) => std::env::set_var("SNAPDIR_VERIFY_COPIES", v),
+            None => std::env::remove_var("SNAPDIR_VERIFY_COPIES"),
+        }
+    }
+}
+
+/// `true` iff `e` is a `StoreError::Integrity`.
+fn is_integrity(e: &StoreError) -> bool {
+    matches!(e, StoreError::Integrity { .. })
+}
+
+/// `true` iff `e` is `Integrity` or `ObjectNotFound` (both are "safe": never a
+/// readable mis-addressed object).
+fn is_rejected_or_absent(e: &StoreError) -> bool {
+    matches!(
+        e,
+        StoreError::Integrity { .. } | StoreError::ObjectNotFound { .. }
+    )
+}
+
+/// Builds a single-file manifest recording `(checksum, len)` for `content`
+/// under `./<rel>` plus the root directory entry, sorted + ready to push.
+fn single_file_manifest(rel: &str, content: &[u8]) -> (Manifest, String) {
+    let hasher = Blake3Hasher::new();
+    let sum = hasher.hash_hex(content);
+    let mut manifest = Manifest::new();
+    manifest.push(ManifestEntry::new(
+        PathType::File,
+        "644",
+        sum.clone(),
+        content.len() as u64,
+        format!("./{rel}"),
+    ));
+    let root_sum = directory_checksum(std::iter::once(sum.as_str()), &hasher);
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        content.len() as u64,
+        "./",
+    ));
+    manifest.sort();
+    (manifest, sum)
+}
+
+/// THE global invariant: scan every blob in `<root>/.objects` and assert that
+/// each one, when read back through `get_object` under the content-address its
+/// sharded path encodes, either hashes to that address or is rejected — NEVER
+/// returns bytes that do not hash to the requested address.
+///
+/// We re-derive the requested checksum by hashing the *file name path* is not
+/// possible (the sharded layout splits the hex), so instead we drive it the
+/// honest way: for every checksum we care about (passed in `addresses`), assert
+/// `get_object` never hands back bytes whose hash differs from the checksum.
+/// Additionally we walk the pool and confirm every present blob's bytes hash to
+/// SOME value and, when looked up under that true hash, round-trips (a blob can
+/// only ever be SAFELY readable under its true content address).
+fn assert_no_readable_misaddress(store: &FileStore, root: &Path, addresses: &[String]) {
+    let hasher = Blake3Hasher::new();
+    for checksum in addresses {
+        match store.get_object(checksum) {
+            Ok(bytes) => {
+                // If a blob is returned for this address it MUST hash to it.
+                assert_eq!(
+                    hasher.hash_hex(&bytes),
+                    *checksum,
+                    "FORBIDDEN: get_object({checksum}) returned bytes that do not hash to it \
+                     (a silently mis-addressed object)"
+                );
+            }
+            Err(e) => assert!(
+                is_rejected_or_absent(&e),
+                "get_object({checksum}) must be Integrity-rejected or absent, got {e:?}"
+            ),
+        }
+    }
+
+    // Independent sweep: every physical blob in the pool, looked up under its
+    // OWN true hash, must round-trip (proves the store never serves a blob whose
+    // bytes diverge from the address it is filed under — i.e. the on-disk
+    // sharded path always equals the true content hash).
+    fn walk(dir: &Path, acc: &mut Vec<Vec<u8>>) {
+        if let Ok(rd) = fs::read_dir(dir) {
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    walk(&p, acc);
+                } else if p.is_file() {
+                    acc.push(fs::read(&p).unwrap());
+                }
+            }
+        }
+    }
+    let mut blobs = Vec::new();
+    walk(&root.join(".objects"), &mut blobs);
+    for bytes in blobs {
+        let true_hash = hasher.hash_hex(&bytes);
+        // The blob's filed-under address is its sharded path; reading it under
+        // its TRUE hash must succeed and yield exactly these bytes. (If a blob
+        // were filed under a DIFFERENT address than its content hash, looking it
+        // up under the true hash would 404 and looking it up under the filed
+        // address would Integrity-reject — both safe, neither silent.)
+        if let Ok(got) = store.get_object(&true_hash) {
+            assert_eq!(
+                got, bytes,
+                "a blob read under its true content hash must return exactly its bytes"
+            );
+        }
+    }
+}
+
+// --- libc utimensat helper (no `filetime` dev-dep; libc is a direct dep) ----
+#[cfg(unix)]
+fn set_mtime_atime(path: &Path, atime: (i64, i64), mtime: (i64, i64)) {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let c = CString::new(path.as_os_str().as_bytes()).expect("path has no NUL");
+    let times = [
+        libc::timespec {
+            tv_sec: atime.0 as libc::time_t,
+            tv_nsec: atime.1 as _,
+        },
+        libc::timespec {
+            tv_sec: mtime.0 as libc::time_t,
+            tv_nsec: mtime.1 as _,
+        },
+    ];
+    let rc = unsafe { libc::utimensat(libc::AT_FDCWD, c.as_ptr(), times.as_ptr(), 0) };
+    assert_eq!(rc, 0, "utimensat must succeed to forge the mtime/atime");
+}
+
+// ===========================================================================
+// CASE 1 — Concurrent mid-stage source mutation. A thread rewrites the source
+// file's content while `push` runs (guards captured just before the push). The
+// resulting snapshot MUST be self-consistent: every object readable in the
+// store hashes to its address, OR the push errored. Never a readable
+// mis-addressed object. Looped over several schedules.
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn concurrent_mid_stage_mutation_never_silently_misaddresses() {
+    // Two-layer model: the write-time guard may catch the race (ctime moves on
+    // the concurrent write) → Integrity; if a particular schedule lets a clone
+    // land, the read-time backstop rejects any mis-addressed blob. Either way:
+    // never a readable object whose bytes != its address.
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None); // default: clone + skip live (the risky path)
+
+    // A spread of schedules: vary content size + how many mutation iterations
+    // the racer performs, and whether B differs in length from A.
+    for schedule in 0..8u32 {
+        let store_dir = TempDir::new(&format!("conc-store-{schedule}"));
+        let src = TempDir::new(&format!("conc-src-{schedule}"));
+
+        let base_len = 32 * 1024 + (schedule as usize) * 7919; // varies per schedule
+        let content_a: Vec<u8> = (0..base_len)
+            .map(|i| ((i as u32).wrapping_mul(2654435761).wrapping_add(schedule)) as u8)
+            .collect();
+
+        let rel = "racey.bin";
+        let target = src.path().join(rel);
+        fs::write(&target, &content_a).unwrap();
+
+        // Build the manifest over A and capture A's guard (the "walk" snapshot).
+        let (manifest, sum_a) = single_file_manifest(rel, &content_a);
+        let guard_a = CopyGuard::from_metadata(&fs::metadata(&target).unwrap()).expect("guard A");
+        let mut guards = HashMap::new();
+        guards.insert(target.clone(), guard_a);
+
+        let store = FileStore::from_root(store_dir.path().to_path_buf()).with_copy_guards(guards);
+
+        // Racer thread: hammer the source with rewrites of differing content so a
+        // schedule may land mid-`copy_file` / mid-stat. Synchronize the start so
+        // both threads run at the same time.
+        let barrier = Arc::new(Barrier::new(2));
+        let racer_target = target.clone();
+        let racer_barrier = Arc::clone(&barrier);
+        let len_b = if schedule % 2 == 0 {
+            base_len // same length (hard case)
+        } else {
+            base_len + 4096 // different length
+        };
+        let sched = schedule;
+        let racer = std::thread::spawn(move || {
+            racer_barrier.wait();
+            for round in 0..40u32 {
+                let content_b: Vec<u8> = (0..len_b)
+                    .map(|i| {
+                        ((i as u32)
+                            .wrapping_mul(40503)
+                            .wrapping_add(round)
+                            .wrapping_add(sched)) as u8
+                            ^ 0xa5
+                    })
+                    .collect();
+                // Atomic-ish overwrite in place (truncate+write) to maximize the
+                // chance of interleaving with the store's open/clone/stat.
+                let _ = fs::write(&racer_target, &content_b);
+            }
+        });
+
+        barrier.wait();
+        let push_res = store.push(&manifest, src.path());
+        racer.join().expect("racer thread joined");
+
+        // Whatever happened, the never-silent invariant holds for checksum(A).
+        match push_res {
+            Err(ref e) => assert!(
+                is_integrity(e) || is_rejected_or_absent(e),
+                "schedule {schedule}: a raced stage that errors must be Integrity / \
+                 absent, got {e:?}"
+            ),
+            Ok(()) => {}
+        }
+        assert_no_readable_misaddress(&store, store_dir.path(), &[sum_a]);
+    }
+}
+
+// ===========================================================================
+// CASE 2 — mtime+size spoof, ctime defeats it (write-time catch). Capture a
+// guard for content A; rewrite to B of the SAME size; `utimensat` the mtime/
+// atime back to A's. The full guard still mismatches because the rewrite (and
+// the utimensat itself) advanced `ctime`, which cannot be set backwards via
+// utimensat → re-hash → Integrity at WRITE time. ctime is the spoof-defeater.
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn mtime_size_spoof_is_caught_at_write_time_by_ctime() {
+    // Layer 1 assertion: a content+mtime+size spoof is caught at write time
+    // because ctime advances on the write and on utimensat (utimensat sets only
+    // atime/mtime). Documented spoof-defeater: ctime_ns.
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None); // default skip mode
+
+    let store_dir = TempDir::new("ctime-store");
+    let src = TempDir::new("ctime-src");
+
+    let content_a: Vec<u8> = (0..(48 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    let content_b: Vec<u8> = content_a.iter().map(|b| b ^ 0xff).collect(); // SAME size
+    assert_eq!(content_a.len(), content_b.len());
+
+    let rel = "spoof.bin";
+    let target = src.path().join(rel);
+
+    // Write A, capture A's stat (mtime/atime + the guard), build the manifest.
+    fs::write(&target, &content_a).unwrap();
+    let md_a = fs::metadata(&target).unwrap();
+    let a_atime = (md_a.atime(), md_a.atime_nsec());
+    let a_mtime = (md_a.mtime(), md_a.mtime_nsec());
+    let guard_a = CopyGuard::from_metadata(&md_a).expect("guard A");
+    let (manifest, sum_a) = single_file_manifest(rel, &content_a);
+
+    // Rewrite to B (same size), then force mtime/atime back to A's. A size+mtime
+    // guard would now be fooled — but ctime advanced (write + utimensat).
+    fs::write(&target, &content_b).unwrap();
+    set_mtime_atime(&target, a_atime, a_mtime);
+
+    // Confirm the spoof actually fooled the (size,mtime) half but NOT ctime.
+    let md_b = fs::metadata(&target).unwrap();
+    let guard_b = CopyGuard::from_metadata(&md_b).expect("guard B");
+    assert_eq!(guard_b.size, guard_a.size, "size spoofed to match");
+    assert_eq!(
+        guard_b.mtime_ns, guard_a.mtime_ns,
+        "mtime spoofed back to A"
+    );
+    // The whole point: ctime could NOT be moved back, so the guard mismatches.
+    if guard_b.ctime_ns == guard_a.ctime_ns && guard_b.ino == guard_a.ino {
+        // On some exotic FS ctime might not move; then this is the fully-defeated
+        // guard and the read-time backstop (case 3) is the safety net. Fall
+        // through to a backstop assertion instead of a hard write-time catch.
+        let mut guards = HashMap::new();
+        guards.insert(target.clone(), guard_a);
+        let store = FileStore::from_root(store_dir.path().to_path_buf()).with_copy_guards(guards);
+        let _ = store.push(&manifest, src.path());
+        assert_no_readable_misaddress(&store, store_dir.path(), &[sum_a]);
+        eprintln!("note: ctime did not advance on this FS; fell through to the read-time backstop");
+        return;
+    }
+
+    // Stage with the A guard: the write-time guard re-stats, sees ctime moved →
+    // Rehash → the B bytes don't hash to checksum(A) → Integrity at WRITE time.
+    let mut guards = HashMap::new();
+    guards.insert(target.clone(), guard_a);
+    let store = FileStore::from_root(store_dir.path().to_path_buf()).with_copy_guards(guards);
+    let err = store
+        .push(&manifest, src.path())
+        .expect_err("ctime-advanced spoof must be CAUGHT at write time");
+    assert!(
+        is_integrity(&err),
+        "the mtime+size spoof must surface as write-time Integrity (ctime defeats it), \
+         got {err:?}"
+    );
+    // And no mis-addressed object is readable.
+    assert_no_readable_misaddress(&store, store_dir.path(), &[sum_a]);
+}
+
+// ===========================================================================
+// CASE 3 — Fully-defeated write-time guard → read-time backstop (LOAD-BEARING).
+// Construct the worst case: capture the guard AFTER mutating the source to B,
+// but keep `expected` = checksum(A). The StatGuarded skip WILL fire (the guard
+// exactly matches the current stat) and clone B into the object filed under
+// checksum(A). Then assert the BACKSTOP: get_object(checksum(A)) is rejected
+// and fetch_files of a manifest referencing A rejects — the mis-addressed
+// object is NEVER silently served. If get_object returns B's bytes as valid →
+// REAL BUG → reopen clone-skip-stores.
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn fully_defeated_guard_blocked_by_read_time_backstop() {
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None); // default skip mode
+
+    let store_dir = TempDir::new("backstop-store");
+    let src = TempDir::new("backstop-src");
+    let dest = TempDir::new("backstop-dest");
+
+    let content_a: Vec<u8> = (0..(64 * 1024u32)).map(|i| (i % 211) as u8).collect();
+    let content_b: Vec<u8> = content_a.iter().map(|b| b ^ 0xff).collect(); // same size, != A
+    let hasher = Blake3Hasher::new();
+    let sum_a = hasher.hash_hex(&content_a);
+    let sum_b = hasher.hash_hex(&content_b);
+    assert_ne!(sum_a, sum_b);
+
+    let rel = "defeated.bin";
+    let target = src.path().join(rel);
+
+    // The manifest records checksum(A)+len(A) (the "walk" hashed A)...
+    let (manifest, _sum) = single_file_manifest(rel, &content_a);
+
+    // ...but the on-disk source is OVERWRITTEN with B, and the guard is captured
+    // from B's CURRENT metadata — simulating a guard that utterly fails to
+    // detect the change (it matches the live stat exactly). The StatGuarded
+    // SKIP is therefore guaranteed to fire: B gets cloned under checksum(A).
+    fs::write(&target, &content_b).unwrap();
+    let guard_b = CopyGuard::from_metadata(&fs::metadata(&target).unwrap()).expect("guard B");
+    let mut guards = HashMap::new();
+    guards.insert(target.clone(), guard_b);
+
+    let store = FileStore::from_root(store_dir.path().to_path_buf()).with_copy_guards(guards);
+    // The push may succeed (skip fires, B cloned under A's address) — that is
+    // the WHOLE POINT: it exercises a mis-addressed object on disk.
+    let push_res = store.push(&manifest, src.path());
+
+    // LOAD-BEARING BACKSTOP ASSERTION: regardless of whether the push reported
+    // success, get_object(checksum(A)) must NEVER hand back B's bytes.
+    match store.get_object(&sum_a) {
+        Ok(bytes) => {
+            // If this ever returns B → REAL BUG (silent mis-address) → reopen
+            // clone-skip-stores.
+            assert_ne!(
+                bytes, content_b,
+                "REAL BUG: get_object(checksum(A)) returned bytes(B) — a silently \
+                 mis-addressed object was accepted. Reopen `clone-skip-stores`."
+            );
+            assert_eq!(
+                hasher.hash_hex(&bytes),
+                sum_a,
+                "any object returned at checksum(A) must hash to checksum(A)"
+            );
+        }
+        Err(ref e) => assert!(
+            is_rejected_or_absent(e),
+            "the read-time backstop must Integrity-reject (or 404) the mis-addressed \
+             blob, got {e:?}"
+        ),
+    }
+
+    // And the checkout path (fetch_files) must reject too — never restoring B
+    // under an entry addressed as A.
+    match store.fetch_files(&manifest, dest.path()) {
+        Err(ref e) => assert!(
+            is_rejected_or_absent(e),
+            "fetch_files of a manifest referencing checksum(A) over a mis-addressed \
+             object must be Integrity-rejected, got {e:?}"
+        ),
+        Ok(()) => {
+            let restored = fs::read(dest.path().join(rel)).unwrap_or_default();
+            assert_ne!(
+                restored, content_b,
+                "REAL BUG: checkout restored bytes(B) under an entry addressed as A. \
+                 Reopen `clone-skip-stores`."
+            );
+        }
+    }
+
+    // The push result itself is informational, but if it errored it must be a
+    // safe error (never a panic / wrong-kind).
+    if let Err(ref e) = push_res {
+        assert!(
+            is_rejected_or_absent(e),
+            "a defeated-guard push that errors must do so safely, got {e:?}"
+        );
+    }
+}
+
+// ===========================================================================
+// CASE 4 — inode reuse. Delete+recreate the file (new content, NEW inode); a
+// guard captured for the OLD inode must NOT match (ino differs) → re-hash → no
+// mis-address. Proves the `ino` field of the guard does real work.
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn inode_change_forces_rehash_no_misaddress() {
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None); // default skip mode
+
+    let store_dir = TempDir::new("ino-store");
+    let src = TempDir::new("ino-src");
+
+    let content_a: Vec<u8> = (0..(40 * 1024u32)).map(|i| (i % 199) as u8).collect();
+    let content_b: Vec<u8> = content_a.iter().map(|b| b ^ 0x33).collect(); // same size, != A
+
+    let rel = "reused.bin";
+    let target = src.path().join(rel);
+    fs::write(&target, &content_a).unwrap();
+    let guard_a = CopyGuard::from_metadata(&fs::metadata(&target).unwrap()).expect("guard A");
+    let (manifest, sum_a) = single_file_manifest(rel, &content_a);
+
+    // Delete + recreate with B at the same path. On most filesystems this yields
+    // a different inode (and even when the inode is reused, ctime/mtime advance).
+    fs::remove_file(&target).unwrap();
+    fs::write(&target, &content_b).unwrap();
+    let guard_b = CopyGuard::from_metadata(&fs::metadata(&target).unwrap()).expect("guard B");
+    // At least ONE guard field must differ (ino, or — if ino was recycled —
+    // ctime/mtime), so the StatGuarded skip cannot fire.
+    assert_ne!(
+        guard_a, guard_b,
+        "delete+recreate must change at least one guard field (ino/ctime/mtime)"
+    );
+
+    let mut guards = HashMap::new();
+    guards.insert(target.clone(), guard_a);
+    let store = FileStore::from_root(store_dir.path().to_path_buf()).with_copy_guards(guards);
+    let res = store.push(&manifest, src.path());
+
+    // The stale (old-inode) guard mismatches → re-hash → B != checksum(A) →
+    // Integrity. Never a silent mis-address.
+    match res {
+        Err(ref e) => assert!(
+            is_integrity(e),
+            "an inode-reused source must re-hash and reject with Integrity, got {e:?}"
+        ),
+        Ok(()) => {}
+    }
+    assert_no_readable_misaddress(&store, store_dir.path(), &[sum_a]);
+}
+
+// ===========================================================================
+// CASE 5 — mtime granularity. Two writes within the same coarse mtime tick
+// (different content, same size) where we additionally force the mtime back to
+// the captured value; assert no silently-accepted mis-address (ctime / the
+// read-time backstop covers it even when mtime collides).
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn mtime_granularity_collision_never_silently_misaddresses() {
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None); // default skip mode
+
+    let store_dir = TempDir::new("gran-store");
+    let src = TempDir::new("gran-src");
+
+    let content_a: Vec<u8> = (0..(24 * 1024u32)).map(|i| (i % 173) as u8).collect();
+    let content_b: Vec<u8> = content_a.iter().map(|b| b ^ 0x5a).collect(); // same size
+
+    let rel = "tick.bin";
+    let target = src.path().join(rel);
+
+    // Write A, capture its mtime; build manifest over A.
+    fs::write(&target, &content_a).unwrap();
+    let md_a = fs::metadata(&target).unwrap();
+    let a_atime = (md_a.atime(), md_a.atime_nsec());
+    let a_mtime = (md_a.mtime(), md_a.mtime_nsec());
+    let guard_a = CopyGuard::from_metadata(&md_a).expect("guard A");
+    let (manifest, sum_a) = single_file_manifest(rel, &content_a);
+
+    // Second write of B within (forced to) the same mtime tick.
+    fs::write(&target, &content_b).unwrap();
+    set_mtime_atime(&target, a_atime, a_mtime);
+
+    let mut guards = HashMap::new();
+    guards.insert(target.clone(), guard_a);
+    let store = FileStore::from_root(store_dir.path().to_path_buf()).with_copy_guards(guards);
+    let res = store.push(&manifest, src.path());
+
+    // Same-mtime+same-size cannot fool the full guard (ctime moved) AND, even if
+    // it could, the read-time backstop covers it: never a readable B@A.
+    match res {
+        Err(ref e) => assert!(
+            is_integrity(e) || is_rejected_or_absent(e),
+            "a same-mtime same-size forge that errors must be Integrity/absent, got {e:?}"
+        ),
+        Ok(()) => {}
+    }
+    assert_no_readable_misaddress(&store, store_dir.path(), &[sum_a]);
+}
+
+// ===========================================================================
+// CASE 6 — Property / invariant loop. Over N deterministic (seeded-by-index, no
+// rand) mutate?/when?/how? schedules, assert the GLOBAL invariant: NO object in
+// the store is readable via get_object under a checksum its bytes don't hash to.
+// Covers the matrix of {mutate before guard / mutate after guard / no mutate} ×
+// {same size / different size} × {forge mtime / leave mtime} × modes.
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn property_loop_global_no_readable_misaddress_invariant() {
+    let _g = env_lock();
+
+    // Deterministic schedule space: 36 combinations.
+    for idx in 0..36u32 {
+        let mutate_when = idx % 3; // 0 = none, 1 = before guard, 2 = after guard
+        let same_size = (idx / 3) % 2 == 0;
+        let forge_mtime = (idx / 6) % 2 == 0;
+        let mode_sel = (idx / 12) % 3; // 0 default, 1 verify, 2 clone-off
+
+        let _e = match mode_sel {
+            0 => CopyModeEnv::set(None, None),
+            1 => CopyModeEnv::set(None, Some("1")),
+            _ => CopyModeEnv::set(Some("0"), None),
+        };
+
+        let store_dir = TempDir::new(&format!("prop-store-{idx}"));
+        let src = TempDir::new(&format!("prop-src-{idx}"));
+
+        let len_a = 8 * 1024 + (idx as usize) * 311;
+        let content_a: Vec<u8> = (0..len_a)
+            .map(|i| ((i as u32).wrapping_mul(2246822519).wrapping_add(idx)) as u8)
+            .collect();
+        let len_b = if same_size { len_a } else { len_a + 777 };
+        let content_b: Vec<u8> = (0..len_b)
+            .map(|i| ((i as u32).wrapping_mul(3266489917).wrapping_add(idx)) as u8 ^ 0x7e)
+            .collect();
+
+        let rel = "prop.bin";
+        let target = src.path().join(rel);
+
+        // Always build the manifest over A (records checksum(A)).
+        fs::write(&target, &content_a).unwrap();
+        let md_a = fs::metadata(&target).unwrap();
+        let a_atime = (md_a.atime(), md_a.atime_nsec());
+        let a_mtime = (md_a.mtime(), md_a.mtime_nsec());
+        let (manifest, sum_a) = single_file_manifest(rel, &content_a);
+
+        // Guard captured either BEFORE mutation (stale guard) or AFTER (defeated
+        // guard), or for the unmutated file.
+        let guard = match mutate_when {
+            1 => {
+                // mutate BEFORE guard: guard reflects B, but expected stays A.
+                fs::write(&target, &content_b).unwrap();
+                if forge_mtime {
+                    set_mtime_atime(&target, a_atime, a_mtime);
+                }
+                CopyGuard::from_metadata(&fs::metadata(&target).unwrap())
+            }
+            2 => {
+                // guard for A, THEN mutate to B (stale guard).
+                let g = CopyGuard::from_metadata(&md_a);
+                fs::write(&target, &content_b).unwrap();
+                if forge_mtime {
+                    set_mtime_atime(&target, a_atime, a_mtime);
+                }
+                g
+            }
+            _ => CopyGuard::from_metadata(&md_a), // no mutation: honest input
+        };
+
+        let mut guards = HashMap::new();
+        if let Some(g) = guard {
+            guards.insert(target.clone(), g);
+        }
+        let store = FileStore::from_root(store_dir.path().to_path_buf()).with_copy_guards(guards);
+        let _ = store.push(&manifest, src.path());
+
+        // GLOBAL INVARIANT: no readable mis-address under checksum(A).
+        assert_no_readable_misaddress(&store, store_dir.path(), std::slice::from_ref(&sum_a));
+
+        // When the input was HONEST (no mutation), the object MUST be present and
+        // valid (the optimization must not lose data).
+        if mutate_when == 0 {
+            let got = store
+                .get_object(&sum_a)
+                .unwrap_or_else(|e| panic!("idx {idx}: honest object must be readable: {e:?}"));
+            assert_eq!(
+                got, content_a,
+                "idx {idx}: honest skip path must store the correct bytes"
+            );
+        }
+    }
+}
+
+// ===========================================================================
+// CASE 7 — Honest input on the skip path stores correct bytes under CLONEFILE
+// (cfg macos): proves the global-invariant sweep is not vacuous — the skip path
+// actually rode the clone fast-path and produced a CORRECT object.
+// ===========================================================================
+
+#[cfg(all(unix, target_os = "macos"))]
+#[test]
+fn honest_skip_rides_clone_and_stores_correct_bytes() {
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None);
+
+    let store_dir = TempDir::new("honest-clone-store");
+    let src = TempDir::new("honest-clone-src");
+
+    // >256 KiB so the clone fast-path is firmly engaged.
+    let content: Vec<u8> = (0..(300 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    let rel = "big.bin";
+    let target = src.path().join(rel);
+    fs::write(&target, &content).unwrap();
+    let guard = CopyGuard::from_metadata(&fs::metadata(&target).unwrap()).expect("guard");
+    let (manifest, sum) = single_file_manifest(rel, &content);
+
+    let mut guards = HashMap::new();
+    guards.insert(target.clone(), guard);
+    let store = FileStore::from_root(store_dir.path().to_path_buf()).with_copy_guards(guards);
+
+    let before = snapdir_stores::clonefile_hits();
+    store.push(&manifest, src.path()).expect("honest push");
+    let delta = snapdir_stores::clonefile_hits() - before;
+    assert!(
+        delta >= 1,
+        "the StatGuarded skip must ride the clone fast-path on APFS: delta={delta}"
+    );
+
+    let got = store.get_object(&sum).expect("honest object readable");
+    assert_eq!(got, content, "the skip path stored the correct bytes");
+    assert_eq!(
+        got.len(),
+        content.len(),
+        "the >256 KiB object is full length (skip is not vacuous)"
+    );
+    assert_no_readable_misaddress(&store, store_dir.path(), &[sum]);
+}
+
+// ===========================================================================
+// LINUX REFLINK (FICLONE) — real-reflink TOCTOU / race edges.
+//
+// COVERAGE NOTE (spec clause 4): the cases ABOVE (CASE 1 concurrent mid-stage
+// mutation, CASE 2 ctime stale-guard catch, CASE 3 fully-defeated-guard read-
+// time backstop, CASE 5 same-mtime forge, CASE 6 property loop) are all
+// platform-agnostic and use `std::env::temp_dir()` for their fixtures. On the
+// CI `Reflink (Btrfs FICLONE)` job that dir is `TMPDIR=/mnt/reflink` (a real
+// Btrfs loopback), so EVERY one of those races runs against GENUINE FICLONE
+// reflink with NO new code — the `CopyMethod::Cloned` path the Linux
+// `try_reflink` returns flows through the SAME `clone_skip_decision`
+// StatGuarded/read-time-backstop machinery the cross-platform cases pin. The
+// Linux-specific cases BELOW add reflink-only edges (concurrent mutation +
+// co-located src/store on a real reflink FS, `chattr +i` source, EXDEV
+// cross-mount fallback) that cannot be expressed platform-agnostically.
+//
+// All three are `#[cfg(target_os = "linux")]` + env-gated on
+// `SNAPDIR_REFLINK_TEST_DIR` (skip-on-unset / `panic!` if
+// `SNAPDIR_REFLINK_TEST_REQUIRE=1`), mirroring `reflink.rs`'s gating and the
+// shared `ENV_LOCK`. They compile to nothing on macOS/ext4 and RUN on the CI
+// Btrfs leg, which sets `SNAPDIR_REFLINK_TEST_DIR=/mnt/reflink` +
+// `SNAPDIR_REFLINK_TEST_REQUIRE=1`.
+// ===========================================================================
+
+/// Resolves the reflink-capable root for this run, honoring the env contract
+/// (mirrors `reflink.rs`):
+///   * `SNAPDIR_REFLINK_TEST_DIR` set -> `Some(path)` (place src + store under it
+///     so FICLONE co-locates and actually fires — cross-FS would be EXDEV).
+///   * unset + `SNAPDIR_REFLINK_TEST_REQUIRE=1` -> `panic!` (Btrfs leg enforce).
+///   * unset + not required -> `None` (caller `eprintln!`s a skip note + returns).
+#[cfg(target_os = "linux")]
+fn reflink_root_or_skip(test_name: &str) -> Option<PathBuf> {
+    match std::env::var("SNAPDIR_REFLINK_TEST_DIR") {
+        Ok(dir) if !dir.is_empty() => {
+            let p = PathBuf::from(dir);
+            assert!(
+                p.is_dir(),
+                "SNAPDIR_REFLINK_TEST_DIR={} must be an existing mounted reflink directory",
+                p.display()
+            );
+            Some(p)
+        }
+        _ => {
+            let required = std::env::var("SNAPDIR_REFLINK_TEST_REQUIRE")
+                .map(|v| v == "1")
+                .unwrap_or(false);
+            assert!(
+                !required,
+                "reflink FS required but SNAPDIR_REFLINK_TEST_DIR unset"
+            );
+            eprintln!(
+                "SKIP {test_name}: SNAPDIR_REFLINK_TEST_DIR unset and \
+                 SNAPDIR_REFLINK_TEST_REQUIRE != 1 (no reflink FS on this host)"
+            );
+            None
+        }
+    }
+}
+
+/// A unique temp dir created UNDER `parent` (the reflink root), removed on drop
+/// — co-locating src + store so a same-FS FICLONE can fire. (`TempDir::new`
+/// uses `std::env::temp_dir()`, which is ALSO the reflink dir on the CI Btrfs
+/// leg via `TMPDIR`, but the Linux cases use an explicit parent to be robust
+/// to a `TMPDIR` that differs from `SNAPDIR_REFLINK_TEST_DIR`.)
+#[cfg(target_os = "linux")]
+fn temp_dir_under(parent: &Path, tag: &str) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let path = parent.join(format!(
+        "snapdir-clone-skip-race-reflink-{}-{tag}-{n}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&path);
+    fs::create_dir_all(&path).expect("create temp dir under reflink root");
+    path
+}
+
+// FS_IOC_SETFLAGS / FS_IOC_GETFLAGS ioctl request numbers (asm-generic values
+// used by Btrfs/ext*/XFS on Linux); FS_IMMUTABLE_FL is the immutable bit. This
+// is `chattr +i` at the syscall level (mirrors `reflink.rs`).
+#[cfg(target_os = "linux")]
+const FS_IOC_GETFLAGS: libc::c_ulong = 0x8008_6601;
+#[cfg(target_os = "linux")]
+const FS_IOC_SETFLAGS: libc::c_ulong = 0x4008_6602;
+#[cfg(target_os = "linux")]
+const FS_IMMUTABLE_FL: libc::c_long = 0x0000_0010;
+
+/// Sets/clears FS_IMMUTABLE_FL (the `chattr +i` immutable inode flag) on `path`.
+/// Returns `Ok(())`, or `Err(errno)` — `EPERM`/`EACCES` signal "no privilege"
+/// (needs root; the CI Btrfs job runs as root), `ENOTTY`/`EOPNOTSUPP` signal
+/// "FS does not support flags".
+#[cfg(target_os = "linux")]
+fn set_immutable(path: &Path, immutable: bool) -> Result<(), i32> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let c = CString::new(path.as_os_str().as_bytes()).expect("path has no NUL");
+    let fd = unsafe { libc::open(c.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC) };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error().raw_os_error().unwrap_or(-1));
+    }
+    let result = (|| {
+        let mut flags: libc::c_long = 0;
+        let rc = unsafe { libc::ioctl(fd, FS_IOC_GETFLAGS as _, &mut flags) };
+        if rc != 0 {
+            return Err(std::io::Error::last_os_error().raw_os_error().unwrap_or(-1));
+        }
+        if immutable {
+            flags |= FS_IMMUTABLE_FL;
+        } else {
+            flags &= !FS_IMMUTABLE_FL;
+        }
+        let rc = unsafe { libc::ioctl(fd, FS_IOC_SETFLAGS as _, &flags) };
+        if rc != 0 {
+            return Err(std::io::Error::last_os_error().raw_os_error().unwrap_or(-1));
+        }
+        Ok(())
+    })();
+    unsafe { libc::close(fd) };
+    result
+}
+
+/// A writable dir on a DIFFERENT device than `same_dev_path`, or `None`
+/// (mirrors `reflink.rs`). Used to force the source onto a different FS than
+/// the store so FICLONE returns EXDEV and the impl falls back to `fs::copy`.
+#[cfg(target_os = "linux")]
+fn other_fs_dir(same_dev_path: &Path) -> Option<PathBuf> {
+    let base_dev = fs::metadata(same_dev_path).ok()?.dev();
+    for cand in ["/dev/shm", "/tmp", "/var/tmp", "/run"] {
+        let p = Path::new(cand);
+        if let Ok(md) = fs::metadata(p) {
+            if md.dev() != base_dev {
+                let scratch = p.join(format!(
+                    "snapdir-clone-skip-race-xdev-{}",
+                    std::process::id()
+                ));
+                if fs::create_dir_all(&scratch).is_ok() {
+                    return Some(scratch);
+                }
+            }
+        }
+    }
+    None
+}
+
+// ===========================================================================
+// LINUX CASE A — Concurrent mid-stage source mutation on a REAL reflink FS.
+// src + store co-located under the reflink root so push rides FICLONE
+// (`CopyMethod::Cloned`); a racer thread rewrites the source while `push` runs
+// (guards captured just before). Whatever schedule lands, the resulting
+// snapshot MUST be self-consistent: every object readable via `get_object`
+// hashes to its address, OR the push errored — NEVER a readable object whose
+// bytes != its address. Looped over several schedules.
+//
+// Spec clause: this is CASE 1 (concurrent mid-stage mutation) re-run with the
+// fixtures FORCED under a genuine reflink FS, so the StatGuarded-skip race is
+// proven against the FICLONE clone path (not just APFS / fs::copy), pinning
+// "no silently mis-addressed object on Linux reflink".
+// ===========================================================================
+
+#[cfg(target_os = "linux")]
+#[test]
+fn reflink_concurrent_mid_stage_mutation_never_silently_misaddresses() {
+    let Some(root) =
+        reflink_root_or_skip("reflink_concurrent_mid_stage_mutation_never_silently_misaddresses")
+    else {
+        return;
+    };
+
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None); // clone + skip live (the FICLONE path)
+
+    for schedule in 0..6u32 {
+        let store_root = temp_dir_under(&root, &format!("reflink-conc-store-{schedule}"));
+        let src_root = temp_dir_under(&root, &format!("reflink-conc-src-{schedule}"));
+
+        let base_len = 300 * 1024 + (schedule as usize) * 7919; // >256KiB so FICLONE shares extents
+        let content_a: Vec<u8> = (0..base_len)
+            .map(|i| ((i as u32).wrapping_mul(2654435761).wrapping_add(schedule)) as u8)
+            .collect();
+
+        let rel = "racey.bin";
+        let target = src_root.join(rel);
+        fs::write(&target, &content_a).unwrap();
+
+        let (manifest, sum_a) = single_file_manifest(rel, &content_a);
+        let guard_a = CopyGuard::from_metadata(&fs::metadata(&target).unwrap()).expect("guard A");
+        let mut guards = HashMap::new();
+        guards.insert(target.clone(), guard_a);
+
+        let store = FileStore::from_root(store_root.clone()).with_copy_guards(guards);
+
+        let barrier = Arc::new(Barrier::new(2));
+        let racer_target = target.clone();
+        let racer_barrier = Arc::clone(&barrier);
+        let len_b = if schedule % 2 == 0 {
+            base_len // same length (the hard case)
+        } else {
+            base_len + 4096
+        };
+        let sched = schedule;
+        let racer = std::thread::spawn(move || {
+            racer_barrier.wait();
+            for round in 0..40u32 {
+                let content_b: Vec<u8> = (0..len_b)
+                    .map(|i| {
+                        ((i as u32)
+                            .wrapping_mul(40503)
+                            .wrapping_add(round)
+                            .wrapping_add(sched)) as u8
+                            ^ 0xa5
+                    })
+                    .collect();
+                let _ = fs::write(&racer_target, &content_b);
+            }
+        });
+
+        barrier.wait();
+        let push_res = store.push(&manifest, &src_root);
+        racer.join().expect("racer thread joined");
+
+        match push_res {
+            Err(ref e) => assert!(
+                is_integrity(e) || is_rejected_or_absent(e),
+                "schedule {schedule}: a raced reflink stage that errors must be Integrity / \
+                 absent, got {e:?}"
+            ),
+            Ok(()) => {}
+        }
+        // Whatever landed (or didn't) on the REAL reflink path, no object filed
+        // under checksum(A) may be readable with bytes that don't hash to it.
+        assert_no_readable_misaddress(&store, &store_root, &[sum_a]);
+
+        let _ = fs::remove_dir_all(&store_root);
+        let _ = fs::remove_dir_all(&src_root);
+    }
+}
+
+// ===========================================================================
+// LINUX CASE B — `chattr +i` (FS_IMMUTABLE_FL) source during the stage on a
+// real reflink FS. FICLONE is a DATA-ONLY clone, so the source inode's
+// immutable flag must NOT propagate to the cloned object. Assert the resulting
+// OBJECT (a) is byte-correct AND (b) is REMOVABLE (no un-GC-able object). Needs
+// privilege to set the flag (root on the CI Btrfs job) — skip-with-eprintln on
+// EPERM/EACCES/ENOTTY/EOPNOTSUPP. The source flag is cleared in teardown so the
+// tempdir cleans up.
+//
+// Spec clause: pins "FICLONE data-only clone does NOT propagate the immutable
+// flag — no un-GC-able object on Linux reflink", AND (additionally) that the
+// cloned bytes are correct (no silent mis-address while the source was locked).
+// ===========================================================================
+
+#[cfg(target_os = "linux")]
+#[test]
+fn reflink_immutable_source_clones_correct_and_removable_object() {
+    let Some(root) =
+        reflink_root_or_skip("reflink_immutable_source_clones_correct_and_removable_object")
+    else {
+        return;
+    };
+
+    let store_root = temp_dir_under(&root, "reflink-immut-store");
+    let src_root = temp_dir_under(&root, "reflink-immut-src");
+
+    let content: Vec<u8> = (0..(300 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    let rel = "locked.bin";
+    let target = src_root.join(rel);
+    fs::write(&target, &content).unwrap();
+
+    // Try to set FS_IMMUTABLE_FL on the source. No-privilege / no-FS-support =>
+    // skip (the CI Btrfs job runs as root and exercises this for real).
+    match set_immutable(&target, true) {
+        Ok(()) => {}
+        Err(e) if e == libc::EPERM || e == libc::EACCES => {
+            eprintln!(
+                "SKIP reflink_immutable_source_clones_correct_and_removable_object: \
+                 setting FS_IMMUTABLE_FL needs privilege (errno {e})"
+            );
+            let _ = fs::remove_dir_all(&store_root);
+            let _ = fs::remove_dir_all(&src_root);
+            return;
+        }
+        Err(e) if e == libc::ENOTTY || e == libc::EOPNOTSUPP => {
+            eprintln!(
+                "SKIP reflink_immutable_source_clones_correct_and_removable_object: \
+                 filesystem does not support FS_IOC_SETFLAGS (errno {e})"
+            );
+            let _ = fs::remove_dir_all(&store_root);
+            let _ = fs::remove_dir_all(&src_root);
+            return;
+        }
+        Err(e) => {
+            let _ = fs::remove_dir_all(&store_root);
+            let _ = fs::remove_dir_all(&src_root);
+            panic!("unexpected errno setting FS_IMMUTABLE_FL: {e}");
+        }
+    }
+
+    let (manifest, sum) = single_file_manifest(rel, &content);
+
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None); // fast-path on so a real FICLONE fires
+
+    let store = FileStore::from_root(store_root.clone());
+    let push_res = store.push(&manifest, &src_root);
+
+    // Clear the SOURCE flag NOW so teardown can remove the src tempdir regardless
+    // of the outcome below.
+    let _ = set_immutable(&target, false);
+
+    push_res.expect("push of an immutable source must succeed on a reflink FS");
+
+    // (a) the cloned object is byte-correct (no silent mis-address while the
+    // source was immutable) ...
+    let got = store
+        .get_object(&sum)
+        .expect("the cloned object must be readable + byte-correct");
+    assert_eq!(
+        got, content,
+        "FICLONE of an immutable source must still produce byte-correct object content"
+    );
+    assert_no_readable_misaddress(&store, &store_root, std::slice::from_ref(&sum));
+
+    // ... and (b) KEYSTONE: the object must be REMOVABLE — FICLONE (data-only)
+    // must NOT have propagated FS_IMMUTABLE_FL onto the object inode, so there
+    // is no un-GC-able object.
+    let obj = store_root.join(snapdir_core::store::object_path(&sum));
+    assert!(obj.is_file(), "object must have landed");
+    fs::remove_file(&obj).expect(
+        "the cloned object must NOT be immutable — FICLONE clones data only, so \
+         FS_IMMUTABLE_FL must not propagate (Linux has no un-GC-able-object risk)",
+    );
+    assert!(!obj.exists(), "object must be gone after removal");
+
+    let _ = fs::remove_dir_all(&store_root);
+    let _ = fs::remove_dir_all(&src_root);
+}
+
+// ===========================================================================
+// LINUX CASE C — EXDEV cross-mount. Source on a DIFFERENT filesystem than the
+// store (source under /tmp|/dev/shm|... while the store is on the reflink FS)
+// => FICLONE returns EXDEV => clean `fs::copy` fallback. Assert the object is
+// byte-correct, the snapshot id matches, and NO mis-addressed object results.
+// Skip if a second writable FS distinct from the reflink FS cannot be arranged.
+//
+// Spec clause: pins "cross-mount EXDEV => graceful fs::copy fallback, byte-
+// correct object + matching snapshot id, no mis-address" on Linux reflink.
+// ===========================================================================
+
+#[cfg(target_os = "linux")]
+#[test]
+fn reflink_exdev_cross_mount_falls_back_clean_no_misaddress() {
+    let Some(root) =
+        reflink_root_or_skip("reflink_exdev_cross_mount_falls_back_clean_no_misaddress")
+    else {
+        return;
+    };
+
+    // STORE on the reflink FS; SOURCE on a different FS => source->object is a
+    // cross-mount FICLONE => EXDEV => fs::copy fallback.
+    let store_root = temp_dir_under(&root, "reflink-xdev-store");
+
+    let Some(other) = other_fs_dir(&store_root) else {
+        eprintln!(
+            "SKIP reflink_exdev_cross_mount_falls_back_clean_no_misaddress: \
+             no second writable filesystem distinct from the reflink FS detected"
+        );
+        let _ = fs::remove_dir_all(&store_root);
+        return;
+    };
+
+    let src_root = other.join(format!("src-{}", std::process::id()));
+    fs::create_dir_all(&src_root).unwrap();
+
+    let content: Vec<u8> = (0..(300 * 1024u32)).map(|i| (i % 197) as u8).collect();
+    let rel = "payload.bin";
+    let target = src_root.join(rel);
+    fs::write(&target, &content).unwrap();
+
+    let (manifest, sum) = single_file_manifest(rel, &content);
+
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None); // clone on; impl must fall back on EXDEV
+
+    let store = FileStore::from_root(store_root.clone());
+    let res = store.push(&manifest, &src_root);
+
+    let cleanup = |a: &Path, b: &Path| {
+        let _ = fs::remove_dir_all(a);
+        let _ = fs::remove_dir_all(b);
+    };
+
+    match res {
+        Ok(()) => {
+            // The EXDEV fallback must file a byte-correct object addressed
+            // exactly as the walk hashed it — no mis-address.
+            let got = store.get_object(&sum);
+            assert_no_readable_misaddress(&store, &store_root, std::slice::from_ref(&sum));
+            match got {
+                Ok(bytes) => assert_eq!(
+                    bytes, content,
+                    "cross-FS EXDEV fallback must produce byte-correct object content"
+                ),
+                Err(e) => {
+                    cleanup(&other, &store_root);
+                    panic!("the object filed under its true checksum must be readable, got {e:?}");
+                }
+            }
+            cleanup(&other, &store_root);
+        }
+        Err(e) => {
+            cleanup(&other, &store_root);
+            panic!("cross-FS (EXDEV) push must succeed via the fs::copy fallback, got {e:?}");
+        }
+    }
+}

--- a/crates/snapdir-stores/tests/manifest_list.rs
+++ b/crates/snapdir-stores/tests/manifest_list.rs
@@ -1,0 +1,785 @@
+//! Adversarial integration suite for the `list_manifest_ids` primitive
+//! (phase 28, gate `manifest-listing-spec-tests`).
+//!
+//! BLACK-BOX: authored from the gate SPEC ALONE, with NO visibility into a
+//! `list_manifest_ids` implementation (none exists yet). It will NOT compile/
+//! pass until the stores-impl teammate moves this file into
+//! `crates/snapdir-stores/tests/manifest_list.rs` and wires the method shape.
+//! Do NOT weaken any assertion to make it green — if a behavior here fails
+//! against the landed impl, that is a real bug in the impl, not in this test.
+//!
+//! SPEC under test — `list_manifest_ids(&self) -> Result<Vec<String>, StoreError>`
+//! enumerates the snapshot ids present under a store prefix's `.manifests/`
+//! tree. It lives on `StreamStore` (default impl returns a `StoreError` —
+//! "listing unsupported" — so non-listing stores fail closed) and is overridden
+//! by the in-process backends (`FileStore` walks the `.manifests/` shard tree
+//! and reconstructs the 64-hex id from the `3/3/3/rest` shard segments).
+//!
+//! CONTRACT pinned here:
+//!   - each id returned AT MOST ONCE (dedup);
+//!   - ONLY valid ids matching `^[0-9a-f]{64}$` — a stray / non-manifest key
+//!     under `.manifests/` is IGNORED, not an error;
+//!   - ORDER is unspecified — every assertion SORTS both sides before comparing.
+//!
+//! Construction shape assumed (the impl teammate may adjust the exact call site
+//! while preserving these behaviors): `store.list_manifest_ids()` returning
+//! `Result<Vec<String>, StoreError>`, over a `FileStore` (and a `SplitStore`
+//! over two `FileStore` prefixes for the shared-pool isolation case). If the
+//! real signature differs, fix ONLY the call shape, never the assertions.
+
+// The negative-membership assertions are written as `!v.iter().any(|x| *x ==
+// needle)` for readability; clippy prefers `!v.contains(&needle)`. Allowing the
+// style lints here keeps every assertion byte-for-byte as authored (no logic /
+// strength change) under the crate's `-D warnings` gate.
+#![allow(clippy::manual_contains, clippy::explicit_auto_deref)]
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
+use snapdir_core::merkle::{directory_checksum, Blake3Hasher, Hasher};
+use snapdir_core::snapshot_id;
+use snapdir_core::store::{manifest_path, Store, StoreError};
+
+use snapdir_stores::{FileStore, SplitStore, StreamStore};
+
+// ---------------------------------------------------------------------------
+// Test scaffolding (no dev-dependencies; mirrors the existing split/shim tests).
+// ---------------------------------------------------------------------------
+
+/// A unique temp dir removed on drop.
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "snapdir-manifest-list-test-{}-{tag}-{n}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).expect("create temp dir");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+/// Builds a real source tree under `src` and returns the matching `Manifest`
+/// plus its snapshot id. Mirrors the split-store fixture: object addressing uses
+/// the NON-keyed `Blake3Hasher`, a single `D ./` root entry keeps the manifest a
+/// valid snapshot, and `snapshot_id` over the sorted manifest yields the id the
+/// store files the manifest under. `tag_byte` lets callers produce DISTINCT ids
+/// trivially (different content => different snapshot id).
+fn build_tree(src: &Path, files: &[(&str, &[u8])]) -> (Manifest, String) {
+    let hasher = Blake3Hasher::new();
+    let mut manifest = Manifest::new();
+
+    let mut file_sums: Vec<String> = Vec::new();
+    for (rel, content) in files {
+        let target = src.join(rel);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&target, content).unwrap();
+        let sum = hasher.hash_hex(content);
+        file_sums.push(sum.clone());
+        manifest.push(ManifestEntry::new(
+            PathType::File,
+            "600",
+            sum,
+            content.len() as u64,
+            format!("./{rel}"),
+        ));
+    }
+
+    let root_sum = directory_checksum(file_sums.iter().map(String::as_str), &hasher);
+    let root_size: u64 = files.iter().map(|(_, c)| c.len() as u64).sum();
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        root_size,
+        "./",
+    ));
+
+    manifest.sort();
+    let id = snapshot_id(&manifest, &hasher);
+    (manifest, id)
+}
+
+/// Seeds N distinct snapshots into a `StreamStore` via the public
+/// `put_manifest`, returning their ids. Each snapshot is a one-file tree whose
+/// file content is `seed-<i>` — distinct content => distinct snapshot id, so the
+/// returned ids are guaranteed unique and 64-hex.
+fn seed_manifests<S: StreamStore>(store: &S, n: usize) -> Vec<String> {
+    let mut ids = Vec::with_capacity(n);
+    for i in 0..n {
+        let src = TempDir::new(&format!("seed-{i}"));
+        let body = format!("seed-{i}\n");
+        let (manifest, id) = build_tree(src.path(), &[("f", body.as_bytes())]);
+        store.put_manifest(&id, &manifest).expect("put_manifest");
+        ids.push(id);
+    }
+    ids
+}
+
+/// Sorts a vec of ids so order-unspecified results can be compared by set.
+fn sorted(mut v: Vec<String>) -> Vec<String> {
+    v.sort();
+    v
+}
+
+/// `assert_eq` on the SORTED ids (the SPEC says order is unspecified — the
+/// caller sorts), with a uniqueness guard so a list that secretly duplicated an
+/// id can't accidentally sort-equal an expected set.
+fn assert_same_set(got: Vec<String>, mut expected: Vec<String>) {
+    let unique: HashSet<&String> = got.iter().collect();
+    assert_eq!(
+        unique.len(),
+        got.len(),
+        "list_manifest_ids must return each id AT MOST ONCE (dedup); got duplicates in {got:?}"
+    );
+    expected.sort();
+    assert_eq!(sorted(got), expected);
+}
+
+// ===========================================================================
+// KNOWN-SET ROUND-TRIP
+// ===========================================================================
+
+#[test]
+fn list_known_set_roundtrip_returns_exactly_the_put_ids() {
+    // SPEC: put_manifest a set of N manifests into a FileStore, then
+    // list_manifest_ids returns EXACTLY those N ids (sorted-equal).
+    let root = TempDir::new("known");
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    let ids = seed_manifests(&store, 5);
+
+    let listed = store.list_manifest_ids().expect("list_manifest_ids");
+    assert_same_set(listed, ids);
+}
+
+#[test]
+fn list_single_manifest_returns_just_that_id() {
+    // SPEC: round-trip with N=1 — the simplest non-empty case.
+    let root = TempDir::new("single");
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    let src = TempDir::new("single-src");
+    let (manifest, id) = build_tree(src.path(), &[("only", b"only file\n")]);
+    store.put_manifest(&id, &manifest).expect("put_manifest");
+
+    assert_same_set(store.list_manifest_ids().expect("list"), vec![id]);
+}
+
+#[test]
+fn list_reflects_ids_written_through_full_push() {
+    // SPEC: ids written via the full `Store::push` path (not just put_manifest)
+    // are listed too — list reads the on-disk `.manifests/` tree, however it was
+    // populated.
+    let root = TempDir::new("push");
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    let mut ids = Vec::new();
+    for i in 0..3 {
+        let src = TempDir::new(&format!("push-src-{i}"));
+        let body = format!("pushed-{i}\n");
+        let (manifest, id) = build_tree(src.path(), &[("f", body.as_bytes())]);
+        store.push(&manifest, src.path()).expect("push");
+        ids.push(id);
+    }
+
+    assert_same_set(store.list_manifest_ids().expect("list"), ids);
+}
+
+// ===========================================================================
+// DEDUP
+// ===========================================================================
+
+#[test]
+fn list_dedups_a_reput_manifest_to_a_single_id() {
+    // SPEC: each id returned AT MOST ONCE. Putting the SAME manifest twice (an
+    // idempotent re-put writes the same sharded path) must still list its id
+    // exactly ONCE — never twice.
+    let root = TempDir::new("dedup");
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    let src = TempDir::new("dedup-src");
+    let (manifest, id) = build_tree(src.path(), &[("f", b"dup\n")]);
+    store.put_manifest(&id, &manifest).expect("put once");
+    store.put_manifest(&id, &manifest).expect("put again");
+
+    let listed = store.list_manifest_ids().expect("list");
+    assert_eq!(
+        listed.iter().filter(|x| **x == id).count(),
+        1,
+        "a re-put manifest must appear exactly once: {listed:?}"
+    );
+    assert_same_set(listed, vec![id]);
+}
+
+// ===========================================================================
+// HEX-ONLY FILTERING / MALFORMED-SHARD SKIP (ignored, NOT an error)
+// ===========================================================================
+
+#[test]
+fn list_ignores_a_short_non_hex_shard_path_without_error() {
+    // SPEC: a stray / non-manifest key under `.manifests/` (e.g. a short or
+    // non-hex shard path) is IGNORED, not an error. Plant ONE real manifest plus
+    // a too-short shard tree that cannot reconstruct a 64-hex id; list must
+    // return ONLY the real id (no error, no garbage).
+    let root = TempDir::new("short");
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    let src = TempDir::new("short-src");
+    let (manifest, id) = build_tree(src.path(), &[("f", b"real\n")]);
+    store.put_manifest(&id, &manifest).expect("put real");
+
+    // A stray file whose 3/3/3/rest reconstruction is far too short for 64 hex.
+    let stray = root.path().join(".manifests").join("aaa").join("bbb");
+    fs::create_dir_all(&stray).unwrap();
+    fs::write(stray.join("c"), b"junk").unwrap();
+
+    let listed = store
+        .list_manifest_ids()
+        .expect("a malformed shard path must be skipped, NOT error");
+    assert_same_set(listed, vec![id]);
+}
+
+#[test]
+fn list_ignores_non_hex_characters_in_a_full_length_shard_path() {
+    // SPEC: ONLY ids matching `^[0-9a-f]{64}$` are returned. Plant a shard tree
+    // whose segments reconstruct to a 64-CHARACTER but NON-hex string (contains
+    // 'z'); it must be filtered out, leaving only the genuine manifest id.
+    let root = TempDir::new("nonhex");
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    let src = TempDir::new("nonhex-src");
+    let (manifest, id) = build_tree(src.path(), &[("f", b"genuine\n")]);
+    store.put_manifest(&id, &manifest).expect("put real");
+
+    // 64 chars total across the 3/3/3/55 shard split, but with non-hex 'z's.
+    let s0 = "zzz";
+    let s1 = "zzz";
+    let s2 = "zzz";
+    let rest = "z".repeat(55);
+    assert_eq!(s0.len() + s1.len() + s2.len() + rest.len(), 64);
+    let bogus = root.path().join(".manifests").join(s0).join(s1).join(s2);
+    fs::create_dir_all(&bogus).unwrap();
+    fs::write(bogus.join(&rest), b"not a manifest").unwrap();
+
+    let listed = store
+        .list_manifest_ids()
+        .expect("a non-hex shard path must be skipped, NOT error");
+    assert_same_set(listed, vec![id]);
+}
+
+#[test]
+fn list_ignores_uppercase_hex_shard_path() {
+    // SPEC: the regex is lowercase `^[0-9a-f]{64}$` — an UPPERCASE 64-hex id (an
+    // out-of-spec key snapdir never writes) must be IGNORED, not surfaced.
+    let root = TempDir::new("upper");
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    let src = TempDir::new("upper-src");
+    let (manifest, id) = build_tree(src.path(), &[("f", b"lower\n")]);
+    store.put_manifest(&id, &manifest).expect("put real");
+
+    // An uppercased copy of a valid id, planted at its (uppercased) shard path.
+    let upper = id.to_uppercase();
+    let p = manifest_path(&upper); // 3/3/3/rest split of the uppercase string
+    let disk = root.path().join(&p);
+    fs::create_dir_all(disk.parent().unwrap()).unwrap();
+    fs::write(&disk, b"uppercase impostor").unwrap();
+
+    let listed = store
+        .list_manifest_ids()
+        .expect("an uppercase-hex key must be skipped, NOT error");
+    assert!(
+        !listed.iter().any(|x| *x == upper),
+        "uppercase id must not be listed: {listed:?}"
+    );
+    assert_same_set(listed, vec![id]);
+}
+
+#[test]
+fn list_ignores_an_extra_directory_level_under_manifests() {
+    // SPEC: a non-manifest key whose path has the WRONG shard depth (an extra
+    // nested dir so the reconstruction can't be a clean 3/3/3/rest 64-hex id)
+    // is ignored, not an error. Mixes a valid id with the malformed sibling.
+    let root = TempDir::new("depth");
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    let ids = seed_manifests(&store, 2);
+
+    // Bury a file one level too deep under a plausible-looking shard prefix.
+    let deep = root
+        .path()
+        .join(".manifests")
+        .join("abc")
+        .join("def")
+        .join("012")
+        .join("extra-level");
+    fs::create_dir_all(&deep).unwrap();
+    fs::write(deep.join("blob"), b"too deep").unwrap();
+
+    let listed = store
+        .list_manifest_ids()
+        .expect("an over-deep shard path must be skipped, NOT error");
+    assert_same_set(listed, ids);
+}
+
+// ===========================================================================
+// ORDER-INSENSITIVE (caller sorts)
+// ===========================================================================
+
+#[test]
+fn list_is_order_insensitive_compare_as_a_set() {
+    // SPEC: ORDER is unspecified — the caller sorts. We assert the SET equality
+    // after sorting; we must NOT depend on insertion or filesystem-walk order.
+    let root = TempDir::new("order");
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    // Seed several manifests; their ids land in pseudo-random hash order.
+    let ids = seed_manifests(&store, 7);
+
+    let listed = store.list_manifest_ids().expect("list");
+    // Sorted-equal is the ONLY contract; the raw order is not asserted.
+    assert_same_set(listed, ids);
+}
+
+#[test]
+fn list_two_calls_yield_the_same_set() {
+    // SPEC: idempotent read — listing twice over an unchanged store yields the
+    // same SET (sorted-equal), no spurious additions/drops between calls.
+    let root = TempDir::new("twice");
+    let store = FileStore::from_root(root.path().to_path_buf());
+    let _ids = seed_manifests(&store, 4);
+
+    let a = sorted(store.list_manifest_ids().expect("first"));
+    let b = sorted(store.list_manifest_ids().expect("second"));
+    assert_eq!(a, b, "two listings of an unchanged store must be set-equal");
+}
+
+// ===========================================================================
+// EMPTY PREFIX (empty vec, NOT an error)
+// ===========================================================================
+
+#[test]
+fn list_empty_prefix_no_manifests_dir_returns_empty_vec() {
+    // SPEC empty prefix: no `.manifests/` tree yet => EMPTY vec, NOT an error.
+    let root = TempDir::new("empty-none");
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    let listed = store
+        .list_manifest_ids()
+        .expect("an absent .manifests/ must yield Ok(empty), not an error");
+    assert!(
+        listed.is_empty(),
+        "no manifests => empty vec, got {listed:?}"
+    );
+}
+
+#[test]
+fn list_empty_manifests_dir_returns_empty_vec() {
+    // SPEC empty prefix: an EXISTING but empty `.manifests/` dir => empty vec.
+    let root = TempDir::new("empty-dir");
+    fs::create_dir_all(root.path().join(".manifests")).unwrap();
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    let listed = store
+        .list_manifest_ids()
+        .expect("an empty .manifests/ must yield Ok(empty), not an error");
+    assert!(
+        listed.is_empty(),
+        "empty .manifests/ => empty vec, got {listed:?}"
+    );
+}
+
+#[test]
+fn list_prefix_with_only_objects_no_manifests_returns_empty_vec() {
+    // SPEC: a store that has pushed OBJECTS but no manifest yet (e.g. only
+    // `.objects/` populated) lists ZERO manifests, not an error and not the
+    // object shards.
+    let root = TempDir::new("only-objects");
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    let blob = b"loose object\n".to_vec();
+    let sum = Blake3Hasher::new().hash_hex(&blob);
+    store.put_object(&sum, blob).expect("put_object");
+
+    let listed = store.list_manifest_ids().expect("list");
+    assert!(
+        listed.is_empty(),
+        "objects without manifests => empty vec, got {listed:?}"
+    );
+    assert!(
+        !listed.iter().any(|x| *x == sum),
+        "an object checksum must never be reported as a manifest id"
+    );
+}
+
+// ===========================================================================
+// SHARED-POOL ISOLATION (SplitStore over two FileStore prefixes, one pool)
+// ===========================================================================
+
+#[test]
+fn list_split_lists_only_its_own_manifests_not_the_shared_pool_objects() {
+    // SPEC shared-pool isolation: a manifest store that SHARES its `.objects`
+    // pool lists ONLY its OWN `.manifests/` ids — never the pool's objects. Push
+    // a real tree through a SplitStore (objects -> shared pool, manifest -> the
+    // manifests side); listing must return that one manifest id and NONE of the
+    // object checksums sitting in the shared pool's `.objects`.
+    let pool = TempDir::new("iso-pool");
+    let man = TempDir::new("iso-man");
+    let src = TempDir::new("iso-src");
+
+    let objects = FileStore::from_root(pool.path().to_path_buf());
+    let manifests = FileStore::from_root(man.path().to_path_buf());
+    let store = SplitStore::new(objects, manifests);
+
+    let (manifest, id) = build_tree(
+        src.path(),
+        &[("a", b"alpha\n"), ("b", b"beta\n"), ("c", b"gamma\n")],
+    );
+    store.push(&manifest, src.path()).expect("push");
+
+    let listed = store.list_manifest_ids().expect("list");
+    // Exactly the one manifest id — no object checksums from the shared pool.
+    assert_same_set(listed.clone(), vec![id.clone()]);
+    let objects: [(&str, &[u8]); 3] = [("a", b"alpha\n"), ("b", b"beta\n"), ("c", b"gamma\n")];
+    for (_, content) in &objects {
+        let osum = Blake3Hasher::new().hash_hex(*content);
+        assert!(
+            !listed.iter().any(|x| *x == osum),
+            "a shared-pool object checksum {osum} must NOT be listed as a manifest id"
+        );
+    }
+}
+
+#[test]
+fn list_split_two_prefixes_over_one_pool_do_not_see_each_others_manifests() {
+    // SPEC shared-pool isolation: two manifest prefixes A and B sharing ONE
+    // objects pool each list ONLY their own `.manifests/` ids — never the other
+    // prefix's manifests. Push DIFFERENT trees to A and B (same shared pool);
+    // each side's list is its own single id, disjoint from the other.
+    let pool = TempDir::new("two-pool");
+    let man_a = TempDir::new("two-man-a");
+    let man_b = TempDir::new("two-man-b");
+    let src_a = TempDir::new("two-src-a");
+    let src_b = TempDir::new("two-src-b");
+
+    let store_a = SplitStore::new(
+        FileStore::from_root(pool.path().to_path_buf()),
+        FileStore::from_root(man_a.path().to_path_buf()),
+    );
+    let store_b = SplitStore::new(
+        FileStore::from_root(pool.path().to_path_buf()),
+        FileStore::from_root(man_b.path().to_path_buf()),
+    );
+
+    let (man_tree_a, id_a) = build_tree(src_a.path(), &[("only-a", b"distinct A bytes\n")]);
+    let (man_tree_b, id_b) = build_tree(src_b.path(), &[("only-b", b"distinct B bytes\n")]);
+    store_a.push(&man_tree_a, src_a.path()).expect("push A");
+    store_b.push(&man_tree_b, src_b.path()).expect("push B");
+
+    assert_ne!(id_a, id_b, "the two trees must have distinct ids");
+
+    let listed_a = store_a.list_manifest_ids().expect("list A");
+    let listed_b = store_b.list_manifest_ids().expect("list B");
+
+    assert_same_set(listed_a.clone(), vec![id_a.clone()]);
+    assert_same_set(listed_b.clone(), vec![id_b.clone()]);
+    assert!(
+        !listed_a.iter().any(|x| *x == id_b),
+        "prefix A must NOT see prefix B's manifest id"
+    );
+    assert!(
+        !listed_b.iter().any(|x| *x == id_a),
+        "prefix B must NOT see prefix A's manifest id"
+    );
+}
+
+#[test]
+fn list_filestore_isolated_from_objects_planted_under_its_own_objects_dir() {
+    // SPEC: list reads ONLY `.manifests/` — a plain FileStore with both objects
+    // AND manifests must list its manifest ids and NEVER any `.objects` shard,
+    // even though both trees use the IDENTICAL 3/3/3/rest sharding.
+    let root = TempDir::new("colo-iso");
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    let src = TempDir::new("colo-iso-src");
+    let (manifest, id) = build_tree(src.path(), &[("f", b"colo bytes\n")]);
+    store.push(&manifest, src.path()).expect("push");
+
+    // After a push there's at least one `.objects/<shard>/...` blob present.
+    let listed = store.list_manifest_ids().expect("list");
+    let osum = Blake3Hasher::new().hash_hex(b"colo bytes\n");
+    assert!(
+        !listed.iter().any(|x| *x == osum),
+        "the object checksum {osum} (under .objects/) must not be listed"
+    );
+    assert_same_set(listed, vec![id]);
+}
+
+// ===========================================================================
+// DEFAULT-IMPL FAIL-CLOSED (a StreamStore that does NOT override the method)
+// ===========================================================================
+
+/// A minimal `StreamStore` that does NOT override `list_manifest_ids`, so it
+/// inherits the trait's DEFAULT impl. Per the SPEC the default fails closed —
+/// returning a `StoreError` ("listing unsupported") — so non-listing stores
+/// never silently claim an empty/garbage listing. Every other method is a
+/// trivial stub; only `list_manifest_ids` is under test here.
+struct NonListingStore;
+
+impl Store for NonListingStore {
+    fn get_manifest(&self, id: &str) -> Result<Manifest, StoreError> {
+        Err(StoreError::ManifestNotFound { id: id.to_string() })
+    }
+    fn fetch_files(&self, _manifest: &Manifest, _dest: &Path) -> Result<(), StoreError> {
+        Ok(())
+    }
+    fn push(&self, _manifest: &Manifest, _source: &Path) -> Result<(), StoreError> {
+        Ok(())
+    }
+}
+
+impl StreamStore for NonListingStore {
+    fn has_object(&self, _checksum: &str) -> Result<bool, StoreError> {
+        Ok(false)
+    }
+    fn get_object(&self, checksum: &str) -> Result<Vec<u8>, StoreError> {
+        Err(StoreError::ObjectNotFound {
+            checksum: checksum.to_string(),
+        })
+    }
+    fn put_object(&self, _checksum: &str, _bytes: Vec<u8>) -> Result<(), StoreError> {
+        Ok(())
+    }
+    fn put_manifest(&self, _id: &str, _manifest: &Manifest) -> Result<(), StoreError> {
+        Ok(())
+    }
+    // NOTE: deliberately does NOT override `list_manifest_ids` — it must inherit
+    // the fail-closed default.
+}
+
+#[test]
+fn list_default_impl_fails_closed_with_store_error() {
+    // SPEC default-impl fail-closed: a StreamStore that does NOT override
+    // list_manifest_ids returns a StoreError ("listing unsupported"), never
+    // Ok(empty). A store that cannot enumerate must NOT pretend it has zero
+    // snapshots.
+    let store = NonListingStore;
+    let result = store.list_manifest_ids();
+    assert!(
+        result.is_err(),
+        "the default list_manifest_ids must fail closed (Err), got {result:?}"
+    );
+    // It should be a Backend-style "unsupported" error, not a NotFound/Integrity.
+    match result {
+        Err(StoreError::Backend { .. }) => {}
+        Err(other) => {
+            panic!("expected a Backend(\"listing unsupported\")-style error, got {other:?}")
+        }
+        Ok(v) => panic!("expected fail-closed Err, got Ok({v:?})"),
+    }
+}
+
+// ===========================================================================
+// SHARD-RECONSTRUCTION BOUNDARIES (now-visible impl: the helper requires
+// EXACTLY 4 segments `3/3/3/rest` AND total length == 64 hex). These pin the
+// `segments.len() != 4` and `is_hex64` length branches that the black-box
+// suite could only approach indirectly.
+//
+// NOTE: S3/GCS/B2 reuse the SAME reconstruction (`manifest_ids_from_keys` ->
+// `manifest_id_from_shard_segments`), so these FileStore boundary tests cover
+// that shared key->id logic. The S3/GCS LIVE paths (the listing transport
+// itself) are creds-gated and not exercised here.
+// ===========================================================================
+
+/// A valid lowercase 64-hex id, planted at its real `3/3/3/rest` shard path.
+/// Distinct from any seeded snapshot id; used to drive the boundary plants.
+const VALID_ID: &str = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+
+#[test]
+fn list_ignores_a_too_shallow_key_whose_first_segments_already_total_64() {
+    // SPEC + IMPL (`segments.len() != 4`): a key at the WRONG (too-SHALLOW)
+    // depth must be skipped even when its segments happen to concatenate to a
+    // 64-hex string. Plant `.manifests/<32hex>/<32hex>` (depth 2, concat == 64
+    // valid hex). is_hex64 alone would accept the concat, so this pins that the
+    // DEPTH==4 guard runs FIRST and rejects it. Mixed with one real manifest.
+    let root = TempDir::new("shallow64");
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    let src = TempDir::new("shallow64-src");
+    let (manifest, id) = build_tree(src.path(), &[("f", b"shallow real\n")]);
+    store.put_manifest(&id, &manifest).expect("put real");
+
+    // Two 32-hex halves of VALID_ID => concat is the valid 64-hex id, but only
+    // TWO segments deep, not four.
+    let half_a = &VALID_ID[..32];
+    let half_b = &VALID_ID[32..];
+    let shallow = root.path().join(".manifests").join(half_a);
+    fs::create_dir_all(&shallow).unwrap();
+    fs::write(shallow.join(half_b), b"too shallow").unwrap();
+
+    let listed = store
+        .list_manifest_ids()
+        .expect("a too-shallow key must be skipped, NOT error");
+    assert!(
+        !listed.iter().any(|x| *x == VALID_ID),
+        "a depth-2 key that concatenates to 64-hex must NOT be listed: {listed:?}"
+    );
+    assert_same_set(listed, vec![id]);
+}
+
+#[test]
+fn list_ignores_a_correct_depth_key_whose_rest_makes_total_length_below_64() {
+    // SPEC + IMPL (`is_hex64` length check at depth 4): a key at the CORRECT
+    // `3/3/3/rest` depth whose segments are all valid hex but whose total
+    // length is 63 (one short of 64) must be skipped — depth is right, length
+    // is wrong. Pins the length arm of is_hex64 independently of the depth arm.
+    let root = TempDir::new("len63");
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    let src = TempDir::new("len63-src");
+    let (manifest, id) = build_tree(src.path(), &[("f", b"len63 real\n")]);
+    store.put_manifest(&id, &manifest).expect("put real");
+
+    // 3 + 3 + 3 + 54 = 63 valid-hex chars across the correct 4 segments.
+    let s0 = &VALID_ID[0..3];
+    let s1 = &VALID_ID[3..6];
+    let s2 = &VALID_ID[6..9];
+    let rest = "a".repeat(54);
+    assert_eq!(s0.len() + s1.len() + s2.len() + rest.len(), 63);
+    let short = root.path().join(".manifests").join(s0).join(s1).join(s2);
+    fs::create_dir_all(&short).unwrap();
+    fs::write(short.join(&rest), b"one char short").unwrap();
+
+    let listed = store
+        .list_manifest_ids()
+        .expect("a 63-char (length != 64) key must be skipped, NOT error");
+    assert_same_set(listed, vec![id]);
+}
+
+#[test]
+fn list_ignores_a_correct_depth_key_whose_rest_makes_total_length_above_64() {
+    // SPEC + IMPL (`is_hex64` length check at depth 4): the symmetric over-long
+    // case — correct depth, all valid hex, total length 65 (one over 64). Must
+    // be skipped; pins that is_hex64 rejects > 64 just as it rejects < 64.
+    let root = TempDir::new("len65");
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    let src = TempDir::new("len65-src");
+    let (manifest, id) = build_tree(src.path(), &[("f", b"len65 real\n")]);
+    store.put_manifest(&id, &manifest).expect("put real");
+
+    // 3 + 3 + 3 + 56 = 65 valid-hex chars across the correct 4 segments.
+    let s0 = &VALID_ID[0..3];
+    let s1 = &VALID_ID[3..6];
+    let s2 = &VALID_ID[6..9];
+    let rest = "b".repeat(56);
+    assert_eq!(s0.len() + s1.len() + s2.len() + rest.len(), 65);
+    let long = root.path().join(".manifests").join(s0).join(s1).join(s2);
+    fs::create_dir_all(&long).unwrap();
+    fs::write(long.join(&rest), b"one char long").unwrap();
+
+    let listed = store
+        .list_manifest_ids()
+        .expect("a 65-char (length != 64) key must be skipped, NOT error");
+    assert_same_set(listed, vec![id]);
+}
+
+#[test]
+fn list_does_not_list_a_64hex_value_that_is_a_directory_name_not_a_leaf() {
+    // SPEC + IMPL (the walk inserts ONLY on `is_dir() == false`): a 64-hex id
+    // that exists in the tree purely as the NAME of a DIRECTORY (the leaf
+    // `rest` segment is a dir, with no file under it) must NOT be listed —
+    // list reconstructs ids from FILE leaves, not directory nodes. This pins
+    // the file-vs-dir classification in `push_manifest_walk_entry`.
+    let root = TempDir::new("dir-leaf");
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    let src = TempDir::new("dir-leaf-src");
+    let (manifest, id) = build_tree(src.path(), &[("f", b"dir-leaf real\n")]);
+    store.put_manifest(&id, &manifest).expect("put real");
+
+    // Build the real `3/3/3/rest` shard path of VALID_ID, but make `rest` a
+    // DIRECTORY (mkdir, no file leaf under it). The reconstruction-to-64-hex is
+    // valid, yet there is no FILE leaf, so it must not surface.
+    let p = manifest_path(VALID_ID); // ".manifests/abc/def/012/3456...."
+    let as_dir = root.path().join(&p);
+    fs::create_dir_all(&as_dir).unwrap();
+
+    let listed = store
+        .list_manifest_ids()
+        .expect("a 64-hex directory node must be skipped, NOT error");
+    assert!(
+        !listed.iter().any(|x| *x == VALID_ID),
+        "a 64-hex value that is only a directory name must NOT be listed: {listed:?}"
+    );
+    assert_same_set(listed, vec![id]);
+}
+
+#[test]
+fn list_returns_only_the_valids_among_several_mixed_invalid_keys() {
+    // SPEC + IMPL: a tree mixing SEVERAL distinct malformed keys (wrong depth,
+    // wrong length, non-hex, uppercase) with SEVERAL genuine manifests returns
+    // EXACTLY the genuine ids — every invalid skipped without error, no valid
+    // dropped. Exercises the accumulate-while-skipping loop over many entries.
+    let root = TempDir::new("mixed");
+    let store = FileStore::from_root(root.path().to_path_buf());
+
+    // Several genuine manifests.
+    let ids = seed_manifests(&store, 3);
+
+    let manifests = root.path().join(".manifests");
+
+    // (a) too shallow: depth-1 file directly under .manifests/.
+    fs::write(manifests.join("not-a-shard"), b"x").unwrap();
+
+    // (b) too deep: 5 segments.
+    let deep = manifests.join("aaa").join("bbb").join("ccc").join("ddd");
+    fs::create_dir_all(&deep).unwrap();
+    fs::write(deep.join("eee"), b"x").unwrap();
+
+    // (c) correct depth, non-hex leaf (contains 'z'), length 64.
+    let nonhex = manifests.join("zzz").join("zzz").join("zzz");
+    fs::create_dir_all(&nonhex).unwrap();
+    fs::write(nonhex.join("z".repeat(55)), b"x").unwrap();
+
+    // (d) uppercase 64-hex at its uppercased shard path.
+    let up = manifest_path(&VALID_ID.to_uppercase());
+    let up_disk = root.path().join(&up);
+    fs::create_dir_all(up_disk.parent().unwrap()).unwrap();
+    fs::write(&up_disk, b"x").unwrap();
+
+    // (e) correct depth, valid hex, wrong length (63).
+    let short = manifests
+        .join(&VALID_ID[0..3])
+        .join(&VALID_ID[3..6])
+        .join(&VALID_ID[6..9]);
+    fs::create_dir_all(&short).unwrap();
+    fs::write(short.join("c".repeat(54)), b"x").unwrap();
+
+    let listed = store
+        .list_manifest_ids()
+        .expect("a mix of malformed keys must be skipped, NOT error");
+    assert_same_set(listed, ids);
+}

--- a/crates/snapdir-stores/tests/reflink.rs
+++ b/crates/snapdir-stores/tests/reflink.rs
@@ -1,0 +1,1032 @@
+//! Adversarial integration suite for the Linux `FICLONE` (reflink) copy-on-write
+//! fast-path in the `FileStore` file-copy primitive (phase 29, gate
+//! `reflink-spec-tests`).
+//!
+//! BLACK-BOX: authored from the gate SPEC alone, with NO visibility into the
+//! `copy_file` / `try_reflink` internals being added (the Linux clone branch
+//! does NOT exist yet — `try_reflink` is unwritten). It will NOT pass until the
+//! stores-impl teammate moves this file into
+//! `crates/snapdir-stores/tests/reflink.rs`, lands the `#[cfg(target_os="linux")]`
+//! FICLONE branch, and the Btrfs CI leg provides a real reflink filesystem. Do
+//! NOT weaken any assertion to make it green — if a behavior here fails against
+//! the landed impl on a reflink FS, that is a real bug in the impl.
+//!
+//! ## SPEC under test (Linux reflink / FICLONE)
+//!
+//! The impl adds a `#[cfg(target_os = "linux")]` branch to the `FileStore`'s
+//! internal copy primitive: when the source and the store/cache share a
+//! reflink-capable filesystem (Btrfs / XFS reflink=1 / `OpenZFS` 2.2+ / OCFS2 /
+//! bcachefs), `stage`/`push`/`checkout` clone objects copy-on-write via the
+//! `FICLONE` ioctl instead of a byte-copy; it falls back to `fs::copy` on
+//! ext4/F2FS/tmpfs, across filesystems (`EXDEV`), or on unsupported kernels.
+//! It REUSES the existing macOS knobs/counter — NO new symbol:
+//!   * `SNAPDIR_CLONEFILE=0` disables the clone fast-path (-> `fs::copy`),
+//!     unified across macOS + Linux.
+//!   * `snapdir_stores::clonefile_hits() -> u64` — the shared CoW-clone-fire
+//!     counter; the Linux FICLONE path bumps it too.
+//!   * `SNAPDIR_VERIFY_COPIES=1` — strict write-time re-hash (already exists).
+//!
+//! ## Env-gating contract (set by the Btrfs CI leg)
+//!
+//! Standard CI / dev hosts are ext4 (NO reflink), so FICLONE would silently
+//! fall back to `fs::copy` and the "clone actually fired" assertions could never
+//! pass. The suite is therefore gated on a reflink-capable directory:
+//!   * `SNAPDIR_REFLINK_TEST_DIR` — path to a mounted reflink FS (the Btrfs leg
+//!     sets it, e.g. to `/mnt/reflink`). When set, BOTH the source tree AND the
+//!     `FileStore`/cache are placed UNDER it (FICLONE returns `EXDEV`
+//!     cross-filesystem, so co-location is mandatory or the clone never fires).
+//!   * `SNAPDIR_REFLINK_TEST_REQUIRE=1` — on the Btrfs leg, a MISSING
+//!     `SNAPDIR_REFLINK_TEST_DIR` is a hard `panic!` (enforce — do NOT let the
+//!     required leg silently pass without exercising real FICLONE).
+//!   * Neither set (the ext4 matrix): `eprintln!` a skip note and `return`, so
+//!     the ext4 legs stay green without a reflink FS.
+//!
+//! The whole file is `#[cfg(target_os = "linux")]`, so it compiles to NOTHING on
+//! the macOS dev host (correct — structural verification only checks the file
+//! exists and contains `#[test]`).
+//!
+//! ## Env / parallelism note
+//!
+//! `SNAPDIR_CLONEFILE` / `SNAPDIR_VERIFY_COPIES` are process-global and Rust runs
+//! `#[test]`s multithreaded in one binary, so every test that touches a knob (or
+//! compares a `clonefile_hits()` delta) holds a single process-wide `ENV_LOCK`
+//! for its whole body and RESTORES the prior values on drop, so a parallel test
+//! never observes a half-set knob. This mirrors `apfs_clone.rs`.
+
+#![cfg(target_os = "linux")]
+// Wiring (shape only, no assertion change): silence workspace `-D warnings`
+// clippy lints on this adversary-authored suite.
+#![allow(
+    unused_imports,
+    clippy::type_complexity,
+    clippy::single_match_else,
+    clippy::single_match,
+    clippy::manual_let_else,
+    clippy::too_many_lines,
+    clippy::doc_markdown,
+    clippy::similar_names,
+    // These pedantic lints only ever compile on the Linux target (the whole file
+    // is `#![cfg(target_os = "linux")]`), so they are invisible to the macOS dev
+    // host's clippy but fire on CI's Linux `clippy --all-targets -D warnings`:
+    //   * map_unwrap_or / manual_assert — the env-contract gate `reflink_root_or_skip`,
+    //   * cast_possible_truncation — `len() as usize` / errno `as i32` in test asserts,
+    //   * unnested_or_patterns — the skip-on-EPERM/EACCES match arm.
+    // Pure shape; no assertion or test logic is affected.
+    clippy::map_unwrap_or,
+    clippy::manual_assert,
+    clippy::cast_possible_truncation,
+    clippy::unnested_or_patterns,
+    dead_code
+)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
+use snapdir_core::merkle::{directory_checksum, Blake3Hasher, Hasher};
+use snapdir_core::snapshot_id;
+use snapdir_core::store::{manifest_path, object_path, Store};
+
+use snapdir_stores::{FileStore, StreamStore};
+
+// ---------------------------------------------------------------------------
+// Reflink-FS gating: every test starts by resolving the reflink root, or
+// skips/panics per the env contract above.
+// ---------------------------------------------------------------------------
+
+/// Resolves the reflink-capable root for this run, honoring the env contract:
+///   * `SNAPDIR_REFLINK_TEST_DIR` set -> `Some(path)` (place src + store under it).
+///   * unset + `SNAPDIR_REFLINK_TEST_REQUIRE=1` -> `panic!` (Btrfs leg enforce).
+///   * unset + not required -> `None` (caller `eprintln!`s a skip note + returns).
+///
+/// Spec clause: "If UNSET and SNAPDIR_REFLINK_TEST_REQUIRE=1 -> panic; if UNSET
+/// and not required -> skip + return; when set, co-locate src AND store under it."
+fn reflink_root_or_skip(test_name: &str) -> Option<PathBuf> {
+    match std::env::var("SNAPDIR_REFLINK_TEST_DIR") {
+        Ok(dir) if !dir.is_empty() => {
+            let p = PathBuf::from(dir);
+            assert!(
+                p.is_dir(),
+                "SNAPDIR_REFLINK_TEST_DIR={} must be an existing mounted reflink directory",
+                p.display()
+            );
+            Some(p)
+        }
+        _ => {
+            let required = std::env::var("SNAPDIR_REFLINK_TEST_REQUIRE")
+                .map(|v| v == "1")
+                .unwrap_or(false);
+            if required {
+                panic!("reflink FS required but SNAPDIR_REFLINK_TEST_DIR unset");
+            }
+            eprintln!(
+                "SKIP {test_name}: SNAPDIR_REFLINK_TEST_DIR unset and \
+                 SNAPDIR_REFLINK_TEST_REQUIRE != 1 (no reflink FS on this host)"
+            );
+            None
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test scaffolding (no dev-dependencies; mirrors apfs_clone.rs / clone_skip.rs).
+// ---------------------------------------------------------------------------
+
+/// A unique temp dir under `parent`, removed on drop. Used to keep src + store
+/// UNDER the reflink root so FICLONE can actually fire (same-FS co-location).
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    /// Create a unique dir under `parent` (the reflink root for reflink cases).
+    fn under(parent: &Path, tag: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = parent.join(format!(
+            "snapdir-reflink-test-{}-{tag}-{n}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).expect("create temp dir");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        // Best-effort: clear any immutable flag a case set so the dir can be
+        // removed, then remove. (The immutable case clears its own flag too;
+        // this is belt-and-suspenders for the temp root.)
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+/// Process-global lock guarding `SNAPDIR_CLONEFILE` + `SNAPDIR_VERIFY_COPIES`
+/// and the process-global `clonefile_hits()` counter. Any test that reads/sets a
+/// knob or compares a counter delta MUST hold this for its whole body.
+fn env_lock() -> MutexGuard<'static, ()> {
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// RAII guard that sets/clears `SNAPDIR_CLONEFILE` and `SNAPDIR_VERIFY_COPIES`
+/// and restores the prior values on drop. Caller must already hold `env_lock()`.
+struct CopyModeEnv {
+    prev_clone: Option<String>,
+    prev_verify: Option<String>,
+}
+
+impl CopyModeEnv {
+    /// `clonefile`: `Some("0")` disables the clone fast-path (forces `fs::copy`);
+    /// `None` leaves it default-enabled. `verify`: `Some("1")` forces the
+    /// write-time re-hash even on the clone path; `None` leaves it default.
+    fn set(clonefile: Option<&str>, verify: Option<&str>) -> Self {
+        let prev_clone = std::env::var("SNAPDIR_CLONEFILE").ok();
+        let prev_verify = std::env::var("SNAPDIR_VERIFY_COPIES").ok();
+        match clonefile {
+            Some(v) => std::env::set_var("SNAPDIR_CLONEFILE", v),
+            None => std::env::remove_var("SNAPDIR_CLONEFILE"),
+        }
+        match verify {
+            Some(v) => std::env::set_var("SNAPDIR_VERIFY_COPIES", v),
+            None => std::env::remove_var("SNAPDIR_VERIFY_COPIES"),
+        }
+        Self {
+            prev_clone,
+            prev_verify,
+        }
+    }
+}
+
+impl Drop for CopyModeEnv {
+    fn drop(&mut self) {
+        match &self.prev_clone {
+            Some(v) => std::env::set_var("SNAPDIR_CLONEFILE", v),
+            None => std::env::remove_var("SNAPDIR_CLONEFILE"),
+        }
+        match &self.prev_verify {
+            Some(v) => std::env::set_var("SNAPDIR_VERIFY_COPIES", v),
+            None => std::env::remove_var("SNAPDIR_VERIFY_COPIES"),
+        }
+    }
+}
+
+/// Writes a real source tree under `src` and returns the matching `Manifest`
+/// plus its snapshot id. `files` is `(relative path, content, octal-mode-str)`.
+/// A `D ./` root entry is synthesized so the manifest is a valid snapshot.
+/// Object addressing uses the NON-keyed `Blake3Hasher` (the content-address
+/// hasher the file store files objects under), as the shipped tests do.
+fn build_tree(src: &Path, files: &[(&str, &[u8], &str)]) -> (Manifest, String) {
+    let hasher = Blake3Hasher::new();
+    let mut manifest = Manifest::new();
+
+    let mut file_sums: Vec<String> = Vec::new();
+    for (rel, content, mode) in files {
+        let target = src.join(rel);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&target, content).unwrap();
+        let perms = fs::Permissions::from_mode(u32::from_str_radix(mode, 8).unwrap());
+        fs::set_permissions(&target, perms).unwrap();
+        let sum = hasher.hash_hex(content);
+        file_sums.push(sum.clone());
+        manifest.push(ManifestEntry::new(
+            PathType::File,
+            *mode,
+            sum,
+            content.len() as u64,
+            format!("./{rel}"),
+        ));
+    }
+
+    let root_sum = directory_checksum(file_sums.iter().map(String::as_str), &hasher);
+    let root_size: u64 = files.iter().map(|(_, c, _)| c.len() as u64).sum();
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        root_size,
+        "./",
+    ));
+
+    manifest.sort();
+    let id = snapshot_id(&manifest, &hasher);
+    (manifest, id)
+}
+
+/// Counts the regular files under `<root>/.objects`.
+fn count_objects(root: &Path) -> usize {
+    fn walk(dir: &Path, acc: &mut usize) {
+        if let Ok(rd) = fs::read_dir(dir) {
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    walk(&p, acc);
+                } else if p.is_file() {
+                    *acc += 1;
+                }
+            }
+        }
+    }
+    let mut n = 0;
+    walk(&root.join(".objects"), &mut n);
+    n
+}
+
+/// Collects every `.objects` blob under `root` as `(sharded relative path,
+/// bytes)`, sorted by path — for the clone-vs-fs::copy pool comparisons.
+fn object_inventory(root: &Path) -> Vec<(String, Vec<u8>)> {
+    fn walk(base: &Path, dir: &Path, acc: &mut Vec<(String, Vec<u8>)>) {
+        if let Ok(rd) = fs::read_dir(dir) {
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    walk(base, &p, acc);
+                } else if p.is_file() {
+                    let rel = p.strip_prefix(base).unwrap().to_string_lossy().into_owned();
+                    acc.push((rel, fs::read(&p).unwrap()));
+                }
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(root, &root.join(".objects"), &mut out);
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}
+
+/// On-disk sharded path of an object blob under `root`.
+fn object_disk(root: &Path, checksum: &str) -> PathBuf {
+    root.join(object_path(checksum))
+}
+
+/// On-disk sharded path of a manifest under `root`.
+fn manifest_disk(root: &Path, id: &str) -> PathBuf {
+    root.join(manifest_path(id))
+}
+
+/// The unix mode bits (permission portion) of `path`.
+fn mode_bits(path: &Path) -> Option<u32> {
+    Some(fs::metadata(path).ok()?.permissions().mode() & 0o7777)
+}
+
+/// A representative tree exercising the boundary sizes the SPEC calls out: a
+/// file LARGER than 256 KiB (so FICLONE shares real extents), a tiny file, and a
+/// 0-byte file. Contents are deterministic so checksums are stable.
+fn mixed_size_files() -> Vec<(&'static str, Vec<u8>, &'static str)> {
+    // >256 KiB so it spans many extents — the regime where a CoW clone differs
+    // from a byte-copy and a truncation/aliasing bug would surface.
+    let big: Vec<u8> = (0..(300 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    vec![
+        ("big.bin", big, "644"),
+        ("tiny.txt", b"x".to_vec(), "644"),
+        ("empty", Vec::new(), "644"),
+        (
+            "nested/deep/leaf.bin",
+            vec![0u8, 1, 2, 3, 255, 254, 0],
+            "600",
+        ),
+    ]
+}
+
+/// One full stage->object->checkout cycle, with src/store/dest ALL under
+/// `reflink_root`, returning (object-pool inventory, restored-content map,
+/// restored-mode map, snapshot id). The env knob is set by the caller.
+fn roundtrip_once(
+    reflink_root: &Path,
+    tag: &str,
+    files: &[(&str, &[u8], &str)],
+) -> (
+    Vec<(String, Vec<u8>)>,
+    Vec<(String, Vec<u8>)>,
+    Vec<(String, Option<u32>)>,
+    String,
+) {
+    let store_dir = TempDir::under(reflink_root, &format!("rt-store-{tag}"));
+    let src = TempDir::under(reflink_root, &format!("rt-src-{tag}"));
+    let dest = TempDir::under(reflink_root, &format!("rt-dest-{tag}"));
+
+    let (manifest, id) = build_tree(src.path(), files);
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    store.push(&manifest, src.path()).expect("push");
+    store
+        .fetch_files(&manifest, dest.path())
+        .expect("fetch_files");
+
+    let inv = object_inventory(store_dir.path());
+
+    let mut restored: Vec<(String, Vec<u8>)> = Vec::new();
+    let mut modes: Vec<(String, Option<u32>)> = Vec::new();
+    for (rel, _, _) in files {
+        let p = dest.path().join(rel);
+        restored.push(((*rel).to_string(), fs::read(&p).expect("restored file")));
+        modes.push(((*rel).to_string(), mode_bits(&p)));
+    }
+    restored.sort_by(|a, b| a.0.cmp(&b.0));
+    modes.sort_by(|a, b| a.0.cmp(&b.0));
+
+    (inv, restored, modes, id)
+}
+
+// ===========================================================================
+// CASE 1 — FICLONE actually fires (anti-silent-fallback). On the reflink dir,
+// a push (source -> object) clones >=1 object and a fetch (object -> working
+// file) clones >=1 more, so clonefile_hits() advances by at least 2. This
+// PROVES the reflink branch fired rather than silently byte-copying.
+// Spec clause (case 1): "after - before >= 2 (push clones >=1 + fetch clones
+// >=1) — proves the reflink fired, not a silent fallback."
+// ===========================================================================
+
+#[test]
+fn ficlone_fires_on_reflink_fs_push_and_fetch_bump_counter() {
+    // Spec clause (case 1): on a reflink FS, push + fetch each ride FICLONE, so
+    // clonefile_hits() must increase by >= 2 across one stage+checkout cycle.
+    let Some(root) =
+        reflink_root_or_skip("ficlone_fires_on_reflink_fs_push_and_fetch_bump_counter")
+    else {
+        return;
+    };
+
+    let files_owned = mixed_size_files();
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None); // fast-path on so FICLONE really fires
+
+    let store_dir = TempDir::under(&root, "fires-store");
+    let src = TempDir::under(&root, "fires-src");
+    let dest = TempDir::under(&root, "fires-dest");
+    let (manifest, _id) = build_tree(src.path(), &files);
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+
+    let before = snapdir_stores::clonefile_hits();
+    store
+        .push(&manifest, src.path())
+        .expect("push on reflink FS");
+    store
+        .fetch_files(&manifest, dest.path())
+        .expect("fetch_files on reflink FS");
+    let after = snapdir_stores::clonefile_hits();
+
+    assert!(
+        after - before >= 2,
+        "FICLONE must fire for BOTH push (source->object, >=1) and fetch \
+         (object->working file, >=1) on a reflink FS — proving the reflink \
+         fast-path fired and did not silently fall back to fs::copy: \
+         {before} -> {after}"
+    );
+}
+
+// ===========================================================================
+// CASE 2 — Identical output: reflink ON (default) vs OFF (SNAPDIR_CLONEFILE=0,
+// fs::copy) vs strict (SNAPDIR_VERIFY_COPIES=1) produce byte-identical object
+// pools (sharded filenames + bytes), identical restored content + perms, and
+// the identical snapshot id.
+// Spec clause (case 2): "identical restored content, identical object pool
+// (sharded filenames + bytes), identical snapshot id; also vs VERIFY_COPIES=1."
+// ===========================================================================
+
+#[test]
+fn reflink_on_off_and_verify_produce_identical_objects_content_and_id() {
+    // Spec clause (case 2): the reflink path must be OBSERVABLY IDENTICAL to the
+    // fs::copy path and to the strict re-hash path — same object pool, restored
+    // content, restored perms, and snapshot id.
+    let Some(root) =
+        reflink_root_or_skip("reflink_on_off_and_verify_produce_identical_objects_content_and_id")
+    else {
+        return;
+    };
+
+    let files_owned = mixed_size_files();
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let _g = env_lock();
+
+    // (a) reflink ON (default), (b) reflink OFF (fs::copy), (c) strict re-hash.
+    let on = {
+        let _e = CopyModeEnv::set(None, None);
+        roundtrip_once(&root, "on", &files)
+    };
+    let off = {
+        let _e = CopyModeEnv::set(Some("0"), None);
+        roundtrip_once(&root, "off", &files)
+    };
+    let verify = {
+        let _e = CopyModeEnv::set(None, Some("1"));
+        roundtrip_once(&root, "verify", &files)
+    };
+
+    assert_eq!(
+        on.0, off.0,
+        "object pool (sharded filenames + bytes) must be byte-identical between \
+         the FICLONE fast-path and the fs::copy path"
+    );
+    assert_eq!(
+        on.0, verify.0,
+        "object pool must be byte-identical between FICLONE and the strict \
+         (VERIFY_COPIES=1) re-hash path"
+    );
+    assert_eq!(
+        on.1, off.1,
+        "restored file content must be identical between FICLONE and fs::copy"
+    );
+    assert_eq!(
+        on.1, verify.1,
+        "restored file content must be identical between FICLONE and strict mode"
+    );
+    assert_eq!(
+        on.2, off.2,
+        "restored permission bits must be identical between FICLONE and fs::copy"
+    );
+    assert_eq!(
+        on.3, off.3,
+        "snapshot id must round-trip identically regardless of the copy path"
+    );
+    assert_eq!(
+        on.3, verify.3,
+        "snapshot id must be identical between FICLONE and strict mode"
+    );
+
+    // Sanity: the >256 KiB object is present full-length so the equivalence is
+    // not vacuously over only tiny inputs.
+    let big_sum = Blake3Hasher::new().hash_hex(&files_owned[0].1);
+    let big_rel = object_path(&big_sum);
+    assert!(
+        on.0.iter()
+            .any(|(rel, bytes)| *rel == big_rel && bytes.len() == files_owned[0].1.len()),
+        "the >256 KiB object must be present in the pool at full length"
+    );
+}
+
+// ===========================================================================
+// CASE 3 — Sizes: a >256 KiB file AND a 0-byte file both clone correctly
+// (content + id correct). The big file proves real-extent CoW; the 0-byte file
+// proves no empty-file choke on the FICLONE path.
+// Spec clause (case 3): ">256 KiB file and a 0-byte file both clone correctly."
+// ===========================================================================
+
+#[test]
+fn reflink_large_and_zero_byte_files_clone_with_correct_content_and_id() {
+    // Spec clause (case 3): boundary sizes — a >256 KiB (multi-extent) file and a
+    // 0-byte file both produce byte-correct objects with the clone fast-path on.
+    let Some(root) =
+        reflink_root_or_skip("reflink_large_and_zero_byte_files_clone_with_correct_content_and_id")
+    else {
+        return;
+    };
+
+    // 1 MiB so it spans many extents; deterministic so the checksum is stable.
+    let big: Vec<u8> = (0..(1024 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    let files_owned: Vec<(&str, Vec<u8>, &str)> = vec![
+        ("big/payload.bin", big.clone(), "640"),
+        ("empty", Vec::new(), "644"),
+    ];
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None); // fast-path on
+
+    let store_dir = TempDir::under(&root, "sizes-store");
+    let src = TempDir::under(&root, "sizes-src");
+    let dest = TempDir::under(&root, "sizes-dest");
+    let (manifest, id) = build_tree(src.path(), &files);
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+
+    let before = snapdir_stores::clonefile_hits();
+    store.push(&manifest, src.path()).expect("push sizes");
+    store
+        .fetch_files(&manifest, dest.path())
+        .expect("fetch sizes");
+    let after = snapdir_stores::clonefile_hits();
+
+    // The big (non-empty) object travelled the clone path at least once on push.
+    assert!(
+        after - before >= 1,
+        "the >256 KiB object must travel the FICLONE fast-path (so the byte \
+         comparison is not vacuous over a silent fs::copy): {before} -> {after}"
+    );
+
+    // Big object: present, full length, byte-correct, and the clone shared a
+    // real (non-empty) extent.
+    let big_sum = Blake3Hasher::new().hash_hex(&big);
+    let big_obj = object_disk(store_dir.path(), &big_sum);
+    assert_eq!(
+        fs::read(&big_obj).expect("big object bytes"),
+        big,
+        "the cloned >256 KiB object must be byte-for-byte the source (no truncated CoW)"
+    );
+    assert_eq!(
+        fs::metadata(&big_obj).unwrap().len() as usize,
+        big.len(),
+        "cloned >256 KiB object must have the full source length"
+    );
+
+    // 0-byte object: present and exactly empty.
+    let empty_sum = Blake3Hasher::new().hash_hex(b"");
+    let empty_obj = object_disk(store_dir.path(), &empty_sum);
+    assert!(empty_obj.is_file(), "0-byte object must exist");
+    assert_eq!(
+        fs::metadata(&empty_obj).unwrap().len(),
+        0,
+        "0-byte object must be exactly empty"
+    );
+
+    // Restored content correct for both, and the snapshot round-trips.
+    assert_eq!(
+        fs::read(dest.path().join("big/payload.bin")).expect("restored big"),
+        big,
+        "restored >256 KiB file must equal the source"
+    );
+    assert!(
+        fs::read(dest.path().join("empty"))
+            .expect("restored empty")
+            .is_empty(),
+        "restored 0-byte file must be empty"
+    );
+    assert_eq!(
+        store.get_manifest(&id).expect("get_manifest").to_string(),
+        manifest.to_string(),
+        "the snapshot manifest must round-trip identically"
+    );
+}
+
+// ===========================================================================
+// CASE 4 — EXDEV cross-FS fallback. When the SOURCE is on a DIFFERENT
+// filesystem than the store, FICLONE returns EXDEV and the impl must fall back
+// to fs::copy; the push must still succeed with byte-correct object content and
+// id. Skip if a second filesystem cannot be arranged.
+// Spec clause (case 4): "source on a DIFFERENT FS than the store -> push still
+// succeeds with correct bytes/id (graceful fs::copy; clone didn't fire)."
+// ===========================================================================
+
+/// A writable dir on a DIFFERENT device than `same_dev_path`, or `None`.
+fn other_fs_dir(same_dev_path: &Path) -> Option<PathBuf> {
+    let base_dev = fs::metadata(same_dev_path).ok()?.dev();
+    // `/tmp`, `/dev/shm`, `/var/tmp` are usually tmpfs/ext4 — NOT the reflink FS.
+    for cand in ["/dev/shm", "/tmp", "/var/tmp", "/run"] {
+        let p = Path::new(cand);
+        if let Ok(md) = fs::metadata(p) {
+            if md.dev() != base_dev {
+                let scratch = p.join(format!("snapdir-reflink-xdev-{}", std::process::id()));
+                if fs::create_dir_all(&scratch).is_ok() {
+                    return Some(scratch);
+                }
+            }
+        }
+    }
+    None
+}
+
+#[test]
+fn cross_fs_source_falls_back_to_fscopy_with_correct_bytes_and_id() {
+    // Spec clause (case 4): cross-filesystem (EXDEV) must gracefully fall back to
+    // fs::copy and still produce a byte-correct object + committed manifest.
+    let Some(root) =
+        reflink_root_or_skip("cross_fs_source_falls_back_to_fscopy_with_correct_bytes_and_id")
+    else {
+        return;
+    };
+
+    // The STORE lives on the reflink FS; the SOURCE lives on a different FS, so
+    // source->object crosses a device boundary and FICLONE must return EXDEV.
+    let store_dir = TempDir::under(&root, "xdev-store");
+
+    let other = match other_fs_dir(store_dir.path()) {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "SKIP cross_fs_source_falls_back_to_fscopy_with_correct_bytes_and_id: \
+                 no second writable filesystem distinct from the reflink FS detected"
+            );
+            return;
+        }
+    };
+
+    let src = other.join(format!("src-{}", std::process::id()));
+    fs::create_dir_all(&src).unwrap();
+
+    let content: Vec<u8> = (0..(280 * 1024u32)).map(|i| (i % 197) as u8).collect();
+    let files: Vec<(&str, &[u8], &str)> = vec![("payload.bin", content.as_slice(), "644")];
+    let (manifest, id) = build_tree(&src, &files);
+
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None); // fast-path on; impl must fall back on EXDEV
+
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    let res = store.push(&manifest, &src);
+
+    let cleanup = |p: &Path| {
+        let _ = fs::remove_dir_all(p);
+    };
+
+    match res {
+        Ok(()) => {
+            let sum = Blake3Hasher::new().hash_hex(&content);
+            let blob = fs::read(object_disk(store_dir.path(), &sum));
+            let manifest_ok = manifest_disk(store_dir.path(), &id).is_file();
+            cleanup(&other);
+            let blob = blob.expect("object blob must exist after cross-FS push");
+            assert_eq!(
+                blob, content,
+                "cross-FS EXDEV fallback must still file byte-correct object content"
+            );
+            assert!(
+                manifest_ok,
+                "the manifest must commit (manifest-last) after the EXDEV fs::copy fallback"
+            );
+        }
+        Err(e) => {
+            cleanup(&other);
+            panic!("cross-FS push must succeed via the fs::copy (EXDEV) fallback, got {e}");
+        }
+    }
+}
+
+// ===========================================================================
+// CASE 5 — Perms parity. A source file with an unusual mode (0o600, 0o755)
+// yields the SAME restored/object perms under reflink vs fs::copy.
+// Spec clause (case 5): "unusual mode yields the same restored/object perms with
+// reflink vs fs::copy."
+// ===========================================================================
+
+#[test]
+fn reflink_and_fscopy_yield_identical_restored_permissions() {
+    // Spec clause (case 5): identical restored-file mode between the FICLONE path
+    // and the fs::copy path for unusual source modes (0o600, 0o755), and each
+    // restored file honors its manifest-recorded mode (no silent perm widening).
+    let Some(root) =
+        reflink_root_or_skip("reflink_and_fscopy_yield_identical_restored_permissions")
+    else {
+        return;
+    };
+
+    let mut files_owned: Vec<(&str, Vec<u8>, &str)> = vec![
+        ("secret", b"private\n".to_vec(), "600"),
+        ("script.sh", b"#!/bin/sh\necho hi\n".to_vec(), "755"),
+    ];
+    files_owned.sort_by(|a, b| a.0.cmp(b.0));
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let _g = env_lock();
+
+    let on = {
+        let _e = CopyModeEnv::set(None, None);
+        roundtrip_once(&root, "perm-on", &files)
+    };
+    let off = {
+        let _e = CopyModeEnv::set(Some("0"), None);
+        roundtrip_once(&root, "perm-off", &files)
+    };
+
+    assert_eq!(
+        on.2, off.2,
+        "restored-file permission bits must be identical between FICLONE and fs::copy"
+    );
+    for ((rel, mode), (_, _, want)) in on.2.iter().zip(files_owned.iter()) {
+        let want_bits = u32::from_str_radix(want, 8).unwrap();
+        assert_eq!(
+            *mode,
+            Some(want_bits),
+            "restored {rel} must carry the manifest-recorded mode {want}"
+        );
+    }
+}
+
+// ===========================================================================
+// CASE 6 — Immutable source (FS_IMMUTABLE_FL via FS_IOC_SETFLAGS) does NOT
+// yield an immutable object. FICLONE is a DATA-ONLY clone, so the inode
+// immutable flag must NOT propagate to the object (unlike macOS uchg, Linux has
+// no un-GC-able-object risk — but PIN it). Needs privilege: skip-if-EPERM.
+// Spec clause (case 6): "set FS_IMMUTABLE_FL on a source via libc; if EPERM ->
+// skip; else assert the resulting OBJECT is removable (fs::remove_file ok)."
+// ===========================================================================
+
+// FS_IOC_SETFLAGS / FS_IOC_GETFLAGS ioctl request numbers (long-arg, asm-generic
+// values used by Btrfs/ext*/XFS on Linux). FS_IMMUTABLE_FL is the immutable bit.
+const FS_IOC_GETFLAGS: libc::c_ulong = 0x8008_6601;
+const FS_IOC_SETFLAGS: libc::c_ulong = 0x4008_6602;
+const FS_IMMUTABLE_FL: libc::c_long = 0x0000_0010;
+
+/// Sets/clears FS_IMMUTABLE_FL on `path`. Returns `Ok(())`, or `Err(errno)` —
+/// `EPERM` (1) signals "no privilege" so the caller can skip.
+fn set_immutable(path: &Path, immutable: bool) -> Result<(), i32> {
+    use std::ffi::CString;
+    use std::os::unix::ffi::OsStrExt;
+
+    let c = CString::new(path.as_os_str().as_bytes()).expect("path has no NUL");
+    // O_RDONLY is sufficient for FS_IOC_*FLAGS.
+    let fd = unsafe { libc::open(c.as_ptr(), libc::O_RDONLY | libc::O_CLOEXEC) };
+    if fd < 0 {
+        return Err(std::io::Error::last_os_error().raw_os_error().unwrap_or(-1));
+    }
+    let result = (|| {
+        let mut flags: libc::c_long = 0;
+        let rc = unsafe { libc::ioctl(fd, FS_IOC_GETFLAGS as _, &mut flags) };
+        if rc != 0 {
+            return Err(std::io::Error::last_os_error().raw_os_error().unwrap_or(-1));
+        }
+        if immutable {
+            flags |= FS_IMMUTABLE_FL;
+        } else {
+            flags &= !FS_IMMUTABLE_FL;
+        }
+        let rc = unsafe { libc::ioctl(fd, FS_IOC_SETFLAGS as _, &flags) };
+        if rc != 0 {
+            return Err(std::io::Error::last_os_error().raw_os_error().unwrap_or(-1));
+        }
+        Ok(())
+    })();
+    unsafe { libc::close(fd) };
+    result
+}
+
+#[test]
+fn immutable_source_does_not_produce_an_immutable_object() {
+    // Spec clause (case 6): FICLONE clones data only; the FS_IMMUTABLE_FL on the
+    // SOURCE inode must NOT propagate to the cloned object — the object must be
+    // removable/GC-able. Requires privilege to set the flag; skip on EPERM.
+    let Some(root) = reflink_root_or_skip("immutable_source_does_not_produce_an_immutable_object")
+    else {
+        return;
+    };
+
+    let store_dir = TempDir::under(&root, "immut-store");
+    let src = TempDir::under(&root, "immut-src");
+
+    let content = b"immutable-source-bytes-cloned-data-only\n".to_vec();
+    let rel = "locked.bin";
+    let target = src.path().join(rel);
+    fs::write(&target, &content).unwrap();
+
+    // Try to set FS_IMMUTABLE_FL on the source. EPERM (or EACCES) => skip.
+    match set_immutable(&target, true) {
+        Ok(()) => {}
+        Err(libc::EPERM) | Err(libc::EACCES) => {
+            eprintln!(
+                "SKIP immutable_source_does_not_produce_an_immutable_object: \
+                 setting FS_IMMUTABLE_FL needs privilege (EPERM/EACCES)"
+            );
+            return;
+        }
+        Err(errno) if errno == libc::ENOTTY || errno == libc::EOPNOTSUPP => {
+            eprintln!(
+                "SKIP immutable_source_does_not_produce_an_immutable_object: \
+                 filesystem does not support FS_IOC_SETFLAGS (errno {errno})"
+            );
+            return;
+        }
+        Err(errno) => panic!("unexpected errno setting FS_IMMUTABLE_FL: {errno}"),
+    }
+
+    // Build the manifest AFTER setting the flag (content is unchanged).
+    let hasher = Blake3Hasher::new();
+    let sum = hasher.hash_hex(&content);
+    let mut manifest = Manifest::new();
+    manifest.push(ManifestEntry::new(
+        PathType::File,
+        "644",
+        sum.clone(),
+        content.len() as u64,
+        format!("./{rel}"),
+    ));
+    let root_sum = directory_checksum(std::iter::once(sum.as_str()), &hasher);
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        content.len() as u64,
+        "./",
+    ));
+    manifest.sort();
+
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None); // fast-path on so a real FICLONE fires
+
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    let push_res = store.push(&manifest, src.path());
+
+    // Clear the SOURCE flag now so the src TempDir can be cleaned up regardless
+    // of the assertion outcome below.
+    let _ = set_immutable(&target, false);
+
+    push_res.expect("push of an immutable source must succeed");
+
+    // KEYSTONE: the resulting object must be REMOVABLE — FICLONE (data-only)
+    // must NOT have propagated FS_IMMUTABLE_FL onto the object inode.
+    let obj = object_disk(store_dir.path(), &sum);
+    assert!(obj.is_file(), "object must have landed");
+    fs::remove_file(&obj).expect(
+        "the cloned object must NOT be immutable — FICLONE clones data only, so \
+         FS_IMMUTABLE_FL must not propagate (Linux has no un-GC-able-object risk)",
+    );
+    assert!(!obj.exists(), "object must be gone after removal");
+}
+
+// ===========================================================================
+// CASE 7 (impl-revealed) — Knob OFF on the reflink FS: with `SNAPDIR_CLONEFILE=0`,
+// `copy_file`'s `clonefile_enabled()` guard short-circuits BEFORE `try_reflink`
+// is ever called, so the FICLONE ioctl never runs and the counter must NOT
+// advance — EVEN when src + store are co-located on a genuinely reflink-capable
+// filesystem (the one host where the clone WOULD otherwise fire). This pins that
+// the disable knob is honored on the reflink path (read per-copy, not cached),
+// while a byte-correct object is still produced via `fs::copy`. Complements
+// case 2 (which compares pools) with a direct counter-stays-flat assertion on
+// the reflink FS specifically.
+// ===========================================================================
+
+#[test]
+fn clonefile_disabled_does_not_advance_counter_on_reflink_fs() {
+    // Impl: `copy_file` only enters the Linux branch when `clonefile_enabled()`
+    // is true; with SNAPDIR_CLONEFILE=0 it falls straight through to fs::copy, so
+    // CLONEFILE_HITS must be untouched even on a reflink-capable FS.
+    let Some(root) =
+        reflink_root_or_skip("clonefile_disabled_does_not_advance_counter_on_reflink_fs")
+    else {
+        return;
+    };
+
+    let files_owned = mixed_size_files();
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(Some("0"), None); // clone fast-path DISABLED
+
+    let store_dir = TempDir::under(&root, "off-counter-store");
+    let src = TempDir::under(&root, "off-counter-src");
+    let dest = TempDir::under(&root, "off-counter-dest");
+    let (manifest, id) = build_tree(src.path(), &files);
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+
+    let before = snapdir_stores::clonefile_hits();
+    store
+        .push(&manifest, src.path())
+        .expect("push with clone disabled on reflink FS");
+    store
+        .fetch_files(&manifest, dest.path())
+        .expect("fetch_files with clone disabled on reflink FS");
+    let after = snapdir_stores::clonefile_hits();
+
+    assert_eq!(
+        after, before,
+        "SNAPDIR_CLONEFILE=0 must short-circuit the FICLONE fast-path even on a \
+         reflink-capable FS, so clonefile_hits() must NOT advance: {before} -> {after}"
+    );
+
+    // The fs::copy fallback must still produce a byte-correct object pool + a
+    // round-trippable snapshot (disabling the clone must not corrupt anything).
+    let big_sum = Blake3Hasher::new().hash_hex(&files_owned[0].1);
+    let big_obj = object_disk(store_dir.path(), &big_sum);
+    assert_eq!(
+        fs::read(&big_obj).expect("big object via fs::copy"),
+        files_owned[0].1,
+        "the >256 KiB object must be byte-correct on the fs::copy (clone-off) path"
+    );
+    assert_eq!(
+        store.get_manifest(&id).expect("get_manifest").to_string(),
+        manifest.to_string(),
+        "the snapshot manifest must round-trip on the clone-off path"
+    );
+}
+
+// ===========================================================================
+// CASE 8 (impl-revealed) — Fallback subdir under a NON-reflink mount still
+// produces a correct object with the clone fast-path ENABLED. The impl's
+// `try_reflink` returns `Ok(false)` on EXDEV/EOPNOTSUPP/ENOTTY (FS without
+// reflink) and `copy_file` then falls through to `fs::copy`; this asserts that
+// the fallback object is byte-correct, the manifest commits, AND the counter
+// does NOT advance for that store (no false clone-fire credited to a byte copy).
+// This is the EXDEV/non-reflink path of case 4, but additionally pins the
+// counter-does-not-move invariant on the fallback. Skip if no second FS exists.
+// ===========================================================================
+
+#[test]
+fn non_reflink_fallback_produces_correct_object_without_counter_bump() {
+    // Impl: a store whose objects live on a NON-reflink FS forces try_reflink to
+    // return Ok(false) (EXDEV/EOPNOTSUPP/ENOTTY), so fs::copy runs and the
+    // counter is never bumped for that copy — yet the object is byte-correct.
+    let Some(root) =
+        reflink_root_or_skip("non_reflink_fallback_produces_correct_object_without_counter_bump")
+    else {
+        return;
+    };
+
+    // Put the STORE on a non-reflink FS (e.g. tmpfs /dev/shm or ext4 /tmp) while
+    // the SOURCE is on the reflink FS, so source->object crosses the device
+    // boundary (EXDEV) — FICLONE cannot fire and the impl must fall back.
+    let src = TempDir::under(&root, "fallback-src");
+
+    let other = match other_fs_dir(src.path()) {
+        Some(p) => p,
+        None => {
+            eprintln!(
+                "SKIP non_reflink_fallback_produces_correct_object_without_counter_bump: \
+                 no second writable filesystem distinct from the reflink FS detected"
+            );
+            return;
+        }
+    };
+    let store_root = other.join(format!("store-{}", std::process::id()));
+    fs::create_dir_all(&store_root).unwrap();
+
+    let content: Vec<u8> = (0..(290 * 1024u32)).map(|i| (i % 193) as u8).collect();
+    let files: Vec<(&str, &[u8], &str)> = vec![("payload.bin", content.as_slice(), "640")];
+    let (manifest, id) = build_tree(src.path(), &files);
+
+    let _g = env_lock();
+    let _e = CopyModeEnv::set(None, None); // clone ENABLED; impl must still fall back
+
+    let store = FileStore::from_root(store_root.clone());
+
+    let before = snapdir_stores::clonefile_hits();
+    let push_res = store.push(&manifest, src.path());
+    let after = snapdir_stores::clonefile_hits();
+
+    let sum = Blake3Hasher::new().hash_hex(&content);
+    let blob = fs::read(object_disk(&store_root, &sum));
+    let manifest_ok = manifest_disk(&store_root, &id).is_file();
+    let _ = fs::remove_dir_all(&other);
+
+    push_res.expect("push must succeed via the fs::copy fallback on a non-reflink store FS");
+    assert_eq!(
+        after, before,
+        "the EXDEV/non-reflink fallback uses fs::copy, so no clone may be credited \
+         to it — clonefile_hits() must NOT advance: {before} -> {after}"
+    );
+    let blob = blob.expect("object blob must exist after the fallback push");
+    assert_eq!(
+        blob, content,
+        "the fs::copy fallback object must be byte-for-byte the source content"
+    );
+    assert!(
+        manifest_ok,
+        "the manifest must commit (manifest-last) after the non-reflink fs::copy fallback"
+    );
+}

--- a/crates/snapdir-stores/tests/split.rs
+++ b/crates/snapdir-stores/tests/split.rs
@@ -1,0 +1,1025 @@
+//! Adversarial integration suite for `SplitStore` (phase 28, gate
+//! `split-store-spec-tests`).
+//!
+//! BLACK-BOX: authored from the gate SPEC alone, with NO visibility into a
+//! `SplitStore` implementation (none exists yet). It will NOT compile/pass until
+//! the stores-impl teammate moves this file into
+//! `crates/snapdir-stores/tests/split.rs` and wires the constructor shape. Do
+//! not weaken any assertion to make it green — if a behavior here fails against
+//! the landed impl, that is a real bug in the impl, not in this test.
+//!
+//! `SplitStore` wraps TWO stores:
+//!   - an `objects` pool — only its `.objects/` content-addressed blobs are used;
+//!   - a `manifests` location — only its `.manifests/<id>` is used.
+//!
+//! Object ops (`has`/`get`/`put_object`, `objects_needed`) route to the OBJECTS
+//! store; manifest ops (`get`/`put_manifest`) route to the MANIFESTS store. It
+//! implements both `Store` and `StreamStore`.
+//!
+//! Construction shape assumed (the impl teammate may adjust the exact call site
+//! while preserving these behaviors): `SplitStore::new(objects_store,
+//! manifests_store)` over two `FileStore`s. If the real constructor differs
+//! (e.g. takes URLs / owned vs borrowed), fix ONLY the call shape, never the
+//! assertions.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
+use snapdir_core::merkle::{directory_checksum, Blake3Hasher, Hasher};
+use snapdir_core::snapshot_id;
+use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
+
+use snapdir_stores::{FileStore, SplitStore, StreamStore};
+
+// ---------------------------------------------------------------------------
+// Test scaffolding (no dev-dependencies; mirrors the existing shim test).
+// ---------------------------------------------------------------------------
+
+/// A unique temp dir removed on drop.
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "snapdir-split-test-{}-{tag}-{n}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).expect("create temp dir");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+/// Builds a `SplitStore` over a `FileStore` rooted at `objects_root` (the pool)
+/// and a `FileStore` rooted at `manifests_root` (the manifest location).
+fn split_over(objects_root: &Path, manifests_root: &Path) -> SplitStore {
+    let objects = FileStore::from_root(objects_root.to_path_buf());
+    let manifests = FileStore::from_root(manifests_root.to_path_buf());
+    SplitStore::new(objects, manifests)
+}
+
+/// Writes a real source tree under `src` and returns the matching `Manifest`
+/// plus its snapshot id. Files are `(relative path, content)`. A `D ./` root
+/// entry is always synthesized; nested directory entries are synthesized for
+/// each unique parent component. Object addressing uses the NON-keyed
+/// `Blake3Hasher` (the content-address hasher the file store files objects
+/// under), exactly as the shipped shim/file-store tests do.
+fn build_tree(src: &Path, files: &[(&str, &[u8])]) -> (Manifest, String) {
+    let hasher = Blake3Hasher::new();
+    let mut manifest = Manifest::new();
+
+    // Materialize the files on disk and collect their entries + checksums.
+    let mut file_sums: Vec<String> = Vec::new();
+    for (rel, content) in files {
+        let target = src.join(rel);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&target, content).unwrap();
+        let sum = hasher.hash_hex(content);
+        file_sums.push(sum.clone());
+        manifest.push(ManifestEntry::new(
+            PathType::File,
+            "600",
+            sum,
+            content.len() as u64,
+            format!("./{rel}"),
+        ));
+    }
+
+    // A single root directory entry keeps the manifest a valid snapshot. Its
+    // checksum is the directory_checksum over the direct file children — exact
+    // shape is not the contract under test here (the SPEC pins OBJECT + manifest
+    // BYTES, and objects are files only), so a deterministic root entry that is
+    // identical across colocated/split builds is all parity requires.
+    let root_sum = directory_checksum(file_sums.iter().map(String::as_str), &hasher);
+    let root_size: u64 = files.iter().map(|(_, c)| c.len() as u64).sum();
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        root_size,
+        "./",
+    ));
+
+    manifest.sort();
+    let id = snapshot_id(&manifest, &hasher);
+    (manifest, id)
+}
+
+/// Counts the regular files under `<root>/.objects` (the blob count the SPEC's
+/// invariant (a) asserts is unchanged on a second push of the same tree).
+fn count_objects(root: &Path) -> usize {
+    fn walk(dir: &Path, acc: &mut usize) {
+        if let Ok(rd) = fs::read_dir(dir) {
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    walk(&p, acc);
+                } else if p.is_file() {
+                    *acc += 1;
+                }
+            }
+        }
+    }
+    let mut n = 0;
+    walk(&root.join(".objects"), &mut n);
+    n
+}
+
+/// Returns the on-disk sharded path of an object blob under `root`.
+fn object_disk(root: &Path, checksum: &str) -> PathBuf {
+    root.join(object_path(checksum))
+}
+
+/// Returns the on-disk sharded path of a manifest under `root`.
+fn manifest_disk(root: &Path, id: &str) -> PathBuf {
+    root.join(manifest_path(id))
+}
+
+// ===========================================================================
+// HAPPY-PATH INVARIANTS (a) (b) (c)
+// ===========================================================================
+
+#[test]
+fn split_routes_object_ops_to_objects_pool_manifest_to_manifests_location() {
+    // SPEC routing: object ops -> objects store; manifest ops -> manifests store.
+    let objects = TempDir::new("route-obj");
+    let manifests = TempDir::new("route-man");
+    let src = TempDir::new("route-src");
+    let (manifest, id) = build_tree(src.path(), &[("a.txt", b"alpha\n")]);
+
+    let store = split_over(objects.path(), manifests.path());
+    store.push(&manifest, src.path()).expect("push");
+
+    // Blobs land ONLY in the objects pool; the manifests location holds NO
+    // `.objects`. The manifest lands ONLY in the manifests location.
+    let sum = Blake3Hasher::new().hash_hex(b"alpha\n");
+    assert!(
+        object_disk(objects.path(), &sum).is_file(),
+        "object must land in the OBJECTS pool"
+    );
+    assert!(
+        !objects.path().join(".manifests").exists() || !manifest_disk(objects.path(), &id).exists(),
+        "manifest must NOT land in the objects pool"
+    );
+    assert!(
+        manifest_disk(manifests.path(), &id).is_file(),
+        "manifest must land in the MANIFESTS location"
+    );
+    assert!(
+        !manifests.path().join(".objects").exists() || count_objects(manifests.path()) == 0,
+        "objects must NOT land in the manifests location"
+    );
+}
+
+#[test]
+fn split_shared_pool_two_manifest_prefixes_upload_zero_new_objects_second_time() {
+    // SPEC invariant (a): two manifest locations A and B sharing ONE objects
+    // pool — pushing the SAME tree to A then to B uploads ZERO new objects the
+    // second time.
+    let objects = TempDir::new("share-obj");
+    let man_a = TempDir::new("share-man-a");
+    let man_b = TempDir::new("share-man-b");
+    let src = TempDir::new("share-src");
+    let (manifest, id) = build_tree(
+        src.path(),
+        &[("x", b"data-x\n"), ("y", b"data-y\n"), ("z", b"data-z\n")],
+    );
+
+    let store_a = split_over(objects.path(), man_a.path());
+    store_a.push(&manifest, src.path()).expect("push A");
+    let after_a = count_objects(objects.path());
+    assert!(
+        after_a >= 3,
+        "all file objects must have landed once: {after_a}"
+    );
+
+    let store_b = split_over(objects.path(), man_b.path());
+    store_b.push(&manifest, src.path()).expect("push B");
+    let after_b = count_objects(objects.path());
+
+    assert_eq!(
+        after_a, after_b,
+        "second push to a DIFFERENT manifest prefix over the SAME pool must \
+         upload ZERO new objects (dedup), but the .objects count changed"
+    );
+    // Both manifest locations now resolve the snapshot.
+    assert!(manifest_disk(man_a.path(), &id).is_file());
+    assert!(manifest_disk(man_b.path(), &id).is_file());
+}
+
+#[test]
+fn split_push_then_fetch_files_roundtrips_byte_identical() {
+    // SPEC invariant (b): push -> fetch_files round-trips byte-identical content.
+    let objects = TempDir::new("rt-obj");
+    let manifests = TempDir::new("rt-man");
+    let src = TempDir::new("rt-src");
+    let dest = TempDir::new("rt-dest");
+    let files: &[(&str, &[u8])] = &[
+        ("readme.md", b"# hello\nworld\n"),
+        ("nested/deep/leaf.bin", &[0u8, 1, 2, 3, 255, 254, 0]),
+        ("unicode-\u{2728}.txt", "spark\u{2728}\n".as_bytes()),
+    ];
+    let (manifest, _id) = build_tree(src.path(), files);
+
+    let store = split_over(objects.path(), manifests.path());
+    store.push(&manifest, src.path()).expect("push");
+    store
+        .fetch_files(&manifest, dest.path())
+        .expect("fetch_files");
+
+    for (rel, content) in files {
+        let got = fs::read(dest.path().join(rel)).expect("materialized file");
+        assert_eq!(&got, content, "round-trip must be byte-identical for {rel}");
+    }
+}
+
+#[test]
+fn split_layout_parity_objects_bytes_match_colocated_filestore() {
+    // SPEC invariant (c) — LAYOUT PARITY: the `.objects` bytes produced by a
+    // SplitStore push are byte-for-byte identical to a single COLOCATED
+    // FileStore push of the same tree (frozen sharded-layout interop).
+    let files: &[(&str, &[u8])] = &[
+        ("one", b"first\n"),
+        ("dir/two", b"second\n"),
+        ("dir/sub/three", b"third\n"),
+    ];
+
+    // Colocated reference push.
+    let colo = TempDir::new("parity-colo");
+    let colo_src = TempDir::new("parity-colo-src");
+    let (colo_manifest, _) = build_tree(colo_src.path(), files);
+    FileStore::from_root(colo.path().to_path_buf())
+        .push(&colo_manifest, colo_src.path())
+        .expect("colocated push");
+
+    // Split push into a separate objects pool.
+    let objects = TempDir::new("parity-obj");
+    let manifests = TempDir::new("parity-man");
+    let split_src = TempDir::new("parity-split-src");
+    let (split_manifest, _) = build_tree(split_src.path(), files);
+    split_over(objects.path(), manifests.path())
+        .push(&split_manifest, split_src.path())
+        .expect("split push");
+
+    // Every object blob is byte-identical AND at the same sharded path.
+    for (_, content) in files {
+        let sum = Blake3Hasher::new().hash_hex(content);
+        let colo_blob = fs::read(object_disk(colo.path(), &sum)).expect("colo blob");
+        let split_blob = fs::read(object_disk(objects.path(), &sum)).expect("split blob");
+        assert_eq!(
+            colo_blob, split_blob,
+            "object {sum} bytes must match the colocated store"
+        );
+    }
+    assert_eq!(
+        count_objects(colo.path()),
+        count_objects(objects.path()),
+        "the split pool must hold exactly the same object set as colocated"
+    );
+}
+
+#[test]
+fn split_layout_parity_manifest_bytes_match_colocated_filestore() {
+    // SPEC invariant (c) — LAYOUT PARITY: the A-side manifest bytes are
+    // byte-for-byte identical to the manifest a colocated FileStore push writes.
+    let files: &[(&str, &[u8])] = &[("p", b"P\n"), ("q/r", b"QR\n")];
+
+    let colo = TempDir::new("mparity-colo");
+    let colo_src = TempDir::new("mparity-colo-src");
+    let (colo_manifest, colo_id) = build_tree(colo_src.path(), files);
+    FileStore::from_root(colo.path().to_path_buf())
+        .push(&colo_manifest, colo_src.path())
+        .expect("colocated push");
+
+    let objects = TempDir::new("mparity-obj");
+    let manifests = TempDir::new("mparity-man");
+    let split_src = TempDir::new("mparity-split-src");
+    let (split_manifest, split_id) = build_tree(split_src.path(), files);
+    split_over(objects.path(), manifests.path())
+        .push(&split_manifest, split_src.path())
+        .expect("split push");
+
+    assert_eq!(
+        colo_id, split_id,
+        "the same tree must yield the same snapshot id"
+    );
+    let colo_bytes = fs::read(manifest_disk(colo.path(), &colo_id)).expect("colo manifest");
+    let split_bytes = fs::read(manifest_disk(manifests.path(), &split_id)).expect("split manifest");
+    assert_eq!(
+        colo_bytes, split_bytes,
+        "the manifest bytes must be byte-for-byte identical to the colocated store"
+    );
+}
+
+#[test]
+fn split_get_manifest_reads_from_manifests_location_and_id_verifies() {
+    // SPEC: manifest ops route to the manifests store; get_manifest round-trips
+    // and the stored bytes hash back to the id (StreamStore/Store contract).
+    let objects = TempDir::new("getm-obj");
+    let manifests = TempDir::new("getm-man");
+    let src = TempDir::new("getm-src");
+    let (manifest, id) = build_tree(src.path(), &[("f", b"F\n")]);
+
+    let store = split_over(objects.path(), manifests.path());
+    store.push(&manifest, src.path()).expect("push");
+
+    let got = store.get_manifest(&id).expect("get_manifest");
+    assert_eq!(got.to_string(), manifest.to_string());
+}
+
+// ===========================================================================
+// STREAMSTORE OBJECT-LEVEL ROUTING
+// ===========================================================================
+
+#[test]
+fn split_stream_put_get_has_object_route_to_objects_pool() {
+    // SPEC: has_object/get_object/put_object route to the OBJECTS store.
+    let objects = TempDir::new("stream-obj");
+    let manifests = TempDir::new("stream-man");
+    let store = split_over(objects.path(), manifests.path());
+
+    let bytes = b"streamed payload\n".to_vec();
+    let sum = Blake3Hasher::new().hash_hex(&bytes);
+
+    assert!(!store.has_object(&sum).expect("has before"));
+    store.put_object(&sum, bytes.clone()).expect("put_object");
+    assert!(store.has_object(&sum).expect("has after"));
+    assert_eq!(store.get_object(&sum).expect("get_object"), bytes);
+
+    // The blob physically landed in the OBJECTS pool, not the manifests side.
+    assert!(object_disk(objects.path(), &sum).is_file());
+    assert!(!object_disk(manifests.path(), &sum).exists());
+}
+
+#[test]
+fn split_objects_needed_probes_only_the_objects_pool() {
+    // SPEC: objects_needed routes to the objects store (per-object skip probe).
+    let objects = TempDir::new("needed-obj");
+    let manifests = TempDir::new("needed-man");
+    let store = split_over(objects.path(), manifests.path());
+
+    let present = b"present\n".to_vec();
+    let present_sum = Blake3Hasher::new().hash_hex(&present);
+    let absent_sum = Blake3Hasher::new().hash_hex(b"absent\n");
+    store
+        .put_object(&present_sum, present)
+        .expect("seed present");
+
+    let needed = store
+        .objects_needed(&[present_sum.clone(), absent_sum.clone()])
+        .expect("objects_needed");
+    assert_eq!(
+        needed,
+        vec![absent_sum],
+        "objects_needed must report exactly the blob absent from the OBJECTS pool, \
+         preserving input order"
+    );
+}
+
+#[test]
+fn split_objects_needed_fails_closed_on_invalid_checksum() {
+    // SPEC/StreamStore contract: a malformed checksum is a hard error, answered
+    // before any probe (fail closed) — the split wrapper must not weaken this.
+    let objects = TempDir::new("needfc-obj");
+    let manifests = TempDir::new("needfc-man");
+    let store = split_over(objects.path(), manifests.path());
+
+    let err = store
+        .objects_needed(&["not-hex".to_string()])
+        .expect_err("invalid checksum must error");
+    assert!(matches!(err, StoreError::Backend { .. }), "got {err:?}");
+}
+
+// ===========================================================================
+// FAILURE MODES / EDGE CASES
+// ===========================================================================
+
+#[test]
+fn split_fetch_errors_when_manifest_present_but_object_missing() {
+    // SPEC failure mode: a manifest present but a referenced object missing must
+    // ERROR — never a silent half-snapshot.
+    let objects = TempDir::new("miss-obj");
+    let manifests = TempDir::new("miss-man");
+    let src = TempDir::new("miss-src");
+    let dest = TempDir::new("miss-dest");
+    let (manifest, id) = build_tree(src.path(), &[("needed", b"payload\n")]);
+
+    let store = split_over(objects.path(), manifests.path());
+    store.push(&manifest, src.path()).expect("push");
+
+    // Delete the object from the pool but KEEP the manifest in its location.
+    let sum = Blake3Hasher::new().hash_hex(b"payload\n");
+    fs::remove_file(object_disk(objects.path(), &sum)).expect("remove object");
+    assert!(manifest_disk(manifests.path(), &id).is_file());
+
+    let err = store
+        .fetch_files(&manifest, dest.path())
+        .expect_err("fetch with a missing object must ERROR");
+    assert!(
+        matches!(err, StoreError::ObjectNotFound { .. }),
+        "expected ObjectNotFound, got {err:?}"
+    );
+    // No half-snapshot: the would-be file must NOT exist at dest.
+    assert!(
+        !dest.path().join("needed").exists(),
+        "a failed fetch must not leave a partial materialized file"
+    );
+}
+
+#[test]
+fn split_get_object_rejects_corrupted_blob_on_read() {
+    // SPEC failure mode: a corrupted/edited blob fails BLAKE3 verification on
+    // read (StreamStore verify-on-read, preserved through the split wrapper).
+    let objects = TempDir::new("corrupt-obj");
+    let manifests = TempDir::new("corrupt-man");
+    let store = split_over(objects.path(), manifests.path());
+
+    let bytes = b"genuine\n".to_vec();
+    let sum = Blake3Hasher::new().hash_hex(&bytes);
+    store.put_object(&sum, bytes).expect("put_object");
+
+    // Tamper the on-disk blob in the objects pool.
+    fs::write(object_disk(objects.path(), &sum), b"TAMPERED\n").expect("corrupt");
+
+    let err = store
+        .get_object(&sum)
+        .expect_err("corrupt blob must fail verification");
+    assert!(matches!(err, StoreError::Integrity { .. }), "got {err:?}");
+}
+
+#[test]
+fn split_fetch_corrupted_blob_surfaces_integrity_error() {
+    // SPEC failure mode: a corrupted blob must not silently materialize through
+    // fetch_files — the BLAKE3 check guards the whole-tree read too.
+    let objects = TempDir::new("fcorrupt-obj");
+    let manifests = TempDir::new("fcorrupt-man");
+    let src = TempDir::new("fcorrupt-src");
+    let dest = TempDir::new("fcorrupt-dest");
+    let (manifest, _id) = build_tree(src.path(), &[("doc", b"the real bytes\n")]);
+
+    let store = split_over(objects.path(), manifests.path());
+    store.push(&manifest, src.path()).expect("push");
+
+    let sum = Blake3Hasher::new().hash_hex(b"the real bytes\n");
+    fs::write(object_disk(objects.path(), &sum), b"evil\n").expect("corrupt");
+
+    let err = store
+        .fetch_files(&manifest, dest.path())
+        .expect_err("fetch of a corrupt blob must error");
+    assert!(
+        matches!(err, StoreError::Integrity { .. } | StoreError::Io(_)),
+        "expected Integrity (corruption) error, got {err:?}"
+    );
+}
+
+#[test]
+fn split_fetch_files_into_clashing_destination_does_not_silently_corrupt() {
+    // SPEC failure mode: fetch_files into a non-empty / clashing destination.
+    // A pre-existing WRONG file at the target path must end up either repaired
+    // to the manifest content or surfaced as an error — never left as the stale
+    // clashing bytes silently passed off as the snapshot.
+    let objects = TempDir::new("clash-obj");
+    let manifests = TempDir::new("clash-man");
+    let src = TempDir::new("clash-src");
+    let dest = TempDir::new("clash-dest");
+    let (manifest, _id) = build_tree(src.path(), &[("file", b"correct content\n")]);
+
+    let store = split_over(objects.path(), manifests.path());
+    store.push(&manifest, src.path()).expect("push");
+
+    // Pre-populate dest with WRONG content at the clashing path.
+    fs::write(dest.path().join("file"), b"STALE WRONG BYTES\n").expect("seed clash");
+
+    let result = store.fetch_files(&manifest, dest.path());
+    match result {
+        Ok(()) => {
+            let got = fs::read(dest.path().join("file")).expect("read materialized");
+            assert_eq!(
+                got, b"correct content\n",
+                "a clashing destination file must be repaired to the manifest content, \
+                 never left as stale bytes"
+            );
+        }
+        Err(e) => {
+            // Refusing to overwrite is acceptable; silently keeping stale bytes
+            // (Ok with wrong content) is the failure this test forbids.
+            assert!(
+                matches!(
+                    e,
+                    StoreError::Io(_) | StoreError::Backend { .. } | StoreError::Integrity { .. }
+                ),
+                "unexpected error kind for clashing dest: {e:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn split_empty_tree_pushes_no_objects_and_roundtrips() {
+    // SPEC edge case: empty tree. A manifest with only the root directory entry
+    // (no files) must push with ZERO objects and fetch into an existing dest.
+    let objects = TempDir::new("empty-obj");
+    let manifests = TempDir::new("empty-man");
+    let src = TempDir::new("empty-src");
+    let dest = TempDir::new("empty-dest");
+    let (manifest, id) = build_tree(src.path(), &[]);
+
+    let store = split_over(objects.path(), manifests.path());
+    store.push(&manifest, src.path()).expect("push empty");
+
+    assert_eq!(
+        count_objects(objects.path()),
+        0,
+        "an empty tree must upload zero objects"
+    );
+    assert!(
+        manifest_disk(manifests.path(), &id).is_file(),
+        "the empty-tree manifest must still be written"
+    );
+    store
+        .fetch_files(&manifest, dest.path())
+        .expect("fetch empty");
+    assert_eq!(
+        store.get_manifest(&id).expect("get").to_string(),
+        manifest.to_string()
+    );
+}
+
+#[test]
+fn split_duplicate_content_files_dedupe_to_one_object() {
+    // SPEC edge case: duplicate-content files dedupe to a single object.
+    let objects = TempDir::new("dup-obj");
+    let manifests = TempDir::new("dup-man");
+    let src = TempDir::new("dup-src");
+    let dest = TempDir::new("dup-dest");
+    let dup: &[u8] = b"identical payload\n";
+    let (manifest, _id) = build_tree(
+        src.path(),
+        &[("first", dup), ("second", dup), ("dir/third", dup)],
+    );
+
+    let store = split_over(objects.path(), manifests.path());
+    store.push(&manifest, src.path()).expect("push");
+
+    assert_eq!(
+        count_objects(objects.path()),
+        1,
+        "three files with identical content must dedupe to exactly ONE object"
+    );
+
+    // Round-trip still materializes all three distinct paths byte-identically.
+    store.fetch_files(&manifest, dest.path()).expect("fetch");
+    for rel in ["first", "second", "dir/third"] {
+        assert_eq!(fs::read(dest.path().join(rel)).unwrap(), dup, "{rel}");
+    }
+}
+
+#[test]
+fn split_interrupted_push_leaves_no_manifest_at_manifests_location() {
+    // SPEC failure mode: an interrupted push (an object write fails mid-way)
+    // leaves NO manifest at the manifests location (objects-before-manifest,
+    // all-or-nothing). We force the object copy to fail by deleting the SOURCE
+    // file the push must read from, AFTER building the manifest.
+    let objects = TempDir::new("intr-obj");
+    let manifests = TempDir::new("intr-man");
+    let src = TempDir::new("intr-src");
+    let (manifest, id) = build_tree(
+        src.path(),
+        &[("good", b"good bytes\n"), ("doomed", b"doomed bytes\n")],
+    );
+
+    // Remove a source file so the object copy fails mid-push.
+    fs::remove_file(src.path().join("doomed")).expect("remove source");
+
+    let store = split_over(objects.path(), manifests.path());
+    let result = store.push(&manifest, src.path());
+    assert!(
+        result.is_err(),
+        "a push whose source object is missing must fail, not silently succeed"
+    );
+
+    // The crux: NO manifest may be observable at the manifests location after a
+    // failed (interrupted) push.
+    assert!(
+        !manifest_disk(manifests.path(), &id).exists(),
+        "an interrupted push must leave NO manifest at the manifests location"
+    );
+}
+
+#[test]
+fn split_push_skips_objects_already_in_pool_then_writes_manifest_last() {
+    // SPEC: per-object skip probed on objects.has_object; manifest written LAST.
+    // Pre-seed ONE of the two objects directly into the pool, then push: the
+    // pre-seeded blob is skipped, the other is uploaded, and the manifest lands.
+    let objects = TempDir::new("skip-obj");
+    let manifests = TempDir::new("skip-man");
+    let src = TempDir::new("skip-src");
+    let (manifest, id) = build_tree(
+        src.path(),
+        &[("seeded", b"seed me\n"), ("fresh", b"fresh me\n")],
+    );
+
+    let store = split_over(objects.path(), manifests.path());
+    let seeded = b"seed me\n".to_vec();
+    let seeded_sum = Blake3Hasher::new().hash_hex(&seeded);
+    store.put_object(&seeded_sum, seeded).expect("pre-seed");
+    assert_eq!(count_objects(objects.path()), 1);
+
+    store.push(&manifest, src.path()).expect("push");
+
+    // Both objects now present, manifest written last.
+    assert_eq!(
+        count_objects(objects.path()),
+        2,
+        "fresh object must be uploaded"
+    );
+    let fresh_sum = Blake3Hasher::new().hash_hex(b"fresh me\n");
+    assert!(object_disk(objects.path(), &fresh_sum).is_file());
+    assert!(
+        manifest_disk(manifests.path(), &id).is_file(),
+        "the manifest must be written LAST after objects land"
+    );
+}
+
+#[test]
+fn split_manifest_fast_path_probes_the_manifests_side_not_the_pool() {
+    // SPEC: the manifest-present fast-path is probed on the MANIFESTS side. If
+    // the manifest already exists at the manifests location, a re-push must be a
+    // no-op even when the objects pool is missing the blobs (the fast path must
+    // not depend on the pool). Conversely it must NOT be fooled by a manifest of
+    // the SAME id sitting only in the objects pool.
+    let objects = TempDir::new("fast-obj");
+    let manifests = TempDir::new("fast-man");
+    let src = TempDir::new("fast-src");
+    let (manifest, id) = build_tree(src.path(), &[("only", b"only file\n")]);
+
+    let store = split_over(objects.path(), manifests.path());
+    store.push(&manifest, src.path()).expect("first push");
+
+    // Wipe the objects pool entirely; the manifest still lives on the manifests
+    // side, so a second push must short-circuit (skip-if-present) without
+    // erroring on the now-empty pool.
+    fs::remove_dir_all(objects.path().join(".objects")).ok();
+    store
+        .push(&manifest, src.path())
+        .expect("re-push must be a manifest-side no-op fast path");
+    assert_eq!(
+        count_objects(objects.path()),
+        0,
+        "the manifest fast path must not re-touch the objects pool"
+    );
+    assert!(manifest_disk(manifests.path(), &id).is_file());
+}
+
+#[test]
+fn split_get_manifest_missing_id_maps_to_manifest_not_found() {
+    // SPEC/Store contract: an absent manifest id on the manifests side surfaces
+    // ManifestNotFound (routed to the manifests store, not the pool).
+    let objects = TempDir::new("nfm-obj");
+    let manifests = TempDir::new("nfm-man");
+    let store = split_over(objects.path(), manifests.path());
+
+    let missing = "abcdef0123456789abcdef0123456789abcdef0123456789abcdef0123456789";
+    match store.get_manifest(missing) {
+        Err(StoreError::ManifestNotFound { id }) => assert_eq!(id, missing),
+        other => panic!("expected ManifestNotFound, got {other:?}"),
+    }
+}
+
+#[test]
+fn split_put_manifest_routes_to_manifests_side_objects_pool_unaffected() {
+    // SPEC: put_manifest (StreamStore) routes to the manifests location; it must
+    // not write into the objects pool.
+    let objects = TempDir::new("pm-obj");
+    let manifests = TempDir::new("pm-man");
+    let src = TempDir::new("pm-src");
+    let (manifest, id) = build_tree(src.path(), &[("g", b"G\n")]);
+
+    let store = split_over(objects.path(), manifests.path());
+    store.put_manifest(&id, &manifest).expect("put_manifest");
+
+    assert!(
+        manifest_disk(manifests.path(), &id).is_file(),
+        "put_manifest must write to the MANIFESTS location"
+    );
+    assert!(
+        !manifest_disk(objects.path(), &id).exists(),
+        "put_manifest must NOT write into the objects pool"
+    );
+}
+
+#[test]
+fn split_put_object_rejects_blob_not_matching_its_address() {
+    // SPEC/StreamStore contract: put_object verifies BEFORE writing — a blob
+    // whose bytes do not hash to `checksum` stores nothing. The split wrapper
+    // must preserve this on the objects-pool side.
+    let objects = TempDir::new("badput-obj");
+    let manifests = TempDir::new("badput-man");
+    let store = split_over(objects.path(), manifests.path());
+
+    let wrong_address = Blake3Hasher::new().hash_hex(b"the address bytes\n");
+    let err = store
+        .put_object(&wrong_address, b"DIFFERENT bytes\n".to_vec())
+        .expect_err("mismatched put must error");
+    assert!(matches!(err, StoreError::Integrity { .. }), "got {err:?}");
+    assert!(
+        !object_disk(objects.path(), &wrong_address).exists(),
+        "nothing may be stored when the blob fails its address check"
+    );
+}
+
+// ===========================================================================
+// REVIEW-GATE STRENGTHENING (phase 28, split-store-tests-review)
+//
+// The implementation is now visible (src/split.rs). The black-box suite above
+// could only inject a mid-push failure by deleting a SOURCE file (the
+// `std::fs::read` arm). These tests reach the OTHER failure arm the impl
+// exposes — a pool whose `put_object` itself rejects a blob — plus the precise
+// routing/contract clauses the now-visible delegation reveals. They use a
+// fault-injecting `StreamStore` double that wraps a real `FileStore` objects
+// pool, which only the visible constructor (`SplitStore::new` over any
+// `impl StreamStore + Sync + 'static`) makes possible to assemble.
+// ===========================================================================
+
+use std::sync::atomic::AtomicUsize;
+
+use snapdir_core::store::Store as _StoreTrait;
+
+/// A `StreamStore` that delegates everything to an inner `FileStore` EXCEPT it
+/// makes `put_object` fail (`StoreError::Backend`) for one specific checksum,
+/// and counts how many `put_object` calls landed. Lets us inject a mid-push
+/// failure in the objects-pool `put_object` itself (the SPEC's "mid-push
+/// failure" seam) and assert no manifest lands on the manifests side.
+struct FailingPool {
+    inner: FileStore,
+    fail_checksum: String,
+    puts_attempted: AtomicUsize,
+    puts_succeeded: AtomicUsize,
+}
+
+impl FailingPool {
+    fn new(root: &Path, fail_checksum: &str) -> Self {
+        Self {
+            inner: FileStore::from_root(root.to_path_buf()),
+            fail_checksum: fail_checksum.to_string(),
+            puts_attempted: AtomicUsize::new(0),
+            puts_succeeded: AtomicUsize::new(0),
+        }
+    }
+}
+
+impl _StoreTrait for FailingPool {
+    fn get_manifest(&self, id: &str) -> Result<Manifest, StoreError> {
+        self.inner.get_manifest(id)
+    }
+    fn fetch_files(&self, manifest: &Manifest, dest: &Path) -> Result<(), StoreError> {
+        self.inner.fetch_files(manifest, dest)
+    }
+    fn push(&self, manifest: &Manifest, source: &Path) -> Result<(), StoreError> {
+        self.inner.push(manifest, source)
+    }
+}
+
+impl StreamStore for FailingPool {
+    fn has_object(&self, checksum: &str) -> Result<bool, StoreError> {
+        self.inner.has_object(checksum)
+    }
+    fn get_object(&self, checksum: &str) -> Result<Vec<u8>, StoreError> {
+        self.inner.get_object(checksum)
+    }
+    fn put_object(&self, checksum: &str, bytes: Vec<u8>) -> Result<(), StoreError> {
+        self.puts_attempted.fetch_add(1, Ordering::Relaxed);
+        if checksum == self.fail_checksum {
+            return Err(StoreError::Backend {
+                message: format!("injected put_object failure for {checksum}"),
+                source: None,
+            });
+        }
+        self.inner.put_object(checksum, bytes)?;
+        self.puts_succeeded.fetch_add(1, Ordering::Relaxed);
+        Ok(())
+    }
+    fn put_manifest(&self, id: &str, manifest: &Manifest) -> Result<(), StoreError> {
+        self.inner.put_manifest(id, manifest)
+    }
+}
+
+#[test]
+fn split_put_object_failure_midpush_leaves_no_manifest_and_aborts() {
+    // SPEC mid-push failure (objects-before-manifest + all-or-nothing): when the
+    // objects-pool `put_object` itself REJECTS a blob mid-push, the push must
+    // error and NO manifest may land at the manifests location. This exercises
+    // the `self.objects.put_object(...)?` early-return arm in src/split.rs that
+    // the source-deletion test cannot reach.
+    let objects = TempDir::new("putfail-obj");
+    let manifests = TempDir::new("putfail-man");
+    let src = TempDir::new("putfail-src");
+    // Two distinct file objects; we poison the second one's address.
+    let (manifest, id) = build_tree(
+        src.path(),
+        &[("ok", b"good content\n"), ("bad", b"poison content\n")],
+    );
+    let poison_sum = Blake3Hasher::new().hash_hex(b"poison content\n");
+
+    let pool = FailingPool::new(objects.path(), &poison_sum);
+    let mani = FileStore::from_root(manifests.path().to_path_buf());
+    let store = SplitStore::new(pool, mani);
+
+    let err = store
+        .push(&manifest, src.path())
+        .expect_err("a put_object failure mid-push must abort the push");
+    assert!(matches!(err, StoreError::Backend { .. }), "got {err:?}");
+
+    // The crux: NO manifest may be observable at the manifests location.
+    assert!(
+        !manifest_disk(manifests.path(), &id).exists(),
+        "a push that fails in put_object must leave NO manifest (all-or-nothing)"
+    );
+    // And get_manifest must still report it absent (not a half-written slot).
+    assert!(
+        matches!(
+            store.get_manifest(&id),
+            Err(StoreError::ManifestNotFound { .. })
+        ),
+        "no snapshot may resolve after an interrupted push"
+    );
+}
+
+#[test]
+fn split_objects_needed_routes_to_pool_not_manifests_and_keeps_duplicates() {
+    // SPEC: objects_needed delegates to the OBJECTS pool (not manifests) and
+    // preserves the order-preserving / NO-dedup contract. Pins the
+    // `self.objects.objects_needed(checksums)` delegation in src/split.rs: an
+    // object present ONLY on the manifests side must still be reported needed
+    // (proves routing), and an absent checksum supplied TWICE is reported twice.
+    let objects = TempDir::new("needroute-obj");
+    let manifests = TempDir::new("needroute-man");
+    let store = split_over(objects.path(), manifests.path());
+
+    let in_pool = b"lives in pool\n".to_vec();
+    let in_pool_sum = Blake3Hasher::new().hash_hex(&in_pool);
+    // Seed a blob ONLY into the manifests-side store's object pool. If the split
+    // wrongly probed the manifests side, it would (incorrectly) treat this as
+    // present.
+    let decoy = b"decoy in manifests pool\n".to_vec();
+    let decoy_sum = Blake3Hasher::new().hash_hex(&decoy);
+    FileStore::from_root(manifests.path().to_path_buf())
+        .put_object(&decoy_sum, decoy)
+        .expect("seed decoy on manifests side");
+
+    store.put_object(&in_pool_sum, in_pool).expect("seed pool");
+
+    // Order: present-in-pool, decoy (present only on manifests side -> needed),
+    // decoy again (duplicate must be reported twice, no dedup).
+    let needed = store
+        .objects_needed(&[in_pool_sum.clone(), decoy_sum.clone(), decoy_sum.clone()])
+        .expect("objects_needed");
+    assert_eq!(
+        needed,
+        vec![decoy_sum.clone(), decoy_sum],
+        "objects_needed must probe the OBJECTS pool only (decoy on the manifests \
+         side is still needed) and preserve duplicates in input order"
+    );
+}
+
+#[test]
+fn split_fetch_reads_objects_from_pool_regardless_of_which_manifests_side() {
+    // SPEC: fetch_files reads object blobs from the OBJECTS pool while the
+    // manifest is sourced independently. Push to a SHARED pool under manifests
+    // location A, then build a SECOND SplitStore reusing the SAME pool but a
+    // FRESH (empty) manifests side, write the manifest there, and fetch: the
+    // objects must still materialize from the shared pool. Pins that
+    // `fetch_files` delegates to `self.objects` and is decoupled from the
+    // manifests routing.
+    let objects = TempDir::new("fetchroute-obj");
+    let man_a = TempDir::new("fetchroute-man-a");
+    let man_b = TempDir::new("fetchroute-man-b");
+    let src = TempDir::new("fetchroute-src");
+    let dest = TempDir::new("fetchroute-dest");
+    let (manifest, id) = build_tree(
+        src.path(),
+        &[
+            ("alpha", b"alpha bytes\n"),
+            ("beta/gamma", b"gamma bytes\n"),
+        ],
+    );
+
+    // First store: objects land in the shared pool; manifest lands at A.
+    let store_a = split_over(objects.path(), man_a.path());
+    store_a.push(&manifest, src.path()).expect("push to A");
+
+    // Second store: SAME pool, a DIFFERENT empty manifests side. Replicate just
+    // the manifest object there (as a store-to-store copy would).
+    let store_b = split_over(objects.path(), man_b.path());
+    store_b
+        .put_manifest(&id, &manifest)
+        .expect("replicate manifest to B");
+
+    // B has the manifest and shares the pool, so fetch must succeed entirely
+    // from the shared pool's blobs.
+    store_b
+        .fetch_files(&manifest, dest.path())
+        .expect("fetch via B must read objects from the shared pool");
+    assert_eq!(
+        fs::read(dest.path().join("alpha")).unwrap(),
+        b"alpha bytes\n"
+    );
+    assert_eq!(
+        fs::read(dest.path().join("beta/gamma")).unwrap(),
+        b"gamma bytes\n"
+    );
+}
+
+#[test]
+fn split_get_manifest_ignores_a_decoy_manifest_in_the_objects_pool() {
+    // SPEC routing: get_manifest is answered ONLY by the manifests side. A
+    // manifest of the SAME id sitting in the OBJECTS pool's `.manifests` must
+    // NOT satisfy get_manifest — the pool is never consulted for manifests.
+    // Pins `self.manifests.get_manifest(id)` in src/split.rs against being
+    // fooled by a pool-side decoy.
+    let objects = TempDir::new("decoym-obj");
+    let manifests = TempDir::new("decoym-man");
+    let src = TempDir::new("decoym-src");
+    let (manifest, id) = build_tree(src.path(), &[("only", b"only bytes\n")]);
+
+    // Plant the manifest ONLY in the objects-pool store, NOT the manifests side.
+    FileStore::from_root(objects.path().to_path_buf())
+        .put_manifest(&id, &manifest)
+        .expect("plant decoy manifest in pool");
+
+    let store = split_over(objects.path(), manifests.path());
+    assert!(
+        matches!(
+            store.get_manifest(&id),
+            Err(StoreError::ManifestNotFound { .. })
+        ),
+        "get_manifest must ignore a manifest present only in the objects pool"
+    );
+
+    // And the skip-if-present push fast path must likewise NOT be satisfied by
+    // the pool-side decoy: a real push must still write the manifest to the
+    // manifests side.
+    store.push(&manifest, src.path()).expect("push");
+    assert!(
+        manifest_disk(manifests.path(), &id).is_file(),
+        "push must write the manifest to the manifests side despite the pool decoy"
+    );
+}
+
+#[test]
+fn split_fetch_corrupted_blob_retries_then_surfaces_integrity() {
+    // SPEC: fetch_files inherits the objects backend's verify-retry discipline
+    // (copy -> BLAKE3-verify -> retry up to N -> error), reading blobs from the
+    // POOL. A blob corrupted in the shared pool must NOT silently materialize
+    // through the split's fetch delegation; it must surface an Integrity/Io
+    // error and leave no good file at dest. Complements the black-box corruption
+    // test by pinning that the retry/verify path runs on the POOL side via the
+    // split delegation, with the manifest sourced from the manifests side.
+    let objects = TempDir::new("fretry-obj");
+    let manifests = TempDir::new("fretry-man");
+    let src = TempDir::new("fretry-src");
+    let dest = TempDir::new("fretry-dest");
+    let (manifest, id) = build_tree(src.path(), &[("payload", b"authentic bytes\n")]);
+
+    let store = split_over(objects.path(), manifests.path());
+    store.push(&manifest, src.path()).expect("push");
+    // Confirm the manifest is genuinely on the manifests side (decoupled source).
+    assert!(manifest_disk(manifests.path(), &id).is_file());
+
+    // Corrupt the blob in the POOL after a valid push.
+    let sum = Blake3Hasher::new().hash_hex(b"authentic bytes\n");
+    fs::write(object_disk(objects.path(), &sum), b"corrupted!\n").expect("corrupt pool blob");
+
+    let err = store
+        .fetch_files(&manifest, dest.path())
+        .expect_err("a corrupt pool blob must fail fetch, not materialize");
+    assert!(
+        matches!(err, StoreError::Integrity { .. } | StoreError::Io(_)),
+        "expected Integrity/Io from the pool verify-retry, got {err:?}"
+    );
+    // The corrupted bytes must NEVER be passed off as the snapshot file.
+    if let Ok(got) = fs::read(dest.path().join("payload")) {
+        assert_ne!(
+            got, b"corrupted!\n",
+            "corrupted pool bytes must never be materialized at dest"
+        );
+    }
+}

--- a/crates/snapdir/Cargo.toml
+++ b/crates/snapdir/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 # is the flagship-named shim so `cargo install snapdir` installs the binary.
 # Path+version dep (not [workspace.dependencies]): only this crate consumes
 # it, and an unused workspace-level entry would be flagged by cargo-shear.
-snapdir-cli = { path = "../snapdir-cli", version = "1.6.0" }
+snapdir-cli = { path = "../snapdir-cli", version = "1.7.0" }
 
 [lints]
 workspace = true

--- a/crates/snapdir/README.md
+++ b/crates/snapdir/README.md
@@ -67,6 +67,55 @@ The cloud backends are built in — native SDKs and standard credential chains,
 no bespoke env vars, no CLI shell-outs. The `ssh://` and `sftp://` stores ship
 as two external-store binaries; `cargo install snapdir-ssh-store` provides both.
 
+On the receiving side of an accelerated `ssh://` push, `SNAPDIR_FSYNC` controls
+crash durability: `batch` (the default) fsyncs every received object before
+committing the manifest, so a crash mid-receive can never leave a manifest
+pointing at objects that aren't durably on disk. That safety costs ~20% on a
+small-files receive (measured v1 +19.5% / zstd +29.9% on 5,000 × 4 KiB on
+Linux); `SNAPDIR_FSYNC=off` is faster but not crash-safe. The cost is on the
+receive-pack path only — the ordinary `file://`/S3/GCS push path is unaffected.
+
+## Scheduled inventories — one object pool, many manifests
+
+A snapshot's manifest and its content objects don't have to live together. The
+global `--objects-store` / `$SNAPDIR_OBJECTS_STORE` flag routes **objects** to
+one shared pool's `.objects/`, while **manifests** go wherever `--store` points
+(`.manifests/`). One pool, many manifest locations — and the caller owns the
+layout (by date, host, or environment):
+
+```sh
+# Cron: a new manifest path per run, all sharing ONE object pool.
+snapdir push \
+  --objects-store s3://inventory/objects \
+  --store "s3://inventory/manifests/$(date +%Y/%m/%d)" \
+  /var/lib/app/data
+```
+
+Objects are content-addressed, so re-pushing to the same pool only costs the
+**changed bytes** — unchanged objects are skipped. Scheduled inventories of
+mostly-static data are therefore cheap. Leave `--objects-store` unset and
+behavior is byte-for-byte unchanged.
+
+For **bucket-to-bucket** copies, `snapdir sync --from-objects/--to-objects`
+names an explicit object pool per side — source and destination can be different
+buckets, and objects already present in the destination pool are skipped.
+
+`snapdir diff` compares two sides — each a **set of manifest locations**
+(`--from`/`--to`, both repeatable and unioned per side) — and reports file-level
+changes (`A`/`D`/`M`). It **reads manifests only**, never downloading an object,
+so diffing across scheduled inventories is cheap:
+
+```sh
+snapdir diff \
+  --from s3://inventory/manifests/2026/06/10 \
+  --to   s3://inventory/manifests/2026/06/11
+```
+
+`--all` also lists unchanged paths, `--json` emits a `{status, path}` array,
+`--exit-code` gives git-style exit codes (`1` on any difference), and
+`--on-conflict <error|last-wins>` resolves a same-path/differing-content
+collision when two refs are unioned on one side.
+
 ## Links
 
 - Full documentation — install, command reference, guides, and use cases:

--- a/docs/adr/0000-index.md
+++ b/docs/adr/0000-index.md
@@ -8,12 +8,13 @@ Records use the [MADR](https://adr.github.io/madr/) format. Each record states t
 **Context**, the **Decision**, the **Alternatives considered**, and the
 **Consequences**, plus a short status line. Records are immutable once accepted; a
 later decision that changes course is written as a new record that supersedes the
-earlier one.
+earlier one (see ADR-0024, which supersedes ADR-0001).
 
 ## Index
 
 | ADR | Title | Status |
 | --- | --- | --- |
+| [0001](0001-differential-oracle-methodology.md) | Differential-oracle methodology | Accepted (superseded by 0024) |
 | [0002](0002-manifest-format-freeze.md) | Freeze the manifest format and on-disk layout | Accepted |
 | [0003](0003-snapshot-id-is-blake3-of-manifest-text.md) | Snapshot ID is BLAKE3 of the `#`-stripped manifest text | Accepted |
 | [0004](0004-ring-tls-provider.md) | Use the `ring` rustls provider, ban aws-lc-rs | Accepted |
@@ -29,10 +30,14 @@ earlier one.
 | [0014](0014-remove-verify-purge.md) | Remove `verify --purge` | Accepted |
 | [0015](0015-all-14-subcommands-wired.md) | Wire all 14 CLI subcommands, no stubs | Accepted |
 | [0016](0016-rust-only-public-docs.md) | Rust-only public documentation | Accepted |
+| [0017](0017-gatesmith-pm-orchestration.md) | Gatesmith PM orchestration model | Accepted |
+| [0018](0018-no-false-passes.md) | No false passes: every checkpoint has a machine check | Accepted |
+| [0019](0019-frozen-interface-sha-locks.md) | Frozen-interface SHA locks | Accepted |
+| [0020](0020-interop-diff-keystone-gate.md) | Interop-diff keystone gate | Accepted |
 | [0021](0021-performance-secondary-to-correctness.md) | Performance is secondary to byte-identical output | Accepted |
 | [0022](0022-testing-strategy.md) | Testing strategy: proptest, trycmd, cargo-fuzz | Accepted |
-| [0023](0023-b2-scope-rust-and-format-compat.md) | Scope the B2 interop to Rust round-trip and format compat | Accepted |
-| [0024](0024-retire-the-bash-oracle.md) | Retire the Bash oracle (full cut) | Accepted |
+| [0023](0023-b2-scope-rust-and-format-compat.md) | Scope the B2 interop gate to Rust round-trip and format compat | Accepted |
+| [0024](0024-retire-the-bash-oracle.md) | Retire the Bash oracle (full cut) | Accepted (supersedes 0001) |
 | [0025](0025-keep-native-certs.md) | Keep native-certs in the scratch image | Accepted |
 | [0026](0026-latest-deps-with-release-age-cooldown.md) | Adopt latest deps with a 3-day minimum-release-age | Accepted |
 | [0027](0027-ssh-sftp-stores-system-openssh-wire-plumbing.md) | SSH/SFTP stores via system OpenSSH + wire-versioned plumbing | Accepted |

--- a/docs/adr/0001-differential-oracle-methodology.md
+++ b/docs/adr/0001-differential-oracle-methodology.md
@@ -1,0 +1,42 @@
+# 0001 — Differential-oracle methodology
+
+Status: Accepted (superseded by [ADR-0024](0024-retire-the-bash-oracle.md)), 2026-06
+
+## Context
+
+The goal of the port was byte-for-byte interoperability with the existing Bash
+`snapdir`: identical manifest lines, snapshot IDs, object/manifest keys, and bucket
+layout, so caches and remote stores written by either implementation stay mutually
+readable. A specification document alone was not a sufficient source of truth, because
+the existing public docs carried known bugs (for example `--link` vs `--linked`,
+`verify-transactions` vs `ensure-no-errors`) and several behaviours were only knowable
+by reading the shell.
+
+## Decision
+
+Treat the frozen Bash scripts (`snapdir`, `snapdir-manifest`, the `snapdir-*-store`
+helpers, `snapdir-sqlite3-catalog`) plus `utils/qa-fixtures/` as the executable source
+of truth. Every Rust output was diffed against the live oracle: the manifest/ID
+differential harness drove both implementations over a fixture corpus and compared
+their output with `cmp`; the remote-store harnesses ran cross-tool push/fetch in both
+directions. A divergence from the oracle was a defect in the Rust port, not in the
+spec.
+
+## Alternatives considered
+
+- **Spec-only port.** Rejected: the docs were known-buggy and incomplete, so a
+  spec-driven reimplementation would have encoded the doc bugs.
+- **Manual golden snapshots transcribed once.** Rejected at this stage: static golden
+  values cannot catch behaviours not anticipated by the author. (They become the
+  anchor later — see ADR-0024 — but only after the contract was exhaustively pinned
+  against the live oracle.)
+
+## Consequences
+
+- The Rust implementation was validated against real shell behaviour, catching subtle
+  rules (symlink stat semantics, directory-size summation, sort/dedup hashing).
+- The Bash scripts had to remain frozen and untouched for the duration of the port;
+  they were read-only behavioural references.
+- This methodology was historical: once the contract was fully captured as Rust
+  golden-constant tests and a format SHA-lock, the live oracle was retired
+  (ADR-0024). This record is kept for the historical rationale.

--- a/docs/adr/0002-manifest-format-freeze.md
+++ b/docs/adr/0002-manifest-format-freeze.md
@@ -7,12 +7,12 @@ Status: Accepted, 2026-06
 The manifest is the interoperability boundary of snapdir. Its exact byte layout,
 sort order, checksum rules, and the content-addressable directory layout all had to
 match the Bash oracle so that caches and stores written by either tool remain mutually
-readable. Without an explicit freeze, downstream components (stores, catalog, CLI) would
+readable. Without an explicit freeze, downstream lanes (stores, catalog, CLI) would
 build against a moving target.
 
 ## Decision
 
-Freeze the manifest format and layout once the core hashing was in place, exactly as
+Freeze the manifest format and layout after the core hashing lane landed, exactly as
 read from the Bash source:
 
 - **Manifest line:** `PATH_TYPE PERMISSIONS CHECKSUM SIZE PATH`, single-space
@@ -30,21 +30,19 @@ read from the Bash source:
   `.manifests/<id[0:3]>/<id[3:6]>/<id[6:9]>/<id[9:]>` — a 3-level shard, mirrored in
   the cache and in every store.
 
-The freeze is guarded by the Rust golden tests
-(`crates/snapdir-core/tests/compat_golden.rs`), which assert the frozen byte layout so
-any accidental change to the format-defining code fails the test suite.
+The freeze is recorded in `.gatesmith/manifest-format.sha.lock`, re-verified each
+tick.
 
 ## Alternatives considered
 
 - **A new, cleaner Rust-native format.** Rejected: it would break interoperability,
   which is the hard constraint of the whole port.
-- **Document the format without an enforced guard.** Rejected: golden tests make
-  accidental drift in the core files a hard failure rather than a silent change.
+- **Document the format without a lock.** Rejected: a SHA-lock makes accidental drift
+  in the core files a hard failure rather than a silent change.
 
 ## Consequences
 
-- Downstream components build against an immutable contract.
-- Any change to the frozen byte layout fails the golden tests and requires explicit
-  approval.
+- Downstream lanes build against an immutable contract.
+- Any change to the frozen files trips the SHA-lock and requires explicit approval.
 - The format carries forward a few oracle quirks (octal perms, dir-size summation)
   that are now contractually fixed rather than free to "improve".

--- a/docs/adr/0003-snapshot-id-is-blake3-of-manifest-text.md
+++ b/docs/adr/0003-snapshot-id-is-blake3-of-manifest-text.md
@@ -40,5 +40,5 @@ checksums `dba5865c…` and `4a0732cf…`.
   rustdoc, tests) before the contract was frozen.
 - A dedicated `snapshot_id` function exists rather than reusing the directory-checksum
   path.
-- This was caught precisely because the port diffed against the live oracle rather than
-  trusting the docs.
+- This was caught precisely because the port diffed against the live oracle (ADR-0001)
+  rather than trusting the docs.

--- a/docs/adr/0004-ring-tls-provider.md
+++ b/docs/adr/0004-ring-tls-provider.md
@@ -42,5 +42,5 @@ empty (and likewise no `openssl-sys`).
 - The SDK wiring is more verbose (custom connector, manual provider install) than the
   defaults.
 - `deny.toml` enforces the ban permanently; the `grep -i aws-lc Cargo.lock` empty check
-  runs in CI on every dependency change. (The provider stack was later unified on
+  is part of every dependency-touching gate. (The provider stack was later unified on
   rustls 0.23 / hyper-rustls 0.27 while keeping ring — see ADR-0026.)

--- a/docs/adr/0005-native-in-process-cloud-stores.md
+++ b/docs/adr/0005-native-in-process-cloud-stores.md
@@ -13,10 +13,10 @@ zero runtime dependencies: requiring those external CLIs at runtime would defeat
 Implement all cloud stores in-process using native Rust SDKs: `aws-sdk-s3` for S3 and
 B2, `google-cloud-storage` for GCS. The shipped binary never shells out to `aws`,
 `gcloud`, `b2`, `b3sum`, or `sqlite3`. External system binaries are permitted only in
-the test suite, never in `crates/`. The emit-shell-command shim is retained
-only for third-party external stores, dispatched by the store router.
+the test/oracle harness, never in `crates/`. The emit-shell-command shim is retained
+only for third-party external stores (see ADR-0017's lane map and the store router).
 
-This is proven by a zero-external-dependency test that runs the Rust round-trip
+This is proven by a zero-external-dependency test lane that runs the Rust round-trip
 with `aws`, `b2`, and `gcloud` removed from `PATH` via a sanitized symlink farm.
 
 ## Alternatives considered
@@ -32,4 +32,4 @@ with `aws`, `b2`, and `gcloud` removed from `PATH` via a sanitized symlink farm.
   env vars), simplifying the auth story.
 - The binary depends on the SDK crates and their TLS stack — see ADR-0004 for the
   resulting `ring`/aws-lc constraint.
-- The PATH-sanitized test is a standing guard that no accidental shell-out slips in.
+- The PATH-sanitized lane is a standing guard that no accidental shell-out slips in.

--- a/docs/adr/0013-coverage-floor-75.md
+++ b/docs/adr/0013-coverage-floor-75.md
@@ -4,9 +4,9 @@ Status: Accepted, 2026-06
 
 ## Context
 
-The coverage check was originally hollow: an `echo` plus a manual confirmation over a CI
-job that ran `cargo llvm-cov … --fail-under-lines 0`. A floor of zero enforces nothing,
-and the manual confirmation could mask a regression.
+The coverage gate was originally a hollow check: an `echo` plus a human confirmation
+over a CI job that ran `cargo llvm-cov … --fail-under-lines 0`. A floor of zero enforces
+nothing, and the human-confirm step nearly produced a false pass.
 
 ## Decision
 
@@ -16,25 +16,28 @@ Enforce a real machine-checked line-coverage floor of **75%**:
 cargo llvm-cov --workspace --all-features --locked --fail-under-lines 75 --summary-only
 ```
 
-Both the local check and the GitHub CI coverage job use the same floor (the CI job's
-`--fail-under-lines 0` was changed to `75`). The manual confirmation was dropped in
-favour of the machine check.
+Both the local gate and the GitHub CI coverage job use the same floor (the CI job's
+`--fail-under-lines 0` was changed to `75`). The human-confirm step was dropped in favour
+of the machine check.
 
 ## Alternatives considered
 
 - **`--fail-under-lines 0`** (the prior state). Rejected: enforces nothing.
 - **A higher floor (e.g. 90%).** Rejected for now: the env-gated live cloud paths
-  (s3/gcs/b2 stores) are uncovered hermetically — that interop is exercised by the live
-  integration tests, which are invisible to `llvm-cov`. Measured workspace coverage was
-  ~79%, so 75% is a meaningful floor that does not require credential-bearing CI. The
-  floor was proven real (90 → fail, 75 → pass).
-- **Keep the manual confirmation.** Rejected: a coverage claim must be backed by an
-  automated check, not a manual sign-off that can drift from reality.
+  (s3/gcs/b2 stores) are uncovered hermetically — that interop is exercised by the shell
+  harnesses, which are invisible to `llvm-cov`. Measured workspace coverage was ~79%, so
+  75% is a meaningful floor that does not require credential-bearing CI. The floor was
+  proven real (90 → fail, 75 → pass).
+
+## Alternatives considered (cont.)
+
+- **Keep the human-confirm.** Rejected per ADR-0018 (every checkpoint needs a machine
+  check).
 
 ## Consequences
 
 - Coverage regressions below 75% fail both locally and in CI.
 - The floor accounts for the hermetically-uncovered live-cloud paths, which are covered
-  instead by the live integration tests.
-- Replacing the manual confirmation with a machine check removes a step that could
-  otherwise report a pass without actually measuring coverage.
+  instead by the integration harnesses.
+- This was one of the near-false-passes that motivated the no-false-passes rule
+  (ADR-0018).

--- a/docs/adr/0014-remove-verify-purge.md
+++ b/docs/adr/0014-remove-verify-purge.md
@@ -37,5 +37,5 @@ is unchanged. No cache or store purge is added to `verify`.
 
 - `--purge` has one clear home: `verify-cache`.
 - Users get an actionable error instead of a no-op.
-- `verify` keeps a single, well-defined responsibility: store-side verification, with
-  cache purging handled exclusively by `verify-cache`.
+- The decision was implemented through the gate (a premature direct edit was reverted
+  for traceability — see ADR-0017).

--- a/docs/adr/0015-all-14-subcommands-wired.md
+++ b/docs/adr/0015-all-14-subcommands-wired.md
@@ -9,8 +9,8 @@ The CLI surface reproduces the oracle's orchestrator subcommands: `manifest`, `i
 `locations`, `ancestors`, `revisions`, `defaults`. Mid-port, 7 of these were still CLI
 stubs that printed "not implemented yet", even though the underlying library logic
 already existed (`snapdir-core::cache` had `verify_cache`/`flush_cache`;
-`snapdir-catalog` had `locations`/`ancestors`/`revisions`/`rebuild`). Release was
-conditioned on feature-completeness.
+`snapdir-catalog` had `locations`/`ancestors`/`revisions`/`rebuild`). The release
+sign-off was gated on feature-completeness.
 
 ## Decision
 
@@ -26,8 +26,8 @@ acceptance check guards against vacuous test filters (`running [1-9]`).
 
 ## Alternatives considered
 
-- **Ship with some commands stubbed.** Rejected: the operator required
-  feature-completeness for release; stubs are not a releasable surface.
+- **Ship with some commands stubbed.** Rejected: the operator gated release on
+  feature-completeness; stubs are not a releasable surface.
 - **Drop the unimplemented subcommands from the surface.** Rejected: the surface must
   reproduce the oracle's 14 subcommands for compatibility.
 

--- a/docs/adr/0016-rust-only-public-docs.md
+++ b/docs/adr/0016-rust-only-public-docs.md
@@ -8,8 +8,8 @@ The repository carried a bash-era public documentation set: a Retype website
 (`docs/index.md`, `install.md`, `guide.md`, `authoring-stores.md`,
 `understanding-manifests.md`, per-script readmes, `docs/api/**`, `docs/images/**`,
 `retype.yml`) plus a README and CONTRIBUTING framed around installing and running the
-shell scripts. Those docs also carried known bugs. After the port, this material
-describes a tool that no longer ships.
+shell scripts. Those docs also carried known bugs (ADR-0001). After the port, this
+material describes a tool that no longer ships.
 
 ## Decision
 
@@ -20,7 +20,7 @@ Make the public documentation Rust-only:
 - Rewrite `README.md` (Rust-only, discovery-oriented, no bash-install/script framing,
   no AI/historical reasoning) and `CONTRIBUTING.md` (a Rust contributor guide: cargo
   build/test/fmt/clippy, workspace layout, MSRV, the frozen-oracle note).
-- Keep `docs/rust-port/**` (manifest spec, CHANGELOG, migration guide).
+- Keep `docs/rust-port/**` (PLAN, manifest spec, CHANGELOG, migration guide).
 - Fix the known doc bugs in the Rust docs (`--linked` not `--link`; `ensure-no-errors`
   not `verify-transactions`).
 
@@ -31,7 +31,7 @@ The frozen oracle scripts themselves are never edited — only their docs.
 - **Maintain the bash-era docs alongside the Rust docs.** Rejected: they describe a
   retired tool and would mislead users.
 - **Delete all docs and start over.** Rejected: `docs/rust-port/**` (spec, migration
-  guide, CHANGELOG) is the accurate, transitional documentation and is kept.
+  guide, changelog) is the accurate, transitional documentation and is kept.
 
 ## Consequences
 

--- a/docs/adr/0017-gatesmith-pm-orchestration.md
+++ b/docs/adr/0017-gatesmith-pm-orchestration.md
@@ -1,0 +1,42 @@
+# 0017 — Gatesmith PM orchestration model
+
+Status: Accepted, 2026-06
+
+## Context
+
+The port is a large, multi-component effort (core, catalog, stores, CLI, tests, CI,
+benches, docs, packaging) with a hard interop contract. It needs an execution model that
+keeps changes traceable, prevents scope creep across components, and does not let
+under-verified work be marked done.
+
+## Decision
+
+Drive the port with the **Gatesmith** project-management model: a deterministic gate
+ledger executed one tick at a time.
+
+- Work is decomposed into **gates** with explicit dependencies, an owning **lane**, and
+  a machine-checkable **pass-criteria** DSL (exit codes, regex matches).
+- Each tick spawns **at most one teammate** for one gate; the teammate stays inside its
+  **lane** (a fenced set of files). An out-of-lane diff fails the fence.
+- The PM verifies the pass-criteria and only then commits; teammates never commit.
+- Frozen interfaces are protected by **SHA locks** re-verified each tick (ADR-0019).
+- The model forbids **false passes**: every human checkpoint must be backed by a machine
+  check (ADR-0018).
+
+The plan ledger is itself the authoritative plan; the journal is an append-only audit
+log written before any gate mutation.
+
+## Alternatives considered
+
+- **Ad-hoc multi-file edits.** Rejected: no lane fences, no traceability, easy scope
+  creep across the interop boundary.
+- **Trust human sign-off alone.** Rejected: human-confirm-only gates produced near
+  false passes (ADR-0018).
+
+## Consequences
+
+- Every change is attributable to a gate, an owner, a commit, and evidence.
+- Lane fences kept the frozen oracle and `crates/**` boundaries intact (e.g. a premature
+  PM hand-edit was reverted so the change could go through its gate — ADR-0014).
+- The discipline added overhead (gate authoring, lane routing) in exchange for
+  traceability and no silent drift.

--- a/docs/adr/0018-no-false-passes.md
+++ b/docs/adr/0018-no-false-passes.md
@@ -1,0 +1,41 @@
+# 0018 — No false passes: every checkpoint has a machine check
+
+Status: Accepted, 2026-06
+
+## Context
+
+Two gates nearly passed without verifying anything. The `remote-interop` gate's
+verification was an `echo` followed by a lone human-confirm — a "Yes, all passed" with
+zero evidence almost became a recorded pass; the operator flagged it
+("I DON'T KNOW, YOU HAVE TO VERIFY"). The `coverage-gate` was an `echo` plus a
+human-confirm over a CI job with a `--fail-under-lines 0` floor that enforced nothing
+(ADR-0013).
+
+## Decision
+
+Adopt a hard rule: **no false passes**. Every human checkpoint must be backed by a
+machine check that actually exercises the thing being signed off.
+
+- `remote-interop` was changed to run a live differential harness (MinIO S3 Bash↔Rust
+  cross-tool plus a zero-external-dependency lane), asserting `exit_code 0` and specific
+  regex evidence; the hollow human-confirm was dropped.
+- `coverage-gate` was changed to a real `--fail-under-lines 75` machine check
+  (ADR-0013).
+
+A human sign-off may remain, but only *in addition to* a passing machine check — never
+as the sole gate.
+
+## Alternatives considered
+
+- **Trust human confirmation.** Rejected: it directly produced the two near-misses.
+- **Drop human checkpoints entirely.** Rejected: some decisions (freeze, release
+  sign-off) warrant human judgment — but always over real evidence.
+
+## Consequences
+
+- Verification commands must run something meaningful; an `echo`/`true` placeholder is a
+  defect.
+- Pass-criteria assert concrete evidence (exit codes, regex over harness output).
+- This rule caught and corrected the GCS NotFound bug (ADR-0009) and the B2 credential
+  and endpoint issues (ADR-0023), because the real harness ran instead of being
+  rubber-stamped.

--- a/docs/adr/0019-frozen-interface-sha-locks.md
+++ b/docs/adr/0019-frozen-interface-sha-locks.md
@@ -1,0 +1,39 @@
+# 0019 — Frozen-interface SHA locks
+
+Status: Accepted, 2026-06
+
+## Context
+
+The interop contract — manifest format, directory merkle, snapshot ID, checksum modes,
+excludes — was frozen after the core lane landed (ADR-0002, ADR-0003). Downstream lanes
+build against it. Without a mechanical guard, an accidental edit to a "frozen" core file
+could silently change behaviour and break interoperability.
+
+## Decision
+
+Protect frozen interfaces with **SHA locks**: files recording the content hashes of the
+frozen files, re-verified on every tick.
+
+- `manifest-format.sha.lock` covers the core format files (manifest, merkle, excludes).
+- A golden-fixtures lock covered the bash-era golden fixtures.
+
+If a locked file's hash changes without an approved process, the lock check fails the
+tick. Any intended change to a frozen interface requires explicit human approval and a
+lock update.
+
+## Alternatives considered
+
+- **Rely on lane fences alone.** Rejected: fences catch out-of-lane *edits*, but a SHA
+  lock also catches an in-lane edit to a file that is supposed to be immutable, and
+  documents exactly which bytes are frozen.
+- **No mechanical guard, code review only.** Rejected: too easy to miss a one-line drift
+  in a hashing function.
+
+## Consequences
+
+- Frozen core behaviour cannot drift unnoticed; the lock is checked each tick.
+- A deliberate frozen-interface change (e.g. the operator-approved one-line oracle fix
+  in ADR-0023) is a visible, approved event.
+- The golden-fixtures lock was retired when the bash fixtures were deleted; the
+  `manifest-format.sha.lock` was kept and re-anchored to the Rust golden tests
+  (ADR-0024).

--- a/docs/adr/0020-interop-diff-keystone-gate.md
+++ b/docs/adr/0020-interop-diff-keystone-gate.md
@@ -1,0 +1,38 @@
+# 0020 — Interop-diff keystone gate
+
+Status: Accepted, 2026-06
+
+## Context
+
+Byte-for-byte manifest interoperability is the hard constraint of the port. If the Rust
+`snapdir manifest`/`id` ever diverged from the oracle, every downstream feature (stores,
+catalog, CLI) would be built on a broken foundation. This needed to be proven before any
+downstream phase unlocked.
+
+## Decision
+
+Make `interop-diff` a hard keystone gate that downstream phases depend on. A differential
+harness (`tests/interop/run.sh`) drives both the Bash oracle and the Rust binary over a
+deterministic fixture corpus (nested, symlinks, perms, unicode, spaces, empty, duplicate,
+large) and compares output with `cmp` across all checksum modes:
+`b3sum`/`md5sum`/`sha256sum`, keyed mode, and `--no-follow`. The gate passes only when
+manifests and snapshot IDs are byte-identical across every case on both Linux and macOS,
+with zero hard diffs. It is a human checkpoint backed by the harness (ADR-0018).
+
+Because the harness initially could not pass while `snapdir manifest` was still a stub,
+prerequisite gates (`core-walk`, `cli-manifest-wire`) were added to wire the real
+filesystem walk first.
+
+## Alternatives considered
+
+- **Spot-check a few manifests by hand.** Rejected: cannot prove byte-identity across the
+  format's many rules and modes.
+- **Defer interop validation until later.** Rejected: a late-discovered format diff would
+  invalidate downstream work; this gate fences downstream phases on purpose.
+
+## Consequences
+
+- Byte-for-byte interop was proven (15/15 corpus cases identical) before stores/catalog
+  work proceeded.
+- Any manifest or ID diff freezes downstream until resolved.
+- The harness later seeded the pattern reused for remote-store interop (ADR-0023).

--- a/docs/adr/0021-performance-secondary-to-correctness.md
+++ b/docs/adr/0021-performance-secondary-to-correctness.md
@@ -6,13 +6,13 @@ Status: Accepted, 2026-06
 
 A native Rust implementation with in-process BLAKE3, a parallel walk, and memory-mapped
 hashing is much faster than the Bash version, which forks `b3sum` per file. But the
-whole value of the port depends on byte-for-byte compatibility (ADR-0002).
+whole value of the port depends on byte-for-byte compatibility (ADR-0002, ADR-0020).
 Performance optimizations must never change a single output byte.
 
 ## Decision
 
 Treat performance as secondary to correctness, with byte-identical output as the hard
-guard. The performance benchmark compares Bash vs Rust `manifest` stdout with
+guard. The performance gate's verification compares Bash vs Rust `manifest` stdout with
 `cmp` first; any drift is a hard fail with a diff, before any timing is reported. Timing
 is measured over representative corpora (many small files, few large files) using
 hyperfine when present and a portable median-of-N fallback otherwise.
@@ -25,12 +25,12 @@ from the in-process walk and BLAKE3 — no change to the frozen core was needed.
 
 - **Optimize aggressively, accept minor output differences.** Rejected outright: any
   output difference breaks interop, which is the point of the port.
-- **Skip the performance benchmark.** Rejected: a measurable, output-guarded performance
-  story is part of the value proposition and is worth proving.
+- **Skip a performance gate.** Rejected: a measurable, output-guarded performance story
+  is part of the value proposition and is worth proving.
 
 ## Consequences
 
-- The performance benchmark cannot pass if output drifts, regardless of speed.
+- The performance gate cannot pass if output drifts, regardless of speed.
 - Parallelism/mmap are defaults that were validated to be output-neutral.
 - Performance is a reported benefit, not a tuning knob allowed to trade away
   correctness.

--- a/docs/adr/0023-b2-scope-rust-and-format-compat.md
+++ b/docs/adr/0023-b2-scope-rust-and-format-compat.md
@@ -1,18 +1,18 @@
-# 0023 — Scope the B2 interop to Rust round-trip and format compat
+# 0023 — Scope the B2 interop gate to Rust round-trip and format compat
 
 Status: Accepted, 2026-06
 
 ## Context
 
-Remote-store interop is verified by running byte-identical, bidirectional cross-tool
-push/fetch in both directions (Rust↔Bash) against a real backend. This was fully
-achieved on S3 (MinIO) and GCS (a real bucket). When the B2 backend was exercised
-end-to-end for the first time, it surfaced a chain of failures — all in the **frozen
-Bash oracle's** cold-cache fetch-from-B2 path (legacy bash driving the `b2` CLI), a path
-never exercised before:
+The remote-store interop model proves byte-identical, bidirectional interop by running
+cross-tool push/fetch in both directions (Rust↔Bash) against a real backend. This was
+fully achieved on S3 (MinIO) and GCS (a real bucket). The B2 lane, run end-to-end for
+the first time, surfaced a chain of failures — all in the **frozen Bash oracle's**
+cold-cache fetch-from-B2 path (legacy bash driving the `b2` CLI), a path never exercised
+before:
 
 - The installed `b2` CLI v4 removed the v3 subcommands the oracle's `snapdir-b2-store`
-  calls (worked around with a pinned v3 shim).
+  calls (worked around with a pinned v3 shim in the harness).
 - The oracle emitted `--store`-less object-fetch worker commands (line 395, then line
   169's trailing `ensure-no-errors`), so cold Bash fetch failed "Missing --store".
 - Even with those patched in a throwaway copy, the legacy parallel `b2`-CLI
@@ -23,26 +23,26 @@ verify), and Bash derives the same snapshot id from a Rust-pushed B2 store.
 
 ## Decision
 
-Scope B2 interop verification (2026-06-03) to what is proven and meaningful for the
+Scope the `remote-interop-b2` gate (2026-06-03) to what is proven and meaningful for the
 **port**:
 
 1. Rust round-trip against real B2 (push → fetch → pull → verify) must pass.
 2. Rust↔Bash snapshot-id agreement (Bash derives the same id from a Rust-pushed B2
    store) must pass — proving format/key/id compatibility.
 3. The legacy Bash-oracle cold-cache fetch-from-B2 is a **documented known limitation**
-   of the retired tool: reported loudly, but it does not hard-fail B2 verification.
+   of the retired tool: reported loudly, but it does not hard-fail the B2 lane.
 
-S3 and GCS keep the full bidirectional comparison, unchanged. Only B2 is scoped. One
-operator-approved one-line oracle fix (line 395 `--store`) was applied, then the change
-was reverted.
+S3 and GCS keep the full bidirectional differential, unchanged. Only the B2 lane is
+scoped. One operator-approved one-line oracle fix (line 395 `--store`) was applied under
+a temporary deny-lift, then the oracle was re-locked.
 
 ## Alternatives considered
 
 - **Chase the legacy-bash B2 fetch bugs to full bidirectional green.** Rejected: they
-  are in code being retired (ADR-0024); applying more one-line fixes to the frozen
-  oracle is not worthwhile.
-- **Silently rubber-stamp B2.** Rejected: a claim must reflect reality, so the
-  limitation is reported loudly instead.
+  are in code being retired (ADR-0024); drip-feeding more frozen-oracle one-liners
+  through repeated deny-lifts is not worthwhile.
+- **Silently rubber-stamp the B2 lane.** Rejected: forbidden by ADR-0018; the limitation
+  is reported loudly instead.
 
 ## Consequences
 

--- a/docs/adr/0024-retire-the-bash-oracle.md
+++ b/docs/adr/0024-retire-the-bash-oracle.md
@@ -1,14 +1,15 @@
 # 0024 — Retire the Bash oracle (full cut)
 
-Status: Accepted, 2026-06
+Status: Accepted (supersedes [ADR-0001](0001-differential-oracle-methodology.md)), 2026-06
 
 ## Context
 
-During the port the frozen Bash scripts and `utils/qa-fixtures/` served as the live
-behavioural reference, against which every Rust output was checked. The port is now
-complete (all interop proven), and the byte contract is fully captured. Keeping the Bash
-scripts and their comparison tooling around indefinitely carries maintenance and
-confusion cost, and the legacy B2 cold-fetch path is a known dead end (ADR-0023).
+The differential-oracle methodology (ADR-0001) used the frozen Bash scripts and
+`utils/qa-fixtures/` as the live behavioural source of truth, diffing every Rust output
+against them. By Phase 11 the port is complete (all interop proven), and the byte
+contract is fully captured. Keeping the Bash scripts and their differential harnesses
+around indefinitely carries maintenance and confusion cost, and the legacy B2 cold-fetch
+path is a known dead end (ADR-0023).
 
 ## Decision
 
@@ -16,26 +17,28 @@ Retire the Bash oracle with a full cut:
 
 - Delete the 8 root Bash scripts, the root bash-era Dockerfile, the pre-commit hook, and
   `utils/qa-fixtures/`.
-- Remove the bash test scaffolding and de-bash CI.
-- Re-anchor the byte contract as **pure-Rust golden-constant tests**
-  (`crates/snapdir-core/tests/compat_golden.rs`), which assert the frozen byte layout
-  directly. The bash golden fixtures are dropped (they are gone with the scripts).
-- Add a repo-wide grep guard so no bash references remain. Keep the `ExternalStore` shim
-  (it is a runtime feature, not test scaffolding).
+- Remove the bash test harnesses and de-bash CI.
+- Re-anchor the byte contract as **pure-Rust golden-constant tests** plus the retained
+  `manifest-format.sha.lock`. The golden-fixtures lock is dropped (its fixtures are
+  gone); the format lock stays.
+- Archive the oracle-differential gates, rewrite the PM prompt, and add a repo-wide grep
+  guard so no bash references remain. Keep the `ExternalStore` shim (it is a runtime
+  feature, not oracle scaffolding).
 
-The live oracle is gone; correctness is henceforth defined by the Rust golden tests.
+This supersedes ADR-0001: the live oracle is gone; correctness is henceforth defined by
+the Rust golden tests and the format SHA-lock.
 
 ## Alternatives considered
 
 - **Keep the oracle as a permanent reference.** Rejected: ongoing maintenance of retired
-  shell code, and it tempts re-running a comparison model the port has outgrown.
+  shell code, and it tempts re-running a differential model the port has outgrown.
 - **Archive the bash rather than delete it.** Rejected: the operator chose a clean
   deletion; history preserves it in git.
 
 ## Consequences
 
 - The repository is Rust-only; no shell scripts to maintain or accidentally depend on.
-- The byte contract is now the golden-constant tests, a self-contained anchor that lands
-  before the scripts are deleted.
-- The shift is deliberate: the live behavioural comparison is replaced by static golden
-  assertions.
+- The byte contract is now the golden-constant tests + `manifest-format.sha.lock`, a
+  self-contained anchor that must land before deletion (the `compat-golden-tests` gate).
+- The methodology shift is deliberate: the live oracle-differential model is replaced by
+  static golden assertions.

--- a/docs/rust-port/CHANGELOG.md
+++ b/docs/rust-port/CHANGELOG.md
@@ -7,6 +7,106 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+## [1.7.0] - 2026-06-14
+
+### Added
+
+- **`--walk-jobs <N>` / `$SNAPDIR_WALK_JOBS` — parallel, memory-mapped directory
+  walk and file hashing.** Snapshotting a tree now hashes files across a bounded
+  rayon pool and uses blake3's memory-mapped path for large files, so `id`,
+  `manifest`, `stage`, and `push` no longer hash every file single-threaded —
+  multiple× faster on large trees. The new global `--walk-jobs <N>` flag (and
+  `$SNAPDIR_WALK_JOBS` env) sizes the walk pool; `0`/auto picks the number of
+  CPUs (capped). This is **distinct from `--jobs` / `$SNAPDIR_JOBS`** (which
+  controls transfer concurrency). Purely a performance win: **snapshot ids are
+  unchanged (byte-identical)** with the feature on or off and across every
+  `--walk-jobs` value — additive, default behavior preserved, the frozen
+  manifest format untouched.
+- **Cross-platform copy-on-write object clones — macOS (APFS `clonefile`) and
+  Linux (`FICLONE` reflink).** When the source file and the snapdir store share
+  a copy-on-write-capable filesystem, object copies during `stage`, `push`, and
+  `checkout`/`fetch` now make a CoW clone instead of byte-copying: on macOS via
+  `clonefile(2)` on the same APFS volume, and on Linux via the `FICLONE` ioctl
+  reflink on Btrfs, XFS (`reflink=1`), OpenZFS 2.2+, OCFS2, and bcachefs. A
+  large object is materialized for ~zero additional physical bytes (the clone
+  shares extents) and without rewriting its data. This is additive and falls
+  back gracefully to a plain `fs::copy` everywhere a reflink/clone cannot apply
+  — non-CoW filesystems (ext4, F2FS, tmpfs), across filesystem boundaries, and
+  on unsupported platforms. Set `SNAPDIR_CLONEFILE=0` to disable the fast-path
+  entirely. Object bytes and snapshot ids are unchanged (byte-identical) with
+  the fast-path on or off.
+- **Clone fast-path now skips the redundant post-copy re-hash — a real
+  `stage`/`checkout` speedup on both platforms.** Previously, even when an
+  object was cloned copy-on-write, `persist()` re-read and re-hashed the result,
+  so the clone saved disk space but not wall-clock time (the copy was never the
+  bottleneck; the second full read was). The clone path now elides that
+  redundant re-hash, turning the copy-on-write fast-path into a genuine speedup
+  — multiple× faster `stage` and meaningfully faster `checkout` on large trees
+  wherever a CoW clone fires, on macOS (APFS `clonefile`) or Linux (`FICLONE`
+  reflink) alike. Correctness is preserved on two layers: **`stage`
+  uses stat-validated trust** — the walk records the source file's stat and
+  `persist` re-stats it at clone time, skipping the re-hash only if the source
+  is unchanged since the walk (a changed source falls back to a full re-hash, so
+  a mid-stage mutation is caught at write time); **`checkout` still verifies the
+  source object once** (so on-disk object corruption is still detected) and only
+  skips the redundant destination re-hash. Set **`SNAPDIR_VERIFY_COPIES=1`** to
+  force the strict write-time re-hash even on the clone path. Object bytes and
+  snapshot ids remain byte-identical, and the read-time BLAKE3 verification in
+  `get_object`/`fetch` remains the integrity backstop regardless of this
+  setting.
+- **`--objects-store` / `$SNAPDIR_OBJECTS_STORE` — shared object pool, separate
+  manifest locations.** This global flag routes content objects to one shared
+  pool's `.objects/` while manifests go to `--store`'s `.manifests/`, so a
+  scheduled inventory can write a fresh manifest path per run (by date / host /
+  env) against a single deduplicated object pool. Re-pushing to the same pool
+  only costs the changed bytes — unchanged content-addressed objects are
+  skipped. Both halves resolve in-process; an external `custom://` store is
+  rejected on either side. Unset leaves behavior byte-for-byte unchanged; the
+  catalog records the `--store` (manifest-side) URI.
+- **`snapdir sync --from-objects/--to-objects` — split object pools for
+  bucket-to-bucket sync.** Each side names its own explicit object pool, so the
+  source and destination can be different buckets; the streaming sync engine is
+  unchanged, and objects already present in the destination pool are skipped
+  (cross-pool dedup). These per-side flags are distinct from the global
+  `--objects-store`; a side that omits its flag is a plain colocated store.
+- **`snapdir diff` — file-level diff across manifest locations, reading
+  manifests only.** Compares two sides, each a union of one-or-more manifest
+  refs (`--from`/`--to`, both repeatable), classifying every path as `A` (added),
+  `D` (deleted), or `M` (modified). It reads manifests only — it never downloads
+  an object — so it stays cheap over large or unreachable object pools, which
+  makes it well suited to comparing scheduled inventories. With the global
+  `--id` a side pins to a single manifest. Flags: `--all` (also emit unchanged
+  `=` paths), `--json` (a `{status, path}` array instead of porcelain
+  `X\t./path` lines), `--exit-code` (git `diff --exit-code` semantics: exit `1`
+  on any difference), and `--on-conflict <error|last-wins>` (intra-side
+  same-path/differing-content collision policy; defaults to `error`).
+- **SNAPPACK 1Z — auto-negotiated zstd transport for the `ssh://` accelerated
+  pack stream.** The whole post-magic pack body is sent as a single zstd frame
+  of the unchanged SNAPPACK 1 record grammar; the receiver sniffs the magic
+  (`SNAPPACK 1Z\n`) and accepts both v1 and 1Z forever. Compression is additive
+  (the wire version stays `1`; a new `snappack-zstd` capability token gates it),
+  so it engages only when both ends advertise support — a mixed-version pair
+  falls back to v1 with the v1 acceleration still taken. The level defaults to
+  zstd level 3 and is tunable via `SNAPDIR_SSH_ZSTD_LEVEL` (`1`–`19`, clamped).
+  Every decompressed byte is still BLAKE3-verified and the existing
+  header/manifest bounds apply to the decompressed stream, so a decompression
+  bomb costs CPU only. With SNAPPACK now compressing above the transport,
+  prefer `Compression=no` on the SSH client (WAN / HPN-SSH) to avoid
+  double-compressing.
+- **`SNAPDIR_FSYNC` crash-durability knob on `receive-pack`.** Defaults to
+  `batch`: all received objects are fsynced before the manifest is committed
+  last, so a manifest that survives a crash is backed by durable objects (the
+  manifest-last invariant holds across the crash boundary). `off` skips the
+  barrier and relies on the OS to flush; any other value is a hard error. On a
+  journaling filesystem this matches the crash-consistency guarantee git
+  provides, and claims no more than that. Measured cost: the `batch` default
+  adds ~20% on a small-files receive (v1 +19.5% / zstd +29.9% on a 5,000 ×
+  4 KiB push, Linux CI) — a fixed per-object fsync cost on the receive-pack
+  path only, accepted as the crash-safe default with `SNAPDIR_FSYNC=off` as
+  the opt-out.
+
 ## [1.6.0] — 2026-06-11
 
 ### Added
@@ -247,11 +347,12 @@ finalized.
   retiring the Bash implementation, dependency-cooldown policy, and more).
 - **Rust golden-format contract** — `crates/snapdir-core/tests/compat_golden.rs`
   pins the exact manifest line bytes, directory merkle checksums, and snapshot
-  IDs as golden constants, replacing the live comparison against the Bash version
-  as the guarantor of byte-format stability. Any accidental change to the line
-  format, ordering, checksum algorithm, sharded layout, or exclude sets fails the
-  golden tests.
-- **Local pre-push CI hook** (`utils/ci/pre-push.sh`, installed via
+  IDs as golden constants, replacing the live differential comparison as the
+  guarantor of byte-format stability.
+- **`manifest-format.sha.lock` tripwire** over the format-defining source, so any
+  accidental change to the line format, ordering, checksum algorithm, sharded
+  layout, or exclude sets trips CI and demands an explicit, reviewed bump.
+- **Local pre-push CI gate** (`utils/ci/pre-push.sh`, installed via
   `make install-hooks`) running the fast CI legs (~2–4 min) before every push;
   the slow musl + coverage legs run in CI and via `make ci-local`.
 - **`scratch` Docker image** — a `FROM scratch` final stage shipping only the
@@ -269,9 +370,9 @@ finalized.
 ### Removed
 
 - **The legacy Bash implementation was removed.** Its role as the behavioral
-  source of truth is now served by the Rust golden-format tests. The shipped
-  binary remains fully in-process with no runtime dependency on external
-  executables.
+  source of truth is now served by the Rust golden-format tests and the
+  `manifest-format.sha.lock` tripwire. The shipped binary remains fully
+  in-process with no runtime dependency on external executables.
 
 ## [0.5.0] — Rust port
 
@@ -309,12 +410,12 @@ Bash-written caches and remote buckets stay mutually readable.
 - **`file://` FileStore** with the sharded `.objects`/`.manifests` layout,
   objects-before-manifest push (skip-if-present), and verified fetch
   (temp download → BLAKE3 verify → retry ≤5 → atomic rename).
-- **Interop verification** proving byte-identical manifests and snapshot IDs
-  Bash↔Rust across every checksum/keyed/no-follow mode, plus live cross-tool
-  checks for S3 (MinIO) and GCS.
+- **Differential interop harness** (`tests/interop/run.sh`) proving byte-identical
+  manifests and snapshot IDs Bash↔Rust across every checksum/keyed/no-follow
+  mode, plus live cross-tool harnesses for S3 (MinIO) and GCS.
 - **Performance**: in-process walk + BLAKE3 makes the Rust `manifest` command
   ~33.6× faster on many-small files and ~2.69× faster on few-large files than the
-  Bash version, with byte-identical output.
+  Bash oracle, with byte-identical output.
 
 ### Changed
 
@@ -345,10 +446,11 @@ Bash-written caches and remote buckets stay mutually readable.
 ### Removed
 
 - No runtime dependency on external binaries (`b3sum`, `sqlite3`, `aws`, `b2`,
-  `gcloud`) in the shipped binary. External tools are used only by the test
-  suite.
+  `gcloud`) in the shipped binary. External tools are used only by the test/oracle
+  harness.
 
-[Unreleased]: https://github.com/snapdir/snapdir/compare/v1.6.0...HEAD
+[Unreleased]: https://github.com/snapdir/snapdir/compare/v1.7.0...HEAD
+[1.7.0]: https://github.com/snapdir/snapdir/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/snapdir/snapdir/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/snapdir/snapdir/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/snapdir/snapdir/compare/v1.3.0...v1.4.0

--- a/docs/rust-port/PLAN.md
+++ b/docs/rust-port/PLAN.md
@@ -1,0 +1,142 @@
+# snapdir-rs — locked build plan
+
+> Vendored copy of the approved plan, used by the gatesmith PM and lane teammates.
+> Authoritative for decisions, the frozen contract, and the phase→gate map.
+> This is a historical planning document. During the port, the source of truth
+> for behavior was the original Bash `snapdir` (the `snapdir`, `snapdir-manifest`,
+> and `snapdir-<name>-store` scripts), **not the old docs** (which carried known
+> bugs — see "Doc bugs"). The byte-format contract is now guarded by the Rust
+> golden tests and the `manifest-format.sha.lock` tripwire.
+
+## Goal
+
+Port `snapdir` (MIT, ~99% Bash, `v0.5.0`) to a single statically-linked **zero-runtime-dependency**
+Rust binary that absorbs every `snapdir-*` helper as a subcommand. The binary must NOT shell out
+to `b3sum`, `gcloud`, `aws`, `b2`, or `sqlite3` — all of that becomes in-process Rust
+(`blake3` crate, native cloud SDKs, `redb`). External system binaries are allowed only in the
+**test/oracle** harness (the Bash tool + `b3sum` are the interop oracle), never in the shipped binary.
+
+The hard constraint is **byte-for-byte manifest interoperability** with the Bash version: identical
+manifest lines, identical snapshot IDs, identical object/manifest keys and bucket layout, so Rust-
+and Bash-written caches and remote buckets remain mutually readable.
+
+## Locked decisions
+
+- **Repo/branch:** this repo, branch `rust-port`, fresh Cargo workspace alongside the untouched Bash
+  scripts (which serve as the interop oracle). Merge to `main` at parity.
+- **Execution:** gatesmith ralph-loop. This ledger *is* the plan.
+- **Catalog:** **redb** (pure-Rust embedded KV). SQLite removed. Catalog is private/rebuildable —
+  no on-disk interop, no SQLite→redb importer. Only the JSON-line *output* stays format-identical.
+- **Stores:** native Rust SDKs — `google-cloud-storage` (gs), `aws-sdk-s3` (s3), `aws-sdk-s3` →
+  Backblaze S3-compatible endpoint (b2). Emit-shell-command shim retained ONLY for third-party
+  external stores. Auth delegated entirely to each SDK's own credential chain — no bespoke env vars.
+- **TLS/crypto:** use the **ring** rustls provider (not aws-lc-rs) so the static-musl build stays clean.
+
+## Frozen contract (freeze after Phase 2)
+
+The manifest spec + golden fixtures. Confirmed from the Bash source:
+
+- **Manifest line:** `PATH_TYPE PERMISSIONS CHECKSUM SIZE PATH` — single space separated, sorted by
+  path (`sort -k5`); empty lines stripped; `#` lines are comments excluded from the checksum.
+- `PATH_TYPE` `F`/`D`; directory paths end `/`; relative mode prefixes `./`, `--absolute` keeps the
+  full path.
+- `PERMISSIONS` octal — macOS `stat -f '%A'`, Linux `stat -c '%a'`.
+- `SIZE` content bytes — macOS `%z`, Linux `%s`; directories = **sum of member sizes** (dir metadata
+  excluded).
+- **Symlinks followed by default** (`find -L`); entry inherits the target's type/checksum/size.
+  `--no-follow` drops `-L` and excludes symlinks.
+- **Directory checksum (critical):** the `D ./` line's `CHECKSUM` field. Over the direct children's
+  checksums do `cut -d' ' -f3 | sort -u | tr -d '\n'` then hash the concatenation — i.e.
+  **sort + dedup + concatenate with no separators + re-hash**.
+- **Snapshot ID (critical):** `manifest | grep -v '^#' | b3sum --no-names` — BLAKE3 of the **entire
+  `#`-stripped manifest text**, including the trailing newline the oracle's `echo` appends. The
+  snapshot ID is therefore **NOT** the root directory checksum; it is the hash of the whole manifest
+  document, not of any single line's checksum field.
+- **Hash:** default `b3sum --no-names`; escape hatch `--checksum-bin=` (`md5sum`,`sha256sum`, parse
+  `cut -d' ' -f1`); keyed mode `SNAPDIR_MANIFEST_CONTEXT` → `b3sum --derive-key=<ctx> --no-names`.
+- **Excludes:** `--exclude` is an extended regex (`grep -E -v`); `%system%` expands a built-in set AND
+  forces `--no-follow`; `%common%` expands a second set (`.git`, `.cache`, `node_modules`,
+  `.DS_Store`, Trash, …).
+- **Content-addressable layout:** objects `.objects/<h[0:3]>/<h[3:6]>/<h[6:9]>/<h[9:]>`; manifests
+  `.manifests/<id[0:3]>/<id[3:6]>/<id[6:9]>/<id[9:]>`; mirrored in cache and every store.
+- **Cache:** `${XDG_CACHE_HOME:-$HOME/.cache}/snapdir/`; per-file key = path+context+inode+perms+size+
+  mtime; `cache-id` = hash(context + checksums of all cache files); `--cache-id` pre-verifies.
+
+Golden hashes (from `utils/qa-fixtures/expected-guide-commands.txt`):
+empty-dir id `dba5865c0d91b17958e4d2cac98c338f85cbbda07b71a020ab16c391b5e7af4b`,
+empty-file `af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262`,
+modified-dir `4a0732cfb45ebe9d8d572fc4c77b759384bed029911e35f8859430b889427d4d`,
+object `49dc870df1de7fd60794cebce449f5ccdae575affaa67a24b62acb03e039db92`.
+
+## CLI surface (reproduce exactly)
+
+Orchestrator subcommands: `manifest id stage push fetch pull checkout verify verify-cache
+flush-cache locations ancestors revisions defaults` (+ `test version help`). Global options:
+`--cache-dir --catalog --store --id --exclude --paths --linked --force --purge --keep --dryrun
+--verbose --debug --location`.
+
+Store routing: `--store` protocol → `snapdir-<proto>-store`, **except `gs://` is a hardcoded special
+case → `snapdir-gcs-store`** (adapter named `gcs`, scheme `gs`). Store push: check manifest exists,
+push objects before manifest, only if absent. Fetch: temp download → verify BLAKE3 → retry ≤5× →
+atomic rename.
+
+Catalog JSON-line output shapes (the brief was wrong about `revisions`):
+- `locations` → `{"created_at","id","location"}` (latest id per location).
+- `ancestors` → `{"created_at","id","location"}` (`id` = previous_id), `created_at DESC`.
+- `revisions` → `{"created_at","id","previous_id"}`, `created_at DESC`.
+- Timestamp format `YYYY-MM-DD HH:MM:SS.SSS` (`STRFTIME('%Y-%m-%d %H:%M:%f')`).
+
+## Doc bugs to NOT replicate
+
+`docs/api/snapdir.md` shows `--link` (real: `--linked`); store docs show `verify-transactions`
+(real: `ensure-no-errors`); minor wget/umask/typos. Pin to the scripts' real behavior; fix the docs
+in the Rust port, don't carry the errors.
+
+## Lanes → crates/dirs
+
+```
+crates/snapdir-core/      # manifest + BLAKE3 merkle hashing + Store trait + walk + cache  (lane: core)
+crates/snapdir-catalog/   # redb-backed locations/ancestors/revisions                      (lane: catalog)
+crates/snapdir-stores/    # FileStore, S3Store, B2Store, GcsStore + external-shim          (lane: stores)
+crates/snapdir-cli/       # clap derive bin `snapdir`, all 14 subcommands                  (lane: cli)
+tests/                    # interop differential harness + fixtures + CLI integration      (lane: tests)
+benches/                  # criterion hash/walk/manifest hot paths                         (lane: bench)
+.github/workflows/, deny.toml, _typos.toml, Cargo.toml, rust-toolchain.toml, rustfmt.toml  (lane: ci)
+docs/rust-port/           # rustdoc, migration guide, manifest spec, CHANGELOG             (lane: docs)
+packaging/                # release.yml / cargo-dist, Docker, completions, man page         (lane: packaging)
+```
+
+Library/binary split (jj principle): `snapdir-core` does no terminal I/O and reads no `$HOME`/config.
+`thiserror` in libs, `anyhow` + `.context()` in the bin. Native SDK transfers are `tokio`-async;
+walk+hash stay sync+`rayon`.
+
+## Phase map (→ gates.yaml)
+
+0. **Bootstrap** — gatesmith installed, ledger + templates + settings authored, plan vendored, commit.
+1. **Scaffold + CI** — workspace, clap skeleton (all subcommands), clippy::pedantic, MSRV, ci.yaml
+   (lint/deny/test-matrix incl. **musl**/coverage/semver), skeleton release.yml. Test musl now.
+2. **Core manifest/hashing + FREEZE** — exact line format, dir merkle (sort+dedup+concat+rehash),
+   keyed mode, `--checksum-bin`, excludes, `--no-follow`, both-OS stat. insta vs golden → FREEZE.
+3. **Interop gate (HARD)** — differential harness Bash vs Rust over a fixture corpus; byte-identical
+   manifests + IDs across b3sum/md5sum/sha256sum + keyed mode; Linux + macOS. human_checkpoint.
+4. **Store trait + FileStore** — sharded layout, push/fetch/checkout, external-store shim, gs:// router.
+5. **Remote stores** — S3/B2/GCS via native SDKs (ring rustls); preserve ordering+verify; emulator
+   integration + cross-tool (Bash↔Rust) interop.
+6. **Cache + redb catalog** — cache-id integrity; redb locations/ancestors/revisions matching JSON
+   shapes; `snapdir catalog rebuild`.
+7. **Performance** — rayon+mmap hashing, parallel walk, buffer reuse, allocator eval; criterion/
+   hyperfine/CodSpeed; beat Bash baseline, output bytes unchanged.
+8. **Testing/fuzzing** — proptest, cargo-fuzz parser (cron), trycmd/assert_cmd full CLI, coverage gate.
+9. **Docs** — rustdoc+doctests, README/CHANGELOG, migration guide (subcommand + auth mapping tables),
+   fix doc bugs. human_checkpoint.
+10. **Packaging/release** — cross-compiled per-target archives (musl static etc.), completions+man,
+    crates.io, slim Docker, release-plz + semver-checks. First tag tracks 0.5.0. human_checkpoint.
+
+## Key risks / thresholds
+
+- TLS vs static musl → use ring provider; test musl in Phase 1; fallback to emit-shim per backend.
+- mmap+rayon regression on spinning disks → default streamed hashing, parallelism opt-in.
+- Any manifest diff (P3) or catalog-shape diff (P6) freezes downstream until resolved.
+- External-store shim is load-bearing — implement + test it.
+- Google Cloud Rust SDK is largely pre-1.0 — pin versions.
+- Windows may legitimately diverge on perms/symlinks — separate fixtures, document.

--- a/docs/rust-port/manifest-spec.md
+++ b/docs/rust-port/manifest-spec.md
@@ -5,8 +5,8 @@
 > the original snapdir defined, reproduced byte-for-byte by `snapdir-core`.
 >
 > **The frozen spec wins.** The byte-format contract is now guarded by the Rust
-> golden-constant tests in `crates/snapdir-core/tests/compat_golden.rs`,
-> cross-checked against the core source
+> golden-constant tests in `crates/snapdir-core/tests/compat_golden.rs` and the
+> `manifest-format.sha.lock` tripwire, cross-checked against the core source
 > (`crates/snapdir-core/src/{manifest.rs,merkle.rs,excludes.rs}`). If you find a
 > disagreement between this prose and the golden contract, the contract wins —
 > report the discrepancy rather than "correcting" the spec.

--- a/docs/rust-port/migration.md
+++ b/docs/rust-port/migration.md
@@ -65,7 +65,7 @@ Notes:
   tool used. This keeps third-party stores working without bundling them.
 - The shipped binary never shells out to `b3sum`, `aws`, `b2`, `gcloud`, or
   `sqlite3` for the built-in backends; those tools are only needed by the
-  external shim (for third-party stores) and by the test suite.
+  external shim (for third-party stores) and by the test/oracle harness.
 
 ### 1.3 Subcommand wiring status
 
@@ -236,7 +236,7 @@ frozen format; the essentials for migration:
 Because manifests, IDs, and the sharded object/manifest layout
 (`.objects/…`, `.manifests/…`) are identical, **stores interoperate**: the Rust
 binary can read and write stores written by the Bash tool, and vice-versa. This
-is proven by interop verification (manifests + IDs across every
+is proven by the differential interop harness (manifests + IDs across every
 checksum/keyed/no-follow mode) and live S3 (MinIO) and GCS cross-tool round-trips.
 
 ---

--- a/docs/rust-port/ssh-wire-protocol.md
+++ b/docs/rust-port/ssh-wire-protocol.md
@@ -208,3 +208,123 @@ stores (the dumb-vs-accel oracle gate).
   likely environmental and would hit the dumb path too, and a user retry
   resumes incrementally for free (objects already filed are verified-then-
   skipped; the manifest was never committed).
+
+---
+
+## 5. SNAPPACK 1Z — zstd transport encoding
+
+SNAPPACK 1Z is an **additive** transport encoding: the same record grammar,
+the whole post-magic body compressed once. It is opt-in, sniffed on read, and
+never changes the wire version.
+
+```text
+stream := "SNAPPACK 1Z\n" zstd_frame( record* "end\n" )
+```
+
+- **Magic.** The stream opens with the exact line `SNAPPACK 1Z\n`
+  (`pack::WIRE_MAGIC_ZSTD`). The trailing `Z` is a transport-encoding marker,
+  **not** a new format version: `pack::WIRE_VERSION` stays `1` and the
+  capability line still reports `wire=1` (see negotiation below).
+- **Single-frame framing.** Everything after the magic is **one** zstd frame.
+  Decompressing it yields the *verbatim* SNAPPACK 1 body — `record* "end\n"`,
+  the unchanged v1 record grammar, byte-for-byte. There is no per-record
+  framing, no chunking, no length prefix: the whole body is one frame.
+- **Decompressed-bytes bounds.** The reader sniffs the magic, wraps the
+  remaining input in a streaming zstd decoder, and feeds the **decompressed**
+  bytes to the *same* parser as v1. Every bound applies to the decompressed
+  stream exactly as in §1.1: `MAX_HEADER_BYTES = 128` (header line incl. `\n`),
+  `MAX_MANIFEST_BYTES = 64 MiB` (buffered `manifest` payload), and the
+  lying-`len` preallocation cap. Object payloads still stream through the
+  O(1)-memory temp-sibling path.
+- **Decompression-bomb reasoning.** A hostile peer can craft a frame that
+  decompresses to far more than it sends, but the cost is **CPU only**: every
+  decompressed byte still flows through the incremental BLAKE3 hasher and must
+  match its claimed `hex64`, and the header/manifest caps above bound buffered
+  memory regardless of how large the frame inflates. A bomb cannot file a
+  forged object (the hash will not match), cannot commit a manifest (truncation
+  never reaches `end`), and cannot exhaust memory (the caps are enforced on the
+  decompressed bytes). It can only waste decode CPU on a stream that is then
+  rejected.
+- **Compression level.** The encoder writes at `DEFAULT_ZSTD_LEVEL = 3` by
+  default and accepts `MIN_ZSTD_LEVEL..=MAX_ZSTD_LEVEL` = `1..=19`; the library
+  is environment-free and **clamps** the requested level into that range in
+  `write_pack` (an out-of-range request is clamped, not rejected). The level
+  affects only the sender's frame; the reader needs no level — zstd is
+  self-describing.
+
+### 5.1 Negotiation — sniff on read, advertise to write
+
+The receiver is **always** ready for 1Z: `read_pack` sniffs the magic line and
+accepts `SNAPPACK 1\n` **and** `SNAPPACK 1Z\n` forever — there is no flag, no
+mode, no version gate on the read side. Forward and backward compatible by
+construction.
+
+The **sender** emits 1Z only when negotiation confirms BOTH ends support it:
+
+- `snappack-zstd` is appended to `pack::WIRE_CAPS` (so `version --capabilities`
+  advertises it), but **`wire=1` is unchanged** — an integer version bump would
+  force older peers into a dumb fallback, whereas an additive *capability token*
+  is silently ignored by a peer that lacks it. A 1.5.0 peer simply never sees a
+  1Z stream and the v1 acceleration is still taken.
+- In the `ssh://` engine, `snappack-zstd` (the `ZSTD_CAP` const) is **never**
+  part of the `wire=1`/`objects-needed,receive-pack` acceleration gate; it is a
+  second, independent check layered on top. The emitted push script probes the
+  **local** binary's caps (`snapdir version --capabilities`, guarded so an older
+  local that rejects the flag degrades to v1 cleanly) into `snapdir_local_zstd`,
+  and chooses `--pack-format zstd` only when `snapdir_local_zstd = 1` **AND** the
+  remote's `caps=` list contains `snappack-zstd`. Otherwise it sends v1.
+- The `--pack-format zstd` token is always a **static literal** baked into the
+  script — no environment value is ever interpolated into a baked remote command
+  line. Fetch bakes **two** static remote `send-pack` variants (with and without
+  ` --pack-format zstd`) and picks one at runtime by the same caps check.
+
+The net effect: 1.5.0 ↔ 1.5.0 stays v1 (the cap is absent on both ends),
+1.5.0 ↔ newer falls back to v1 (with the v1 acceleration still taken), and
+newer ↔ newer negotiates 1Z — all without any wire-version change.
+
+---
+
+## 6. Durability
+
+The receive side is batched and manifest-last, and the durability guarantee is
+deliberately scoped to **no more than git claims**.
+
+- **Batch model.** `read_pack` files every verified `obj` as it streams, then
+  in the `end` arm calls a single `flush_barrier()` that forces **every object
+  this pack committed** to stable storage, and only **then** commits the
+  manifest via `put_manifest`. There are exactly two full syncs per pack (the
+  object barrier, then the durable manifest write) — durability is amortized
+  across the whole pack rather than paid per object.
+- **Journal-ordering argument.** Because the barrier runs **before**
+  `put_manifest`, a durable manifest provably implies durable objects: any
+  manifest that survives a crash is backed by objects that also survived. A
+  crash mid-stream can leave (verified) loose objects on disk but never an
+  observable snapshot — the manifest-last invariant (§1.2) holds across the
+  crash boundary, exactly as it holds across a dropped connection. The barrier
+  runs unconditionally (even for a manifest-only / empty pack) so the ordering
+  contract is independent of object count.
+- **`SNAPDIR_FSYNC`.** The receive-pack CLI seam reads `SNAPDIR_FSYNC` and
+  selects the sink's durability mode:
+  - unset / empty / `batch` ⇒ `Durability::Batch` (the **default**) — the
+    batched barrier above is active;
+  - `off` ⇒ `Durability::Off` — the barrier is a no-op (byte-identical to the
+    pre-durability behavior; rely on the OS to flush);
+  - any other value is a **hard error** (fail closed, no silent downgrade).
+- **Measured cost.** The default `batch` is not free: fsync-ing many tiny
+  files before the manifest costs **~20%** on a small-files receive — measured
+  **v1 +19.5%, zstd +29.9%** on a 5,000 × 4 KiB push received over this
+  SNAPPACK path on a Linux CI runner. This is the price of crash-safety-by-
+  default, not a bug — it is a fixed per-object fsync cost and is therefore
+  worst on a small-files-dominated receive; a snapshot of fewer/larger objects
+  pays proportionally less. The cost lands **only** on this receive-pack path
+  (the ssh/store side accepting a push); the ordinary `file://`/S3/GCS push
+  path is untouched. `SNAPDIR_FSYNC=off` trades the guarantee for the speed
+  (a crash mid-receive can then leave a corrupt snapshot); the operator
+  decision is to **keep `batch` the default** and accept the cost.
+- **Non-journaling-fs caveat.** On a journaling filesystem with sane mount
+  options, the fsync ordering above gives the manifest-last crash-consistency
+  argument real teeth. On filesystems or mount configurations that do not order
+  metadata and data the way fsync assumes, the guarantee weakens — this is the
+  **same caveat git carries**, and snapdir claims no more than git does about
+  crash safety. `SNAPDIR_FSYNC` controls when we ask the OS to flush; it cannot
+  make a filesystem honor an ordering it does not implement.

--- a/utils/ci/check-no-bash.sh
+++ b/utils/ci/check-no-bash.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# check-no-bash.sh — the final de-bash guard.
+# check-no-bash.sh — the final de-bash guard (phase 11).
 #
 # The legacy Bash oracle (8 root `snapdir*` scripts, the root bash Dockerfile,
 # utils/qa-fixtures/, the .sh QA harness, and the oracle CI) has been DELETED.
@@ -27,17 +27,21 @@
 #   * .git/ and target/ — VCS internals and build output; never source of truth
 #     and huge, so we never content-scan them.
 #
+#   * .gatesmith/ — the PM's ledger / journal / handoffs / templates. These
+#     record the de-bash history in prose and quote the old invocations on
+#     purpose; they are not executable.
+#
 #   * docs/ — ADRs, the rust-port history, README/CONTRIBUTING. They document
 #     what the port replaced and quote the original commands historically.
 #
 #   * Rust source/doc COMMENTS (*.rs) — engineering notes explaining what the
 #     port reproduces. We never scan .rs files for "invocations": the only
 #     `Command::new`-style references left are in a self-skipping catalog test
-#     whose oracle no longer exists, and the frozen core files
+#     whose oracle no longer exists, and the frozen sha-locked core files
 #     (crates/snapdir-core/src/{manifest,merkle,excludes}.rs) MUST NOT be
 #     edited, so their historical comments are excluded by construction.
 #
-# Re-verify:
+# Re-verify (the PM re-runs this):
 #   bash utils/ci/check-no-bash.sh
 # ---------------------------------------------------------------------------
 

--- a/utils/ci/reflink-vm-check.sh
+++ b/utils/ci/reflink-vm-check.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+#
+# reflink-vm-check.sh — operator-run LOCAL feasibility check for the Linux
+# FICLONE (reflink / copy-on-write) fast-path.
+#
+# Run this INSIDE a Linux VM (Lima / colima / multipass) on a macOS dev box (or
+# on any Linux host) to eyeball that the FICLONE ioctl genuinely fires before —
+# or independent of — the CI `reflink` job in .github/workflows/ci.yaml. The
+# stock ubuntu/dev root FS is usually ext4, where FICLONE never fires (only the
+# fs::copy fallback), so we need a reflink-capable filesystem (Btrfs / XFS
+# reflink=1 / OpenZFS 2.2+ / bcachefs) to actually exercise the clone path.
+#
+# This is NOT a CI gate and NOT wired into pre-push.sh — it is a manual,
+# operator-driven cross-check. The CI gate lives in the `reflink` job, which
+# does the same Btrfs-loopback dance on the hosted ubuntu-latest runner.
+#
+# What it does:
+#   1. Find a reflink-capable dir: prefer an existing one named by
+#      $SNAPDIR_REFLINK_TEST_DIR; otherwise create a loopback Btrfs image at a
+#      temp file, mount it (needs sudo), and clean it up on exit.
+#   2. Build the release `snapdir` binary (cargo build --release -p snapdir).
+#   3. Run `cargo test -p snapdir-stores --test reflink --locked` with
+#      SNAPDIR_REFLINK_TEST_DIR / TMPDIR set + SNAPDIR_REFLINK_TEST_REQUIRE=1
+#      (the suite panics rather than skips if the reflink dir is missing, and
+#      asserts clonefile_hits() advanced = FICLONE fired).
+#   4. Report whether the reflink suite passed (i.e. FICLONE fired).
+#
+# Usage:
+#   utils/ci/reflink-vm-check.sh            # auto: use $SNAPDIR_REFLINK_TEST_DIR
+#                                           # if set, else create a loopback Btrfs
+#   SNAPDIR_REFLINK_TEST_DIR=/mnt/reflink \
+#     utils/ci/reflink-vm-check.sh          # reuse an existing reflink mount
+#   utils/ci/reflink-vm-check.sh --help
+#
+# Exit status: 0 if the reflink suite passed (FICLONE fired); non-zero otherwise.
+
+set -euo pipefail
+
+PROG="$(basename "$0")"
+# Repo root = two levels up from utils/ci/.
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+
+# Loopback image size for the self-created Btrfs FS.
+IMG_SIZE="2G"
+
+# State for cleanup (only used when we create our own loopback mount).
+CREATED_MOUNT=""
+CREATED_IMG=""
+
+usage() {
+  sed -n '2,/^set -euo/p' "${BASH_SOURCE[0]}" | sed '$d' | sed 's/^# \{0,1\}//'
+}
+
+log()  { printf '>> %s\n' "$*"; }
+fail() { printf 'FAIL: %s\n' "$*" >&2; }
+
+# Invoked indirectly via `trap ... EXIT`; shellcheck cannot see that.
+# shellcheck disable=SC2329
+cleanup() {
+  # Only unmount/remove the loopback FS if THIS script created it.
+  if [ -n "$CREATED_MOUNT" ]; then
+    log "cleaning up loopback mount $CREATED_MOUNT"
+    sudo umount "$CREATED_MOUNT" 2>/dev/null || true
+    sudo rmdir "$CREATED_MOUNT" 2>/dev/null || true
+  fi
+  if [ -n "$CREATED_IMG" ] && [ -f "$CREATED_IMG" ]; then
+    rm -f "$CREATED_IMG" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+case "${1:-}" in
+  -h|--help) usage; exit 0 ;;
+  "") : ;;
+  *) echo "$PROG: unknown argument: $1" >&2; echo "Try '$PROG --help'." >&2; exit 2 ;;
+esac
+
+if [ "$(uname -s)" != "Linux" ]; then
+  fail "this is a Linux-only check (FICLONE/reflink). Run it inside a Linux VM (Lima/colima/multipass)."
+  exit 2
+fi
+
+cd "$REPO_ROOT"
+
+# ---------------------------------------------------------------------------
+# 1. Obtain a reflink-capable directory.
+# ---------------------------------------------------------------------------
+REFLINK_DIR=""
+
+if [ -n "${SNAPDIR_REFLINK_TEST_DIR:-}" ]; then
+  REFLINK_DIR="$SNAPDIR_REFLINK_TEST_DIR"
+  log "using existing reflink dir from \$SNAPDIR_REFLINK_TEST_DIR: $REFLINK_DIR"
+  if [ ! -d "$REFLINK_DIR" ]; then
+    fail "\$SNAPDIR_REFLINK_TEST_DIR ($REFLINK_DIR) does not exist or is not a directory"
+    exit 2
+  fi
+else
+  log "no \$SNAPDIR_REFLINK_TEST_DIR set — creating a loopback Btrfs image (needs sudo)"
+  if ! command -v mkfs.btrfs >/dev/null 2>&1; then
+    fail "mkfs.btrfs not found. Install btrfs-progs (e.g. sudo apt-get install -y btrfs-progs)."
+    exit 2
+  fi
+  CREATED_IMG="$(mktemp /tmp/reflink-vm-check.XXXXXX.img)"
+  CREATED_MOUNT="$(mktemp -d /tmp/reflink-vm-check.XXXXXX.mnt)"
+  log "creating ${IMG_SIZE} Btrfs image at $CREATED_IMG, mounting at $CREATED_MOUNT"
+  truncate -s "$IMG_SIZE" "$CREATED_IMG"
+  mkfs.btrfs -q "$CREATED_IMG"
+  sudo mount -o loop "$CREATED_IMG" "$CREATED_MOUNT"
+  # The test user must be able to create src+store dirs under the mount.
+  sudo chmod 1777 "$CREATED_MOUNT"
+  REFLINK_DIR="$CREATED_MOUNT"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Build the release binary.
+# ---------------------------------------------------------------------------
+log "building release snapdir binary"
+cargo build --release -p snapdir
+
+# ---------------------------------------------------------------------------
+# 3. Run the reflink suite against the reflink FS (REQUIRE => panic, not skip).
+# ---------------------------------------------------------------------------
+log "running the reflink suite on $REFLINK_DIR (FICLONE must fire)"
+set +e
+SNAPDIR_REFLINK_TEST_DIR="$REFLINK_DIR" \
+  TMPDIR="$REFLINK_DIR" \
+  SNAPDIR_REFLINK_TEST_REQUIRE=1 \
+  cargo test -p snapdir-stores --test reflink --locked
+status=$?
+set -e
+
+# ---------------------------------------------------------------------------
+# 4. Report.
+# ---------------------------------------------------------------------------
+if [ "$status" -eq 0 ]; then
+  log "PASS — the reflink suite passed: FICLONE fired and clonefile_hits() advanced on $REFLINK_DIR"
+else
+  fail "the reflink suite FAILED (exit $status): FICLONE did not fire as expected on $REFLINK_DIR"
+  fail "check that $REFLINK_DIR is a reflink-capable FS (Btrfs / XFS reflink=1 / OpenZFS 2.2+ / bcachefs)"
+fi
+
+exit "$status"


### PR DESCRIPTION
# Changelog

All notable changes to the snapdir Rust port are documented in this file.

The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).

## [Unreleased]

### Added

## [1.7.0] - 2026-06-14

### Added

- **`--walk-jobs <N>` / `$SNAPDIR_WALK_JOBS` — parallel, memory-mapped directory
  walk and file hashing.** Snapshotting a tree now hashes files across a bounded
  rayon pool and uses blake3's memory-mapped path for large files, so `id`,
  `manifest`, `stage`, and `push` no longer hash every file single-threaded —
  multiple× faster on large trees. The new global `--walk-jobs <N>` flag (and
  `$SNAPDIR_WALK_JOBS` env) sizes the walk pool; `0`/auto picks the number of
  CPUs (capped). This is **distinct from `--jobs` / `$SNAPDIR_JOBS`** (which
  controls transfer concurrency). Purely a performance win: **snapshot ids are
  unchanged (byte-identical)** with the feature on or off and across every
  `--walk-jobs` value — additive, default behavior preserved, the frozen
  manifest format untouched.
- **Cross-platform copy-on-write object clones — macOS (APFS `clonefile`) and
  Linux (`FICLONE` reflink).** When the source file and the snapdir store share
  a copy-on-write-capable filesystem, object copies during `stage`, `push`, and
  `checkout`/`fetch` now make a CoW clone instead of byte-copying: on macOS via
  `clonefile(2)` on the same APFS volume, and on Linux via the `FICLONE` ioctl
  reflink on Btrfs, XFS (`reflink=1`), OpenZFS 2.2+, OCFS2, and bcachefs. A
  large object is materialized for ~zero additional physical bytes (the clone
  shares extents) and without rewriting its data. This is additive and falls
  back gracefully to a plain `fs::copy` everywhere a reflink/clone cannot apply
  — non-CoW filesystems (ext4, F2FS, tmpfs), across filesystem boundaries, and
  on unsupported platforms. Set `SNAPDIR_CLONEFILE=0` to disable the fast-path
  entirely. Object bytes and snapshot ids are unchanged (byte-identical) with
  the fast-path on or off.
- **Clone fast-path now skips the redundant post-copy re-hash — a real
  `stage`/`checkout` speedup on both platforms.** Previously, even when an
  object was cloned copy-on-write, `persist()` re-read and re-hashed the result,
  so the clone saved disk space but not wall-clock time (the copy was never the
  bottleneck; the second full read was). The clone path now elides that
  redundant re-hash, turning the copy-on-write fast-path into a genuine speedup
  — multiple× faster `stage` and meaningfully faster `checkout` on large trees
  wherever a CoW clone fires, on macOS (APFS `clonefile`) or Linux (`FICLONE`
  reflink) alike. Correctness is preserved on two layers: **`stage`
  uses stat-validated trust** — the walk records the source file's stat and
  `persist` re-stats it at clone time, skipping the re-hash only if the source
  is unchanged since the walk (a changed source falls back to a full re-hash, so
  a mid-stage mutation is caught at write time); **`checkout` still verifies the
  source object once** (so on-disk object corruption is still detected) and only
  skips the redundant destination re-hash. Set **`SNAPDIR_VERIFY_COPIES=1`** to
  force the strict write-time re-hash even on the clone path. Object bytes and
  snapshot ids remain byte-identical, and the read-time BLAKE3 verification in
  `get_object`/`fetch` remains the integrity backstop regardless of this
  setting.
- **`--objects-store` / `$SNAPDIR_OBJECTS_STORE` — shared object pool, separate
  manifest locations.** This global flag routes content objects to one shared
  pool's `.objects/` while manifests go to `--store`'s `.manifests/`, so a
  scheduled inventory can write a fresh manifest path per run (by date / host /
  env) against a single deduplicated object pool. Re-pushing to the same pool
  only costs the changed bytes — unchanged content-addressed objects are
  skipped. Both halves resolve in-process; an external `custom://` store is
  rejected on either side. Unset leaves behavior byte-for-byte unchanged; the
  catalog records the `--store` (manifest-side) URI.
- **`snapdir sync --from-objects/--to-objects` — split object pools for
  bucket-to-bucket sync.** Each side names its own explicit object pool, so the
  source and destination can be different buckets; the streaming sync engine is
  unchanged, and objects already present in the destination pool are skipped
  (cross-pool dedup). These per-side flags are distinct from the global
  `--objects-store`; a side that omits its flag is a plain colocated store.
- **`snapdir diff` — file-level diff across manifest locations, reading
  manifests only.** Compares two sides, each a union of one-or-more manifest
  refs (`--from`/`--to`, both repeatable), classifying every path as `A` (added),
  `D` (deleted), or `M` (modified). It reads manifests only — it never downloads
  an object — so it stays cheap over large or unreachable object pools, which
  makes it well suited to comparing scheduled inventories. With the global
  `--id` a side pins to a single manifest. Flags: `--all` (also emit unchanged
  `=` paths), `--json` (a `{status, path}` array instead of porcelain
  `X\t./path` lines), `--exit-code` (git `diff --exit-code` semantics: exit `1`
  on any difference), and `--on-conflict <error|last-wins>` (intra-side
  same-path/differing-content collision policy; defaults to `error`).
- **SNAPPACK 1Z — auto-negotiated zstd transport for the `ssh://` accelerated
  pack stream.** The whole post-magic pack body is sent as a single zstd frame
  of the unchanged SNAPPACK 1 record grammar; the receiver sniffs the magic
  (`SNAPPACK 1Z\n`) and accepts both v1 and 1Z forever. Compression is additive
  (the wire version stays `1`; a new `snappack-zstd` capability token gates it),
  so it engages only when both ends advertise support — a mixed-version pair
  falls back to v1 with the v1 acceleration still taken. The level defaults to
  zstd level 3 and is tunable via `SNAPDIR_SSH_ZSTD_LEVEL` (`1`–`19`, clamped).
  Every decompressed byte is still BLAKE3-verified and the existing
  header/manifest bounds apply to the decompressed stream, so a decompression
  bomb costs CPU only. With SNAPPACK now compressing above the transport,
  prefer `Compression=no` on the SSH client (WAN / HPN-SSH) to avoid
  double-compressing.
- **`SNAPDIR_FSYNC` crash-durability knob on `receive-pack`.** Defaults to
  `batch`: all received objects are fsynced before the manifest is committed
  last, so a manifest that survives a crash is backed by durable objects (the
  manifest-last invariant holds across the crash boundary). `off` skips the
  barrier and relies on the OS to flush; any other value is a hard error. On a
  journaling filesystem this matches the crash-consistency guarantee git
  provides, and claims no more than that. Measured cost: the `batch` default
  adds ~20% on a small-files receive (v1 +19.5% / zstd +29.9% on a 5,000 ×
  4 KiB push, Linux CI) — a fixed per-object fsync cost on the receive-pack
  path only, accepted as the crash-safe default with `SNAPDIR_FSYNC=off` as
  the opt-out.

## [1.6.0] — 2026-06-11

### Added

- **`snapdir` crate: `cargo install snapdir` installs the CLI.** The flagship
  `snapdir` crate name on crates.io now ships the `snapdir` binary (a thin
  shim over the `snapdir-cli` implementation library), so the install command
  matches the binary name.

### Changed

- **`snapdir-cli` is now the implementation library.** The `snapdir` binary
  moved to the new `snapdir` crate; `snapdir-cli` keeps publishing and exposes
  `snapdir_cli::run()` — the binary entrypoint, not a semver-stable
  general-purpose API. Versions ≤ 1.5.0 of `snapdir-cli` are unaffected and
  still install the binary directly.

## [1.5.0] — 2026-06-10

### Added

- **`ssh://` and `sftp://` stores over the system OpenSSH client.** A new
  `snapdir-ssh-store` crate ships two external-store binaries —
  `snapdir-ssh-store` (`ssh://`, needs a remote POSIX shell) and
  `snapdir-sftp-store` (`sftp://`, pure SFTP; works against restricted
  `ForceCommand internal-sftp` chroot accounts) — with no SSH
  reimplementation and zero new crypto dependencies. Store URLs take
  `ssh://[user@]host[:port]/abs/base`; each scheme reads its own
  `SNAPDIR_{SSH,SFTP}_STORE_*` env family (`IDENTITY_FILE`, `KNOWN_HOSTS`,
  `PORT`, `CONNECT_TIMEOUT`, `JOBS`, `CONTROL_PERSIST`, `UMASK`,
  `EXTRA_OPTS`). Every invocation multiplexes over one `ControlMaster`
  connection and starts with an un-weakenable modern-only security floor
  (pinned kex/AEAD-cipher/host-key lists, `StrictHostKeyChecking=yes`,
  `BatchMode=yes`; `EXTRA_OPTS` are appended last and structurally cannot
  weaken it); OpenSSH ≥ 8.5 is required locally, fail-closed. `snapdir sync`
  does not support these stores.
- **Automatic `ssh://` acceleration via SNAPPACK.** When the remote host has
  a wire-compatible `snapdir` on its `PATH`, pushes and fetches negotiate at
  runtime (exact `wire=1` integer match, never semver) and switch to a
  self-verifying pack stream: the object list is diffed remotely and only
  missing objects ride one `send-pack | receive-pack` pipe, with the manifest
  as the last record, committed only after the verified `end` trailer —
  manifest-last preserved end-to-end, byte-identical to the plain path.
  Graceful fallback when the remote lacks the plumbing;
  `SNAPDIR_SSH_NO_ACCEL=1`, `SNAPDIR_SSH_FORCE_ACCEL=1`, and
  `SNAPDIR_SSH_PULL_SENDALL=1` control it. Spec:
  `docs/rust-port/ssh-wire-protocol.md`.
- **Hidden wire plumbing in the CLI.** `snapdir version --capabilities`
  prints the negotiation line (`snapdir <semver> wire=<u32> caps=<csv>`), and
  three hidden subcommands — `objects-needed`, `send-pack`, `receive-pack` —
  implement the pack protocol over any built-in store with fail-closed input
  validation and incremental BLAKE3 verification. The documented CLI surface
  and plain `snapdir version` output are unchanged.
- **`StreamStore::objects_needed`.** A defaulted trait method answering which
  of the offered checksums a store does not hold (order-preserving,
  fail-closed validation), available across the `file://`, `s3://`, `gs://`,
  and `b2://` stores.

### Fixed

- **External-store CLI wiring.** `snapdir push`/`fetch --store` against an
  external `snapdir-<scheme>-store` binary passed directory *trees* where the
  emit-command contract expects *sharded store roots*, breaking every
  external store end-to-end. Push now stages the snapshot into the local
  cache and pushes from the cache root, and fetch lands objects directly in
  the cache root, committing the manifest last. Affects all
  `snapdir-*-store` binaries; the built-in stores were never affected.

## [1.4.0] — 2026-06-09

### Added

- **Transient-failure retries with full-jitter exponential backoff.** Network
  store calls (`s3://`, `gs://`, `b2://`) now retry transient failures — HTTP
  `429`/`503`, S3 `SlowDown`, GCS `RESOURCE_EXHAUSTED`, request timeouts, and
  connection reset/closed — under full-jitter exponential backoff, while a
  non-transient error (e.g. `404` not-found) fails immediately. A server
  `Retry-After` header (or GCS backoff hint) is honored as a floor on the wait.
  Each SDK's built-in retries are disabled so snapdir's policy is the single
  authority. Defaults are **5 total attempts** (the first try plus up to four
  retries), **250 ms** base, doubling, capped at **30 s**; configurable via
  `--max-retries`/`SNAPDIR_MAX_RETRIES`, `--retry-base-ms`/`SNAPDIR_RETRY_BASE_MS`,
  and `--retry-max-ms`/`SNAPDIR_RETRY_MAX_MS`. The local `file://` store does no
  network retrying.
- **Per-second request-rate limiting (`--max-requests`/`SNAPDIR_MAX_REQUESTS`).**
  Complements the existing aggregate byte-throughput cap
  (`--limit-rate`/`SNAPDIR_LIMIT_RATE`) with a requests-per-second cap for the
  network stores. When unset, a conservative **per-backend default** applies,
  taken as the lower of each provider's published read/write limits:
  `s3://` 3500 req/s, `gs://` 1000 req/s, `b2://` 20 req/s + 25 MiB/s, and no
  caps for `file://`/local (sources: AWS S3, GCS, Backblaze B2). Precedence,
  highest to lowest: `--flag` > `SNAPDIR_*` env > per-backend default > global
  default.

### Fixed

- **Input-path normalization.** `snapdir push`/`manifest`/`id`/`stage` now treat
  `foo`, `./foo`, `foo/`, and `./foo/` identically — every form produces the same
  manifest and snapshot id. Previously a trailing slash or a `./` prefix could
  leak absolute paths or a malformed entry into the manifest.
- **`--store` and `sync --from` default to `$SNAPDIR_STORE`.** When the flag is
  omitted and the env var is set, snapdir uses it; an explicit flag still wins.
  `sync --to` stays explicit (a sync needs two distinct stores).
- **crates.io crate pages now render a README.** Each published crate
  (`snapdir-core`/`-catalog`/`-stores`/`-cli`) ships its own README, so the
  crates.io pages are no longer blank.

These additions pull in **no new dependencies** and leave the manifest
byte-format and content-addressed layout unchanged, so snapshots stay fully
interoperable with 1.x.

## [1.3.0]

### Added

- **Opt-in adaptive transfer tuning (`--adaptive[=FRACTION]`).** When passed,
  `push`/`fetch`/`pull`/`checkout`/`stage`/`sync` auto-tune transfer concurrency
  (and, for the network stores, the aggregate byte-rate) toward a polite
  **fraction of measured capacity (default 0.8)**: it probes in-band (TCP-style
  slow-start → AIMD with a latency-gradient guardrail), backs off fast under
  throttling/timeouts or when CPU/memory are tight so it doesn't overwhelm the
  host or co-tenants, and re-probes every ~15s to use newly-free capacity. A
  `--max-jobs` flag (and `SNAPDIR_ADAPTIVE`/`SNAPDIR_MAX_JOBS` env) bound it.
  **Off by default — default behavior is unchanged (full speed)**; `--jobs`/
  `--limit-rate` remain hard overrides. Works across the local `file://` store
  and S3/GCS/B2. Transfers remain byte-identical regardless of the tuner (it
  changes only scheduling/rate).
- **Clearer, steadier transfer progress.** The single-line progress display now
  unambiguously labels counts (`N/M files`) vs sizes (unit-suffixed bytes), uses
  fixed-width columns so the layout no longer reflows as digits change, and shows
  a smoothed, throttled ETA that settles instead of flickering. When adaptive is
  on it surfaces the live `(auto <fraction>)` target.

The manifest byte-format and content-addressed object/manifest layout are unchanged, so
snapshots remain fully interoperable with 1.x.

## [1.2.0]

### Added

- **`snapdir sync` — streaming store-to-store snapshot copy.** A 15th subcommand
  that copies ONE snapshot (manifest + raw content-addressed objects) directly from
  one store to another, streaming through memory with no local-filesystem staging.
  Backed by a new `StreamStore` trait and a `sync_snapshot` orchestrator; it reuses
  the concurrency and aggregate rate-limiting from 1.1.0 (manifest-last,
  skip-already-present). Works across the S3, GCS, and B2 stores and the local
  `file://` store.
- **Live transfer & hashing progress dashboard.** A single-line, self-updating
  stderr progress indicator (spinner/bar plus from→to bytes/s and objects/s,
  concurrency, and best-effort memory/CPU) for `push`/`fetch`/`pull`/`checkout`/
  `stage`/`sync` and the local walk. It is shown only on an interactive TTY
  (auto-disabled when piped); `--no-progress`, `--quiet/-q`, and `--color` control
  it, and it honors `NO_COLOR`/`TERM=dumb`. stdout stays the scriptable snapshot id.
- **Deterministic benchmark & regression-gate suite.** A synthetic-scenario
  generator (regular files and dirs, fixed perms/bytes, no rng/time) drives: a golden
  snapshot-id plus structural-invariants plus full local round-trip determinism gate
  (runs everywhere as integration testing), criterion wall-clock decision benches, and
  an iai-callgrind instruction-count perf gate (5% threshold; macOS via a pinned
  Docker image, enforced in Linux CI). Benches are compile-checked in CI and pre-push.

The manifest byte-format and content-addressed object/manifest layout are unchanged, so
snapshots remain fully interoperable with 1.1.x.

## [1.1.0]

### Added

- **Concurrent object transfers.** `push` and `pull`/`fetch` now transfer objects
  concurrently instead of one at a time — across S3, GCS, and B2 (network) and the
  local `file://` store. Concurrency defaults to the number of available CPUs (capped
  at 16) and is tunable with `--jobs/-j N` (`SNAPDIR_JOBS`); `--jobs 1` restores fully
  sequential transfers.
- **Aggregate bandwidth limiting.** `--limit-rate RATE` (`SNAPDIR_LIMIT_RATE`) caps the
  *total* network throughput across all in-flight transfers via a single token bucket,
  using wget-style suffixes (e.g. `512K`, `10M`, `1G`). It applies to the network stores;
  local `file://` copies are not rate-limited.
- **`--verbose` transfer reporting.** Under `--verbose`, the transfer commands print the
  effective settings to stderr, e.g. `transfers: 8 concurrent, limit 10M`.

### Fixed

- **`--dryrun` is now honored.** The global `--dryrun` flag was declared but never
  checked, so `push --dryrun` (and other mutating commands) still wrote to the store.
  `push` (incl. staged `--id`), `stage`, `fetch`, `checkout`, `pull`, and `flush-cache`
  now perform zero writes under `--dryrun`, and `verify-cache --purge` does not purge.
- **`pull` no longer re-downloads data that is already local.** `fetch_files` skips any
  destination file already present whose checksum matches the manifest (no copy, and no
  network GET), and `fetch`/`pull` skip the store entirely when the snapshot is already
  cached — so a repeated pull of the same snapshot performs no redundant transfers.
  Corrupted local files are detected and repaired.

### Changed

- **`--exclude` and `--paths` accept multiple patterns** — repeated (`--exclude a
  --exclude b`) and/or comma-delimited (`--exclude a,b`) — combined as a logical OR
  (a path matches if it matches any pattern). The `%system%` / `%common%` macros are
  expanded per pattern. A single value behaves exactly as before.

The manifest byte-format and content-addressed object/manifest layout are unchanged, so
snapshots remain fully interoperable with 1.0.x.

## [1.0.1]

### Fixed

- **`snapdir push --store … --id <id>` (no PATH)** now pushes the *staged*
  snapshot named by `--id`. It previously ignored `--id` and fell through to the
  current-working-directory default, silently snapshotting the CWD instead of the
  staged snapshot (which looked like a hang when the CWD was large). Pushing by id
  materializes the snapshot from the local cache and uploads that, mirroring
  `fetch` in reverse.

### Removed

- **The published Docker/GHCR container image** and its build pipeline
  (`packaging/Dockerfile`, the root `Dockerfile`, the `docker-publish.yml`
  workflow, and the `docker` release job) are removed — the image is no longer
  maintained. Install via `cargo install snapdir-cli` or the prebuilt release
  archives. The library crates and signed release archives are unaffected.

## [1.0.0] — Port complete

The Rust port is **complete** and the legacy Bash implementation has been
removed. With nothing left to differentially test against, the byte-format
contract is now guarded entirely in Rust, the dependency tree is modernized, and
the distribution story (static musl on `scratch`, release archives, ADRs) is
finalized.

### Added

- **Migration guide** (`docs/rust-port/migration.md`) and **manifest
  specification** (`docs/rust-port/manifest-spec.md`) documenting the frozen
  manifest format, the content-addressable storage layout, the directory merkle
  rule, and the snapshot-ID derivation.
- **Architecture Decision Records** (`docs/adr/`) capturing the significant port
  decisions (manifest-format freeze, snapshot-ID derivation, ring TLS provider,
  in-process cloud stores, redb catalog, scratch image, bundled CA roots,
  retiring the Bash implementation, dependency-cooldown policy, and more).
- **Rust golden-format contract** — `crates/snapdir-core/tests/compat_golden.rs`
  pins the exact manifest line bytes, directory merkle checksums, and snapshot
  IDs as golden constants, replacing the live differential comparison as the
  guarantor of byte-format stability.
- **`manifest-format.sha.lock` tripwire** over the format-defining source, so any
  accidental change to the line format, ordering, checksum algorithm, sharded
  layout, or exclude sets trips CI and demands an explicit, reviewed bump.
- **Local pre-push CI gate** (`utils/ci/pre-push.sh`, installed via
  `make install-hooks`) running the fast CI legs (~2–4 min) before every push;
  the slow musl + coverage legs run in CI and via `make ci-local`.
- **`scratch` Docker image** — a `FROM scratch` final stage shipping only the
  fully-static musl `snapdir` binary plus the bundled CA roots
  (`ca-certificates.crt`): zero runtime executables, no libc, no shell.

### Changed

- **Dependencies modernized.** TLS/crypto moved to **rustls 0.23** with the
  **ring** provider over **hyper 1.x**; the AWS SDK crates were bumped to their
  latest releases and the `google-cloud-storage` SDK was unpinned. All updates
  honor a **3-day minimum-release-age cooldown** (supply-chain hardening).
- **MSRV raised to 1.91.1**, driven by the AWS SDK crates.

### Removed

- **The legacy Bash implementation was removed.** Its role as the behavioral
  source of truth is now served by the Rust golden-format tests and the
  `manifest-format.sha.lock` tripwire. The shipped binary remains fully
  in-process with no runtime dependency on external executables.

## [0.5.0] — Rust port

The Bash `snapdir` (v0.5.0) is ported to a single, statically-linkable,
**zero-runtime-dependency** Rust binary. The `snapdir` binary absorbs every
`snapdir-*` helper as a subcommand, while remaining **byte-for-byte
interoperable** with the Bash version: identical manifest lines, identical
snapshot IDs, and identical object/manifest keys and bucket layout, so Rust- and
Bash-written caches and remote buckets stay mutually readable.

### Added

- **Single `snapdir` binary** exposing all 14 subcommands (`manifest`, `id`,
  `stage`, `push`, `fetch`, `pull`, `checkout`, `verify`, `verify-cache`,
  `flush-cache`, `locations`, `ancestors`, `revisions`, `defaults`, plus
  `test`/`version`/`help`) via a clap v4 derive interface.
- **In-process BLAKE3** hashing via the `blake3` crate — no shelling out to
  `b3sum`. Includes keyed mode (`SNAPDIR_MANIFEST_CONTEXT` →
  `blake3::derive_key`) and the `--checksum-bin` matrix (`md5sum`/`sha256sum`)
  reproduced in-process via the `md-5`/`sha2` crates.
- **In-process filesystem walk** producing the frozen manifest format, with
  symlink follow/no-follow, `--absolute`, and the `%system%`/`%common%` exclude
  macros — verified byte-for-byte against the original snapdir's manifest output.
- **Native-SDK remote stores** — S3 (`aws-sdk-s3`), B2 (Backblaze's
  S3-compatible endpoint, a thin wrapper over the S3 store), and GCS
  (`google-cloud-storage`). No shelling out to `aws`, `b2`, or `gcloud`.
- **redb-backed internal catalog** replacing the SQLite catalog. The catalog is
  private and rebuildable — there is no on-disk catalog interop and no
  SQLite→redb importer; rebuild it from a store with `snapdir catalog rebuild`.
  Only the JSON-line *output* (`locations`/`ancestors`/`revisions`) stays
  byte-for-byte format-identical to the Bash tool.
- **External-store shim** retained for third-party `snapdir-*-store` binaries:
  the binary emits the store's shell command rather than embedding it. Built-in
  stores (`file`/`s3`/`b2`/`gs`) stay fully in-process.
- **`file://` FileStore** with the sharded `.objects`/`.manifests` layout,
  objects-before-manifest push (skip-if-present), and verified fetch
  (temp download → BLAKE3 verify → retry ≤5 → atomic rename).
- **Differential interop harness** (`tests/interop/run.sh`) proving byte-identical
  manifests and snapshot IDs Bash↔Rust across every checksum/keyed/no-follow
  mode, plus live cross-tool harnesses for S3 (MinIO) and GCS.
- **Performance**: in-process walk + BLAKE3 makes the Rust `manifest` command
  ~33.6× faster on many-small files and ~2.69× faster on few-large files than the
  Bash oracle, with byte-identical output.

### Changed

- **Catalog backend** moved from SQLite (shelling out to `sqlite3`) to the
  pure-Rust embedded `redb` key-value store. Catalog state is now internal and
  rebuildable via `snapdir catalog rebuild` rather than migrated.
- **Authentication** for remote stores is delegated entirely to each native
  SDK's own credential chain (AWS env/profiles/SSO/instance metadata;
  GCS `GOOGLE_APPLICATION_CREDENTIALS`/ADC/metadata) — no bespoke snapdir env
  vars.
- **TLS/crypto** uses the **ring** rustls provider (not aws-lc-rs) so the static
  musl build stays clean; `aws-lc-rs` is banned from the dependency tree.

### Fixed

- Documentation flag/command names corrected from the Bash docs' known bugs: the
  checkout flag is **`--linked`** (the old docs showed `--link`), and the
  store-side transaction check subcommand is **`ensure-no-errors`** (the old
  docs showed `verify-transactions`). The frozen Bash scripts already used the
  correct names; only the docs were wrong, and the Rust-port docs use the real
  names.
- Corrected the documented snapshot-ID derivation: the snapshot ID is the BLAKE3
  of the `#`-stripped manifest text (including the trailing newline), **not** the
  root directory checksum. (The earlier "root dir checksum = snapshot ID" wording
  was a documented bug; the core implementation and the frozen contract now state
  the real derivation. See `docs/rust-port/manifest-spec.md` §4.)

### Removed

- No runtime dependency on external binaries (`b3sum`, `sqlite3`, `aws`, `b2`,
  `gcloud`) in the shipped binary. External tools are used only by the test/oracle
  harness.

[Unreleased]: https://github.com/snapdir/snapdir/compare/v1.7.0...HEAD
[1.7.0]: https://github.com/snapdir/snapdir/compare/v1.6.0...v1.7.0
[1.6.0]: https://github.com/snapdir/snapdir/compare/v1.5.0...v1.6.0
[1.5.0]: https://github.com/snapdir/snapdir/compare/v1.4.0...v1.5.0
[1.4.0]: https://github.com/snapdir/snapdir/compare/v1.3.0...v1.4.0
[1.3.0]: https://github.com/snapdir/snapdir/compare/v1.2.0...v1.3.0
[1.2.0]: https://github.com/snapdir/snapdir/compare/v1.1.0...v1.2.0
[1.1.0]: https://github.com/snapdir/snapdir/compare/v1.0.1...v1.1.0
[1.0.1]: https://github.com/snapdir/snapdir/compare/v1.0.0...v1.0.1
[1.0.0]: https://github.com/snapdir/snapdir/releases/tag/v1.0.0
[0.5.0]: https://github.com/snapdir/snapdir/releases/tag/v0.5.0
