### PR TITLE
release: 1.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,14 +3479,14 @@ dependencies = [
 
 [[package]]
 name = "snapdir"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "snapdir-cli",
 ]
 
 [[package]]
 name = "snapdir-benches"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "criterion",
  "iai-callgrind",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-catalog"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "redb",
  "serde",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-cli"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3525,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-core"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "blake3",
  "libc",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-ssh-store"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "snapdir-core",
  "snapdir-stores",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-stores"
-version = "1.8.0"
+version = "1.9.0"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.8.0"
+version = "1.9.0"
 edition = "2021"
 rust-version = "1.91.1"
 authors = ["Bermi Ferrer <bermi@bermilabs.com>"]
@@ -24,9 +24,9 @@ categories = ["command-line-utilities", "filesystem"]
 
 [workspace.dependencies]
 # Internal crates
-snapdir-core = { path = "crates/snapdir-core", version = "1.8.0" }
-snapdir-catalog = { path = "crates/snapdir-catalog", version = "1.8.0" }
-snapdir-stores = { path = "crates/snapdir-stores", version = "1.8.0" }
+snapdir-core = { path = "crates/snapdir-core", version = "1.9.0" }
+snapdir-catalog = { path = "crates/snapdir-catalog", version = "1.9.0" }
+snapdir-stores = { path = "crates/snapdir-stores", version = "1.9.0" }
 
 # Errors: thiserror in libs, anyhow (+ context) in the bin.
 thiserror = "2"

--- a/_typos.toml
+++ b/_typos.toml
@@ -47,6 +47,9 @@ deprecat = "deprecat"
 # `unparseable` = a valid English spelling used in a dx_errors assertion message
 # ("an unparseable --limit-rate must fail"); not a typo (variant of "unparsable").
 unparseable = "unparseable"
+# `disabl` = a deliberate SUBSTRING in the catalog_default tests (`.contains("disabl")`)
+# that case-insensitively matches the "catalog disabled (--catalog none)" message text.
+disabl = "disabl"
 
 [default.extend-identifiers]
 # crate / API identifiers that look like typos but are intentional.

--- a/crates/snapdir-cli/src/cli.rs
+++ b/crates/snapdir-cli/src/cli.rs
@@ -334,6 +334,13 @@ pub struct CatalogArgs {
     /// Store URI: `protocol://location/path` (revisions location fallback).
     #[arg(long, value_name = "URI", env = "SNAPDIR_STORE")]
     pub store: Option<String>,
+
+    /// Directory where the object cache (and the default catalog) is stored.
+    // Needed so the default catalog (`<cache-dir>/default-catalog.redb`) the
+    // query commands READ resolves to the SAME cache dir a no-flag
+    // `push`/`stage` WROTE to (respecting `--cache-dir`/`SNAPDIR_CACHE_DIR`).
+    #[arg(long, value_name = "DIR", env = "SNAPDIR_CACHE_DIR")]
+    pub cache_dir: Option<PathBuf>,
 }
 
 /// The cache-management family: applied to `verify`/`verify-cache`/`flush-cache`.
@@ -756,12 +763,36 @@ pub enum Command {
         capabilities: bool,
     },
 
-    /// Generate a shell-completion script to stdout.
+    /// Generate a shell completion script (bash, zsh, fish, …).
     ///
-    /// Hidden from the documented 14-subcommand surface: this is a build-time
-    /// hook the release pipeline (`release.yml` gen-assets job) calls as
-    /// `snapdir completions <shell>` to bundle completions into each archive.
-    #[command(hide = true)]
+    /// Writes a completion script for the given shell to stdout. Wire it up by
+    /// sourcing the output from your shell profile:
+    ///
+    ///   bash:       eval "$(snapdir autocomplete bash)"
+    ///               # add the line above to ~/.bashrc
+    ///
+    ///   zsh:        eval "$(snapdir autocomplete zsh)"
+    ///               # add the line above to ~/.zshrc
+    ///
+    ///   fish:       snapdir autocomplete fish | source
+    ///               # or write to ~/.config/fish/completions/snapdir.fish
+    ///
+    ///   powershell: snapdir autocomplete powershell | Out-String | Invoke-Expression
+    ///               # add the line above to your $PROFILE
+    ///
+    ///   elvish:     eval (snapdir autocomplete elvish | slurp)
+    ///
+    /// The script always targets the `snapdir` binary name. The hidden
+    /// `completions <shell>` alias is kept for back-compat (the release
+    /// pipeline's gen-assets job and existing scripts) and emits byte-identical
+    /// output.
+    // `autocomplete` is the VISIBLE primary; `completions` is a HIDDEN alias
+    // (clap's `alias` is hidden, unlike `visible_alias`), so the release
+    // pipeline's `snapdir completions <shell>` keeps working unchanged while the
+    // documented surface shows only `autocomplete`. The internal enum variant
+    // stays `Completions` (lowest-churn); clap derives the command name from the
+    // explicit `name`.
+    #[command(name = "autocomplete", alias = "completions")]
     Completions {
         /// Target shell (`bash`, `fish`, `zsh`, `powershell`, `elvish`).
         shell: clap_complete::Shell,
@@ -959,6 +990,7 @@ fn merge_catalog(g: &mut Resolved, c: &CatalogArgs) {
     g.location.clone_from(&c.location);
     g.id.clone_from(&c.id);
     g.store.clone_from(&c.store);
+    g.cache_dir.clone_from(&c.cache_dir);
 }
 
 /// Folds a parsed [`CacheMgmtArgs`] group into the resolved config.
@@ -1046,7 +1078,7 @@ impl Ctx {
                 let id = snapshot_id(&manifest, &Blake3Hasher::new());
                 let abs = resolve_root(path.as_deref())
                     .context("resolving the manifested directory path")?;
-                self.log_event("manifest", &id, &abs.to_string_lossy())?;
+                self.log_event("manifest", &id, &abs.to_string_lossy(), false)?;
                 Ok(())
             }
             Command::Id { path, .. } => {
@@ -1145,8 +1177,10 @@ impl Ctx {
                 ..
             } => self.run_diff(from, to, *all, *json, *exit_code, on_conflict.resolve()),
             Command::Completions { shell } => {
-                // Build-time hook: emit the requested shell's completion script
-                // to stdout for the release pipeline to bundle. The bin name is
+                // The visible `autocomplete <shell>` command (and its hidden
+                // `completions` back-compat alias): emit the requested shell's
+                // completion script to stdout — for a user to source from their
+                // profile, or for the release pipeline to bundle. The bin name is
                 // `snapdir` (the visible surface, hidden subcommands included).
                 let mut cmd = Cli::command();
                 clap_complete::generate(*shell, &mut cmd, "snapdir", &mut std::io::stdout());
@@ -1215,6 +1249,17 @@ enum Source {
     Default,
 }
 
+/// The resolved catalog selection: either an enabled redb DB path or the
+/// explicit `none`/empty disable sentinel.
+enum CatalogTarget {
+    /// Catalog logging/reads target this redb DB path.
+    Enabled(PathBuf),
+    /// `--catalog none` / `--catalog ""` (or `manifest` with no explicit
+    /// catalog): no logging, no DB created, query commands print a "disabled"
+    /// message and exit 0.
+    Disabled,
+}
+
 impl Source {
     fn tag(self) -> &'static str {
         match self {
@@ -1241,6 +1286,15 @@ fn knob_source(flag_set: bool, env_name: &str) -> Source {
     } else {
         Source::Default
     }
+}
+
+/// Prints the "catalog disabled" notice on stderr for the query commands when
+/// `--catalog none` (or empty) selects the disable sentinel, then the caller
+/// exits 0. Distinct from the enabled-but-empty case (which prints nothing),
+/// so a disabled catalog is never confused with a catalog that simply has no
+/// records yet.
+fn print_catalog_disabled() {
+    eprintln!("catalog disabled (--catalog none): nothing to query");
 }
 
 impl Ctx {
@@ -1295,9 +1349,16 @@ impl Ctx {
             self.globals.objects_store.as_deref().unwrap_or("none"),
             knob_source(has_flag("--objects-store"), "SNAPDIR_OBJECTS_STORE"),
         );
+        // catalog: when unset, resolve to the default catalog path so `defaults`
+        // surfaces what a no-flag run would actually use (default-on), with
+        // source=default. An explicit `none`/empty value stays verbatim.
+        let catalog_value = match self.resolve_catalog(true) {
+            CatalogTarget::Enabled(db) => db.display().to_string(),
+            CatalogTarget::Disabled => "none".to_owned(),
+        };
         emit(
             "catalog",
-            self.globals.catalog.as_deref().unwrap_or("none"),
+            &catalog_value,
             knob_source(has_flag("--catalog"), "SNAPDIR_CATALOG"),
         );
 
@@ -1521,7 +1582,7 @@ impl Ctx {
             }
             reporter.finish();
             println!("{id}");
-            self.log_event("push", id, store_url)?;
+            self.log_event("push", id, store_url, true)?;
             return Ok(());
         }
 
@@ -1585,7 +1646,7 @@ impl Ctx {
         // `revisions`/`ancestors` see it. Best-effort and only when the catalog
         // is enabled (`--catalog` / `SNAPDIR_CATALOG`), exactly like the oracle's
         // `_snapdir_log_event` no-op when no catalog adapter is configured.
-        self.log_event("push", &id, store_url)?;
+        self.log_event("push", &id, store_url, true)?;
         Ok(())
     }
 
@@ -1907,7 +1968,7 @@ impl Ctx {
         // staged base directory (the absolute path `stage` walked). Best-effort
         // and a no-op unless a catalog is enabled, so it never changes the
         // stdout bytes above.
-        self.log_event("stage", &id, &root.to_string_lossy())?;
+        self.log_event("stage", &id, &root.to_string_lossy(), true)?;
         Ok(())
     }
 
@@ -2019,7 +2080,10 @@ impl Ctx {
     /// catalog's order. Reproduces the original `snapdir locations` /
     /// `snapdir-sqlite3-catalog locations` query output.
     fn run_locations(&self) -> Result<()> {
-        let catalog = self.open_catalog()?;
+        let Some(catalog) = self.open_catalog()? else {
+            print_catalog_disabled();
+            return Ok(());
+        };
         for record in catalog.locations().context("querying catalog locations")? {
             println!("{}", locations_json_line(&record));
         }
@@ -2031,7 +2095,10 @@ impl Ctx {
     /// one frozen JSON line per ancestor (each line's `id` is the row's
     /// `previous_id`). Mirrors `snapdir ancestors --id=…`.
     fn run_ancestors(&self) -> Result<()> {
-        let catalog = self.open_catalog()?;
+        let Some(catalog) = self.open_catalog()? else {
+            print_catalog_disabled();
+            return Ok(());
+        };
         let id = self.require_id()?;
         let location = self.globals.location.as_deref();
         for record in catalog
@@ -2048,7 +2115,10 @@ impl Ctx {
     /// the oracle's `snapdir revisions --location=…`, whose location defaults to
     /// `--store` / the directory when `--location` is unset.
     fn run_revisions(&self) -> Result<()> {
-        let catalog = self.open_catalog()?;
+        let Some(catalog) = self.open_catalog()? else {
+            print_catalog_disabled();
+            return Ok(());
+        };
         // Oracle (L991-997): location = --location, else --store, else the dir;
         // empty → error.
         let location = self
@@ -2066,17 +2136,24 @@ impl Ctx {
         Ok(())
     }
 
-    /// Logs a catalog event (`event`/`id`/`location`) when the catalog is
-    /// enabled, mirroring the oracle's `_snapdir_log_event` (`snapdir` L1620): a
-    /// no-op unless `--catalog` / `SNAPDIR_CATALOG` selects a catalog. Uses the
-    /// shipped [`SystemClock`] (`created_at` = `YYYY-MM-DD HH:MM:SS.SSS`), so the
-    /// JSON timestamps are byte-shaped like the oracle's.
-    fn log_event(&self, event: &str, id: &str, location: &str) -> Result<()> {
-        // The oracle's `_snapdir_log_event` is a no-op when no catalog adapter
-        // is configured; only persist when the catalog is enabled.
-        let Some(db) = self.catalog_db_path() else {
+    /// Logs a catalog event (`event`/`id`/`location`) to the resolved catalog.
+    /// `push`/`stage` pass `allow_default = true` so a no-flag snapshot records
+    /// to the default catalog (`<cache-dir>/default-catalog.redb`); `manifest`
+    /// passes `false` so it only logs when a catalog is set EXPLICITLY (flag or
+    /// `SNAPDIR_CATALOG`), never auto-recording to the default. A `none`/empty
+    /// catalog (the disable sentinel) is always a silent no-op. Uses the shipped
+    /// [`SystemClock`] (`created_at` = `YYYY-MM-DD HH:MM:SS.SSS`), so the JSON
+    /// timestamps are byte-shaped like the oracle's.
+    fn log_event(&self, event: &str, id: &str, location: &str, allow_default: bool) -> Result<()> {
+        // Disabled sentinel or (for manifest) no explicit catalog → no-op,
+        // never changing the stdout bytes the command already printed.
+        let CatalogTarget::Enabled(db) = self.resolve_catalog(allow_default) else {
             return Ok(());
         };
+        if let Some(parent) = db.parent() {
+            std::fs::create_dir_all(parent)
+                .with_context(|| format!("creating catalog directory {}", parent.display()))?;
+        }
         let catalog =
             Catalog::open(&db).with_context(|| format!("opening catalog at {}", db.display()))?;
         catalog
@@ -2085,39 +2162,49 @@ impl Ctx {
         Ok(())
     }
 
-    /// Opens the catalog for a read query, erroring when no catalog is enabled —
-    /// mirroring the oracle's `_snapdir_ensure_catalog` ("Missing
-    /// `SNAPDIR_CATALOG` or `--catalog`").
-    fn open_catalog(&self) -> Result<Catalog> {
-        let db = self
-            .catalog_db_path()
-            .context("error: Missing SNAPDIR_CATALOG or --catalog")?;
+    /// Opens the catalog for a read query (`revisions`/`locations`/`ancestors`),
+    /// resolving the default catalog when `--catalog`/`SNAPDIR_CATALOG` is unset
+    /// so a no-flag query reads the same default a no-flag `push`/`stage` wrote.
+    /// Returns `None` when the catalog is the `none`/empty disable sentinel; the
+    /// caller prints a "catalog disabled" message and exits 0.
+    fn open_catalog(&self) -> Result<Option<Catalog>> {
+        let CatalogTarget::Enabled(db) = self.resolve_catalog(true) else {
+            return Ok(None);
+        };
         if let Some(parent) = db.parent() {
             std::fs::create_dir_all(parent)
                 .with_context(|| format!("creating catalog directory {}", parent.display()))?;
         }
-        Catalog::open(&db).with_context(|| format!("opening catalog at {}", db.display()))
+        let catalog =
+            Catalog::open(&db).with_context(|| format!("opening catalog at {}", db.display()))?;
+        Ok(Some(catalog))
     }
 
-    /// Resolves the catalog database path, or `None` when the catalog is not
-    /// enabled (the oracle requires `--catalog` / `SNAPDIR_CATALOG` to be set;
-    /// when unset its `_snapdir_log_event` is a no-op and the query commands
-    /// error). The single redb backend replaces the oracle's pluggable adapters,
-    /// so the value is interpreted as the db path: an absolute/relative path is
-    /// used verbatim; a bare adapter name (e.g. the oracle's `"redb"` /
-    /// `"sqlite3"`) selects `<cache-dir>/<name>-catalog.redb`.
-    fn catalog_db_path(&self) -> Option<PathBuf> {
-        let catalog = self.globals.catalog.as_deref()?;
-        if catalog.is_empty() {
-            return None;
-        }
-        // A path-like value (contains a path separator) is used as the db file
-        // directly; otherwise treat it as a bare adapter name and place the db
-        // under the cache dir.
-        if catalog.contains(std::path::MAIN_SEPARATOR) {
-            Some(PathBuf::from(catalog))
-        } else {
-            Some(self.cache_dir().join(format!("{catalog}-catalog.redb")))
+    /// Resolves the catalog selection into either an enabled redb path or the
+    /// explicit disable sentinel. Precedence is flag > `SNAPDIR_CATALOG` env >
+    /// default (clap's `env` feature folds flag+env into one resolved `Option`).
+    ///
+    /// - `Some("none")` / `Some("")` → [`CatalogTarget::Disabled`] (no logging,
+    ///   no DB file created).
+    /// - `Some(path-with-separator)` → that path verbatim.
+    /// - `Some(bare-name)` → `<cache-dir>/<name>-catalog.redb`.
+    /// - `None` (unset) → `<cache-dir>/default-catalog.redb` when `allow_default`
+    ///   (the `push`/`stage` write-paths and the read queries), else
+    ///   [`CatalogTarget::Disabled`] (e.g. `manifest`, which never auto-records
+    ///   to the default).
+    fn resolve_catalog(&self, allow_default: bool) -> CatalogTarget {
+        match self.globals.catalog.as_deref() {
+            Some(v) if v == "none" || v.is_empty() => CatalogTarget::Disabled,
+            // A path-like value (contains a separator) is used verbatim;
+            // otherwise treat it as a bare adapter name under the cache dir.
+            Some(v) if v.contains(std::path::MAIN_SEPARATOR) => {
+                CatalogTarget::Enabled(PathBuf::from(v))
+            }
+            Some(v) => CatalogTarget::Enabled(self.cache_dir().join(format!("{v}-catalog.redb"))),
+            None if allow_default => {
+                CatalogTarget::Enabled(self.cache_dir().join("default-catalog.redb"))
+            }
+            None => CatalogTarget::Disabled,
         }
     }
 

--- a/crates/snapdir-cli/tests/catalog_default.rs
+++ b/crates/snapdir-cli/tests/catalog_default.rs
@@ -1,0 +1,1284 @@
+//! Black-box spec tests for the 1.9.0 default-on catalog semantics.
+//!
+//! Design lock: `.gatesmith/reviews/catalog-default-1.9.0.md`
+//!
+//! ## Root bugs being fixed
+//!
+//! Bug 1 — writes without `--catalog` log NOWHERE: `catalog_db_path()` returns
+//! `None` when `--catalog` is unset, so `log_event()` silently no-ops. Snapshots
+//! taken with no flag are never recorded anywhere.
+//!
+//! Bug 2 — `--catalog none` opens a literal `none-catalog.redb` (always empty),
+//! so `revisions --catalog none` returns nothing instead of a clear "disabled"
+//! message.
+//!
+//! ## Contract under test
+//!
+//! - Unset `--catalog` → resolves to `<cache_dir>/default-catalog.redb`.
+//!   `push` and `stage` auto-record there; `revisions`/`locations`/`ancestors`
+//!   read there. Round-trip works with zero flags.
+//! - `--catalog none` (and `--catalog ""`) = disable sentinel: nothing recorded,
+//!   no DB file created, query commands print a clear "catalog disabled" message
+//!   and exit 0 (NOT a silent empty result, NOT an error exit).
+//! - `--catalog foo` → `<cache_dir>/foo-catalog.redb`; isolated from default.
+//! - `--catalog <path-with-separator>` → used verbatim as the DB path.
+//! - Precedence: flag > `SNAPDIR_CATALOG` env > default.
+//! - `snapdir defaults` shows `catalog` knob + source (flag|env|default).
+//! - `manifest`/`id` stdout BYTE-IDENTICAL with and without catalog logging
+//!   (catalog is a pure side effect; snapshot ids unaffected).
+//!
+//! ## Sandbox isolation
+//!
+//! Every test sets an isolated `HOME` + `XDG_CACHE_HOME` (both pointing at a
+//! `TempDir`), removes `SNAPDIR_CATALOG` and `SNAPDIR_STORE` from the
+//! environment, so the real `~/.cache/snapdir` is never touched and the default
+//! catalog path is fully deterministic.
+//!
+//! These tests are EXPECTED TO FAIL against the current 1.7.0/1.8.0 binary —
+//! the implementation does not exist yet. Do not weaken assertions to make them
+//! pass. The lane owner moves this file to
+//! `crates/snapdir-cli/tests/catalog_default.rs` during the impl gate.
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+use assert_fs::prelude::*;
+use assert_fs::TempDir;
+
+// ---------------------------------------------------------------------------
+// Harness helpers
+// ---------------------------------------------------------------------------
+
+/// A `snapdir` command with a fully isolated environment:
+/// - `HOME` and `XDG_CACHE_HOME` both point at `cache_dir` (so the default
+///   catalog lands there instead of the real `~/.cache/snapdir`).
+/// - `SNAPDIR_CATALOG` and `SNAPDIR_STORE` are removed so no ambient config
+///   leaks in.
+/// - `PATH` is inherited so the binary loader works.
+///
+/// Tests add the flags / env vars they specifically want to test.
+fn snapdir_isolated(cache_dir: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("snapdir").expect("snapdir binary built");
+    cmd.env_clear();
+    if let Ok(path) = std::env::var("PATH") {
+        cmd.env("PATH", path);
+    }
+    cmd.env("HOME", cache_dir);
+    cmd.env("XDG_CACHE_HOME", cache_dir);
+    cmd.env("SNAPDIR_CACHE_DIR", cache_dir);
+    cmd.env_remove("SNAPDIR_CATALOG");
+    cmd.env_remove("SNAPDIR_STORE");
+    cmd
+}
+
+/// Builds a tiny, deterministic tree: one file `a.txt` with the given content.
+fn build_tree(dir: &TempDir, leaf: &str) {
+    dir.child("a.txt").write_str(leaf).unwrap();
+    std::fs::set_permissions(dir.child("a.txt").path(), PermissionsExt::from_mode(0o644)).unwrap();
+    std::fs::set_permissions(dir.path(), PermissionsExt::from_mode(0o755)).unwrap();
+}
+
+/// Runs `snapdir <args>` with the isolated env, asserts exit 0, returns trimmed
+/// stdout string.
+fn stdout_ok(cache_dir: &Path, args: &[&str]) -> String {
+    let out = snapdir_isolated(cache_dir)
+        .args(args)
+        .output()
+        .expect("run snapdir");
+    assert!(
+        out.status.success(),
+        "snapdir {args:?} failed (code {:?})\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8(out.stdout).unwrap().trim_end().to_owned()
+}
+
+/// Same as `stdout_ok` but returns the RAW (untrimmed) stdout bytes so
+/// byte-identity assertions are exact (including the trailing newline).
+#[allow(dead_code)]
+fn output_ok(cache_dir: &Path, args: &[&str]) -> Vec<u8> {
+    let out = snapdir_isolated(cache_dir)
+        .args(args)
+        .output()
+        .expect("run snapdir");
+    assert!(
+        out.status.success(),
+        "snapdir {args:?} failed (code {:?})\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    out.stdout
+}
+
+/// A `file://<dir>` store URI.
+fn file_store(dir: &Path) -> String {
+    format!("file://{}", dir.display())
+}
+
+/// Minimal JSON field extractor (same idiom as `catalog_commands.rs`).
+fn json_field<'a>(line: &'a str, key: &str) -> Option<&'a str> {
+    let needle = format!("\"{key}\":");
+    let start = line.find(&needle)? + needle.len();
+    let rest = &line[start..];
+    if let Some(stripped) = rest.strip_prefix('"') {
+        let end = stripped.find('"')?;
+        Some(&stripped[..end])
+    } else {
+        let end = rest.find([',', '}']).unwrap_or(rest.len());
+        Some(rest[..end].trim())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (a) Round-trip via the DEFAULT catalog (THE core bug being fixed)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn catalog_default_push_and_stage_round_trip_no_flag() {
+    // Spec clause (a): no-flag push + stage → no-flag revisions --location lists
+    // both snapshots. This is the primary bug: without --catalog, nothing was ever
+    // recorded, so revisions returned empty.
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+
+    // First snapshot: push a tree (no --catalog flag).
+    let src1 = TempDir::new().unwrap();
+    build_tree(&src1, "first push");
+    let push_id = stdout_ok(
+        cache.path(),
+        &["push", "--store", &store, &src1.path().to_string_lossy()],
+    );
+    assert_eq!(
+        push_id.len(),
+        64,
+        "push must print a 64-hex id: {push_id:?}"
+    );
+
+    // Second snapshot: stage a different tree (no --catalog flag).
+    let src2 = TempDir::new().unwrap();
+    build_tree(&src2, "second stage (different)");
+    let stage_id = stdout_ok(cache.path(), &["stage", &src2.path().to_string_lossy()]);
+    assert_eq!(
+        stage_id.len(),
+        64,
+        "stage must print a 64-hex id: {stage_id:?}"
+    );
+    assert_ne!(push_id, stage_id, "distinct trees must have distinct ids");
+
+    // Query: revisions at the store location (no --catalog flag) must list BOTH
+    // snapshots. If the default catalog is not written, this will be empty.
+    let revisions = stdout_ok(cache.path(), &["revisions", "--location", &store]);
+    let lines: Vec<&str> = revisions.lines().collect();
+    assert!(
+        !lines.is_empty(),
+        "revisions (default catalog, no flag) must not be empty after push; \
+        got {revisions:?}. This is the bug: writes without --catalog were silently dropped."
+    );
+
+    // The pushed id must appear in the revision list.
+    let ids_in_output: Vec<&str> = lines.iter().filter_map(|l| json_field(l, "id")).collect();
+    assert!(
+        ids_in_output.contains(&push_id.as_str()),
+        "push id {push_id} must appear in default-catalog revisions; got {revisions:?}"
+    );
+}
+
+#[test]
+fn catalog_default_push_records_to_default_catalog_file() {
+    // Spec clause (a) adversarial edge: after a no-flag push, the default catalog
+    // FILE must actually exist at <cache_dir>/default-catalog.redb.
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+
+    let src = TempDir::new().unwrap();
+    build_tree(&src, "catalog file existence");
+
+    stdout_ok(
+        cache.path(),
+        &["push", "--store", &store, &src.path().to_string_lossy()],
+    );
+
+    let default_catalog = cache.path().join("default-catalog.redb");
+    assert!(
+        default_catalog.exists(),
+        "default-catalog.redb must be created at <cache_dir>/default-catalog.redb \
+        after a no-flag push; file not found at {default_catalog:?}"
+    );
+}
+
+#[test]
+fn catalog_default_revisions_with_no_flag_lists_pushed_id() {
+    // Spec clause (a): the no-flag push → no-flag revisions round-trip — the
+    // pushed id must appear in the output (id matches `snapdir id`).
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+    let src = TempDir::new().unwrap();
+    build_tree(&src, "round-trip");
+    let src_str = src.path().to_string_lossy().into_owned();
+
+    let push_id = stdout_ok(cache.path(), &["push", "--store", &store, &src_str]);
+    let bare_id = stdout_ok(cache.path(), &["id", &src_str]);
+    assert_eq!(push_id, bare_id, "push id must equal `snapdir id`");
+
+    let revisions = stdout_ok(cache.path(), &["revisions", "--location", &store]);
+    assert!(
+        revisions.contains(&push_id),
+        "push id {push_id:?} must appear in no-flag revisions output; got {revisions:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (b) `--catalog none` / empty — disable sentinel
+// ---------------------------------------------------------------------------
+
+#[test]
+fn catalog_none_push_records_nothing() {
+    // Spec clause (b): --catalog none must be an explicit disable sentinel —
+    // nothing is recorded, and no none-catalog.redb is created.
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+    let src = TempDir::new().unwrap();
+    build_tree(&src, "none-disable");
+
+    // Push with --catalog none; the push itself must succeed (exit 0).
+    stdout_ok(
+        cache.path(),
+        &[
+            "push",
+            "--store",
+            &store,
+            "--catalog",
+            "none",
+            &src.path().to_string_lossy(),
+        ],
+    );
+
+    // After the push, none-catalog.redb must NOT be created (the old bug:
+    // --catalog none opened a literal none-catalog.redb file).
+    let none_catalog = cache.path().join("none-catalog.redb");
+    assert!(
+        !none_catalog.exists(),
+        "--catalog none must not create none-catalog.redb; found it at {none_catalog:?}"
+    );
+}
+
+#[test]
+fn catalog_none_revisions_prints_disabled_message_exit_zero() {
+    // Spec clause (b): `revisions --catalog none --location <x>` must exit 0 and
+    // print a clear "catalog disabled" message (matching /disabl/i or mentioning
+    // "none"), NOT a silent empty result and NOT a non-zero exit.
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+
+    let out = snapdir_isolated(cache.path())
+        .args(["revisions", "--catalog", "none", "--location", &store])
+        .output()
+        .expect("run snapdir revisions --catalog none");
+
+    assert!(
+        out.status.success(),
+        "revisions --catalog none must exit 0, not {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout).to_lowercase();
+    let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+    let combined = format!("{stdout}{stderr}");
+
+    assert!(
+        combined.contains("disabl") || combined.contains("none"),
+        "revisions --catalog none must print a 'catalog disabled' (or 'none') message; \
+        got stdout={stdout:?} stderr={stderr:?}"
+    );
+}
+
+#[test]
+fn catalog_none_locations_prints_disabled_message_exit_zero() {
+    // Spec clause (b) edge: `locations --catalog none` → exit 0 + disabled message
+    // (not a crash, not silent empty).
+    let cache = TempDir::new().unwrap();
+
+    let out = snapdir_isolated(cache.path())
+        .args(["locations", "--catalog", "none"])
+        .output()
+        .expect("run snapdir locations --catalog none");
+
+    assert!(
+        out.status.success(),
+        "locations --catalog none must exit 0, not {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout).to_lowercase(),
+        String::from_utf8_lossy(&out.stderr).to_lowercase(),
+    );
+    assert!(
+        combined.contains("disabl") || combined.contains("none"),
+        "locations --catalog none must print a disabled message; got {combined:?}"
+    );
+}
+
+#[test]
+fn catalog_none_ancestors_prints_disabled_message_exit_zero() {
+    // Spec clause (b) edge: `ancestors --catalog none` → exit 0 + disabled message
+    // (not a crash, not silent empty).
+    let cache = TempDir::new().unwrap();
+    let fake_id = "0".repeat(64);
+
+    let out = snapdir_isolated(cache.path())
+        .args(["ancestors", "--catalog", "none", "--id", &fake_id])
+        .output()
+        .expect("run snapdir ancestors --catalog none");
+
+    assert!(
+        out.status.success(),
+        "ancestors --catalog none must exit 0, not {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout).to_lowercase(),
+        String::from_utf8_lossy(&out.stderr).to_lowercase(),
+    );
+    assert!(
+        combined.contains("disabl") || combined.contains("none"),
+        "ancestors --catalog none must print a disabled message; got {combined:?}"
+    );
+}
+
+#[test]
+fn catalog_empty_string_acts_like_none_sentinel() {
+    // Spec clause (b) adversarial edge: --catalog "" (empty string) must behave
+    // identically to --catalog none — disable sentinel, no DB created.
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+    let src = TempDir::new().unwrap();
+    build_tree(&src, "empty-catalog-arg");
+
+    // Push with --catalog ""; must not crash and must not record anything.
+    let out = snapdir_isolated(cache.path())
+        .args([
+            "push",
+            "--store",
+            &store,
+            "--catalog",
+            "",
+            &src.path().to_string_lossy(),
+        ])
+        .output()
+        .expect("run snapdir push --catalog ''");
+
+    // Push must exit 0 (disable is not an error for the push command itself).
+    assert!(
+        out.status.success(),
+        "push --catalog '' must exit 0; got {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // No empty-string-named catalog file should be created.
+    // (The old bug would create none-catalog.redb for "none"; the empty-string
+    // sentinel must also not create a stray file.)
+    let empty_named = cache.path().join("-catalog.redb");
+    assert!(
+        !empty_named.exists(),
+        "--catalog '' must not create a '-catalog.redb' file; found {empty_named:?}"
+    );
+
+    // Revisions via --catalog "" must exit 0 with a disabled message.
+    let rev_out = snapdir_isolated(cache.path())
+        .args(["revisions", "--catalog", "", "--location", &store])
+        .output()
+        .expect("run snapdir revisions --catalog ''");
+
+    assert!(
+        rev_out.status.success(),
+        "revisions --catalog '' must exit 0; got {:?}\nstderr: {}",
+        rev_out.status.code(),
+        String::from_utf8_lossy(&rev_out.stderr),
+    );
+
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&rev_out.stdout).to_lowercase(),
+        String::from_utf8_lossy(&rev_out.stderr).to_lowercase(),
+    );
+    assert!(
+        combined.contains("disabl") || combined.contains("none") || combined.contains("catalog"),
+        "revisions --catalog '' must signal a disabled catalog; got {combined:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (c) Named-catalog isolation (both directions)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn catalog_named_foo_isolated_from_default_both_directions() {
+    // Spec clause (c): --catalog foo (bare name) → <cache_dir>/foo-catalog.redb.
+    // Pushing to --catalog foo must NOT appear in the default catalog, and
+    // pushing with no flag must NOT appear in --catalog foo.
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+
+    // Push to the DEFAULT catalog (no flag).
+    let src_default = TempDir::new().unwrap();
+    build_tree(&src_default, "default-catalog-push");
+    let default_push_id = stdout_ok(
+        cache.path(),
+        &[
+            "push",
+            "--store",
+            &store,
+            &src_default.path().to_string_lossy(),
+        ],
+    );
+
+    // Push to the NAMED "foo" catalog.
+    let src_foo = TempDir::new().unwrap();
+    build_tree(&src_foo, "foo-catalog-push (different)");
+    let foo_push_id = stdout_ok(
+        cache.path(),
+        &[
+            "push",
+            "--store",
+            &store,
+            "--catalog",
+            "foo",
+            &src_foo.path().to_string_lossy(),
+        ],
+    );
+    assert_ne!(
+        default_push_id, foo_push_id,
+        "distinct trees produce distinct ids"
+    );
+
+    // Direction 1: default-catalog revisions must NOT contain foo's id.
+    let default_revisions = stdout_ok(cache.path(), &["revisions", "--location", &store]);
+    assert!(
+        !default_revisions.contains(&foo_push_id),
+        "default-catalog revisions must NOT contain --catalog foo rows; got {default_revisions:?}"
+    );
+
+    // Direction 2: foo-catalog revisions must NOT contain the default-catalog id.
+    let foo_revisions = stdout_ok(
+        cache.path(),
+        &["revisions", "--catalog", "foo", "--location", &store],
+    );
+    assert!(
+        !foo_revisions.contains(&default_push_id),
+        "--catalog foo revisions must NOT contain default-catalog rows; got {foo_revisions:?}"
+    );
+
+    // Sanity: foo-catalog revisions DOES contain foo's id.
+    assert!(
+        foo_revisions.contains(&foo_push_id),
+        "--catalog foo revisions must contain foo's push id; got {foo_revisions:?}"
+    );
+}
+
+#[test]
+fn catalog_named_foo_file_exists_under_cache_dir() {
+    // Spec clause (c) adversarial edge: --catalog foo → the ACTUAL file
+    // foo-catalog.redb must be created under the sandboxed cache dir.
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+    let src = TempDir::new().unwrap();
+    build_tree(&src, "named-foo");
+
+    stdout_ok(
+        cache.path(),
+        &[
+            "push",
+            "--store",
+            &store,
+            "--catalog",
+            "foo",
+            &src.path().to_string_lossy(),
+        ],
+    );
+
+    let foo_catalog = cache.path().join("foo-catalog.redb");
+    assert!(
+        foo_catalog.exists(),
+        "--catalog foo must create foo-catalog.redb in the cache dir; \
+        expected {foo_catalog:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (d) `snapdir defaults` shows the catalog knob + source
+// ---------------------------------------------------------------------------
+
+#[test]
+fn catalog_defaults_shows_catalog_knob_source_default() {
+    // Spec clause (d): `snapdir defaults` on a clean environment must include a
+    // `catalog` line whose source is tagged `default`.
+    let cache = TempDir::new().unwrap();
+
+    let out = snapdir_isolated(cache.path())
+        .args(["defaults"])
+        .output()
+        .expect("run snapdir defaults");
+
+    assert!(
+        out.status.success(),
+        "snapdir defaults failed ({:?})\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+    let low = stdout.to_lowercase();
+
+    // The output must mention the `catalog` knob at all.
+    assert!(
+        low.contains("catalog"),
+        "snapdir defaults must include a 'catalog' knob; got:\n{stdout}"
+    );
+
+    // On a clean env (no SNAPDIR_CATALOG, no --catalog flag), source must be
+    // tagged `default`.
+    assert!(
+        low.contains("default"),
+        "snapdir defaults catalog source must be 'default' on a clean env; got:\n{stdout}"
+    );
+}
+
+#[test]
+fn catalog_defaults_shows_source_env_when_snapdir_catalog_set() {
+    // Spec clause (d): when SNAPDIR_CATALOG is set, the catalog line's source
+    // must be tagged `env`.
+    let cache = TempDir::new().unwrap();
+    let custom_catalog = cache.path().join("custom-catalog.redb");
+
+    let out = snapdir_isolated(cache.path())
+        .env("SNAPDIR_CATALOG", &custom_catalog)
+        .args(["defaults"])
+        .output()
+        .expect("run snapdir defaults with SNAPDIR_CATALOG set");
+
+    assert!(
+        out.status.success(),
+        "snapdir defaults failed ({:?})\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    let stdout = String::from_utf8(out.stdout).expect("utf8");
+    let low = stdout.to_lowercase();
+
+    assert!(
+        low.contains("catalog"),
+        "snapdir defaults must include a 'catalog' knob; got:\n{stdout}"
+    );
+    // Source must be tagged `env` when SNAPDIR_CATALOG is set.
+    assert!(
+        low.contains("env"),
+        "snapdir defaults catalog source must be 'env' when SNAPDIR_CATALOG is set; got:\n{stdout}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (e) KEYSTONE — manifest/id stdout BYTE-IDENTICAL regardless of catalog
+// ---------------------------------------------------------------------------
+
+#[test]
+fn catalog_default_manifest_stdout_byte_identical_with_and_without_logging() {
+    // Spec clause (e) KEYSTONE: `manifest` stdout must be BYTE-IDENTICAL whether
+    // or not catalog logging occurs. The catalog is a pure side effect.
+    let cache1 = TempDir::new().unwrap();
+    let cache2 = TempDir::new().unwrap();
+    let catalog = cache1.path().join("test-catalog.redb");
+
+    let src = TempDir::new().unwrap();
+    build_tree(&src, "keystone-manifest");
+    let src_str = src.path().to_string_lossy().into_owned();
+    let catalog_str = catalog.to_string_lossy().into_owned();
+
+    // With a catalog configured (logs to DB).
+    let with_catalog = snapdir_isolated(cache1.path())
+        .args(["manifest", "--catalog", &catalog_str, &src_str])
+        .output()
+        .expect("run manifest --catalog");
+    assert!(with_catalog.status.success(), "manifest --catalog failed");
+
+    // With --catalog none (no logging, sentinel disabled).
+    let without_catalog = snapdir_isolated(cache2.path())
+        .args(["manifest", "--catalog", "none", &src_str])
+        .output()
+        .expect("run manifest --catalog none");
+    assert!(
+        without_catalog.status.success(),
+        "manifest --catalog none failed"
+    );
+
+    assert_eq!(
+        with_catalog.stdout, without_catalog.stdout,
+        "manifest stdout must be BYTE-IDENTICAL with/without catalog logging. \
+        KEYSTONE: the catalog is a pure side effect."
+    );
+}
+
+#[test]
+fn catalog_default_id_stdout_byte_identical_with_and_without_logging() {
+    // Spec clause (e) KEYSTONE: `id` stdout must be BYTE-IDENTICAL regardless of
+    // whether a catalog is configured via env (id never logs, but the id output
+    // itself must not be contaminated by catalog activity).
+    let cache1 = TempDir::new().unwrap();
+    let cache2 = TempDir::new().unwrap();
+    let catalog = cache1.path().join("test-catalog.redb");
+
+    let src = TempDir::new().unwrap();
+    build_tree(&src, "keystone-id");
+    let src_str = src.path().to_string_lossy().into_owned();
+
+    // With SNAPDIR_CATALOG set (even though `id` never logs).
+    let with_catalog_env = snapdir_isolated(cache1.path())
+        .env("SNAPDIR_CATALOG", &catalog)
+        .args(["id", &src_str])
+        .output()
+        .expect("run id with SNAPDIR_CATALOG");
+    assert!(
+        with_catalog_env.status.success(),
+        "id with SNAPDIR_CATALOG failed"
+    );
+
+    // With no catalog env (clean).
+    let without_catalog_env = snapdir_isolated(cache2.path())
+        .args(["id", &src_str])
+        .output()
+        .expect("run id without SNAPDIR_CATALOG");
+    assert!(
+        without_catalog_env.status.success(),
+        "id without catalog failed"
+    );
+
+    assert_eq!(
+        with_catalog_env.stdout, without_catalog_env.stdout,
+        "id stdout must be BYTE-IDENTICAL with/without SNAPDIR_CATALOG. \
+        KEYSTONE: catalog is a pure side effect."
+    );
+}
+
+#[test]
+fn catalog_default_id_is_64_hex_chars() {
+    // Spec clause (e) subsidiary: the id output is exactly 64 hex chars (the
+    // frozen BLAKE3 snapshot id format must be unaffected by catalog changes).
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    build_tree(&src, "id-format");
+
+    let id = stdout_ok(cache.path(), &["id", &src.path().to_string_lossy()]);
+    assert_eq!(id.len(), 64, "id must be exactly 64 hex chars; got {id:?}");
+    assert!(
+        id.chars().all(|c| c.is_ascii_hexdigit()),
+        "id must be all hex digits; got {id:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (f) Path-like catalog (contains a separator → used verbatim)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn catalog_path_like_arg_used_verbatim() {
+    // Spec clause (f): --catalog <path-with-separator> → used verbatim as the
+    // redb DB path (not expanded to <cache_dir>/<name>-catalog.redb).
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+
+    // Create a temp directory for the path-like catalog.
+    let db_dir = TempDir::new().unwrap();
+    let db_path = db_dir.path().join("x.redb");
+    let db_str = db_path.to_string_lossy().into_owned();
+
+    // Push using the verbatim path.
+    let src = TempDir::new().unwrap();
+    build_tree(&src, "path-like-catalog");
+    let push_id = stdout_ok(
+        cache.path(),
+        &[
+            "push",
+            "--store",
+            &store,
+            "--catalog",
+            &db_str,
+            &src.path().to_string_lossy(),
+        ],
+    );
+    assert_eq!(
+        push_id.len(),
+        64,
+        "push with path catalog must print a 64-hex id"
+    );
+
+    // The DB file must be created at the exact given path (verbatim).
+    assert!(
+        db_path.exists(),
+        "--catalog <path> must create the redb file at that exact path; \
+        expected {db_path:?}"
+    );
+
+    // Revisions with the same verbatim path must list the pushed id.
+    let revisions = stdout_ok(
+        cache.path(),
+        &["revisions", "--catalog", &db_str, "--location", &store],
+    );
+    assert!(
+        revisions.contains(&push_id),
+        "revisions via path-like catalog must list the pushed id {push_id:?}; \
+        got {revisions:?}"
+    );
+}
+
+#[test]
+fn catalog_path_like_isolation_from_default() {
+    // Spec clause (f) adversarial edge: a verbatim-path catalog must be isolated
+    // from the default catalog. Pushing to the path catalog must NOT appear in
+    // the default catalog.
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+    let db_dir = TempDir::new().unwrap();
+    let db_path = db_dir.path().join("isolated.redb");
+    let db_str = db_path.to_string_lossy().into_owned();
+
+    let src = TempDir::new().unwrap();
+    build_tree(&src, "path-like-isolated");
+    let path_id = stdout_ok(
+        cache.path(),
+        &[
+            "push",
+            "--store",
+            &store,
+            "--catalog",
+            &db_str,
+            &src.path().to_string_lossy(),
+        ],
+    );
+
+    // The default catalog revisions must NOT contain the path-catalog push.
+    let default_revisions = stdout_ok(cache.path(), &["revisions", "--location", &store]);
+    assert!(
+        !default_revisions.contains(&path_id),
+        "default-catalog revisions must NOT contain rows from a path-like catalog; \
+        got {default_revisions:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Precedence: --catalog flag overrides SNAPDIR_CATALOG env
+// ---------------------------------------------------------------------------
+
+#[test]
+#[allow(clippy::similar_names)] // catalog_a_str / catalog_b_str are the test subjects
+fn catalog_flag_overrides_snapdir_catalog_env() {
+    // Spec precedence: --catalog flag > SNAPDIR_CATALOG env > default.
+    // Push with env pointing at catalog-A and flag pointing at catalog-B;
+    // the revision must appear in catalog-B, not catalog-A.
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+
+    let catalog_a = cache.path().join("catalog-a.redb");
+    let catalog_b = cache.path().join("catalog-b.redb");
+    let catalog_a_str = catalog_a.to_string_lossy().into_owned();
+    let catalog_b_str = catalog_b.to_string_lossy().into_owned();
+
+    let src = TempDir::new().unwrap();
+    build_tree(&src, "precedence-test");
+
+    // Push: env says catalog-A, flag says catalog-B → flag wins.
+    let push_id = snapdir_isolated(cache.path())
+        .env("SNAPDIR_CATALOG", &catalog_a_str)
+        .args([
+            "push",
+            "--store",
+            &store,
+            "--catalog",
+            &catalog_b_str,
+            &src.path().to_string_lossy(),
+        ])
+        .output()
+        .expect("run push with flag+env");
+    assert!(push_id.status.success(), "push with flag+env must exit 0");
+    let push_id_str = String::from_utf8(push_id.stdout)
+        .unwrap()
+        .trim_end()
+        .to_owned();
+
+    // catalog-B must contain the revision.
+    let rev_b = snapdir_isolated(cache.path())
+        .args([
+            "revisions",
+            "--catalog",
+            &catalog_b_str,
+            "--location",
+            &store,
+        ])
+        .output()
+        .expect("run revisions --catalog B");
+    assert!(rev_b.status.success());
+    let rev_b_str = String::from_utf8(rev_b.stdout).unwrap();
+    assert!(
+        rev_b_str.contains(&push_id_str),
+        "--catalog flag (B) must contain the pushed revision {push_id_str:?}; \
+        got {rev_b_str:?}"
+    );
+
+    // catalog-A must NOT contain the revision (flag beat env).
+    let rev_a = snapdir_isolated(cache.path())
+        .args([
+            "revisions",
+            "--catalog",
+            &catalog_a_str,
+            "--location",
+            &store,
+        ])
+        .output()
+        .expect("run revisions --catalog A");
+    assert!(rev_a.status.success());
+    let rev_a_str = String::from_utf8(rev_a.stdout).unwrap();
+    assert!(
+        !rev_a_str.contains(&push_id_str),
+        "SNAPDIR_CATALOG env (A) must NOT contain the revision when --catalog flag (B) overrides; \
+        got {rev_a_str:?}"
+    );
+}
+
+#[test]
+fn catalog_env_overrides_default_catalog() {
+    // Spec precedence: SNAPDIR_CATALOG env > default. A push with only the env
+    // var set must land in the env-specified catalog, NOT in default-catalog.redb.
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+
+    let custom_catalog = cache.path().join("custom-env-catalog.redb");
+    let custom_str = custom_catalog.to_string_lossy().into_owned();
+
+    let src = TempDir::new().unwrap();
+    build_tree(&src, "env-precedence");
+
+    // Push with SNAPDIR_CATALOG set (no --catalog flag).
+    let push_out = snapdir_isolated(cache.path())
+        .env("SNAPDIR_CATALOG", &custom_str)
+        .args(["push", "--store", &store, &src.path().to_string_lossy()])
+        .output()
+        .expect("run push with SNAPDIR_CATALOG env");
+    assert!(
+        push_out.status.success(),
+        "push with SNAPDIR_CATALOG must exit 0"
+    );
+    let push_id = String::from_utf8(push_out.stdout)
+        .unwrap()
+        .trim_end()
+        .to_owned();
+
+    // The custom catalog must contain the revision.
+    let custom_rev = snapdir_isolated(cache.path())
+        .args(["revisions", "--catalog", &custom_str, "--location", &store])
+        .output()
+        .expect("run revisions --catalog custom");
+    assert!(custom_rev.status.success());
+    let custom_rev_str = String::from_utf8(custom_rev.stdout).unwrap();
+    assert!(
+        custom_rev_str.contains(&push_id),
+        "SNAPDIR_CATALOG env catalog must contain the pushed revision; got {custom_rev_str:?}"
+    );
+
+    // The DEFAULT catalog must NOT contain the revision (env beat default).
+    let default_rev = snapdir_isolated(cache.path())
+        .args(["revisions", "--location", &store])
+        .output()
+        .expect("run revisions (default catalog)");
+    assert!(default_rev.status.success());
+    let default_rev_str = String::from_utf8(default_rev.stdout).unwrap();
+    assert!(
+        !default_rev_str.contains(&push_id),
+        "default catalog must NOT contain a revision pushed via SNAPDIR_CATALOG env; \
+        got {default_rev_str:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Adversarial edge: --catalog none does NOT create default-catalog.redb either
+// ---------------------------------------------------------------------------
+
+#[test]
+fn catalog_none_push_does_not_create_default_catalog_file() {
+    // Spec clause (b) adversarial edge: after push --catalog none, NEITHER
+    // none-catalog.redb NOR default-catalog.redb must be created.
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+    let src = TempDir::new().unwrap();
+    build_tree(&src, "none-no-default-file");
+
+    stdout_ok(
+        cache.path(),
+        &[
+            "push",
+            "--store",
+            &store,
+            "--catalog",
+            "none",
+            &src.path().to_string_lossy(),
+        ],
+    );
+
+    let none_catalog = cache.path().join("none-catalog.redb");
+    let default_catalog = cache.path().join("default-catalog.redb");
+
+    assert!(
+        !none_catalog.exists(),
+        "--catalog none must NOT create none-catalog.redb; found {none_catalog:?}"
+    );
+    assert!(
+        !default_catalog.exists(),
+        "--catalog none must NOT create default-catalog.redb either; found {default_catalog:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Adversarial edge: the disabled message is distinct from "no revisions for <loc>"
+// ---------------------------------------------------------------------------
+
+#[test]
+fn catalog_none_disabled_message_distinct_from_empty_enabled_catalog() {
+    // Spec clause (b) adversarial: the "disabled" response to `revisions --catalog none`
+    // must be DISTINGUISHABLE from the empty-but-enabled response of a valid catalog
+    // with no records. The enabled-empty case must NOT print a disabled message.
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+
+    // Enabled-but-empty catalog (push nothing, query with an explicit catalog path).
+    let empty_catalog = cache.path().join("empty.redb");
+    let empty_str = empty_catalog.to_string_lossy().into_owned();
+
+    let empty_out = snapdir_isolated(cache.path())
+        .args(["revisions", "--catalog", &empty_str, "--location", &store])
+        .output()
+        .expect("run revisions with empty catalog");
+    assert!(
+        empty_out.status.success(),
+        "enabled-empty catalog must exit 0"
+    );
+
+    let empty_combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&empty_out.stdout).to_lowercase(),
+        String::from_utf8_lossy(&empty_out.stderr).to_lowercase(),
+    );
+    // The enabled-but-empty case must NOT say "disabled" — that would be confusing.
+    assert!(
+        !empty_combined.contains("disabl"),
+        "enabled-empty catalog must NOT print 'disabled'; got {empty_combined:?}"
+    );
+
+    // Disabled case (--catalog none) MUST say "disabled" or "none".
+    let none_out = snapdir_isolated(cache.path())
+        .args(["revisions", "--catalog", "none", "--location", &store])
+        .output()
+        .expect("run revisions --catalog none");
+    assert!(none_out.status.success(), "--catalog none must exit 0");
+
+    let none_combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&none_out.stdout).to_lowercase(),
+        String::from_utf8_lossy(&none_out.stderr).to_lowercase(),
+    );
+    assert!(
+        none_combined.contains("disabl") || none_combined.contains("none"),
+        "--catalog none must print a disabled message; got {none_combined:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Impl-revealed: disabled message goes to STDERR only (stdout stays clean)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn catalog_none_disabled_message_is_on_stderr_not_stdout() {
+    // Impl-revealed: `print_catalog_disabled()` uses `eprintln!` → the message
+    // must appear on STDERR; stdout must be empty (no JSON lines, no stray text).
+    // This matters for pipeline users who capture stdout to parse JSON.
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+
+    let out = snapdir_isolated(cache.path())
+        .args(["revisions", "--catalog", "none", "--location", &store])
+        .output()
+        .expect("run revisions --catalog none");
+
+    assert!(
+        out.status.success(),
+        "revisions --catalog none must exit 0; got {:?}\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+
+    // stdout must be empty — the disabled message must NOT appear on stdout.
+    assert!(
+        out.stdout.is_empty(),
+        "revisions --catalog none stdout must be empty; got {:?}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+
+    // stderr MUST carry the disabled message.
+    let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+    assert!(
+        stderr.contains("disabl") || stderr.contains("none"),
+        "disabled message must appear on stderr; got stderr={stderr:?}"
+    );
+}
+
+#[test]
+fn catalog_none_locations_disabled_message_is_on_stderr_not_stdout() {
+    // Impl-revealed: `locations --catalog none` — disabled message on stderr,
+    // empty stdout (same contract as revisions, for pipeline safety).
+    let cache = TempDir::new().unwrap();
+
+    let out = snapdir_isolated(cache.path())
+        .args(["locations", "--catalog", "none"])
+        .output()
+        .expect("run locations --catalog none");
+
+    assert!(out.status.success(), "locations --catalog none must exit 0");
+    assert!(
+        out.stdout.is_empty(),
+        "locations --catalog none stdout must be empty; got {:?}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+    assert!(
+        stderr.contains("disabl") || stderr.contains("none"),
+        "disabled message must appear on stderr; got stderr={stderr:?}"
+    );
+}
+
+#[test]
+fn catalog_none_ancestors_disabled_message_is_on_stderr_not_stdout() {
+    // Impl-revealed: `ancestors --catalog none` — disabled message on stderr,
+    // empty stdout.
+    let cache = TempDir::new().unwrap();
+    let fake_id = "0".repeat(64);
+
+    let out = snapdir_isolated(cache.path())
+        .args(["ancestors", "--catalog", "none", "--id", &fake_id])
+        .output()
+        .expect("run ancestors --catalog none");
+
+    assert!(out.status.success(), "ancestors --catalog none must exit 0");
+    assert!(
+        out.stdout.is_empty(),
+        "ancestors --catalog none stdout must be empty; got {:?}",
+        String::from_utf8_lossy(&out.stdout),
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr).to_lowercase();
+    assert!(
+        stderr.contains("disabl") || stderr.contains("none"),
+        "disabled message must appear on stderr; got stderr={stderr:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Impl-revealed: --cache-dir round-trip (push and query must agree on path)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn catalog_cache_dir_flag_round_trip_push_then_revisions() {
+    // Impl-revealed: `--cache-dir` on the query commands was additive in this
+    // cluster (CatalogArgs gained cache_dir). Push with `--cache-dir X` and
+    // revisions with `--cache-dir X` must resolve the SAME default-catalog.redb
+    // and therefore list the pushed id.
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+
+    // A separate dir to use as the explicit cache (not the HOME-derived default).
+    let explicit_cache = TempDir::new().unwrap();
+    let explicit_cache_str = explicit_cache.path().to_string_lossy().into_owned();
+
+    let src = TempDir::new().unwrap();
+    build_tree(&src, "cache-dir-round-trip");
+
+    // Push with explicit --cache-dir so default-catalog.redb lands there.
+    let push_id = snapdir_isolated(cache.path())
+        .args([
+            "push",
+            "--store",
+            &store,
+            "--cache-dir",
+            &explicit_cache_str,
+            &src.path().to_string_lossy(),
+        ])
+        .output()
+        .expect("run push --cache-dir");
+    assert!(
+        push_id.status.success(),
+        "push --cache-dir must exit 0; stderr: {}",
+        String::from_utf8_lossy(&push_id.stderr),
+    );
+    let push_id_str = String::from_utf8(push_id.stdout)
+        .unwrap()
+        .trim_end()
+        .to_owned();
+    assert_eq!(push_id_str.len(), 64, "push must print a 64-hex id");
+
+    // The default catalog must exist under the EXPLICIT cache dir, not `cache`.
+    let default_catalog_explicit = explicit_cache.path().join("default-catalog.redb");
+    assert!(
+        default_catalog_explicit.exists(),
+        "default-catalog.redb must be in the explicit --cache-dir, not the HOME-derived one; \
+        expected {default_catalog_explicit:?}"
+    );
+    let default_catalog_home = cache.path().join("default-catalog.redb");
+    assert!(
+        !default_catalog_home.exists(),
+        "default-catalog.redb must NOT be in HOME when --cache-dir overrides; \
+        found stray file at {default_catalog_home:?}"
+    );
+
+    // Query with the SAME explicit --cache-dir; must find the pushed id.
+    let revisions = snapdir_isolated(cache.path())
+        .args([
+            "revisions",
+            "--cache-dir",
+            &explicit_cache_str,
+            "--location",
+            &store,
+        ])
+        .output()
+        .expect("run revisions --cache-dir");
+    assert!(
+        revisions.status.success(),
+        "revisions --cache-dir must exit 0; stderr: {}",
+        String::from_utf8_lossy(&revisions.stderr),
+    );
+    let revisions_str = String::from_utf8(revisions.stdout).unwrap();
+    assert!(
+        revisions_str.contains(&push_id_str),
+        "revisions with --cache-dir must list the push id {push_id_str:?}; \
+        got {revisions_str:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Impl-revealed: locations and ancestors end-to-end with default catalog
+// ---------------------------------------------------------------------------
+
+#[test]
+fn catalog_default_locations_end_to_end() {
+    // Impl-revealed: `locations` with the default catalog (no flag) must list
+    // the store URI that was pushed to. This verifies `open_catalog()` wiring
+    // for `run_locations()`.
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+
+    let src = TempDir::new().unwrap();
+    build_tree(&src, "locations-default-catalog");
+
+    // Push with no --catalog flag (goes to default-catalog.redb).
+    stdout_ok(
+        cache.path(),
+        &["push", "--store", &store, &src.path().to_string_lossy()],
+    );
+
+    // No-flag locations must include the store URI.
+    let locations = stdout_ok(cache.path(), &["locations"]);
+    assert!(
+        locations.contains(store_dir.path().to_str().unwrap()),
+        "no-flag locations must list the pushed store URI; got {locations:?}"
+    );
+}
+
+#[test]
+fn catalog_default_ancestors_end_to_end() {
+    // Impl-revealed: `ancestors --id <id>` with the default catalog (no flag)
+    // must return the chain from the default catalog. After two no-flag pushes
+    // at the same location, ancestors of the second id must include the first.
+    let cache = TempDir::new().unwrap();
+    let store_dir = TempDir::new().unwrap();
+    let store = file_store(store_dir.path());
+
+    // First push.
+    let src1 = TempDir::new().unwrap();
+    build_tree(&src1, "ancestors-first");
+    let id1 = stdout_ok(
+        cache.path(),
+        &["push", "--store", &store, &src1.path().to_string_lossy()],
+    );
+    assert_eq!(id1.len(), 64);
+
+    // Second push (different content so different id).
+    let src2 = TempDir::new().unwrap();
+    build_tree(&src2, "ancestors-second (different)");
+    let id2 = stdout_ok(
+        cache.path(),
+        &["push", "--store", &store, &src2.path().to_string_lossy()],
+    );
+    assert_eq!(id2.len(), 64);
+    assert_ne!(id1, id2, "distinct trees must have distinct ids");
+
+    // ancestors of id2 (no --catalog flag) must mention id1 (the previous
+    // revision at the same location).
+    let ancestors = stdout_ok(cache.path(), &["ancestors", "--id", &id2]);
+    assert!(
+        ancestors.contains(&id1),
+        "default-catalog ancestors of id2 must mention id1; got {ancestors:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Impl-revealed: defaults shows the resolved DEFAULT catalog path (not just
+// the word "catalog"), so the value is useful, not just a tag.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn catalog_defaults_value_is_full_path_when_default() {
+    // Impl-revealed: `defaults` on a clean env resolves the catalog knob to
+    // the full `<cache_dir>/default-catalog.redb` path, not the bare string
+    // "default" or "none". Users should see exactly where the DB will land.
+    let cache = TempDir::new().unwrap();
+
+    let out = snapdir_isolated(cache.path())
+        .args(["defaults"])
+        .output()
+        .expect("run snapdir defaults");
+    assert!(out.status.success(), "snapdir defaults must exit 0");
+
+    let stdout = String::from_utf8(out.stdout).unwrap();
+    // The catalog line must contain the path to default-catalog.redb.
+    assert!(
+        stdout.contains("default-catalog.redb"),
+        "defaults must show the resolved default-catalog.redb path; got:\n{stdout}"
+    );
+    // And it must be under the cache dir we pointed at.
+    assert!(
+        stdout.contains(cache.path().to_str().unwrap()),
+        "defaults catalog path must be under the sandboxed cache dir; got:\n{stdout}"
+    );
+}

--- a/crates/snapdir-cli/tests/cmd/help-ancestors.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-ancestors.trycmd
@@ -42,6 +42,11 @@ Options:
       --verbose
           Enable verbose output. Honored by the transfer commands (push/fetch/pull/checkout/stage/sync emit an effective-config banner and CACHED/SAVED notices) and verify-cache (purge notices); inert elsewhere
 
+      --cache-dir <DIR>
+          Directory where the object cache (and the default catalog) is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-autocomplete.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-autocomplete.trycmd
@@ -1,0 +1,55 @@
+```
+$ snapdir autocomplete --help
+Generate a shell completion script (bash, zsh, fish, …).
+
+Writes a completion script for the given shell to stdout. Wire it up by sourcing the output from your shell profile:
+
+bash:       eval "$(snapdir autocomplete bash)" # add the line above to ~/.bashrc
+
+zsh:        eval "$(snapdir autocomplete zsh)" # add the line above to ~/.zshrc
+
+fish:       snapdir autocomplete fish | source # or write to ~/.config/fish/completions/snapdir.fish
+
+powershell: snapdir autocomplete powershell | Out-String | Invoke-Expression # add the line above to your $PROFILE
+
+elvish:     eval (snapdir autocomplete elvish | slurp)
+
+The script always targets the `snapdir` binary name. The hidden `completions <shell>` alias is kept for back-compat (the release pipeline's gen-assets job and existing scripts) and emits byte-identical output.
+
+Usage: snapdir autocomplete [OPTIONS] <SHELL>
+
+Arguments:
+  <SHELL>
+          Target shell (`bash`, `fish`, `zsh`, `powershell`, `elvish`)
+          
+          [possible values: bash, elvish, fish, powershell, zsh]
+
+Options:
+  -q, --quiet
+          Suppress stderr banners and the live progress line
+
+      --color <WHEN>
+          When to colorize progress output: auto, always, or never
+
+          Possible values:
+          - auto:   Color when attached to a TTY and `NO_COLOR` is unset (default)
+          - always: Always emit color
+          - never:  Never emit color
+          
+          [default: auto]
+
+      --no-progress
+          Disable the live progress line (transfers still run)
+          
+          [env: SNAPDIR_NO_PROGRESS=]
+
+      --verbose
+          Enable verbose output. Honored by the transfer commands (push/fetch/pull/checkout/stage/sync emit an effective-config banner and CACHED/SAVED notices) and verify-cache (purge notices); inert elsewhere
+
+  -h, --help
+          Print help (see a summary with '-h')
+
+  -V, --version
+          Print version
+
+```

--- a/crates/snapdir-cli/tests/cmd/help-locations.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-locations.trycmd
@@ -42,6 +42,11 @@ Options:
       --verbose
           Enable verbose output. Honored by the transfer commands (push/fetch/pull/checkout/stage/sync emit an effective-config banner and CACHED/SAVED notices) and verify-cache (purge notices); inert elsewhere
 
+      --cache-dir <DIR>
+          Directory where the object cache (and the default catalog) is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-revisions.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-revisions.trycmd
@@ -42,6 +42,11 @@ Options:
       --verbose
           Enable verbose output. Honored by the transfer commands (push/fetch/pull/checkout/stage/sync emit an effective-config banner and CACHED/SAVED notices) and verify-cache (purge notices); inert elsewhere
 
+      --cache-dir <DIR>
+          Directory where the object cache (and the default catalog) is stored
+          
+          [env: SNAPDIR_CACHE_DIR=]
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help.trycmd
@@ -22,6 +22,7 @@ Commands:
   sync          Copy a snapshot (its manifest + objects) directly between two stores, streaming through memory — no local staging
   diff          Compare two sides, each a set of manifests, reporting file-level differences — reading MANIFESTS ONLY
   version       Print the version
+  autocomplete  Generate a shell completion script (bash, zsh, fish, …)
   help          Print this message or the help of the given subcommand(s)
 
 Options:

--- a/crates/snapdir-cli/tests/dx_autocomplete.rs
+++ b/crates/snapdir-cli/tests/dx_autocomplete.rs
@@ -1,0 +1,764 @@
+//! Black-box spec suite for the `autocomplete` command (phase 31, gate
+//! `autocomplete-spec-tests`).
+//!
+//! AUTHORED FROM THE SPEC ONLY — no feature `src/` was read. These tests pin
+//! the public CLI contract for the new `snapdir autocomplete <shell>` command
+//! (and the back-compat hidden `completions <shell>` alias). They are staged in
+//! `.gatesmith/pending-tests/` so the cargo workspace keeps compiling while the
+//! feature does not yet exist. The lane owner moves this file to
+//! `crates/snapdir-cli/tests/dx_autocomplete.rs` and wires it during the impl
+//! gate.
+//!
+//! THESE TESTS ARE EXPECTED TO FAIL against the current binary (which only has
+//! the HIDDEN `completions` subcommand and no visible `autocomplete` command).
+//! Do NOT weaken them to be passable.
+//!
+//! SPEC UNDER TEST (each test comments the clause it pins)
+//! =======================================================
+//!  (a) `snapdir autocomplete <shell>` for shell in {bash, zsh, fish,
+//!      powershell, elvish} -> exit 0, non-empty script mentioning `snapdir`.
+//!  (b) `autocomplete` is VISIBLE in `snapdir --help` (NOT hidden); AND
+//!      `snapdir autocomplete --help` shows a profile-wiring eval/source example
+//!      for at least bash and zsh.
+//!  (c) Unknown shell (e.g. `tcsh`, `notashell`) -> exit 2 (clap usage error)
+//!      with an error message that LISTS the valid shells (names accepted values).
+//!  (d) The hidden `completions <shell>` alias STILL works and emits IDENTICAL
+//!      output to `autocomplete <shell>` for the same shell (stdout byte-for-byte,
+//!      tested for bash).
+//!  (e) REAL-SHELL sourcing: pipe `autocomplete bash` through `bash -n` (syntax
+//!      check, exit 0). If zsh is on PATH, source the zsh output and assert no
+//!      error. Gate fish/powershell/elvish sourcing on the shell being present.
+//!
+//! Additional adversarial cases:
+//!  (f) `snapdir autocomplete` with NO shell arg -> exit 2 (clap usage error
+//!      naming the missing required `<shell>` argument). Pins required-arg contract.
+//!  (g) Case sensitivity: `snapdir autocomplete BASH` (uppercase) -> EITHER
+//!      exit 0 with a non-empty snapdir script OR exit 2 listing valid shells.
+//!      Never a panic and never exit 0 with empty stdout.
+//!  (h) Determinism: `autocomplete bash` run twice produces byte-identical stdout.
+//!  (i) The bash script targets `snapdir` specifically: output contains `snapdir`
+//!      AND a bash-completion marker (`complete ` or `_snapdir`).
+//!  (j) Stderr cleanliness on the happy path: `autocomplete bash` writes the
+//!      script to stdout (not stderr) and exits 0 (stderr may be empty or warnings,
+//!      but must NOT be the completion script, i.e. stdout is non-empty AND stderr
+//!      is not the primary output).
+
+// Suppress pedantic lints that would fire on test-only style (mirrors sibling
+// suites like `dx_errors.rs`/`dx_args.rs`).
+#![allow(
+    clippy::too_many_lines,
+    clippy::similar_names,
+    clippy::items_after_statements,
+    clippy::doc_markdown,
+    clippy::manual_let_else,
+    clippy::map_unwrap_or,
+    clippy::uninlined_format_args,
+    clippy::manual_assert
+)]
+
+use std::path::PathBuf;
+use std::process::{Command, Output};
+
+// ---------------------------------------------------------------------------
+// Minimal harness (mirrors dx_errors.rs / dx_defaults.rs idioms)
+// ---------------------------------------------------------------------------
+
+/// Path to the compiled `snapdir` binary under test.
+fn snapdir_bin() -> PathBuf {
+    assert_cmd::cargo::cargo_bin("snapdir")
+}
+
+/// Run `snapdir <args>` and return the raw `Output`. No env manipulation needed
+/// for autocomplete (it never touches the store or cache).
+fn run(args: &[&str]) -> Output {
+    Command::new(snapdir_bin())
+        .args(args)
+        .output()
+        .expect("failed to run snapdir")
+}
+
+/// UTF-8 stdout of an `Output` (losslessly decoded).
+fn stdout_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stdout).into_owned()
+}
+
+/// UTF-8 stderr of an `Output` (losslessly decoded).
+fn stderr_of(out: &Output) -> String {
+    String::from_utf8_lossy(&out.stderr).into_owned()
+}
+
+/// Return true if the named binary is on PATH (used to gate real-shell checks).
+fn shell_on_path(shell: &str) -> bool {
+    Command::new("which")
+        .arg(shell)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false)
+}
+
+// ---------------------------------------------------------------------------
+// (a) Happy-path: autocomplete <shell> -> exit 0, non-empty, mentions snapdir
+// ---------------------------------------------------------------------------
+
+/// (a) `snapdir autocomplete bash` exits 0 with a non-empty script mentioning
+/// `snapdir`.
+#[test]
+fn autocomplete_bash_exit0_non_empty_mentions_snapdir() {
+    // (a) happy path for bash
+    let out = run(&["autocomplete", "bash"]);
+    assert!(
+        out.status.success(),
+        "autocomplete bash: expected exit 0, got {:?}\nstderr: {}",
+        out.status.code(),
+        stderr_of(&out),
+    );
+    let stdout = stdout_of(&out);
+    assert!(
+        !stdout.trim().is_empty(),
+        "autocomplete bash: stdout was empty"
+    );
+    assert!(
+        stdout.contains("snapdir"),
+        "autocomplete bash: script does not mention `snapdir`\nstdout (first 200 chars): {}",
+        &stdout[..stdout.len().min(200)],
+    );
+}
+
+/// (a) `snapdir autocomplete zsh` exits 0 with a non-empty script mentioning
+/// `snapdir`.
+#[test]
+fn autocomplete_zsh_exit0_non_empty_mentions_snapdir() {
+    // (a) happy path for zsh
+    let out = run(&["autocomplete", "zsh"]);
+    assert!(
+        out.status.success(),
+        "autocomplete zsh: expected exit 0, got {:?}\nstderr: {}",
+        out.status.code(),
+        stderr_of(&out),
+    );
+    let stdout = stdout_of(&out);
+    assert!(
+        !stdout.trim().is_empty(),
+        "autocomplete zsh: stdout was empty"
+    );
+    assert!(
+        stdout.contains("snapdir"),
+        "autocomplete zsh: script does not mention `snapdir`",
+    );
+}
+
+/// (a) `snapdir autocomplete fish` exits 0 with a non-empty script mentioning
+/// `snapdir`.
+#[test]
+fn autocomplete_fish_exit0_non_empty_mentions_snapdir() {
+    // (a) happy path for fish
+    let out = run(&["autocomplete", "fish"]);
+    assert!(
+        out.status.success(),
+        "autocomplete fish: expected exit 0, got {:?}\nstderr: {}",
+        out.status.code(),
+        stderr_of(&out),
+    );
+    let stdout = stdout_of(&out);
+    assert!(
+        !stdout.trim().is_empty(),
+        "autocomplete fish: stdout was empty"
+    );
+    assert!(
+        stdout.contains("snapdir"),
+        "autocomplete fish: script does not mention `snapdir`",
+    );
+}
+
+/// (a) `snapdir autocomplete powershell` exits 0 with a non-empty script
+/// mentioning `snapdir`.
+#[test]
+fn autocomplete_powershell_exit0_non_empty_mentions_snapdir() {
+    // (a) happy path for powershell
+    let out = run(&["autocomplete", "powershell"]);
+    assert!(
+        out.status.success(),
+        "autocomplete powershell: expected exit 0, got {:?}\nstderr: {}",
+        out.status.code(),
+        stderr_of(&out),
+    );
+    let stdout = stdout_of(&out);
+    assert!(
+        !stdout.trim().is_empty(),
+        "autocomplete powershell: stdout was empty"
+    );
+    assert!(
+        stdout.contains("snapdir"),
+        "autocomplete powershell: script does not mention `snapdir`",
+    );
+}
+
+/// (a) `snapdir autocomplete elvish` exits 0 with a non-empty script mentioning
+/// `snapdir`.
+#[test]
+fn autocomplete_elvish_exit0_non_empty_mentions_snapdir() {
+    // (a) happy path for elvish
+    let out = run(&["autocomplete", "elvish"]);
+    assert!(
+        out.status.success(),
+        "autocomplete elvish: expected exit 0, got {:?}\nstderr: {}",
+        out.status.code(),
+        stderr_of(&out),
+    );
+    let stdout = stdout_of(&out);
+    assert!(
+        !stdout.trim().is_empty(),
+        "autocomplete elvish: stdout was empty"
+    );
+    assert!(
+        stdout.contains("snapdir"),
+        "autocomplete elvish: script does not mention `snapdir`",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (b) Visibility: autocomplete appears in --help; autocomplete --help has eval
+// ---------------------------------------------------------------------------
+
+/// (b) `autocomplete` is NOT hidden — it appears in `snapdir --help` subcommand
+/// list.
+#[test]
+fn autocomplete_visible_in_top_level_help() {
+    // (b) autocomplete must appear in the top-level help (not hidden)
+    let out = run(&["--help"]);
+    let stdout = stdout_of(&out);
+    assert!(
+        stdout.contains("autocomplete"),
+        "`autocomplete` does not appear in `snapdir --help` output\n\
+         (it is hidden or not yet present)\nstdout:\n{}",
+        stdout,
+    );
+}
+
+/// (b) `snapdir autocomplete --help` shows a profile-wiring eval/source example
+/// for bash (e.g. `eval "$(snapdir autocomplete bash)"`).
+#[test]
+fn autocomplete_help_shows_bash_eval_example() {
+    // (b) bash wiring example in autocomplete --help
+    let out = run(&["autocomplete", "--help"]);
+    // --help normally exits 0; accept both 0 and 2 so the test runs even if
+    // clap is configured to exit nonzero on --help.
+    let stdout = stdout_of(&out);
+    let stderr = stderr_of(&out);
+    let combined = format!("{stdout}{stderr}");
+    // The spec requires an eval/source wiring example for bash.
+    assert!(
+        combined.contains("eval") || combined.contains("source"),
+        "`snapdir autocomplete --help` does not show an eval/source wiring example\n\
+         combined output:\n{}",
+        combined,
+    );
+    // The example must reference bash specifically.
+    assert!(
+        combined.to_lowercase().contains("bash"),
+        "`snapdir autocomplete --help` wiring example does not mention bash\n\
+         combined output:\n{}",
+        combined,
+    );
+}
+
+/// (b) `snapdir autocomplete --help` also shows a zsh profile-wiring eval/source
+/// example.
+#[test]
+fn autocomplete_help_shows_zsh_eval_example() {
+    // (b) zsh wiring example in autocomplete --help
+    let out = run(&["autocomplete", "--help"]);
+    let stdout = stdout_of(&out);
+    let stderr = stderr_of(&out);
+    let combined = format!("{stdout}{stderr}");
+    assert!(
+        combined.to_lowercase().contains("zsh"),
+        "`snapdir autocomplete --help` does not mention zsh in a wiring example\n\
+         combined output:\n{}",
+        combined,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (c) Unknown shell -> exit 2 listing valid shells
+// ---------------------------------------------------------------------------
+
+/// (c) `snapdir autocomplete tcsh` -> exit 2 with an error that names the
+/// accepted shells (clap `possible_values` / value enum listing).
+#[test]
+fn autocomplete_unknown_shell_tcsh_exit2_lists_valid() {
+    // (c) unknown shell -> exit 2 listing valid shells
+    let out = run(&["autocomplete", "tcsh"]);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "autocomplete tcsh: expected exit 2 (clap usage error), got {:?}\nstderr: {}",
+        out.status.code(),
+        stderr_of(&out),
+    );
+    let stderr = stderr_of(&out);
+    // clap should list the accepted values; check for at least one known shell.
+    let lists_valid = stderr.contains("bash")
+        || stderr.contains("zsh")
+        || stderr.contains("fish")
+        || stderr.contains("possible")
+        || stderr.contains("valid");
+    assert!(
+        lists_valid,
+        "autocomplete tcsh: exit 2 but stderr does not list valid shells\nstderr: {}",
+        stderr,
+    );
+}
+
+/// (c) `snapdir autocomplete notashell` -> exit 2 with a useful error that
+/// names the accepted shells.
+#[test]
+fn autocomplete_unknown_shell_notashell_exit2_lists_valid() {
+    // (c) unknown shell -> exit 2 listing valid shells
+    let out = run(&["autocomplete", "notashell"]);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "autocomplete notashell: expected exit 2, got {:?}\nstderr: {}",
+        out.status.code(),
+        stderr_of(&out),
+    );
+    let stderr = stderr_of(&out);
+    let lists_valid = stderr.contains("bash")
+        || stderr.contains("zsh")
+        || stderr.contains("fish")
+        || stderr.contains("possible")
+        || stderr.contains("valid");
+    assert!(
+        lists_valid,
+        "autocomplete notashell: exit 2 but stderr does not list valid shells\nstderr: {}",
+        stderr,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (d) Back-compat: hidden `completions` alias emits identical output to
+//     `autocomplete` for the same shell (bash + zsh).
+// ---------------------------------------------------------------------------
+
+/// (d) The hidden `completions bash` alias still works (exit 0, non-empty) and
+/// produces BYTE-IDENTICAL stdout to `autocomplete bash`.
+#[test]
+fn completions_alias_still_works_and_identical_to_autocomplete() {
+    // (d) back-compat: completions alias == autocomplete for bash
+    let new_out = run(&["autocomplete", "bash"]);
+    assert!(
+        new_out.status.success(),
+        "autocomplete bash: failed (prerequisite for alias check)\nstderr: {}",
+        stderr_of(&new_out),
+    );
+
+    let old_out = run(&["completions", "bash"]);
+    assert!(
+        old_out.status.success(),
+        "completions bash (hidden alias): expected exit 0, got {:?}\nstderr: {}",
+        old_out.status.code(),
+        stderr_of(&old_out),
+    );
+
+    assert_eq!(
+        new_out.stdout, old_out.stdout,
+        "completions bash and autocomplete bash differ in stdout\n\
+         (they must be byte-identical for release.yml back-compat)",
+    );
+}
+
+/// (d) The hidden `completions zsh` alias also produces BYTE-IDENTICAL stdout
+/// to `autocomplete zsh`. Extends the alias back-compat check to a second
+/// shell to catch any shell-dispatch path divergence.
+#[test]
+fn completions_alias_zsh_identical_to_autocomplete_zsh() {
+    // (d) back-compat: completions alias == autocomplete for zsh
+    let new_out = run(&["autocomplete", "zsh"]);
+    assert!(
+        new_out.status.success(),
+        "autocomplete zsh: failed (prerequisite for alias check)\nstderr: {}",
+        stderr_of(&new_out),
+    );
+
+    let old_out = run(&["completions", "zsh"]);
+    assert!(
+        old_out.status.success(),
+        "completions zsh (hidden alias): expected exit 0, got {:?}\nstderr: {}",
+        old_out.status.code(),
+        stderr_of(&old_out),
+    );
+
+    assert_eq!(
+        new_out.stdout, old_out.stdout,
+        "completions zsh and autocomplete zsh differ in stdout\n\
+         (they must be byte-identical for release.yml back-compat)",
+    );
+}
+
+/// (d) The hidden `completions` alias does NOT appear in `snapdir --help`.
+/// This pins the contract that the alias is truly hidden from the documented
+/// surface (users see `autocomplete` only) while existing scripts keep working.
+#[test]
+fn completions_alias_is_hidden_from_top_level_help() {
+    // (d) completions alias must NOT appear in --help (it is a hidden clap alias)
+    let out = run(&["--help"]);
+    let stdout = stdout_of(&out);
+    assert!(
+        !stdout.contains("completions"),
+        "`completions` (hidden alias) APPEARS in `snapdir --help` — it should be hidden\n\
+         If visible, users see two commands for the same thing (breaks the documented surface).\n\
+         stdout:\n{}",
+        stdout,
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (e) Real-shell sourcing checks
+// ---------------------------------------------------------------------------
+
+/// (e) Pipe `autocomplete bash` output through `bash -n` (syntax check) and
+/// assert success. Always runs (bash assumed present on unix CI/dev boxes).
+#[test]
+fn autocomplete_bash_output_passes_bash_syntax_check() {
+    // (e) bash -n syntax check
+    let completion_out = run(&["autocomplete", "bash"]);
+    assert!(
+        completion_out.status.success(),
+        "autocomplete bash: prerequisite failed\nstderr: {}",
+        stderr_of(&completion_out),
+    );
+    let script = &completion_out.stdout;
+
+    // bash -n reads from stdin
+    let bash_result = Command::new("bash")
+        .arg("-n")
+        .arg("/dev/stdin")
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(stdin) = child.stdin.take() {
+                let mut stdin = stdin;
+                stdin.write_all(script).ok();
+            }
+            child.wait_with_output()
+        });
+
+    match bash_result {
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            // bash not available; skip gracefully rather than panic.
+            eprintln!(
+                "SKIP autocomplete_bash_output_passes_bash_syntax_check: bash not found on PATH"
+            );
+        }
+        Err(e) => panic!("failed to run bash -n: {e}"),
+        Ok(out) => {
+            assert!(
+                out.status.success(),
+                "bash -n rejected the autocomplete bash output (syntax error)\nstderr: {}",
+                String::from_utf8_lossy(&out.stderr),
+            );
+        }
+    }
+}
+
+/// (e) If `zsh` is on PATH, source the `autocomplete zsh` output in a
+/// `zsh -c 'source /dev/stdin'`-style check and assert no error.
+#[test]
+fn autocomplete_zsh_output_sources_cleanly_if_zsh_present() {
+    // (e) zsh source check — gated on zsh being available
+    if !shell_on_path("zsh") {
+        eprintln!(
+            "SKIP autocomplete_zsh_output_sources_cleanly_if_zsh_present: zsh not found on PATH"
+        );
+        return;
+    }
+
+    let completion_out = run(&["autocomplete", "zsh"]);
+    assert!(
+        completion_out.status.success(),
+        "autocomplete zsh: prerequisite failed\nstderr: {}",
+        stderr_of(&completion_out),
+    );
+    let script = &completion_out.stdout;
+
+    // The clap-generated zsh script ends in `compdef _snapdir snapdir`, so it
+    // can only be sourced after the zsh completion system is initialized — which
+    // is exactly the interactive-shell context a user wires it into. Initialize
+    // it (autoload compinit + compinit) before sourcing, mirroring a real
+    // `~/.zshrc` so the source check exercises the script in a valid context
+    // rather than a bare non-interactive shell where `compdef` is undefined.
+    let zsh_result = Command::new("zsh")
+        .args([
+            "-c",
+            "autoload -Uz compinit && compinit -u && source /dev/stdin",
+        ])
+        .stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped())
+        .spawn()
+        .and_then(|mut child| {
+            use std::io::Write;
+            if let Some(stdin) = child.stdin.take() {
+                let mut stdin = stdin;
+                stdin.write_all(script).ok();
+            }
+            child.wait_with_output()
+        });
+
+    match zsh_result {
+        Err(e) => panic!("failed to run zsh -c 'source /dev/stdin': {e}"),
+        Ok(out) => {
+            assert!(
+                out.status.success(),
+                "zsh source check failed for autocomplete zsh output\nstderr: {}",
+                String::from_utf8_lossy(&out.stderr),
+            );
+        }
+    }
+}
+
+/// (e) If `fish` is on PATH, verify that `autocomplete fish` output passes
+/// `fish --no-execute` syntax check.
+#[test]
+fn autocomplete_fish_output_syntax_check_if_fish_present() {
+    // (e) fish syntax check — gated on fish being available
+    if !shell_on_path("fish") {
+        eprintln!(
+            "SKIP autocomplete_fish_output_syntax_check_if_fish_present: fish not found on PATH"
+        );
+        return;
+    }
+
+    let completion_out = run(&["autocomplete", "fish"]);
+    assert!(
+        completion_out.status.success(),
+        "autocomplete fish: prerequisite failed\nstderr: {}",
+        stderr_of(&completion_out),
+    );
+
+    // Write the fish completion to a temp file then run `fish --no-execute` on it.
+    let tmp = std::env::temp_dir().join(format!(
+        "snapdir-fish-completion-{}-check.fish",
+        std::process::id()
+    ));
+    std::fs::write(&tmp, &completion_out.stdout).expect("write fish completion to tempfile");
+
+    let fish_result = Command::new("fish")
+        .args(["--no-execute", tmp.to_str().unwrap()])
+        .output();
+
+    let _ = std::fs::remove_file(&tmp);
+
+    match fish_result {
+        Err(e) => panic!("failed to run fish --no-execute: {e}"),
+        Ok(out) => {
+            assert!(
+                out.status.success(),
+                "fish --no-execute rejected the autocomplete fish output\nstderr: {}",
+                String::from_utf8_lossy(&out.stderr),
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (f) No shell arg -> exit 2 (required arg missing)
+// ---------------------------------------------------------------------------
+
+/// (f) `snapdir autocomplete` (no shell arg) -> exit 2 naming the missing
+/// required `<shell>` argument.
+#[test]
+fn autocomplete_no_shell_arg_exit2_names_required_arg() {
+    // (f) missing required <shell> arg -> exit 2
+    let out = run(&["autocomplete"]);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "autocomplete with no arg: expected exit 2, got {:?}\nstderr: {}",
+        out.status.code(),
+        stderr_of(&out),
+    );
+    // The error should say something about the missing argument.
+    let stderr = stderr_of(&out);
+    assert!(
+        !stderr.trim().is_empty(),
+        "autocomplete with no arg: exit 2 but stderr was empty (should name missing arg)",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (g) Case sensitivity / surprising input
+// ---------------------------------------------------------------------------
+
+/// (g) `snapdir autocomplete BASH` (uppercase) -> either exit 0 with a
+/// non-empty snapdir script (case-insensitive clap value-enum) OR exit 2
+/// listing valid shells. Never a panic, never exit 0 with empty stdout.
+#[test]
+fn autocomplete_uppercase_bash_deterministic_behavior() {
+    // (g) case sensitivity / surprising input
+    let out = run(&["autocomplete", "BASH"]);
+    let code = out.status.code();
+    let stdout = stdout_of(&out);
+    let stderr = stderr_of(&out);
+
+    match code {
+        Some(0) => {
+            // clap value-enum is case-insensitive: accepted -> must produce a real script
+            assert!(
+                !stdout.trim().is_empty(),
+                "autocomplete BASH: exit 0 but stdout was empty (invalid: must emit a script or exit 2)",
+            );
+            assert!(
+                stdout.contains("snapdir"),
+                "autocomplete BASH: exit 0 with non-empty stdout but output never mentions `snapdir`\nstdout (first 200): {}",
+                &stdout[..stdout.len().min(200)],
+            );
+        }
+        Some(2) => {
+            // case-sensitive clap: error listing valid shells is acceptable
+            let lists_valid = stderr.contains("bash")
+                || stderr.contains("zsh")
+                || stderr.contains("fish")
+                || stderr.contains("possible")
+                || stderr.contains("valid");
+            assert!(
+                lists_valid,
+                "autocomplete BASH: exit 2 but stderr does not list valid shells\nstderr: {}",
+                stderr,
+            );
+        }
+        other => {
+            panic!(
+                "autocomplete BASH: unexpected exit code {other:?} (must be 0 or 2)\nstdout: {stdout}\nstderr: {stderr}",
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (c-exact) The exact set of valid shells: exactly {bash, elvish, fish,
+//           powershell, zsh} — the clap_complete::Shell enum's five variants.
+// ---------------------------------------------------------------------------
+
+/// (c-exact) The error message for an unknown shell names all five accepted
+/// values: bash, elvish, fish, powershell, zsh — and no others. This pins the
+/// shell-set contract so any future addition/removal is caught immediately.
+#[test]
+fn autocomplete_unknown_shell_error_lists_exactly_five_shells() {
+    // (c-exact) clap must list all five valid shells; no more, no less
+    let out = run(&["autocomplete", "tcsh"]);
+    assert_eq!(
+        out.status.code(),
+        Some(2),
+        "autocomplete tcsh: expected exit 2\nstderr: {}",
+        stderr_of(&out),
+    );
+    let stderr = stderr_of(&out);
+    for shell in &["bash", "elvish", "fish", "powershell", "zsh"] {
+        assert!(
+            stderr.contains(shell),
+            "autocomplete tcsh: error message does not list expected shell `{shell}`\nstderr: {stderr}",
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// (h) Determinism: two consecutive runs produce byte-identical stdout
+// ---------------------------------------------------------------------------
+
+/// (h) `snapdir autocomplete bash` run twice produces byte-identical stdout.
+#[test]
+fn autocomplete_bash_is_deterministic() {
+    // (h) determinism across two runs
+    let out1 = run(&["autocomplete", "bash"]);
+    let out2 = run(&["autocomplete", "bash"]);
+
+    assert!(
+        out1.status.success() && out2.status.success(),
+        "autocomplete bash: one or both runs failed (cannot test determinism)\n\
+         run1 exit={:?}, run2 exit={:?}",
+        out1.status.code(),
+        out2.status.code(),
+    );
+    assert_eq!(
+        out1.stdout, out2.stdout,
+        "autocomplete bash: two consecutive runs produced different stdout (non-deterministic!)",
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (i) Bash completion targets the `snapdir` binary by name
+// ---------------------------------------------------------------------------
+
+/// (i) The generated bash completion script defines a completion for the
+/// `snapdir` binary name: output contains `snapdir` AND a bash-completion
+/// marker (`complete ` or `_snapdir`), proving it targets the right binary.
+#[test]
+fn autocomplete_bash_script_targets_snapdir_binary() {
+    // (i) bash script targets snapdir binary name
+    let out = run(&["autocomplete", "bash"]);
+    assert!(
+        out.status.success(),
+        "autocomplete bash: prerequisite failed\nstderr: {}",
+        stderr_of(&out),
+    );
+    let stdout = stdout_of(&out);
+    assert!(
+        stdout.contains("snapdir"),
+        "autocomplete bash script does not mention `snapdir` at all",
+    );
+    let has_bash_marker = stdout.contains("complete ") || stdout.contains("_snapdir");
+    assert!(
+        has_bash_marker,
+        "autocomplete bash script missing expected bash-completion marker \
+         (`complete ` or `_snapdir`)\nstdout (first 400 chars):\n{}",
+        &stdout[..stdout.len().min(400)],
+    );
+}
+
+// ---------------------------------------------------------------------------
+// (j) Stderr cleanliness on the happy path
+// ---------------------------------------------------------------------------
+
+/// (j) `snapdir autocomplete bash` writes the script to STDOUT (not stderr):
+/// exits 0, stdout is non-empty, and the completion script content is NOT being
+/// printed only on stderr (i.e., stdout is the primary output channel).
+#[test]
+fn autocomplete_bash_happy_path_stderr_clean() {
+    // (j) stderr cleanliness: script goes to stdout, not stderr
+    let out = run(&["autocomplete", "bash"]);
+    assert!(
+        out.status.success(),
+        "autocomplete bash: expected exit 0\nstderr: {}",
+        stderr_of(&out),
+    );
+    let stdout = stdout_of(&out);
+    let stderr = stderr_of(&out);
+
+    assert!(
+        !stdout.trim().is_empty(),
+        "autocomplete bash: stdout was empty (script must go to stdout)",
+    );
+    // The completion script (which mentions `snapdir`) must be on stdout, not only stderr.
+    assert!(
+        stdout.contains("snapdir"),
+        "autocomplete bash: script content not on stdout\nstdout (first 200): {}\nstderr (first 200): {}",
+        &stdout[..stdout.len().min(200)],
+        &stderr[..stderr.len().min(200)],
+    );
+    // Stderr should NOT be the primary bearer of the script — the script must
+    // be on stdout. (Warnings/diagnostics on stderr are tolerated; the check is
+    // that stdout carries the output, not that stderr is totally empty.)
+    // If stderr is non-empty but stdout also contains the script, we pass.
+    // If stdout is empty while stderr contains the script, that is a bug.
+    if stdout.trim().is_empty() {
+        panic!(
+            "autocomplete bash: stdout empty while stderr has content — script written to wrong fd\nstderr: {}",
+            stderr,
+        );
+    }
+}

--- a/crates/snapdir-core/src/hash_file.rs
+++ b/crates/snapdir-core/src/hash_file.rs
@@ -12,15 +12,18 @@
 //! most memory-friendly engine:
 //!
 //! - **Unkeyed BLAKE3** ([`Blake3Hasher`](crate::Blake3Hasher)): for files at or
-//!   above [`MMAP_THRESHOLD`] it memory-maps the file and hashes it with
-//!   `update_mmap_rayon`, which both avoids a large heap copy and uses the
-//!   `rayon` thread-pool to hash a single large file in parallel. Files below
+//!   above [`MMAP_THRESHOLD`] it memory-maps the file and hashes it with the
+//!   single-threaded `update_mmap`, which avoids a large heap copy. Files below
 //!   the threshold (and **all empty / 0-byte files**) take the plain
-//!   [`std::fs::read`] branch — see the SIGBUS caveat below for why an empty
+//!   [`std::fs::read`] branch — see the SIGBUS note below for why an empty
 //!   file is never mmapped. The streaming `Hasher::new()+update+finalize`
-//!   shape is byte-identical to the one-shot [`blake3::hash`], so the per-file
-//!   checksums — and therefore the snapshot ids — are unchanged from the
-//!   read-then-`hash_hex` path.
+//!   shape is byte-identical to the one-shot [`blake3::hash`] (and to the prior
+//!   `update_mmap_rayon` path), so the per-file checksums — and therefore the
+//!   snapshot ids — are unchanged from the read-then-`hash_hex` path. The
+//!   cross-file parallel walk (`walk.rs`) still hashes many files concurrently
+//!   on a bounded rayon pool; only the rare *intra-file* `update_mmap_rayon`
+//!   fan-out is dropped so each file is hashed on a single thread (a
+//!   prerequisite for the SIGBUS guard below).
 //! - **Keyed BLAKE3** ([`Blake3KeyedHasher`](crate::Blake3KeyedHasher)): the
 //!   derive-key context lives in a private field of the frozen
 //!   [`merkle`](crate::merkle) module, so this module cannot re-seed a raw
@@ -34,17 +37,23 @@
 //!   defer to [`Hasher::hash_hex`](crate::merkle::Hasher::hash_hex), staying
 //!   byte-identical to the previous `fs::read` + `hash_hex` pair.
 //!
-//! ## SIGBUS on concurrent truncation (mmap caveat)
+//! ## SIGBUS on concurrent truncation (mmap)
 //!
-//! `update_mmap_rayon` memory-maps the file and reads it through the mapping.
-//! A snapshot assumes a **static tree**: if another process **truncates or
+//! `update_mmap` memory-maps the file and reads it through the mapping. A
+//! snapshot assumes a **static tree**: if another process **truncates or
 //! shrinks** a file *while it is being hashed*, accessing the now-invalid pages
-//! raises `SIGBUS` and aborts the process. This is the **same exposure as
-//! `b3sum`** (which mmaps by default) and is intrinsic to mmap-based hashing;
-//! we deliberately do **not** install a `SIGBUS` handler. Callers that cannot
-//! guarantee a quiescent tree should hash a copied/quiesced snapshot. Empty
-//! and sub-threshold files take the plain-read branch and are not exposed to
-//! this hazard.
+//! raises `SIGBUS`. Historically this aborted the process with no snapdir
+//! message (the "fails without printing anything" symptom). On **unix** the
+//! large-file mmap hash now runs inside [`sigbus::guard_mmap_hash`], which arms
+//! a per-thread guard and turns a mid-hash truncation into a clean
+//! [`io::Error`] ("file changed during hashing (mmap fault)") instead of a
+//! silent process kill — the [`walk`](crate::walk) layer maps that to a typed
+//! tree-in-flux error. Hashing each file **single-threaded** (`update_mmap`,
+//! not `update_mmap_rayon`) is what makes the guard sound: the faulting thread
+//! is always the thread that armed the jump buffer. Empty and sub-threshold
+//! files take the plain-read branch and are never mmapped. On **non-unix** there
+//! is no handler, but the engine still uses mmap; callers that cannot guarantee
+//! a quiescent tree should hash a copied/quiesced snapshot.
 
 use std::fs;
 use std::io;
@@ -99,37 +108,45 @@ pub trait HashFile {
     }
 }
 
-/// Hashes a BLAKE3 `hasher` over the file at `path`, choosing the mmap+rayon
-/// engine for files `>= MMAP_THRESHOLD` and a plain read otherwise.
+/// Memory-maps `path` into `hasher` with `update_mmap`, guarded against a
+/// concurrent-truncation `SIGBUS` on unix.
 ///
-/// `hasher` arrives pre-seeded (plain `new()` for unkeyed, `new_derive_key` for
-/// keyed); this only selects the read strategy. Returns `(hex, byte_len)`.
+/// `update_mmap` is **single-threaded** (no intra-file `rayon` fan-out), which
+/// is exactly what makes the unix [`sigbus::guard_mmap_hash`] guard sound: the
+/// thread that touches the mapping is the thread that armed the jump buffer, so
+/// a mid-hash truncation longjmps back here as a clean `io::Error` rather than
+/// killing the process. On non-unix there is no handler, so we map+hash
+/// directly (same byte-identical engine, no guard).
+fn blake3_update_mmap_guarded(hasher: &mut blake3::Hasher, path: &Path) -> io::Result<()> {
+    #[cfg(unix)]
+    {
+        crate::sigbus::guard_mmap_hash(|| hasher.update_mmap(path).map(|_| ()))
+    }
+    #[cfg(not(unix))]
+    {
+        hasher.update_mmap(path).map(|_| ())
+    }
+}
+
+/// Hashes a BLAKE3 `hasher` over the file at `path`, choosing the single-thread
+/// `update_mmap` engine for files `>= MMAP_THRESHOLD` and a plain read
+/// otherwise.
+///
+/// `hasher` arrives pre-seeded (plain `new()` for unkeyed); this only selects
+/// the read strategy. Returns `(hex, byte_len)`. There is no longer a separate
+/// rayon-fan-out engine: every large file is hashed on a single thread (the
+/// cross-file parallelism in `walk.rs` is the dominant win and is unchanged),
+/// which the SIGBUS guard requires.
 fn blake3_hash_file(mut hasher: blake3::Hasher, path: &Path) -> io::Result<(String, u64)> {
     let len = fs::metadata(path)?.len();
     if len >= MMAP_THRESHOLD {
-        // Large file: memory-map + hash in parallel, no large heap copy. Never
-        // reached for an empty file (len 0 < MMAP_THRESHOLD), so mmap of a
+        // Large file: memory-map + hash single-threaded, no large heap copy.
+        // Never reached for an empty file (len 0 < MMAP_THRESHOLD), so mmap of a
         // zero-length file — which can SIGBUS — never happens.
-        hasher.update_mmap_rayon(path)?;
+        blake3_update_mmap_guarded(&mut hasher, path)?;
     } else {
         // Small/empty file: a plain read is cheaper than the mmap setup, and
         // the streaming update is byte-identical to the one-shot hash.
-        let bytes = fs::read(path)?;
-        hasher.update(&bytes);
-    }
-    Ok((hasher.finalize().to_hex().to_string(), len))
-}
-
-/// Single-threaded BLAKE3 file hash: same mmap/plain-read selection as
-/// [`blake3_hash_file`] but using `update_mmap` (no nested `rayon`) for large
-/// files. Byte-identical output; only the engine differs.
-fn blake3_hash_file_seq(mut hasher: blake3::Hasher, path: &Path) -> io::Result<(String, u64)> {
-    let len = fs::metadata(path)?.len();
-    if len >= MMAP_THRESHOLD {
-        // Large file: memory-map + hash single-threaded (no intra-file rayon
-        // fan-out). Empty files never reach this branch (len 0 < threshold).
-        hasher.update_mmap(path)?;
-    } else {
         let bytes = fs::read(path)?;
         hasher.update(&bytes);
     }
@@ -142,7 +159,11 @@ impl HashFile for Blake3Hasher {
     }
 
     fn hash_file_hex_seq(&self, path: &Path) -> io::Result<(String, u64)> {
-        blake3_hash_file_seq(blake3::Hasher::new(), path)
+        // Both engines now hash large files single-threaded via `update_mmap`,
+        // so the `_seq` variant and the default share one implementation. The
+        // distinct trait method is kept because `walk.rs` selects it for its
+        // oversubscription guard; the output is byte-identical either way.
+        blake3_hash_file(blake3::Hasher::new(), path)
     }
 }
 

--- a/crates/snapdir-core/src/lib.rs
+++ b/crates/snapdir-core/src/lib.rs
@@ -25,6 +25,8 @@ pub mod manifest;
 pub mod merkle;
 pub mod progress;
 pub mod resources;
+#[cfg(unix)]
+pub mod sigbus;
 pub mod store;
 pub mod walk;
 

--- a/crates/snapdir-core/src/sigbus.rs
+++ b/crates/snapdir-core/src/sigbus.rs
@@ -1,0 +1,304 @@
+//! Unix-only `SIGBUS` guard for memory-mapped file hashing.
+//!
+//! # Why this exists
+//!
+//! [`hash_file`](crate::hash_file) memory-maps files at or above
+//! [`MMAP_THRESHOLD`](crate::hash_file::MMAP_THRESHOLD) and hashes them through
+//! the mapping (no large heap copy). A snapshot assumes a **static tree**, but
+//! if another process **truncates or shrinks** a file *while it is being
+//! hashed*, touching the now-invalid pages raises `SIGBUS`. With no handler the
+//! kernel kills the process with no snapdir message — the "fails without
+//! printing anything" symptom. This module installs a `SIGBUS` handler so a
+//! mid-hash truncation yields a clean [`io::Error`] instead.
+//!
+//! # Ownership test — choice (a): a thread-local "in guarded mmap hash" flag
+//!
+//! Per the design lock (`flux-robustness-1.9.0.md`, section A) two ownership
+//! tests were offered. We pick **(a)**: a thread-local flag set only while this
+//! thread is inside [`guard_mmap_hash`]. It is the *simplest-correct* option and
+//! — crucially — it works with `blake3::Hasher::update_mmap`, which maps the
+//! file *internally* (we never see its `(base, len)`), so the more precise
+//! `si_addr`-range test of option (b) is not even available to us without
+//! reimplementing the mmap+hash loop by hand. A SIGBUS that arrives while a
+//! thread's flag is set is, by construction, a fault on the file that thread is
+//! currently mmap-hashing; any other SIGBUS (flag clear) is forwarded to the
+//! previously-installed handler so we never swallow an unrelated fault.
+//!
+//! Because hashing runs **single-threaded per file** (see
+//! [`hash_file`](crate::hash_file): the large-file path uses `update_mmap`, not
+//! `update_mmap_rayon`), the faulting thread is always the thread that armed the
+//! [`sigsetjmp`] buffer, so the [`siglongjmp`] lands in a valid frame on the
+//! same thread.
+//!
+//! # Async-signal-safety
+//!
+//! The handler body does **only** async-signal-safe work: it reads two
+//! thread-local cells (a `bool` flag and a pointer to this thread's jump
+//! buffer) and either calls [`siglongjmp`] (async-signal-safe) or forwards to
+//! the saved previous handler. It performs **no** heap allocation, locking,
+//! formatting, or other unsafe-in-signal calls. The handler/altstack install
+//! runs once via [`Once`] off the signal path.
+//!
+//! # Chaining the previous handler
+//!
+//! On install we save the prior `sigaction`. When a SIGBUS arrives and the
+//! current thread is **not** in a guarded region, we forward to that saved
+//! handler (honouring `SA_SIGINFO`), or re-raise with the default disposition
+//! if there was none — so an unrelated SIGBUS keeps its original behaviour.
+
+use std::cell::Cell;
+use std::error::Error as StdError;
+use std::fmt;
+use std::io;
+use std::mem::MaybeUninit;
+use std::ptr;
+use std::sync::Once;
+
+// `sigsetjmp` / `siglongjmp` are not exported by the `libc` crate (they have
+// platform-specific buffer layouts), so we bind the real libc symbols
+// ourselves. `siglongjmp` is a genuine exported function everywhere. For
+// `sigsetjmp` the platforms differ: on **glibc** it is NOT an exported
+// function — it is a C macro that calls the real symbol `__sigsetjmp(jmp_buf,
+// savesigs)`, so binding plain `sigsetjmp` fails to link (`undefined symbol:
+// sigsetjmp`). On **musl** and **macOS/BSD (libSystem)** `sigsetjmp` IS a real
+// exported function. We therefore bind `__sigsetjmp` on glibc and `sigsetjmp`
+// elsewhere; the signature `(jmp_buf, int) -> int` is identical, so the call
+// site is unchanged. `JmpBuf` is an opaque, generously-oversized,
+// pointer-aligned byte buffer: macOS `sigjmp_buf` is at most ~38 ints and
+// glibc's is ~200 bytes, both comfortably under our reserve.
+const JMP_BUF_BYTES: usize = 512;
+
+#[repr(C, align(16))]
+struct JmpBuf([u8; JMP_BUF_BYTES]);
+
+extern "C" {
+    fn siglongjmp(env: *mut JmpBuf, val: libc::c_int) -> !;
+}
+
+// glibc: `sigsetjmp` is a macro over the real exported symbol `__sigsetjmp`;
+// bind that under the unchanged `sigsetjmp` call-site name. `savesigs != 0` =>
+// also save/restore the signal mask (the `sig` variant).
+#[cfg(target_env = "gnu")]
+extern "C" {
+    #[link_name = "__sigsetjmp"]
+    fn sigsetjmp(env: *mut JmpBuf, savesigs: libc::c_int) -> libc::c_int;
+}
+
+// musl + macOS/BSD: `sigsetjmp` is a real exported function.
+#[cfg(not(target_env = "gnu"))]
+extern "C" {
+    fn sigsetjmp(env: *mut JmpBuf, savesigs: libc::c_int) -> libc::c_int;
+}
+
+/// Marker payload carried by the [`io::Error`] returned when a guarded `SIGBUS`
+/// is caught (a file truncated/shrunk mid-mmap-hash). It lets the
+/// [`walk`](crate::walk) layer *recognize* the mmap-fault error by downcasting
+/// the inner error (via [`io::Error::get_ref`]) rather than string-matching the
+/// message — see [`is_mmap_fault`]. Kept private to this module: callers use the
+/// [`is_mmap_fault`] predicate, not the type directly.
+#[derive(Debug)]
+struct MmapFault;
+
+impl fmt::Display for MmapFault {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("file changed during hashing (mmap fault)")
+    }
+}
+
+impl StdError for MmapFault {}
+
+/// Returns `true` if `err` is the synthetic [`io::Error`] produced by
+/// [`guard_mmap_hash`] when it caught a guarded `SIGBUS` (a concurrent
+/// truncation/shrink faulting the mmap). The walk layer maps such an error to a
+/// typed `FileChangedDuringWalk`, while a genuine permission/IO `io::Error`
+/// (for which this returns `false`) maps to `WalkError::Io`.
+#[must_use]
+pub fn is_mmap_fault(err: &io::Error) -> bool {
+    err.get_ref()
+        .is_some_and(<dyn StdError + Send + Sync>::is::<MmapFault>)
+}
+
+thread_local! {
+    /// Set only while this thread is executing inside [`guard_mmap_hash`].
+    static IN_GUARD: Cell<bool> = const { Cell::new(false) };
+    /// Pointer to the [`JmpBuf`] armed by the active [`guard_mmap_hash`] frame
+    /// on this thread (null when no frame is armed).
+    static JMP_TARGET: Cell<*mut JmpBuf> = const { Cell::new(ptr::null_mut()) };
+}
+
+/// The previous `SIGBUS` disposition, captured at install time so we can chain
+/// to it for faults that are not ours. Written once under [`INSTALL`]; only
+/// read from the (single-threaded-per-fault) handler afterwards.
+static mut PREV_ACTION: MaybeUninit<libc::sigaction> = MaybeUninit::uninit();
+static INSTALL: Once = Once::new();
+
+/// The `SIGBUS` handler. Async-signal-safe: reads two thread-locals and either
+/// `siglongjmp`s out of the guarded region or forwards to the saved handler.
+extern "C" fn handle_sigbus(sig: libc::c_int, info: *mut libc::siginfo_t, ctx: *mut libc::c_void) {
+    // Is THIS thread inside a guarded mmap hash? If so the fault is on the file
+    // we are hashing: jump back to the guard frame with a non-zero value.
+    let armed = IN_GUARD.with(Cell::get);
+    if armed {
+        let target = JMP_TARGET.with(Cell::get);
+        if !target.is_null() {
+            // SAFETY: `target` points at a `JmpBuf` armed by `sigsetjmp` in this
+            // thread's live `guard_mmap_hash` frame; `siglongjmp` is
+            // async-signal-safe.
+            unsafe { siglongjmp(target, 1) };
+        }
+    }
+
+    // Not ours: chain to whatever was installed before us.
+    // SAFETY: `PREV_ACTION` is initialised before any handler can run (the
+    // install `Once` completes the sigaction call only after writing it). We
+    // take a raw pointer (not a reference to the mutable static) and read it.
+    let prev: &libc::sigaction = unsafe { &*(&raw const PREV_ACTION).cast::<libc::sigaction>() };
+    let prev_handler = prev.sa_sigaction;
+    if prev.sa_flags & libc::SA_SIGINFO != 0 {
+        if prev_handler != libc::SIG_DFL && prev_handler != libc::SIG_IGN {
+            // SAFETY: prev was a SA_SIGINFO handler; call with the 3-arg shape.
+            let f: extern "C" fn(libc::c_int, *mut libc::siginfo_t, *mut libc::c_void) =
+                unsafe { std::mem::transmute(prev_handler) };
+            f(sig, info, ctx);
+            return;
+        }
+    } else if prev_handler != libc::SIG_DFL && prev_handler != libc::SIG_IGN {
+        // SAFETY: prev was a classic 1-arg handler.
+        let f: extern "C" fn(libc::c_int) = unsafe { std::mem::transmute(prev_handler) };
+        f(sig);
+        return;
+    }
+
+    // No prior handler (default/ignore): restore the default disposition and
+    // re-raise so the process dies as it would have without us.
+    // SAFETY: async-signal-safe libc calls only.
+    unsafe {
+        let mut dfl: libc::sigaction = std::mem::zeroed();
+        dfl.sa_sigaction = libc::SIG_DFL;
+        libc::sigaction(libc::SIGBUS, &raw const dfl, ptr::null_mut());
+        libc::raise(libc::SIGBUS);
+    }
+}
+
+/// Installs (once) the alternate signal stack and the chaining `SIGBUS`
+/// handler. Idempotent and cheap on repeat calls.
+fn ensure_installed() {
+    INSTALL.call_once(|| {
+        // SAFETY: standard one-time sigaltstack + sigaction install. The
+        // altstack memory is intentionally leaked for the process lifetime so
+        // the kernel always has a valid stack to deliver SIGBUS on (the mmap
+        // fault can occur with an arbitrarily-grown user stack).
+        unsafe {
+            let stack_size = libc::SIGSTKSZ.max(libc::MINSIGSTKSZ * 4);
+            let mem = vec![0u8; stack_size].into_boxed_slice();
+            let mem = Box::leak(mem);
+            let ss = libc::stack_t {
+                ss_sp: mem.as_mut_ptr().cast(),
+                ss_flags: 0,
+                ss_size: stack_size,
+            };
+            libc::sigaltstack(&raw const ss, ptr::null_mut());
+
+            let mut action: libc::sigaction = std::mem::zeroed();
+            action.sa_sigaction = handle_sigbus as *const () as usize;
+            action.sa_flags = libc::SA_SIGINFO | libc::SA_ONSTACK | libc::SA_NODEFER;
+            libc::sigemptyset(&raw mut action.sa_mask);
+            libc::sigaction(
+                libc::SIGBUS,
+                &raw const action,
+                (&raw mut PREV_ACTION).cast::<libc::sigaction>(),
+            );
+        }
+    });
+}
+
+/// Runs `f` (a single-threaded mmap-based file hash) with a `SIGBUS` guard
+/// armed on the current thread.
+///
+/// If a `SIGBUS` is raised on this thread while `f` runs — the signature of a
+/// file truncated/shrunk mid-hash — the handler `siglongjmp`s back here and we
+/// return a clean [`io::Error`] instead of letting the kernel kill the process.
+/// A `SIGBUS` from anywhere else (no guard armed) is chained to the
+/// previously-installed handler.
+///
+/// `f` must keep its mmap-touching work on **this** thread (no rayon fan-out),
+/// so the faulting thread is the one that armed the jump buffer.
+///
+/// # Errors
+///
+/// Returns `f`'s own [`io::Result`], or a synthetic [`io::Error`] carrying the
+/// private `MmapFault` marker ("file changed during hashing (mmap fault)") if a
+/// guarded `SIGBUS` was caught. Recognize that error with [`is_mmap_fault`].
+pub fn guard_mmap_hash<T, F: FnOnce() -> io::Result<T>>(f: F) -> io::Result<T> {
+    ensure_installed();
+
+    let mut env = JmpBuf([0u8; JMP_BUF_BYTES]);
+    let env_ptr: *mut JmpBuf = &raw mut env;
+
+    // Arm the jump buffer BEFORE setting the flag. `sigsetjmp` returns 0 on the
+    // initial call and the `siglongjmp` value (1) when we are jumped back.
+    // SAFETY: `env` lives for the whole function; `sigsetjmp` is the standard
+    // setjmp contract.
+    let jumped = unsafe { sigsetjmp(env_ptr, 1) };
+    if jumped != 0 {
+        // We were longjmp'd back from the handler: a guarded SIGBUS fired.
+        // Disarm and report a clean error. (The thread-locals are restored
+        // below via the same disarm path.)
+        JMP_TARGET.with(|t| t.set(ptr::null_mut()));
+        IN_GUARD.with(|fl| fl.set(false));
+        // Carry the `MmapFault` marker so the walk layer can recognize this as a
+        // mid-hash truncation (`is_mmap_fault`) and map it to a typed
+        // `FileChangedDuringWalk`, distinct from a genuine IO fault.
+        return Err(io::Error::other(MmapFault));
+    }
+
+    // Save any outer frame's state so nested guards (none today, but cheap and
+    // correct) restore cleanly, then arm THIS frame.
+    let prev_target = JMP_TARGET.with(|t| t.replace(env_ptr));
+    let prev_in_guard = IN_GUARD.with(|fl| fl.replace(true));
+
+    let result = f();
+
+    // Disarm: restore the outer frame's state.
+    IN_GUARD.with(|fl| fl.set(prev_in_guard));
+    JMP_TARGET.with(|t| t.set(prev_target));
+
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn passes_through_ok_result() {
+        let got = guard_mmap_hash(|| Ok::<_, io::Error>(7u32)).unwrap();
+        assert_eq!(got, 7);
+    }
+
+    #[test]
+    fn passes_through_err_result() {
+        let err = guard_mmap_hash(|| {
+            Err::<u32, _>(io::Error::new(io::ErrorKind::PermissionDenied, "nope"))
+        })
+        .unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::PermissionDenied);
+    }
+
+    #[test]
+    fn disarms_after_run() {
+        // After a normal run the guard flag must be clear so a later, unrelated
+        // SIGBUS would chain rather than be swallowed.
+        guard_mmap_hash(|| Ok::<_, io::Error>(())).unwrap();
+        assert!(!IN_GUARD.with(Cell::get));
+        assert!(JMP_TARGET.with(Cell::get).is_null());
+    }
+
+    #[test]
+    fn install_is_idempotent() {
+        ensure_installed();
+        ensure_installed();
+        // A second guarded call still works after repeated installs.
+        assert_eq!(guard_mmap_hash(|| Ok::<_, io::Error>(1u8)).unwrap(), 1);
+    }
+}

--- a/crates/snapdir-core/src/walk.rs
+++ b/crates/snapdir-core/src/walk.rs
@@ -135,6 +135,45 @@ pub enum WalkError {
     /// UTF-8 text; non-UTF-8 paths cannot be represented.
     #[error("path is not valid UTF-8: {0:?}")]
     NonUtf8Path(PathBuf),
+
+    /// A regular file enumerated during discovery was gone before/at hashing —
+    /// a transient tree-in-flux race (the tree changed under snapdir), NOT a
+    /// durable IO fault. Distinct from [`WalkError::Io`], which is reserved for
+    /// genuine permission/IO errors.
+    #[error(
+        "file vanished during walk (tree changed under snapdir): {path:?}; \
+         re-run on a quiescent tree"
+    )]
+    FileVanishedDuringWalk {
+        /// The path of the file that vanished mid-walk.
+        path: PathBuf,
+    },
+
+    /// A file's size/mtime/content changed while it was being hashed, so the
+    /// recorded checksum/size would be incoherent (detected via a mid-mmap
+    /// `SIGBUS` fault or a stat-before/stat-after / bytes-vs-recorded-size
+    /// discrepancy). The tree changed under snapdir.
+    #[error(
+        "file changed during walk (tree changed under snapdir): {path:?}; \
+         re-run on a quiescent tree"
+    )]
+    FileChangedDuringWalk {
+        /// The path of the file that changed mid-hash.
+        path: PathBuf,
+    },
+
+    /// A directory invariant expected during the bottom-up finalize pass was
+    /// violated because the tree mutated mid-walk (e.g. a directory vanished
+    /// after discovery). Replaces the former `expect()` panics so an in-flux
+    /// tree yields a clean typed error rather than a backtrace.
+    #[error(
+        "tree structure changed during walk (tree changed under snapdir): {path:?}; \
+         re-run on a quiescent tree"
+    )]
+    TreeStructureChanged {
+        /// The path/key whose structural invariant was violated.
+        path: PathBuf,
+    },
 }
 
 impl WalkError {
@@ -201,6 +240,14 @@ struct PendingHash {
     file_index: usize,
     /// Path to hash the content through (follows symlinks).
     content_path: PathBuf,
+    /// The size recorded at discovery (the entry's own `lstat` length). The
+    /// hash pass compares the bytes it actually streams/maps against this to
+    /// catch a file that GREW or SHRANK mid-hash (→ `FileChangedDuringWalk`).
+    recorded_size: u64,
+    /// Whether this entry is a followed symlink. A symlink's recorded SIZE is
+    /// its own `lstat` length (deliberately != the dereferenced content
+    /// length), so the bytes-vs-`recorded_size` drift check is SKIPPED for it.
+    is_symlink: bool,
 }
 
 /// A discovered directory, holding its absolute path and (filled during the
@@ -394,9 +441,15 @@ fn walk_inner<H: Hasher + HashFile + Sync>(
             member_size += file.size;
         }
         for child in &record.child_dirs {
-            let (csum, size) = finalized
-                .get(child)
-                .expect("child dir finalized before parent (reverse key order)");
+            // On a quiescent tree a child dir is always finalized before its
+            // parent (reverse key order). A miss means the tree mutated
+            // mid-walk (the child vanished after discovery): a clean typed
+            // error instead of the former `expect()` panic/backtrace.
+            let Some((csum, size)) = finalized.get(child) else {
+                return Err(WalkError::TreeStructureChanged {
+                    path: PathBuf::from(child),
+                });
+            };
             child_checksums.push(csum.clone());
             member_size += size;
         }
@@ -568,6 +621,8 @@ fn discover_dir(
                 dir_key: abs_path.to_owned(),
                 file_index,
                 content_path: entry_path,
+                recorded_size: link_meta.len(),
+                is_symlink,
             });
         }
         // Anything else (sockets, fifos, devices) is neither `-type d` nor
@@ -612,12 +667,41 @@ fn hash_pending<H: Hasher + HashFile + Sync>(
     let per_file_seq = pending.len() >= jobs;
 
     let hash_one = |item: &PendingHash| -> Result<(String, usize, String), WalkError> {
-        let (checksum, hashed_bytes) = if per_file_seq {
+        let (checksum, hashed_bytes) = match if per_file_seq {
             hasher.hash_file_hex_seq(&item.content_path)
         } else {
             hasher.hash_file_hex(&item.content_path)
+        } {
+            Ok(ok) => ok,
+            // A file enumerated in discovery is now gone: a transient tree-in-flux
+            // race, not a durable IO fault.
+            Err(e) if e.kind() == io::ErrorKind::NotFound => {
+                return Err(WalkError::FileVanishedDuringWalk {
+                    path: item.content_path.clone(),
+                });
+            }
+            // The SIGBUS guard caught a mid-hash truncation/shrink (mmap fault):
+            // the recorded checksum would be incoherent.
+            Err(e) if crate::sigbus::is_mmap_fault(&e) => {
+                return Err(WalkError::FileChangedDuringWalk {
+                    path: item.content_path.clone(),
+                });
+            }
+            // Genuine permission / IO fault.
+            Err(e) => return Err(WalkError::io(&item.content_path, e)),
+        };
+
+        // Size-drift guard: the bytes actually hashed must match the size
+        // recorded at discovery, or the file grew/shrank mid-walk and the
+        // (size, checksum) pair would be incoherent. SKIP for followed symlinks,
+        // whose recorded SIZE is the symlink's own `lstat` length (deliberately
+        // != the dereferenced content length the hasher reports).
+        if !item.is_symlink && hashed_bytes != item.recorded_size {
+            return Err(WalkError::FileChangedDuringWalk {
+                path: item.content_path.clone(),
+            });
         }
-        .map_err(|e| WalkError::io(&item.content_path, e))?;
+
         if let Some(meter) = meter {
             meter.add_in(hashed_bytes);
             meter.object_finished();
@@ -648,9 +732,14 @@ fn hash_pending<H: Hasher + HashFile + Sync>(
     // Write each result back into its fixed slot. Order-independent: the slot is
     // addressed by (dir_key, file_index), so completion order is irrelevant.
     for (dir_key, file_index, checksum) in results {
-        let record = dirs
-            .get_mut(&dir_key)
-            .expect("pending file's owning dir was discovered");
+        // The owning dir was discovered before its files were queued; a miss
+        // means the tree mutated mid-walk. Clean typed error, not an `expect()`
+        // panic.
+        let Some(record) = dirs.get_mut(&dir_key) else {
+            return Err(WalkError::TreeStructureChanged {
+                path: PathBuf::from(&dir_key),
+            });
+        };
         record.files[file_index].checksum = checksum;
     }
     Ok(())

--- a/crates/snapdir-core/tests/concurrent_mutation.rs
+++ b/crates/snapdir-core/tests/concurrent_mutation.rs
@@ -1,0 +1,1319 @@
+//! Concurrent-mutation robustness suite for `snapdir-core` walk — ADVERSARY, black-box.
+//!
+//! ## What this pins
+//!
+//! The files-in-flux invariant locked in `.gatesmith/reviews/flux-robustness-1.9.0.md`:
+//! every walk of a tree that mutates DURING hashing must return EITHER
+//!   - `Ok(manifest)` with a well-formed 64-hex `snapshot_id` AND the CONTROL
+//!     file's entry unchanged (no silent corruption of untouched files), OR
+//!   - `Err(WalkError::{FileVanishedDuringWalk|FileChangedDuringWalk|
+//!     TreeStructureChanged|Io})` whose `Display` names a path.
+//!
+//! NEVER a process kill (SIGBUS), NEVER a panic/backtrace, NEVER an `Ok` with
+//! a malformed id, NEVER a silently mis-recorded size.
+//!
+//! ## Black-box authoring note
+//!
+//! These tests reference `WalkError::FileVanishedDuringWalk`,
+//! `WalkError::FileChangedDuringWalk`, and `WalkError::TreeStructureChanged` — three
+//! variants that DO NOT EXIST yet (only `Io`, `RootNotAbsolute`, `RootNotDirectory`,
+//! `NonUtf8Path` exist today).  The tests are therefore expected to **fail to compile**
+//! until the `flux-impl-core-detect` gate adds those variants. That is intentional:
+//! the spec names them precisely so the impl must provide them.
+//!
+//! ## Sandbox hygiene
+//!
+//! Each test builds a private `TempTree` (RAII scratch dir under `std::env::temp_dir()`
+//! with a unique tag, mimicking the `Scratch` struct in `fast_walk.rs` — the crate has
+//! NO `tempfile` dev-dep, so we hand-roll the same pattern). Mutator threads are joined
+//! before the scratch dir is dropped. Fixed PRNG seed (`(i * 31 + 7) & 0xff` — the same
+//! ramp used in `fast_walk.rs` and the bench crate) makes failures reproducible.
+
+// Test-shape allows (impl-lane wiring only, NOT assertion changes).
+#![allow(
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss,
+    clippy::doc_markdown,
+    clippy::missing_panics_doc,
+    // The `WalkError::FileVanishedDuringWalk` etc. patterns reference new enum
+    // variants that don't exist until the impl gate. Once the impl lands and
+    // the file is `git mv`-ed into the crate, the allow below is removed.
+    clippy::match_wildcard_for_single_variants,
+    // Test-shape pedantic lints in the adversary-authored fixture (style only,
+    // no assertion impact): the impl gate may suppress these as wiring so the
+    // suite builds under `-D warnings` without rewriting adversary source.
+    clippy::map_unwrap_or,
+    clippy::match_single_binding,
+    clippy::uninlined_format_args,
+    clippy::needless_borrows_for_generic_args,
+    clippy::ignored_unit_patterns
+)]
+
+use std::fs;
+use std::io::Write as _;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use snapdir_core::{snapshot_id, walk, Blake3Hasher, WalkError, WalkOptions};
+
+// ---------------------------------------------------------------------------
+// Shared scratch-dir helpers (mirrors fast_walk.rs — no `tempfile` dep).
+// ---------------------------------------------------------------------------
+
+static SCRATCH_SEQ: AtomicU64 = AtomicU64::new(0);
+
+struct TempTree {
+    path: PathBuf,
+}
+
+impl TempTree {
+    fn new(tag: &str) -> Self {
+        let seq = SCRATCH_SEQ.fetch_add(1, Ordering::Relaxed);
+        let ts = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .map(|d| d.as_nanos())
+            .unwrap_or(0);
+        let path = std::env::temp_dir().join(format!(
+            "snapdir_concmut_{}_{}_{}_{}",
+            tag,
+            std::process::id(),
+            seq,
+            ts,
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).expect("create scratch dir");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempTree {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Fixture helpers.
+// ---------------------------------------------------------------------------
+
+/// The deterministic ramp from `fast_walk.rs` / `benches` (MUST stay byte-identical).
+fn ramp(len: usize) -> Vec<u8> {
+    (0..len)
+        .map(|i| u8::try_from(i.wrapping_mul(31).wrapping_add(7) & 0xff).expect("masked to u8"))
+        .collect()
+}
+
+/// Write `content` to `path`, creating parent dirs as needed.
+fn write_file(path: &Path, content: &[u8]) {
+    if let Some(p) = path.parent() {
+        fs::create_dir_all(p).expect("create_dir_all");
+    }
+    fs::write(path, content).expect("write_file");
+}
+
+/// Truncate `path` to `new_len` bytes (silently ignore "no such file" races).
+fn try_truncate(path: &Path, new_len: u64) {
+    let _ = fs::OpenOptions::new()
+        .write(true)
+        .open(path)
+        .and_then(|f| f.set_len(new_len));
+}
+
+/// Append `extra` bytes to `path` (grow; silently ignore races).
+fn try_append(path: &Path, extra: &[u8]) {
+    let _ = fs::OpenOptions::new()
+        .append(true)
+        .open(path)
+        .and_then(|mut f| f.write_all(extra).map(|_| f));
+}
+
+/// Delete `path` (silently ignore "no such file" races).
+fn try_delete(path: &Path) {
+    let _ = fs::remove_file(path);
+}
+
+/// Delete + recreate `path` with different content (inode change).
+fn try_replace(path: &Path, seed: u8) {
+    let _ = fs::remove_file(path);
+    let content: Vec<u8> = (0..4096).map(|i| seed.wrapping_add(i as u8)).collect();
+    let _ = fs::write(path, content);
+}
+
+/// Atomic rename-replace: write `new_content` to a sibling tmp path, then
+/// rename it over `path` (inode changes atomically from the walk's perspective).
+fn try_atomic_replace(path: &Path, new_content: &[u8]) {
+    let tmp = path.with_extension("_tmp_rename");
+    if fs::write(&tmp, new_content).is_ok() {
+        let _ = fs::rename(&tmp, path);
+    }
+}
+
+// The MMAP_THRESHOLD from the design doc: 256 KiB.
+const MMAP_THRESHOLD: usize = 256 * 1024;
+
+// ---------------------------------------------------------------------------
+// Helpers to validate the per-iteration invariant.
+// ---------------------------------------------------------------------------
+
+/// Returns true if `id` is a well-formed 64-hex snapshot id.
+fn is_valid_snapshot_id(id: &str) -> bool {
+    id.len() == 64
+        && id
+            .chars()
+            .all(|c| c.is_ascii_hexdigit() && !c.is_ascii_uppercase())
+}
+
+/// Returns true if `err` is one of the four acceptable typed `WalkError` variants
+/// (the two pre-existing `Io`/`NonUtf8Path` plus the three new ones locked by the
+/// design doc).  The assertion is explicit about variant names so the impl MUST
+/// provide them.
+fn is_acceptable_error(err: &WalkError) -> bool {
+    matches!(
+        err,
+        WalkError::FileVanishedDuringWalk { .. }
+            | WalkError::FileChangedDuringWalk { .. }
+            | WalkError::TreeStructureChanged { .. }
+            | WalkError::Io { .. }
+    )
+}
+
+/// Every acceptable error's `Display` must name a path (non-empty string that is
+/// not just whitespace, and whose `Display` text does not just say "walk" or a
+/// generic message without any path-like substring).
+fn error_display_names_a_path(err: &WalkError) -> bool {
+    let msg = err.to_string();
+    // Must not be blank and must contain at least one '/' or '.' which indicates a
+    // path-like component.  The spec says the Display is "actionable" and names a file.
+    !msg.trim().is_empty() && (msg.contains('/') || msg.contains('.'))
+}
+
+// ---------------------------------------------------------------------------
+// 1. Concurrent-mutation fuzz loop.
+// ---------------------------------------------------------------------------
+
+/// Build a fixture tree with:
+///   - Several large files (≥ 512 KiB up to 4 MiB) as mutation victims.
+///   - Several small files (< MMAP_THRESHOLD) as mutation victims.
+///   - One CONTROL file that is NEVER touched by the mutator.
+///
+/// Returns (root, control_path, victim_paths, control_content).
+fn build_flux_fixture(scratch: &TempTree) -> (PathBuf, PathBuf, Vec<PathBuf>, Vec<u8>) {
+    let root = scratch.path().to_path_buf();
+
+    // Large victim files: 512 KiB, 1 MiB, 2 MiB, 4 MiB.
+    let large_sizes = [
+        MMAP_THRESHOLD * 2,
+        MMAP_THRESHOLD * 4,
+        MMAP_THRESHOLD * 8,
+        MMAP_THRESHOLD * 16,
+    ];
+    let mut victims = Vec::new();
+    for (i, &sz) in large_sizes.iter().enumerate() {
+        let p = root.join(format!("large_{i:02}.bin"));
+        write_file(&p, &ramp(sz));
+        victims.push(p);
+    }
+
+    // Small victim files.
+    for i in 0..8 {
+        let p = root.join(format!("small_{i:02}.bin"));
+        write_file(&p, &ramp(64 + i * 7));
+        victims.push(p);
+    }
+
+    // Subdirectory with a few more victims (directory-vanish target).
+    let sub = root.join("subdir");
+    fs::create_dir_all(&sub).expect("create subdir");
+    for i in 0..4 {
+        let p = sub.join(format!("sub_{i:02}.bin"));
+        write_file(&p, &ramp(MMAP_THRESHOLD + i * 1024));
+        victims.push(p);
+    }
+
+    // CONTROL file: never mutated; must be present and byte-identical after every
+    // successful walk.
+    let control_content = ramp(1024);
+    let control_path = root.join("control_NEVER_TOUCHED.bin");
+    write_file(&control_path, &control_content);
+
+    (root, control_path, victims, control_content)
+}
+
+#[test]
+fn concurrent_mutation_fuzz_loop() {
+    // Spec clause: concurrent-mutation invariant.
+    // Every walk of an in-flux tree returns a Result (never unwinds/aborts); if Ok,
+    // the snapshot_id matches ^[0-9a-f]{64}$ AND the CONTROL file's entry is
+    // unchanged; if Err, it is one of the four named WalkError variants and its
+    // Display names a path. This is the primary regression guard for all four
+    // failure modes (SIGBUS, expect() panics, silent wrong-size, generic ENOENT).
+
+    const ITERATIONS: usize = 300;
+    let walk_jobs_matrix: &[Option<usize>] = &[Some(1), Some(4), None];
+
+    for &walk_jobs in walk_jobs_matrix {
+        for iter in 0..ITERATIONS {
+            let scratch = TempTree::new("flux_fuzz");
+            let (root, control_path, victims, control_content) = build_flux_fixture(&scratch);
+
+            // Capture the golden control entry from a quiescent pre-walk so we can
+            // compare it after in-flux walks.
+            let hasher = Blake3Hasher::new();
+            let opts = WalkOptions {
+                walk_jobs,
+                ..WalkOptions::default()
+            };
+
+            // Launch the mutator thread; it runs until the walk_done flag is set.
+            let walk_done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let walk_done_c = Arc::clone(&walk_done);
+            let victims_c = victims.clone();
+            let iter_seed = (iter * 31 + 7) & 0xff;
+
+            let mutator = std::thread::spawn(move || {
+                let mut prng = iter_seed as u8;
+                while !walk_done_c.load(Ordering::Relaxed) {
+                    let victim_idx = (prng as usize) % victims_c.len();
+                    let victim = &victims_c[victim_idx];
+                    match prng % 5 {
+                        0 => try_truncate(victim, 0),
+                        1 => {
+                            // Truncate to roughly half the file.
+                            if let Ok(meta) = fs::metadata(victim) {
+                                try_truncate(victim, meta.len() / 2);
+                            }
+                        }
+                        2 => try_append(victim, &[prng; 4096]),
+                        3 => try_delete(victim),
+                        _ => try_replace(victim, prng),
+                    }
+                    // Advance the PRNG.
+                    prng = prng.wrapping_mul(31).wrapping_add(7);
+                    // Tiny yield to interleave with the walk without burning all CPU.
+                    std::hint::spin_loop();
+                }
+            });
+
+            // Run the walk while the mutator hammers.
+            let result = walk(&root, &opts, &hasher);
+
+            // Signal the mutator to stop and join (must not leave orphan threads).
+            walk_done.store(true, Ordering::Relaxed);
+            mutator.join().expect("mutator thread panicked");
+
+            // --- INVARIANT CHECK ---
+            match &result {
+                Ok(manifest) => {
+                    let id = snapshot_id(manifest, &hasher);
+                    assert!(
+                        is_valid_snapshot_id(&id),
+                        "iter={iter} jobs={walk_jobs:?}: Ok(manifest) produced malformed \
+                         snapshot_id {:?} (want 64-hex)",
+                        id
+                    );
+                    // Control file must not have been silently corrupted in the manifest.
+                    // Find the control file's entry by path suffix.
+                    let manifest_text = manifest.to_string();
+                    let control_name = "control_NEVER_TOUCHED.bin";
+                    if manifest_text.lines().any(|l| l.contains(control_name)) {
+                        // Re-read the control file's CONTENT; it must be unchanged
+                        // because the mutator never touches it.
+                        let on_disk = fs::read(&control_path)
+                            .expect("control file must still exist after a successful walk");
+                        assert_eq!(
+                            on_disk, control_content,
+                            "iter={iter} jobs={walk_jobs:?}: control file was silently mutated \
+                             during an Ok walk — the walk corrupted an untouched file's content"
+                        );
+                    }
+                }
+                Err(err) => {
+                    assert!(
+                        is_acceptable_error(err),
+                        "iter={iter} jobs={walk_jobs:?}: Err is not one of the four acceptable \
+                         WalkError variants: {err:?}"
+                    );
+                    assert!(
+                        error_display_names_a_path(err),
+                        "iter={iter} jobs={walk_jobs:?}: error Display does not name a path: {:?}",
+                        err.to_string()
+                    );
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 2. Mid-mmap truncation repro (SIGBUS regression guard).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mid_mmap_truncation_is_clean_error_not_sigbus() {
+    // Spec clause: SIGBUS regression guard (design §A).
+    // A large (≥ 256 KiB) file truncated to a small size WHILE it is being hashed
+    // via mmap must produce a clean Err — NEVER a SIGBUS process kill.
+    //
+    // NOTE: Pre-fix (before flux-impl-core-sigbus), this SIGBUS-kills the test
+    // process; the test merely completing (reaching the assertion) is itself the
+    // regression guard.  The panic_handler in Rust will catch panics but NOT SIGBUS;
+    // if the process is killed by SIGBUS the ENTIRE test binary dies, making it
+    // obvious as a CI failure.
+    //
+    // Strategy: create a very large file (4 MiB) so hashing takes enough wall-clock
+    // time for a racing truncator to reliably hit the mmap window.  We loop many
+    // times with a tight truncation window to maximize the race probability.
+
+    const LARGE_SIZE: usize = 4 * 1024 * 1024; // 4 MiB — well above MMAP_THRESHOLD
+    const RACE_ATTEMPTS: usize = 50;
+
+    let hasher = Blake3Hasher::new();
+
+    for attempt in 0..RACE_ATTEMPTS {
+        let scratch = TempTree::new("sigbus_repro");
+        let victim = scratch.path().join("victim_large.bin");
+        write_file(&victim, &ramp(LARGE_SIZE));
+
+        let victim_c = victim.clone();
+        let root = scratch.path().to_path_buf();
+
+        // Truncator thread: hammers the victim to 0 bytes as quickly as possible
+        // while the main thread is hashing.
+        let start_signal = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let start_c = Arc::clone(&start_signal);
+        let done_signal = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let done_c = Arc::clone(&done_signal);
+
+        let truncator = std::thread::spawn(move || {
+            // Busy-loop until the walker has had a chance to start.
+            while !start_c.load(Ordering::Relaxed) {
+                std::thread::yield_now();
+            }
+            // Now hammer truncations.
+            while !done_c.load(Ordering::Relaxed) {
+                try_truncate(&victim_c, 0);
+                try_truncate(&victim_c, (LARGE_SIZE / 3) as u64);
+                try_truncate(&victim_c, 0);
+            }
+        });
+
+        // Signal the truncator right before starting the walk.
+        start_signal.store(true, Ordering::Relaxed);
+        let result = walk(
+            &root,
+            &WalkOptions {
+                walk_jobs: Some(1), // single-thread so the sigsetjmp is on the right thread
+                ..WalkOptions::default()
+            },
+            &hasher,
+        );
+        done_signal.store(true, Ordering::Relaxed);
+        truncator.join().expect("truncator thread panicked");
+
+        // The invariant: must be Ok OR a typed in-flux error.  Must NOT be a
+        // process-level SIGBUS (which would kill the whole binary, never reaching here).
+        match &result {
+            Ok(manifest) => {
+                let id = snapshot_id(manifest, &hasher);
+                assert!(
+                    is_valid_snapshot_id(&id),
+                    "attempt={attempt}: Ok with malformed id {id:?}"
+                );
+            }
+            Err(err) => {
+                // The EXPECTED post-fix outcome on a truncation race: a clean typed error.
+                assert!(
+                    matches!(
+                        err,
+                        WalkError::FileChangedDuringWalk { .. }
+                            | WalkError::FileVanishedDuringWalk { .. }
+                            | WalkError::Io { .. }
+                    ),
+                    "attempt={attempt}: Err variant unexpected: {err:?}"
+                );
+                assert!(
+                    error_display_names_a_path(err),
+                    "attempt={attempt}: error Display must name a path: {:?}",
+                    err.to_string()
+                );
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 3. Directory vanishes mid-walk.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn directory_vanish_mid_walk_no_panic() {
+    // Spec clause: expect() → TreeStructureChanged (design §C).
+    // walk.rs:399 and walk.rs:653 had bare `expect()` calls that fired when a
+    // directory vanished mid-finalize.  After the fix, the result must be Ok OR
+    // a typed WalkError (including TreeStructureChanged) — never a backtrace.
+
+    const ATTEMPTS: usize = 100;
+    let hasher = Blake3Hasher::new();
+
+    for attempt in 0..ATTEMPTS {
+        let scratch = TempTree::new("dir_vanish");
+        let root = scratch.path().to_path_buf();
+
+        // Deep-ish tree so the finalize pass has multiple directories to process.
+        let sub_a = root.join("alpha");
+        let sub_b = root.join("alpha").join("beta");
+        let sub_c = root.join("gamma");
+        fs::create_dir_all(&sub_b).expect("create alpha/beta");
+        fs::create_dir_all(&sub_c).expect("create gamma");
+
+        write_file(&sub_a.join("a1.bin"), &ramp(MMAP_THRESHOLD + 1024));
+        write_file(&sub_b.join("b1.bin"), &ramp(MMAP_THRESHOLD + 2048));
+        write_file(&sub_b.join("b2.bin"), &ramp(1024));
+        write_file(&sub_c.join("c1.bin"), &ramp(MMAP_THRESHOLD * 2));
+        write_file(&root.join("root.bin"), &ramp(512));
+
+        // The vanishing victim: the whole `alpha` subtree (incl. `alpha/beta`).
+        let vanish_target = sub_a.clone();
+
+        let start_signal = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let start_c = Arc::clone(&start_signal);
+        let done_signal = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let done_c = Arc::clone(&done_signal);
+
+        let remover = std::thread::spawn(move || {
+            while !start_c.load(Ordering::Relaxed) {
+                std::thread::yield_now();
+            }
+            // Remove the directory while the walk is running.
+            while !done_c.load(Ordering::Relaxed) {
+                let _ = fs::remove_dir_all(&vanish_target);
+            }
+        });
+
+        start_signal.store(true, Ordering::Relaxed);
+        let result = walk(
+            &root,
+            &WalkOptions {
+                walk_jobs: Some(4),
+                ..WalkOptions::default()
+            },
+            &hasher,
+        );
+        done_signal.store(true, Ordering::Relaxed);
+        remover.join().expect("remover thread panicked");
+
+        // Invariant: must complete without panic/backtrace; result is Ok or typed error.
+        match &result {
+            Ok(manifest) => {
+                let id = snapshot_id(manifest, &hasher);
+                assert!(
+                    is_valid_snapshot_id(&id),
+                    "attempt={attempt}: Ok with malformed id {id:?}"
+                );
+            }
+            Err(err) => {
+                assert!(
+                    matches!(
+                        err,
+                        WalkError::TreeStructureChanged { .. }
+                            | WalkError::FileVanishedDuringWalk { .. }
+                            | WalkError::Io { .. }
+                    ),
+                    "attempt={attempt}: dir-vanish produced unexpected error variant: {err:?}"
+                );
+                assert!(
+                    error_display_names_a_path(err),
+                    "attempt={attempt}: error Display must name a path: {:?}",
+                    err.to_string()
+                );
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 4. Quiescent control: snapshot_id is byte-identical across two consecutive
+//    walks of the same static tree (no behavior overhead on a quiescent tree).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn quiescent_tree_snapshot_id_is_stable_and_deterministic() {
+    // Spec clause: byte-identical on a quiescent tree (design KEYSTONE).
+    // Two consecutive walks of the same static tree (with no mutations) must
+    // produce the SAME snapshot_id.  This proves the flux guards add zero
+    // behavior overhead on a static tree.  Mirrors the golden-capture pattern
+    // from fast_walk.rs (walk-twice determinism).
+
+    let scratch = TempTree::new("quiescent");
+    let root = scratch.path().to_path_buf();
+
+    // Mix of sub-threshold and large files (same diversity as the fuzz fixture).
+    write_file(&root.join("control.bin"), &ramp(1024));
+    write_file(&root.join("small_a.bin"), &ramp(256));
+    write_file(&root.join("large_a.bin"), &ramp(MMAP_THRESHOLD * 2));
+    write_file(&root.join("large_b.bin"), &ramp(MMAP_THRESHOLD + 7919));
+    let sub = root.join("sub");
+    fs::create_dir_all(&sub).expect("create sub");
+    write_file(&sub.join("nested.bin"), &ramp(MMAP_THRESHOLD + 1));
+    write_file(&sub.join("tiny.bin"), &ramp(0)); // 0-byte file (boundary case)
+
+    let hasher = Blake3Hasher::new();
+
+    for &walk_jobs in &[Some(1usize), Some(4), None] {
+        let opts = WalkOptions {
+            walk_jobs,
+            ..WalkOptions::default()
+        };
+
+        let m1 = walk(&root, &opts, &hasher).expect("first quiescent walk must succeed");
+        let m2 = walk(&root, &opts, &hasher).expect("second quiescent walk must succeed");
+
+        let id1 = snapshot_id(&m1, &hasher);
+        let id2 = snapshot_id(&m2, &hasher);
+
+        assert!(
+            is_valid_snapshot_id(&id1),
+            "walk_jobs={walk_jobs:?}: first walk produced malformed id {id1:?}"
+        );
+        assert_eq!(
+            id1, id2,
+            "walk_jobs={walk_jobs:?}: quiescent walk produced different ids across two runs \
+             (non-deterministic — the flux guards introduced behavior overhead on a static tree)"
+        );
+        assert_eq!(
+            m1.to_string(),
+            m2.to_string(),
+            "walk_jobs={walk_jobs:?}: Manifest Display differs across two quiescent walks"
+        );
+    }
+
+    // Additionally assert walk_jobs=Some(1) and walk_jobs=None yield the SAME id
+    // (i.e. the guard logic is transparent to the snapshot).
+    let opts_1 = WalkOptions {
+        walk_jobs: Some(1),
+        ..WalkOptions::default()
+    };
+    let opts_none = WalkOptions {
+        walk_jobs: None,
+        ..WalkOptions::default()
+    };
+    let id_1 = snapshot_id(
+        &walk(&root, &opts_1, &hasher).expect("walk jobs=1"),
+        &hasher,
+    );
+    let id_none = snapshot_id(
+        &walk(&root, &opts_none, &hasher).expect("walk jobs=none"),
+        &hasher,
+    );
+    assert_eq!(
+        id_1, id_none,
+        "quiescent snapshot_id differs between walk_jobs=Some(1) and None — \
+         guards must not change the output on a static tree"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 5. Empty directory / zero-byte victim.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn empty_dir_and_zero_byte_file_no_panic_valid_id() {
+    // Spec clause: 0-byte / empty-dir boundary (never divide-by-zero; no panic;
+    // valid id).  Exercises the 0-byte `FileChangedDuringWalk` guard edge
+    // (growing a 0-byte file to non-zero is a valid mutation) and the empty-dir
+    // merkle path.
+
+    let scratch = TempTree::new("empty_edges");
+    let root = scratch.path().to_path_buf();
+
+    // Empty directory.
+    fs::create_dir_all(root.join("empty_dir")).expect("create empty_dir");
+    // 0-byte file (boundary: size == 0).
+    write_file(&root.join("zero.bin"), &[]);
+    // Another file for good measure.
+    write_file(&root.join("normal.bin"), &ramp(64));
+
+    let hasher = Blake3Hasher::new();
+    let result = walk(&root, &WalkOptions::default(), &hasher);
+
+    match &result {
+        Ok(manifest) => {
+            let id = snapshot_id(manifest, &hasher);
+            assert!(
+                is_valid_snapshot_id(&id),
+                "Ok(manifest) with empty-dir/0-byte file produced malformed id {id:?}"
+            );
+        }
+        Err(err) => {
+            // An error here is unexpected on a quiescent tree, but must still be typed.
+            assert!(
+                is_acceptable_error(err),
+                "Err on quiescent empty-dir tree is an unacceptable variant: {err:?}"
+            );
+        }
+    }
+
+    // Now mutate the 0-byte file to a large file WHILE a new walk runs (concurrent).
+    // This exercises the grow-from-zero edge in the stat-before/after guard.
+    let zero_path = root.join("zero.bin");
+    let zero_c = zero_path.clone();
+    let root_c = root.clone();
+
+    let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+    let done_c = Arc::clone(&done);
+
+    let grower = std::thread::spawn(move || {
+        while !done_c.load(Ordering::Relaxed) {
+            let _ = fs::write(&zero_c, ramp(MMAP_THRESHOLD * 2));
+            let _ = fs::write(&zero_c, &[]);
+        }
+    });
+
+    for _ in 0..30 {
+        let result2 = walk(
+            &root_c,
+            &WalkOptions {
+                walk_jobs: Some(1),
+                ..WalkOptions::default()
+            },
+            &hasher,
+        );
+        match &result2 {
+            Ok(manifest) => {
+                let id = snapshot_id(manifest, &hasher);
+                assert!(
+                    is_valid_snapshot_id(&id),
+                    "Ok with malformed id on 0-byte grow race: {id:?}"
+                );
+            }
+            Err(err) => {
+                assert!(
+                    is_acceptable_error(err),
+                    "Err on 0-byte grow is unacceptable variant: {err:?}"
+                );
+                assert!(
+                    error_display_names_a_path(err),
+                    "error Display must name a path: {:?}",
+                    err.to_string()
+                );
+            }
+        }
+    }
+
+    done.store(true, Ordering::Relaxed);
+    grower.join().expect("grower thread panicked");
+}
+
+// ---------------------------------------------------------------------------
+// 6. Silent-wrong-size guard: a file that GROWS during hashing must NOT be
+//    recorded with its pre-walk size in an Ok manifest (the stat-after guard
+//    must detect the discrepancy and return FileChangedDuringWalk).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn silent_wrong_size_detected_not_silently_recorded() {
+    // Spec clause: silent wrong-size (design §B) — a file that GROWS between
+    // stat-before and stat-after must produce FileChangedDuringWalk, never an Ok
+    // manifest with the wrong size silently recorded.
+    //
+    // Strategy: create a file that starts at 0 bytes, then atomically replace it
+    // with a large file before the hash pass runs.  We detect the wrong-size case
+    // by comparing the manifest's recorded size for that file against what's
+    // actually on disk AFTER the walk.
+
+    const ATTEMPTS: usize = 50;
+    let hasher = Blake3Hasher::new();
+
+    for attempt in 0..ATTEMPTS {
+        let scratch = TempTree::new("wrong_size");
+        let root = scratch.path().to_path_buf();
+
+        // A file that starts small but will grow during the walk.
+        let victim = root.join("growing.bin");
+        write_file(&victim, &ramp(16)); // small initial content
+
+        // CONTROL: untouched file for the manifest-vs-disk comparison.
+        write_file(&root.join("anchor.bin"), &ramp(512));
+
+        let victim_c = victim.clone();
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let done_c = Arc::clone(&done);
+
+        // Grower thread: hammers the victim from small → large as fast as possible.
+        let grower = std::thread::spawn(move || {
+            while !done_c.load(Ordering::Relaxed) {
+                let _ = fs::write(&victim_c, ramp(MMAP_THRESHOLD * 4));
+                let _ = fs::write(&victim_c, ramp(16));
+            }
+        });
+
+        let result = walk(
+            &root,
+            &WalkOptions {
+                walk_jobs: Some(1),
+                ..WalkOptions::default()
+            },
+            &hasher,
+        );
+        done.store(true, Ordering::Relaxed);
+        grower.join().expect("grower thread panicked");
+
+        match &result {
+            Ok(manifest) => {
+                let id = snapshot_id(manifest, &hasher);
+                assert!(
+                    is_valid_snapshot_id(&id),
+                    "attempt={attempt}: Ok with malformed id {id:?}"
+                );
+                // If we got Ok, verify that the manifest's size for `growing.bin`
+                // matches the ACTUAL bytes hashed (not silently stale).
+                let manifest_text = manifest.to_string();
+                // Find the growing.bin row: format is "F <perm> <checksum> <size> <path>".
+                for line in manifest_text.lines() {
+                    if line.ends_with("./growing.bin") {
+                        let parts: Vec<&str> = line.split_whitespace().collect();
+                        // parts[3] is the recorded size
+                        if parts.len() >= 4 {
+                            let recorded_size: u64 =
+                                parts[3].parse().expect("size field must be a valid u64");
+                            // The recorded checksum (parts[2]) should match
+                            // the blake3 of exactly `recorded_size` bytes starting
+                            // from offset 0 of whatever the file contained.
+                            // We cannot know the exact bytes, but we CAN assert
+                            // that the recorded size is non-negative and the
+                            // checksum is valid hex (weak guard; the impl's
+                            // stat-after is the real protection).
+                            assert!(
+                                parts[2].len() == 64
+                                    && parts[2].chars().all(|c| c.is_ascii_hexdigit()),
+                                "attempt={attempt}: manifest checksum for growing.bin is \
+                                 not 64-hex: {:?}",
+                                parts[2]
+                            );
+                            // Most importantly: the recorded size MUST equal the
+                            // number of bytes actually hashed.  The impl's stat-after
+                            // should catch any size mismatch; if it lets an Ok through,
+                            // the size must be consistent with the checksum.
+                            let _ = recorded_size; // Used above
+                        }
+                    }
+                }
+            }
+            Err(err) => {
+                // The EXPECTED post-fix behavior on a grow race:
+                // FileChangedDuringWalk (or Io on transient races).
+                assert!(
+                    matches!(
+                        err,
+                        WalkError::FileChangedDuringWalk { .. }
+                            | WalkError::FileVanishedDuringWalk { .. }
+                            | WalkError::Io { .. }
+                    ),
+                    "attempt={attempt}: wrong-size race produced unexpected variant: {err:?}"
+                );
+                assert!(
+                    error_display_names_a_path(err),
+                    "attempt={attempt}: error Display must name a path: {:?}",
+                    err.to_string()
+                );
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 7. Atomic rename-replace of a victim mid-hash (inode change).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn atomic_rename_replace_mid_hash_typed_error_or_valid_id() {
+    // Spec clause: stat-before/stat-after guard (design §B) — an atomic rename
+    // swap changes a file's inode/size/content under the walk without exposing
+    // a mid-file partial state.  The walk must produce a typed error OR a valid
+    // id; it must NEVER silently record a mismatched (size, checksum) pair.
+    //
+    // A rename is the sharpest TOCTOU: the `link_meta.len()` at discovery
+    // differs from the bytes actually hashed through the renamed-in file.
+    // The size-drift guard (walk.rs, `hashed_bytes != item.recorded_size`)
+    // or the `FileVanishedDuringWalk` path (if the original is gone between
+    // discovery stat and hash) must catch this.
+    const ATTEMPTS: usize = 60;
+    let hasher = Blake3Hasher::new();
+
+    for attempt in 0..ATTEMPTS {
+        let scratch = TempTree::new("atomic_rename");
+        let root = scratch.path().to_path_buf();
+
+        // Victim: large (mmap path) so the rename has time to land mid-hash.
+        let victim = root.join("victim_rename.bin");
+        write_file(&victim, &ramp(MMAP_THRESHOLD * 3));
+        // A different-size replacement payload (to guarantee a size mismatch
+        // if the stat-after still sees the old metadata).
+        let replacement = ramp(MMAP_THRESHOLD * 2 + 4097);
+        // Control file: must not be corrupted.
+        let control_content = ramp(512);
+        write_file(&root.join("anchor_rename.bin"), &control_content);
+
+        let victim_c = victim.clone();
+        let replacement_c = replacement.clone();
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let done_c = Arc::clone(&done);
+
+        // Renamer thread: hammers the victim with an atomic rename-swap.
+        let renamer = std::thread::spawn(move || {
+            let mut seed: u8 = 0xab;
+            while !done_c.load(Ordering::Relaxed) {
+                try_atomic_replace(&victim_c, &replacement_c);
+                // Also restore the original size to keep the race interesting.
+                let _ = fs::write(&victim_c, ramp(MMAP_THRESHOLD * 3));
+                seed = seed.wrapping_mul(31).wrapping_add(7);
+                let _ = seed; // PRNG advance for future use
+                std::hint::spin_loop();
+            }
+        });
+
+        let result = walk(
+            &root,
+            &WalkOptions {
+                walk_jobs: Some(1),
+                ..WalkOptions::default()
+            },
+            &hasher,
+        );
+        done.store(true, Ordering::Relaxed);
+        renamer.join().expect("renamer thread panicked");
+
+        // Invariant: Ok with valid id OR typed in-flux error.  Never a panic,
+        // never a silently wrong (size, checksum) pair in an Ok manifest.
+        match &result {
+            Ok(manifest) => {
+                let id = snapshot_id(manifest, &hasher);
+                assert!(
+                    is_valid_snapshot_id(&id),
+                    "attempt={attempt}: Ok with malformed id {id:?}"
+                );
+                // Verify the control file wasn't corrupted.
+                let anchor_on_disk =
+                    fs::read(root.join("anchor_rename.bin")).expect("control must exist");
+                assert_eq!(
+                    anchor_on_disk, control_content,
+                    "attempt={attempt}: control file corrupted in Ok manifest"
+                );
+            }
+            Err(err) => {
+                assert!(
+                    is_acceptable_error(err),
+                    "attempt={attempt}: rename-replace produced unexpected error variant: {err:?}"
+                );
+                assert!(
+                    error_display_names_a_path(err),
+                    "attempt={attempt}: error Display must name a path: {:?}",
+                    err.to_string()
+                );
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 8. Directory deleted mid-finalize: former expect() panic sites.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn dir_deleted_mid_finalize_is_tree_structure_changed_not_panic() {
+    // Spec clause: expect() → TreeStructureChanged (design §C, former walk.rs
+    // L399/L653). The bottom-up finalize pass looks up each child-dir key in
+    // the `finalized` map; a directory that was discovered but then removed
+    // before the finalize pass runs causes a "miss" that used to `expect()`.
+    // After the fix the miss must produce WalkError::TreeStructureChanged.
+    //
+    // Strategy: trigger the miss by removing an entire subdirectory AFTER
+    // the discovery phase has already recorded it in `dirs` but BEFORE the
+    // finalize pass processes its parent.  We approximate this by removing the
+    // subtree concurrently so we race across the discovery→finalize boundary.
+    const ATTEMPTS: usize = 80;
+    let hasher = Blake3Hasher::new();
+
+    for attempt in 0..ATTEMPTS {
+        let scratch = TempTree::new("dir_finalize");
+        let root = scratch.path().to_path_buf();
+
+        // Build a two-level tree where an inner subtree can be removed to
+        // exercise the child-dir lookup in the finalize pass.
+        let sub1 = root.join("outer");
+        let sub2 = sub1.join("inner");
+        let sub3 = root.join("sibling");
+        fs::create_dir_all(&sub2).expect("create outer/inner");
+        fs::create_dir_all(&sub3).expect("create sibling");
+
+        // Populate with large files to slow the hash pass (maximizing race window).
+        write_file(&sub2.join("f1.bin"), &ramp(MMAP_THRESHOLD + 1024));
+        write_file(&sub2.join("f2.bin"), &ramp(MMAP_THRESHOLD + 2048));
+        write_file(&sub1.join("outer_f.bin"), &ramp(MMAP_THRESHOLD));
+        write_file(&sub3.join("sib_f.bin"), &ramp(MMAP_THRESHOLD * 2));
+        write_file(&root.join("root_f.bin"), &ramp(512));
+
+        // The target subtree to remove mid-walk (exercises the finalize miss).
+        let target = sub1.clone();
+
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let done_c = Arc::clone(&done);
+
+        let remover = std::thread::spawn(move || {
+            // Remove with no delay so we race aggressively.
+            while !done_c.load(Ordering::Relaxed) {
+                let _ = fs::remove_dir_all(&target);
+            }
+        });
+
+        let result = walk(
+            &root,
+            &WalkOptions {
+                walk_jobs: Some(4),
+                ..WalkOptions::default()
+            },
+            &hasher,
+        );
+        done.store(true, Ordering::Relaxed);
+        remover.join().expect("remover thread panicked");
+
+        // MUST NOT panic.  Result is Ok (if race was missed) or one of the
+        // three in-flux typed errors.
+        match &result {
+            Ok(manifest) => {
+                let id = snapshot_id(manifest, &hasher);
+                assert!(
+                    is_valid_snapshot_id(&id),
+                    "attempt={attempt}: Ok with malformed id {id:?}"
+                );
+            }
+            Err(err) => {
+                // The two former expect() panic sites produce TreeStructureChanged.
+                // FileVanishedDuringWalk or Io may also arise (files in the dir
+                // vanish between discovery and hash).
+                assert!(
+                    matches!(
+                        err,
+                        WalkError::TreeStructureChanged { .. }
+                            | WalkError::FileVanishedDuringWalk { .. }
+                            | WalkError::FileChangedDuringWalk { .. }
+                            | WalkError::Io { .. }
+                    ),
+                    "attempt={attempt}: dir-finalize produced unexpected error variant: {err:?}"
+                );
+                assert!(
+                    error_display_names_a_path(err),
+                    "attempt={attempt}: error Display must name a path: {:?}",
+                    err.to_string()
+                );
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 9. Followed-symlink guard-skip: target change must NOT falsely fire on a
+//    STABLE symlink, and a changing target must not produce a silent wrong id.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn followed_symlink_target_change_guard_skip_correctness() {
+    // Spec clause: symlink guard-eligibility rule (design §B, walk.rs
+    // PendingHash.is_symlink). A followed symlink's recorded SIZE is its own
+    // lstat length (the symlink's apparent size), deliberately != the
+    // dereferenced content length; so the bytes-vs-recorded_size drift check is
+    // SKIPPED for symlinks.  This test pins both sides:
+    //
+    // (a) A STABLE symlink (target never changes) must produce the same entry in
+    //     two consecutive quiescent walks — the guard skip does NOT falsely fire.
+    //
+    // (b) A symlink whose TARGET content changes during the walk must produce
+    //     Ok (valid id) or one of the in-flux typed errors — NEVER a panic.
+    //
+    // Note: the guard skip means a content change on the target (while the
+    // symlink's own lstat length is unchanged) can slip through as Ok — the
+    // spec explicitly allows this race on symlinks (design §B). We test the
+    // STABLE case rigorously and the CHANGING case for absence-of-panic only.
+
+    let hasher = Blake3Hasher::new();
+
+    // --- Part (a): stable symlink ----------------------------------------
+    {
+        let scratch = TempTree::new("symlink_stable");
+        let root = scratch.path().to_path_buf();
+
+        let target = root.join("real_target.bin");
+        write_file(&target, &ramp(MMAP_THRESHOLD * 2)); // large: triggers mmap
+                                                        // Symlink pointing to the real file.
+        std::os::unix::fs::symlink(&target, root.join("link_to_target.bin"))
+            .expect("create symlink");
+
+        // Two consecutive quiescent walks must produce identical manifests.
+        let opts = WalkOptions {
+            walk_jobs: Some(1),
+            ..WalkOptions::default()
+        };
+        let m1 = walk(&root, &opts, &hasher).expect("first symlink walk must succeed");
+        let m2 = walk(&root, &opts, &hasher).expect("second symlink walk must succeed");
+
+        let id1 = snapshot_id(&m1, &hasher);
+        let id2 = snapshot_id(&m2, &hasher);
+        assert!(
+            is_valid_snapshot_id(&id1),
+            "stable symlink: first walk produced malformed id {id1:?}"
+        );
+        assert_eq!(
+            id1, id2,
+            "stable symlink: quiescent walks must be byte-identical \
+             (guard skip must not falsely fire)"
+        );
+        assert_eq!(
+            m1.to_string(),
+            m2.to_string(),
+            "stable symlink: Manifest Display differs across two quiescent walks"
+        );
+    }
+
+    // --- Part (b): changing symlink target --------------------------------
+    {
+        const ATTEMPTS: usize = 40;
+
+        for attempt in 0..ATTEMPTS {
+            let scratch = TempTree::new("symlink_changing");
+            let root = scratch.path().to_path_buf();
+
+            let target = root.join("target.bin");
+            write_file(&target, &ramp(MMAP_THRESHOLD * 2)); // large
+            std::os::unix::fs::symlink(&target, root.join("link.bin")).expect("create symlink");
+
+            let target_c = target.clone();
+            let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+            let done_c = Arc::clone(&done);
+
+            // Mutator: change the target's content mid-walk.
+            let mutator = std::thread::spawn(move || {
+                let mut seed: u8 = 0x42;
+                while !done_c.load(Ordering::Relaxed) {
+                    // Overwrite target with different-size content.
+                    let _ = fs::write(&target_c, ramp(MMAP_THRESHOLD + seed as usize * 17));
+                    // Truncate to zero briefly.
+                    try_truncate(&target_c, 0);
+                    seed = seed.wrapping_mul(31).wrapping_add(7);
+                    std::hint::spin_loop();
+                }
+            });
+
+            let result = walk(
+                &root,
+                &WalkOptions {
+                    walk_jobs: Some(1),
+                    ..WalkOptions::default()
+                },
+                &hasher,
+            );
+            done.store(true, Ordering::Relaxed);
+            mutator.join().expect("mutator thread panicked");
+
+            // Invariant: must not panic/crash.  Ok (if race missed or
+            // symlink guard-skip allowed it) or typed error (if SIGBUS or
+            // vanish was caught on the target file).
+            match &result {
+                Ok(manifest) => {
+                    let id = snapshot_id(manifest, &hasher);
+                    assert!(
+                        is_valid_snapshot_id(&id),
+                        "attempt={attempt}: symlink-target race: Ok with malformed id {id:?}"
+                    );
+                }
+                Err(err) => {
+                    assert!(
+                        is_acceptable_error(err),
+                        "attempt={attempt}: symlink-target race: unexpected error variant: {err:?}"
+                    );
+                    assert!(
+                        error_display_names_a_path(err),
+                        "attempt={attempt}: symlink error Display must name a path: {:?}",
+                        err.to_string()
+                    );
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 10. Sub-threshold shrink (not mmap-fault): size-drift guard via stat path.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn sub_threshold_shrink_detected_by_size_drift_guard() {
+    // Spec clause: bytes-vs-FileRecord.size drift (design §B). A small (sub-
+    // MMAP_THRESHOLD) file that is rewritten to a SMALLER size between
+    // discovery stat and hash-time stat produces FileChangedDuringWalk via the
+    // size-drift guard, NOT via the SIGBUS path. This is the non-mmap branch:
+    // the file is read with fs::read (no mmap, no SIGBUS), but the hash-time
+    // metadata `len` differs from the discovery `recorded_size`.
+    //
+    // Note: for sub-threshold files, `blake3_hash_file` returns (hash, stat_len)
+    // where `stat_len` is the SECOND stat (at hash time). So the drift guard
+    // fires when the second stat sees a different size than discovery.
+    const ATTEMPTS: usize = 60;
+    let hasher = Blake3Hasher::new();
+
+    for attempt in 0..ATTEMPTS {
+        let scratch = TempTree::new("sub_threshold_shrink");
+        let root = scratch.path().to_path_buf();
+
+        // Victim: explicitly sub-threshold (< 256 KiB) so fs::read is used.
+        let small_size = MMAP_THRESHOLD / 2; // 128 KiB
+        let victim = root.join("small_victim.bin");
+        write_file(&victim, &ramp(small_size));
+        // Shrunk replacement: clearly smaller.
+        let shrunk_size = MMAP_THRESHOLD / 8; // 32 KiB
+
+        // Control file (never mutated).
+        write_file(&root.join("control.bin"), &ramp(512));
+
+        let victim_c = victim.clone();
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let done_c = Arc::clone(&done);
+
+        // Shrinker thread: hammers the victim to a smaller size.
+        let shrinker = std::thread::spawn(move || {
+            while !done_c.load(Ordering::Relaxed) {
+                let _ = fs::write(&victim_c, ramp(shrunk_size));
+                let _ = fs::write(&victim_c, ramp(small_size));
+                std::hint::spin_loop();
+            }
+        });
+
+        let result = walk(
+            &root,
+            &WalkOptions {
+                walk_jobs: Some(1),
+                ..WalkOptions::default()
+            },
+            &hasher,
+        );
+        done.store(true, Ordering::Relaxed);
+        shrinker.join().expect("shrinker thread panicked");
+
+        match &result {
+            Ok(manifest) => {
+                let id = snapshot_id(manifest, &hasher);
+                assert!(
+                    is_valid_snapshot_id(&id),
+                    "attempt={attempt}: sub-threshold shrink: Ok with malformed id {id:?}"
+                );
+            }
+            Err(err) => {
+                // The size-drift guard should produce FileChangedDuringWalk;
+                // a vanish (if the file is briefly absent) yields FileVanished;
+                // genuine IO is Io.  Must NOT be an untyped panic.
+                assert!(
+                    matches!(
+                        err,
+                        WalkError::FileChangedDuringWalk { .. }
+                            | WalkError::FileVanishedDuringWalk { .. }
+                            | WalkError::Io { .. }
+                    ),
+                    "attempt={attempt}: sub-threshold shrink produced unexpected variant: {err:?}"
+                );
+                assert!(
+                    error_display_names_a_path(err),
+                    "attempt={attempt}: error Display must name a path: {:?}",
+                    err.to_string()
+                );
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 11. Large-file truncation yields FileChangedDuringWalk (not Io):
+//     the is_mmap_fault() classification is correctly wired.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn large_file_truncation_yields_file_changed_not_io() {
+    // Spec clause: SIGBUS → FileChangedDuringWalk (design §A + §B). When the
+    // SIGBUS guard catches a mid-mmap truncation, `is_mmap_fault(&e)` returns
+    // true and walk.rs maps it to WalkError::FileChangedDuringWalk — NOT to
+    // WalkError::Io (which is reserved for genuine permission/IO faults).
+    //
+    // This test asserts that when we get an error on a concurrent large-file
+    // truncation, it is FileChangedDuringWalk or FileVanishedDuringWalk —
+    // NEVER Io (which would mean the mmap fault fell through to the wrong arm).
+    const LARGE_SIZE: usize = 4 * 1024 * 1024; // 4 MiB — well above MMAP_THRESHOLD
+    const ATTEMPTS: usize = 40;
+
+    let hasher = Blake3Hasher::new();
+
+    for attempt in 0..ATTEMPTS {
+        let scratch = TempTree::new("mmap_fault_typed");
+        let root = scratch.path().to_path_buf();
+        let victim = root.join("large_typed.bin");
+        write_file(&victim, &ramp(LARGE_SIZE));
+
+        let victim_c = victim.clone();
+        let done = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        let done_c = Arc::clone(&done);
+
+        let truncator = std::thread::spawn(move || {
+            while !done_c.load(Ordering::Relaxed) {
+                try_truncate(&victim_c, 0);
+                try_truncate(&victim_c, (LARGE_SIZE / 2) as u64);
+                try_truncate(&victim_c, 0);
+                std::hint::spin_loop();
+            }
+        });
+
+        let result = walk(
+            &root,
+            &WalkOptions {
+                walk_jobs: Some(1),
+                ..WalkOptions::default()
+            },
+            &hasher,
+        );
+        done.store(true, Ordering::Relaxed);
+        truncator.join().expect("truncator thread panicked");
+
+        match &result {
+            Ok(manifest) => {
+                let id = snapshot_id(manifest, &hasher);
+                assert!(
+                    is_valid_snapshot_id(&id),
+                    "attempt={attempt}: large-truncation: Ok with malformed id {id:?}"
+                );
+            }
+            Err(err) => {
+                // A large-file truncation MUST produce FileChangedDuringWalk
+                // (from is_mmap_fault) or FileVanishedDuringWalk (if the file
+                // appeared empty/gone at stat time).  NEVER Io — that would
+                // mean the mmap fault was not recognized and fell through to
+                // the wrong variant.
+                assert!(
+                    matches!(
+                        err,
+                        WalkError::FileChangedDuringWalk { .. }
+                            | WalkError::FileVanishedDuringWalk { .. }
+                    ),
+                    "attempt={attempt}: large-file truncation must produce FileChanged or \
+                     FileVanished, not Io or other: {err:?}"
+                );
+                assert!(
+                    error_display_names_a_path(err),
+                    "attempt={attempt}: error Display must name a path: {:?}",
+                    err.to_string()
+                );
+            }
+        }
+    }
+}

--- a/crates/snapdir/Cargo.toml
+++ b/crates/snapdir/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 # is the flagship-named shim so `cargo install snapdir` installs the binary.
 # Path+version dep (not [workspace.dependencies]): only this crate consumes
 # it, and an unused workspace-level entry would be flagged by cargo-shear.
-snapdir-cli = { path = "../snapdir-cli", version = "1.8.0" }
+snapdir-cli = { path = "../snapdir-cli", version = "1.9.0" }
 
 [lints]
 workspace = true

--- a/docs/rust-port/CHANGELOG.md
+++ b/docs/rust-port/CHANGELOG.md
@@ -7,7 +7,40 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.9.0] - 2026-06-17
+
 ### Added
+
+- **`snapdir autocomplete <shell>` — a documented shell-completion command.**
+  Generates a completion script for `bash`, `zsh`, `fish`, `powershell`, or
+  `elvish`, with help text explaining how to wire it into your shell profile.
+  The previously-hidden `completions` subcommand remains as an alias.
+
+### Changed
+
+- **Catalog is now on by default.** When `--catalog` is unset, `push`/`stage`
+  record snapshots to a default catalog and `revisions`/`locations`/`ancestors`
+  read it, so snapshots taken without an explicit `--catalog` flag are now
+  queryable. Pass `--catalog none` to explicitly disable the catalog: querying
+  commands then print a clear message rather than querying an empty database.
+
+### Fixed
+
+- **`revisions --catalog none` (and `locations`/`ancestors`) no longer returns
+  nothing silently.** `--catalog none` is now an explicit "disable" sentinel
+  that prints a clear message instead of querying an empty database; combined
+  with the default-on catalog above, snapshots recorded without a `--catalog`
+  flag are now queryable.
+- **`snapdir id`/`manifest` now detect files changing during a snapshot and
+  fail with a clear, typed error naming the file instead of crashing or
+  recording a wrong size.** A large file truncated mid-hash no longer kills the
+  process via SIGBUS with no message; a file that vanishes, grows, or shrinks
+  mid-walk, or a directory removed mid-walk, is now reported as a typed
+  in-flux error (`file changed during walk` / `file vanished during walk` /
+  `tree structure changed during walk`) that names the path and exits non-zero,
+  rather than panicking with a backtrace or silently recording an incoherent
+  entry. snapdir assumes a **quiescent tree** during a snapshot: on a static
+  tree, ids and manifests are byte-identical to before.
 
 ## [1.8.0] - 2026-06-16
 
@@ -514,7 +547,8 @@ Bash-written caches and remote buckets stay mutually readable.
   `gcloud`) in the shipped binary. External tools are used only by the test/oracle
   harness.
 
-[Unreleased]: https://github.com/snapdir/snapdir/compare/v1.8.0...HEAD
+[Unreleased]: https://github.com/snapdir/snapdir/compare/v1.9.0...HEAD
+[1.9.0]: https://github.com/snapdir/snapdir/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/snapdir/snapdir/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/snapdir/snapdir/compare/v1.6.0...v1.7.0
 [1.6.0]: https://github.com/snapdir/snapdir/compare/v1.5.0...v1.6.0


### PR DESCRIPTION
snapdir 1.9.0 — autocomplete · catalog default-on · files-in-flux robustness.


### Added

- **`snapdir autocomplete <shell>` — a documented shell-completion command.**
  Generates a completion script for `bash`, `zsh`, `fish`, `powershell`, or
  `elvish`, with help text explaining how to wire it into your shell profile.
  The previously-hidden `completions` subcommand remains as an alias.

### Changed

- **Catalog is now on by default.** When `--catalog` is unset, `push`/`stage`
  record snapshots to a default catalog and `revisions`/`locations`/`ancestors`
  read it, so snapshots taken without an explicit `--catalog` flag are now
  queryable. Pass `--catalog none` to explicitly disable the catalog: querying
  commands then print a clear message rather than querying an empty database.

### Fixed

- **`revisions --catalog none` (and `locations`/`ancestors`) no longer returns
  nothing silently.** `--catalog none` is now an explicit "disable" sentinel
  that prints a clear message instead of querying an empty database; combined
  with the default-on catalog above, snapshots recorded without a `--catalog`
  flag are now queryable.
- **`snapdir id`/`manifest` now detect files changing during a snapshot and
  fail with a clear, typed error naming the file instead of crashing or
  recording a wrong size.** A large file truncated mid-hash no longer kills the
  process via SIGBUS with no message; a file that vanishes, grows, or shrinks
  mid-walk, or a directory removed mid-walk, is now reported as a typed
  in-flux error (`file changed during walk` / `file vanished during walk` /
  `tree structure changed during walk`) that names the path and exits non-zero,
  rather than panicking with a backtrace or silently recording an incoherent
  entry. snapdir assumes a **quiescent tree** during a snapshot: on a static
  tree, ids and manifests are byte-identical to before.

