### PR TITLE
release: 1.10.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3479,14 +3479,14 @@ dependencies = [
 
 [[package]]
 name = "snapdir"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "snapdir-cli",
 ]
 
 [[package]]
 name = "snapdir-benches"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "criterion",
  "iai-callgrind",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-catalog"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "redb",
  "serde",
@@ -3507,7 +3507,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-cli"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "anyhow",
  "assert_cmd",
@@ -3525,7 +3525,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-core"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "blake3",
  "libc",
@@ -3539,7 +3539,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-ssh-store"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "snapdir-core",
  "snapdir-stores",
@@ -3547,7 +3547,7 @@ dependencies = [
 
 [[package]]
 name = "snapdir-stores"
-version = "1.9.0"
+version = "1.10.0"
 dependencies = [
  "aws-config",
  "aws-sdk-s3",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "1.9.0"
+version = "1.10.0"
 edition = "2021"
 rust-version = "1.91.1"
 authors = ["Bermi Ferrer <bermi@bermilabs.com>"]
@@ -24,9 +24,9 @@ categories = ["command-line-utilities", "filesystem"]
 
 [workspace.dependencies]
 # Internal crates
-snapdir-core = { path = "crates/snapdir-core", version = "1.9.0" }
-snapdir-catalog = { path = "crates/snapdir-catalog", version = "1.9.0" }
-snapdir-stores = { path = "crates/snapdir-stores", version = "1.9.0" }
+snapdir-core = { path = "crates/snapdir-core", version = "1.10.0" }
+snapdir-catalog = { path = "crates/snapdir-catalog", version = "1.10.0" }
+snapdir-stores = { path = "crates/snapdir-stores", version = "1.10.0" }
 
 # Errors: thiserror in libs, anyhow (+ context) in the bin.
 thiserror = "2"

--- a/README.md
+++ b/README.md
@@ -185,6 +185,79 @@ snapdir diff \
 - `--exit-code` adopts git's `diff --exit-code` semantics: exit `1` when any difference is found (after writing the report), `0` otherwise.
 - `--on-conflict <error|last-wins>` controls an intra-side collision (the same path with differing content unioned across two refs on one side): `error` (the default) fails hard naming the path; `last-wins` lets the last ref win.
 
+## Exact mirror — prune the destination
+
+By default `checkout` and `pull` only *add* to the destination: files already there that aren't in the snapshot are left alone. Pass **`--delete`** to make the destination an **exact mirror** of the snapshot — after materializing the manifest, anything in the destination that is *not* in the manifest is pruned (deepest-first, idempotent).
+
+```sh
+# Mirror a snapshot into ./site, removing anything not in the snapshot
+snapdir checkout --id "$id" --delete ./site
+
+# Same for a pull straight from a store
+snapdir pull --store s3://my-bucket/snaps --id "$id" --delete ./site
+```
+
+`--dryrun` with `--delete` lists exactly what *would* be pruned and removes nothing:
+
+```sh
+snapdir checkout --id "$id" --delete --dryrun ./site   # lists prune candidates, deletes nothing
+```
+
+**Protect extraneous paths with `--exclude`.** A destination path that would otherwise be pruned is kept if it matches a `--exclude` pattern (extended-regex, the same `-E` flavor as the walk-side `--exclude`; repeatable / comma-delimited, OR-combined):
+
+```sh
+# Mirror, but never prune a local .env or anything under cache/
+snapdir checkout --id "$id" --delete --exclude '\.env$' --exclude '^\./cache/' ./site
+```
+
+### Safety (this deletes user data — by design, narrowly)
+
+`--delete` is bounded and unforgiving on purpose:
+
+- It **only ever deletes inside the destination root** — the prune set is a path-set difference computed against the manifest, always destination-relative.
+- An extraneous **symlink is unlinked, never followed** — a link pointing outside the destination is removed as a link; its target is never touched.
+- It **hard-refuses a dangerous destination** — `/`, `$HOME`, the cache directory, or a store path — and **`--force` does NOT bypass** this. Nothing is deleted on refusal.
+
+### Materialization modes
+
+By default the destination entries are **independent, editable files** — written via a reflink (copy-on-write clone) on filesystems that support it (APFS, Btrfs, XFS), falling back to a plain copy elsewhere.
+
+**`--linked`** instead makes each destination entry a **symlink into the local store's content-addressed objects** — zero-copy on any filesystem:
+
+```sh
+snapdir checkout --id "$id" --linked ./readonly-view
+```
+
+`--linked` trades editability for speed:
+
+- The linked entries are **read-only**: the store objects are mode `0444`, so writing *through* a link fails (`EACCES`). This protects the shared content-addressed store from being corrupted through a checkout.
+- It is valid **only against a local store** — `--linked` against a remote/object store (`s3://`, `gs://`, `b2://`, `ssh://`) is a hard error.
+
+On a copy-on-write filesystem (or with `--linked`) a mirror is applied via a zero-copy staged swap. In **every** mode, a long-running process that already holds a destination file open keeps reading the old content through its open descriptor (POSIX inode retention) — a mirror never yanks bytes out from under a live reader.
+
+### Re-snapshotting a linked tree (checksum-only fast path)
+
+Because a `--linked` entry's symlink target *is* an object whose path encodes its BLAKE3 hash, re-running `snapdir id` / `snapdir manifest` over a linked tree recovers each file's checksum **directly from the object path — without re-reading or re-hashing the bytes**. This is fast, but **checksum-only**: it does **not**, by itself, reproduce the original snapshot ID, because a followed symlink reports the *link's* size and permissions, not the original file's (those live only in the source manifest).
+
+The fast path is conservative — it falls back to a normal content hash whenever it cannot safely trust the address:
+
+- It is **disabled under a non-default checksum** (`--checksum-bin md5sum`/`sha256sum`) or a keyed context (`SNAPDIR_MANIFEST_CONTEXT`), since the embedded hash would then be the wrong algorithm.
+- **`SNAPDIR_VERIFY_COPIES=1`** forces a full content re-hash and errors on any mismatch.
+
+## Sync as an exact mirror
+
+`snapdir sync --delete` mirrors a **manifest set**: after copying the snapshot into the destination store, it prunes destination **manifests** that are not present in the source store's manifest set.
+
+```sh
+# Make the dest store's manifest set an exact mirror of the source's
+snapdir sync --id "$id" --from "file://$PWD/src" --to "file://$PWD/dst" --delete
+```
+
+Two guarantees worth stating plainly:
+
+- **Objects are NEVER deleted.** Garbage collection is out of scope; an object that no surviving manifest references is left in place (orphans are reclaimable later). Only manifests are pruned.
+- It is supported **only on a local `file://` destination**. A `sync --delete` to an object/remote store (`s3://`, `gs://`, `b2://`, `ssh://`, `sftp://`) is refused with a clear error. `--dryrun` is honored.
+
 ## Rate limiting & retries
 
 For the network backends (`s3://`, `gs://`, `b2://`), snapdir paces its requests and retries transient failures so transfers stay polite to the provider and survive throttling. The local `file://` store does no network retrying. No extra dependencies are pulled in for any of this — it is all in-process.

--- a/benches/baselines/README.md
+++ b/benches/baselines/README.md
@@ -1,0 +1,43 @@
+# Committed iai-callgrind baseline references
+
+This directory holds **human-readable committed reference snapshots** of the
+deterministic instruction-count perf gate (`benches/benches/iai_hot.rs`,
+iai-callgrind). They are NOT the machine baseline iai-callgrind compares against
+at runtime — that lives under `target/iai/` (in `target/`, which is not
+committed; CI persists/restores it). These JSON files are a tracked, reviewable
+record of the *expected* `Ir` (instructions retired) and `EstimatedCycles` for a
+benched hot path, captured from a known-good run, so a reviewer can see the
+order-of-magnitude a change is measured against without having to run valgrind.
+
+## How a baseline relates to the 5% soft-limit gate
+
+`iai_hot.rs` wires a **5% soft limit** on both `Ir` and `EstimatedCycles`
+(`callgrind_5pct()` → `Callgrind::soft_limits([(Ir, 5.0), (EstimatedCycles,
+5.0)])`). On each run iai-callgrind compares the freshly measured counts against
+its saved baseline and **FAILS** the bench when either metric regresses by more
+than 5%. The numbers in these JSON files are the reference point: if a change
+moves `prune_set`'s `Ir` more than ~5% off the committed `ir` here, expect the
+gate to fire (and, if the change is justified, refresh both the machine baseline
+*and* the committed reference here in the same commit, explaining why).
+
+## Recording / refreshing
+
+These numbers come from the **sanctioned Docker runner** (valgrind is Linux-only;
+this is a macOS host with no native valgrind):
+
+```sh
+bash benches/run-iai-docker.sh
+```
+
+It runs `cargo bench -p snapdir-benches --bench iai_hot` inside the pinned
+`rust:1.91-slim-bookworm` image (pinned `linux/amd64` so counts match CI) with
+`iai-callgrind-runner 0.16.1`. Read the `prune_set` group's reported `Ir` and
+`EstimatedCycles` from its output and update the matching JSON. On a brand-new
+bench (no prior baseline) the first run simply ESTABLISHES the baseline — that is
+the run these references were captured from.
+
+## Files
+
+- `mirror_prune_set.json` — the Phase-32 `mirror::prune_set` group
+  (`checkout/sync --delete` set-difference) over a fixed tiny `mixed` manifest +
+  a constant planted-extraneous `DestEntry` listing.

--- a/benches/baselines/mirror_prune_set.json
+++ b/benches/baselines/mirror_prune_set.json
@@ -1,0 +1,12 @@
+{
+  "bench": "iai_hot::hot::bench_prune_set",
+  "ir": null,
+  "estimated_cycles": null,
+  "tool": "iai-callgrind 0.16.1",
+  "image": "rust:1.91-slim-bookworm",
+  "platform": "linux/amd64",
+  "recorded_by": "run-iai-docker.sh",
+  "soft_limit_pct": 5,
+  "metrics_pending": true,
+  "note": "Committed human-readable reference for the Phase-32 mirror::prune_set instruction-count gate (5% Ir/EstimatedCycles soft limit; see ../benches/iai_hot.rs and ./README.md). The benched input is a FIXED tiny `mixed` GATE-tier manifest plus a constant planted-extraneous DestEntry listing (PRUNE_EXTRANEOUS=16). `ir`/`estimated_cycles` are null because callgrind counts could NOT be captured on the Apple-Silicon macOS dev host: valgrind/callgrind is Linux-only, and under Docker the amd64-emulated container crashes QEMU (rcu_read_unlock assertion / SIGABRT and `Instructions: 0|N/A`), while an arm64 container is refused by iai-callgrind's `setarch` ASLR-disable (the same failure the script documents). The first GREEN run on a native-amd64 Linux CI (with valgrind) ESTABLISHES the baseline: read the `iai_hot::hot::bench_prune_set` group's reported Instructions (Ir) and Estimated Cycles from that run and replace the two nulls here (set metrics_pending=false), in the same commit that records the machine baseline under target/iai/."
+}

--- a/benches/benches/iai_hot.rs
+++ b/benches/benches/iai_hot.rs
@@ -20,19 +20,24 @@
 //! single source of truth ([`snapdir_benches`]): [`deterministic_bytes`] (a fixed
 //! byte ramp, no RNG) and a single small GATE-tier [`Scenario`].
 //!
-//! Three groups, mirroring the perf-critical paths:
+//! Groups, mirroring the perf-critical paths:
 //!
 //! 1. `blake3`      — `Blake3Hasher::hash_hex` over a fixed small buffer.
 //! 2. `walk`        — `walk()` over a small fixed scenario materialized ONCE in
 //!    `setup` (the materialization is not counted; only the walk is).
 //! 3. `snapshot_id` — `snapshot_id()` over a small pre-built manifest.
+//! 4. `read_pack`   — SNAPPACK receive (`read_pack` into a fresh `FileSink`).
+//! 5. `prune_set`   — `mirror::prune_set` over a small pre-built manifest + a
+//!    fixed `DestEntry` listing carrying a constant set of planted extraneous
+//!    paths (Phase 32 `checkout/sync --delete` set-difference).
 
 use iai_callgrind::{
     library_benchmark, library_benchmark_group, main, Callgrind, EventKind, LibraryBenchmarkConfig,
 };
 use snapdir_benches::{deterministic_bytes, gate_scenarios, Scenario};
 use snapdir_core::merkle::snapshot_id;
-use snapdir_core::{walk, Blake3Hasher, Hasher, Manifest, WalkOptions};
+use snapdir_core::mirror::{prune_set, DestEntry};
+use snapdir_core::{walk, Blake3Hasher, Hasher, Manifest, PathType, WalkOptions};
 use snapdir_stores::{
     read_pack, write_pack, Durability, FileSink, FileStore, PackReadReport, StreamStore,
 };
@@ -200,6 +205,70 @@ fn bench_read_pack(input: (TempDir, Vec<u8>)) -> PackReadReport {
 }
 
 // ---------------------------------------------------------------------------
+// 5. mirror prune-set hot path (Phase 32: checkout/sync `--delete`).
+// ---------------------------------------------------------------------------
+
+/// Fixed count of planted extraneous dest paths (NOT in the manifest). Small +
+/// constant so callgrind's instruction counts for `prune_set` stay byte-stable.
+const PRUNE_EXTRANEOUS: usize = 16;
+
+/// Builds the fixed `prune_set` input ONCE (NOT counted — runs in `setup`): the
+/// small `mixed` GATE-tier manifest plus a deterministic `DestEntry` listing.
+///
+/// The dest listing mirrors what a real `--delete` checkout walk produces: every
+/// KEPT path (each manifest entry, so the set-difference must skip them) PLUS a
+/// constant block of planted EXTRANEOUS paths (files + a couple of dirs) absent
+/// from the manifest. Fully deterministic — no RNG/clock — so the benched
+/// set-difference + deepest-first sort counts the same work every run. Only
+/// `prune_set` itself is counted; this construction is not.
+fn setup_prune_set(name: &str) -> (Manifest, Vec<DestEntry>) {
+    let tmp = TempDir::new().expect("create temp dir");
+    scenario_by_name(name)
+        .materialize(tmp.path())
+        .expect("materialize scenario");
+    let manifest =
+        walk(tmp.path(), &WalkOptions::default(), &Blake3Hasher::new()).expect("walk for manifest");
+
+    // Start from the KEPT set: every manifest path is present in the dest and
+    // must be retained by the set-difference.
+    let mut dest_entries: Vec<DestEntry> = manifest
+        .entries()
+        .iter()
+        .map(|e| DestEntry::new(e.path.clone(), e.path_type))
+        .collect();
+
+    // Plant a CONSTANT block of extraneous paths absent from the manifest: a
+    // couple of extraneous directories, then files distributed across them and
+    // the root. Deterministic names (no RNG) keep the prune set fixed.
+    dest_entries.push(DestEntry::new("./extra_a/", PathType::Directory));
+    dest_entries.push(DestEntry::new("./extra_b/", PathType::Directory));
+    for i in 0..PRUNE_EXTRANEOUS {
+        let path = match i % 3 {
+            0 => format!("./stale{i:03}.bin"),
+            1 => format!("./extra_a/stale{i:03}.bin"),
+            _ => format!("./extra_b/stale{i:03}.bin"),
+        };
+        dest_entries.push(DestEntry::new(path, PathType::File));
+    }
+
+    (manifest, dest_entries)
+}
+
+// `prune_set` over the fixed manifest + dest listing (no excludes). Only this
+// body — the set-difference, exclude check, and deepest-first sort — is counted.
+// The first run sets the baseline; a >5% Ir/EstimatedCycles drift fails the gate.
+#[library_benchmark]
+#[bench::fixed(args = (WALK_SCENARIO,), setup = setup_prune_set)]
+fn bench_prune_set(input: (Manifest, Vec<DestEntry>)) -> Vec<String> {
+    let (manifest, dest_entries) = input;
+    black_box(prune_set(
+        black_box(&manifest),
+        black_box(&dest_entries),
+        black_box(&[]),
+    ))
+}
+
+// ---------------------------------------------------------------------------
 // Groups + harness. The 5% Ir / EstimatedCycles soft limit is wired in via the
 // group `config` so every benched fn inherits the regression gate.
 // ---------------------------------------------------------------------------
@@ -207,7 +276,7 @@ fn bench_read_pack(input: (TempDir, Vec<u8>)) -> PackReadReport {
 library_benchmark_group!(
     name = hot;
     config = callgrind_5pct();
-    benchmarks = bench_blake3, bench_walk, bench_snapshot_id, bench_read_pack
+    benchmarks = bench_blake3, bench_walk, bench_snapshot_id, bench_read_pack, bench_prune_set
 );
 
 main!(library_benchmark_groups = hot);

--- a/benches/benches/pipeline.rs
+++ b/benches/benches/pipeline.rs
@@ -31,11 +31,12 @@
 //! the "make an informed decision" tool, NOT a hard gate.
 
 use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput};
-use snapdir_benches::{bench_scenarios, Scenario};
+use snapdir_benches::{bench_scenarios, deterministic_bytes, Scenario};
 use snapdir_core::merkle::snapshot_id;
+use snapdir_core::mirror::{prune_set, DestEntry};
 use snapdir_core::store::Store;
 use snapdir_core::{walk, Blake3Hasher, Manifest, PathType, WalkOptions};
-use snapdir_stores::{sync_snapshot, FileStore, TransferConfig};
+use snapdir_stores::{sync_snapshot, FileStore, MaterializeMode, TransferConfig};
 use std::hint::black_box;
 use std::path::Path;
 use tempfile::TempDir;
@@ -201,6 +202,195 @@ fn bench_sync(c: &mut Criterion) {
     group.finish();
 }
 
+// ---------------------------------------------------------------------------
+// 6. `mirror`: checkout `--delete` exact-mirror cost (Phase 32).
+//
+// The CLI's `checkout --delete` = `fetch_files` (materialize) THEN an exact-mirror
+// prune: walk the dest, compute `prune_set` (paths present in the dest but absent
+// from the manifest), and unlink them deepest-first. The store's `fetch_files`
+// is the only public copy-in; the prune is `snapdir_core::mirror::prune_set` +
+// std-fs deletions, replicated here verbatim from the CLI's private `prune_dest`
+// so the bench measures the SHIPPED mirror path without touching `crates/**`.
+//
+// Headline asserted below: a ZERO-extraneous mirror ≈ a plain checkout — when
+// nothing in the dest is extraneous, the prune walk + set-difference add only
+// negligible cost on top of `fetch_files` (no deletions happen).
+//
+// Phase-27 Darwin caveat: macOS fsync inflation is a Darwin artifact, NOT the
+// acceptance number. The headline (mirror ≈ checkout) is validated on Linux/CI;
+// the macOS wall-clock deltas here are indicative only.
+// ---------------------------------------------------------------------------
+
+/// How many extraneous files to plant in the dest for the `with_extraneous`
+/// mirror arm (the `zero_extraneous` arm plants none).
+const MIRROR_EXTRANEOUS: usize = 256;
+
+/// Walks `dest` into the `./`-prefixed [`DestEntry`] listing `prune_set` expects
+/// (dirs end `/`), skipping the root. Mirrors the CLI's private
+/// `collect_dest_entries` so the bench drives the exact set-difference input.
+fn collect_dest_entries(root: &Path, dir: &Path, out: &mut Vec<DestEntry>) {
+    for entry in std::fs::read_dir(dir).expect("read dest dir") {
+        let entry = entry.expect("dest dir entry");
+        let path = entry.path();
+        let meta = std::fs::symlink_metadata(&path).expect("stat dest entry");
+        let rel = path
+            .strip_prefix(root)
+            .expect("dest entry under root")
+            .to_string_lossy()
+            .into_owned();
+        if meta.file_type().is_dir() {
+            out.push(DestEntry::new(format!("./{rel}/"), PathType::Directory));
+            collect_dest_entries(root, &path, out);
+        } else {
+            out.push(DestEntry::new(format!("./{rel}"), PathType::File));
+        }
+    }
+}
+
+/// Plants `n` extraneous files (absent from any manifest) into `dest`, split
+/// across the root and two extra subdirs. Deterministic content (no RNG).
+fn plant_extraneous(dest: &Path, n: usize) {
+    use std::os::unix::fs::PermissionsExt;
+    let extra_a = dest.join("extra_a");
+    let extra_b = dest.join("extra_b");
+    std::fs::create_dir_all(&extra_a).expect("mkdir extra_a");
+    std::fs::create_dir_all(&extra_b).expect("mkdir extra_b");
+    let content = deterministic_bytes(64);
+    for i in 0..n {
+        let target = match i % 3 {
+            0 => dest.join(format!("stale{i:05}.bin")),
+            1 => extra_a.join(format!("stale{i:05}.bin")),
+            _ => extra_b.join(format!("stale{i:05}.bin")),
+        };
+        std::fs::write(&target, &content).expect("write extraneous file");
+        std::fs::set_permissions(&target, PermissionsExt::from_mode(0o644))
+            .expect("chmod extraneous file");
+    }
+}
+
+/// The exact-mirror prune step: walk the dest, compute the prune set, and unlink
+/// the extraneous paths deepest-first. A faithful copy of the CLI's `prune_dest`
+/// body (no excludes, no dry-run) over the public `prune_set`.
+fn mirror_prune(manifest: &Manifest, dest: &Path) {
+    let mut entries = Vec::new();
+    collect_dest_entries(dest, dest, &mut entries);
+    let prune = prune_set(manifest, &entries, &[]);
+    for path in &prune {
+        let rel = path.strip_prefix("./").unwrap_or(path);
+        let rel = rel.strip_suffix('/').unwrap_or(rel);
+        let target = dest.join(rel);
+        let meta = match std::fs::symlink_metadata(&target) {
+            Ok(m) => m,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => panic!("stat {}: {e}", target.display()),
+        };
+        if meta.file_type().is_dir() {
+            std::fs::remove_dir(&target).expect("remove extraneous dir");
+        } else {
+            std::fs::remove_file(&target).expect("remove extraneous path");
+        }
+    }
+}
+
+/// 6. `mirror`: compares, per BENCH scenario, three timed arms into a FRESH dest
+///    per iteration (so each does real copy + prune work):
+///
+///    * `checkout`         — plain `fetch_files` (the baseline, no prune).
+///    * `zero_extraneous`  — `fetch_files` + mirror prune with NOTHING extraneous
+///      (the headline: this should be ≈ `checkout`).
+///    * `with_extraneous`  — `fetch_files`, plant `MIRROR_EXTRANEOUS` stale files,
+///      then mirror prune (real deletions happen).
+///
+/// `iter_batched` hands each timed iteration a fresh empty dest. The store is
+/// seeded ONCE; the apply strategy is `MaterializeMode::Auto` (reflink-or-copy
+/// into real inodes — the default checkout). Linked (symlink) and atomic
+/// (reflink-swap) apply strategies are exercised by the dedicated `fetch` arms
+/// elsewhere; the mirror headline is strategy-independent (the prune walk runs
+/// after whichever apply produced the dest).
+fn bench_mirror(c: &mut Criterion) {
+    let mut group = c.benchmark_group("mirror");
+    for scenario in bench_scenarios() {
+        let source = materialize(&scenario);
+        let manifest = walk_manifest(source.path());
+        let store_dir = fresh_dir();
+        let store = FileStore::from_root(store_dir.path());
+        store.push(&manifest, source.path()).expect("seed push");
+        group.throughput(Throughput::Bytes(manifest_bytes(&manifest)));
+
+        // Baseline: plain checkout (fetch_files, no prune).
+        group.bench_with_input(
+            BenchmarkId::new("checkout", scenario.name),
+            &manifest,
+            |b, manifest| {
+                b.iter_batched(
+                    fresh_dir,
+                    |dest_dir| {
+                        store
+                            .fetch_files_with_mode(
+                                black_box(manifest),
+                                dest_dir.path(),
+                                MaterializeMode::Auto,
+                            )
+                            .expect("checkout");
+                        dest_dir
+                    },
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+
+        // Headline: zero-extraneous mirror — fetch + prune walk with nothing to
+        // delete. Should be ≈ the plain checkout above.
+        group.bench_with_input(
+            BenchmarkId::new("zero_extraneous", scenario.name),
+            &manifest,
+            |b, manifest| {
+                b.iter_batched(
+                    fresh_dir,
+                    |dest_dir| {
+                        store
+                            .fetch_files_with_mode(
+                                black_box(manifest),
+                                dest_dir.path(),
+                                MaterializeMode::Auto,
+                            )
+                            .expect("checkout");
+                        mirror_prune(black_box(manifest), dest_dir.path());
+                        dest_dir
+                    },
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+
+        // With extraneous: fetch, plant N stale files, then mirror prune (real
+        // deletions). The delta vs `checkout` is the cost of removing them.
+        group.bench_with_input(
+            BenchmarkId::new("with_extraneous", scenario.name),
+            &manifest,
+            |b, manifest| {
+                b.iter_batched(
+                    fresh_dir,
+                    |dest_dir| {
+                        store
+                            .fetch_files_with_mode(
+                                black_box(manifest),
+                                dest_dir.path(),
+                                MaterializeMode::Auto,
+                            )
+                            .expect("checkout");
+                        plant_extraneous(dest_dir.path(), MIRROR_EXTRANEOUS);
+                        mirror_prune(black_box(manifest), dest_dir.path());
+                        dest_dir
+                    },
+                    BatchSize::PerIteration,
+                );
+            },
+        );
+    }
+    group.finish();
+}
+
 criterion_group!(
     pipeline,
     bench_walk_hash,
@@ -208,5 +398,6 @@ criterion_group!(
     bench_push,
     bench_fetch,
     bench_sync,
+    bench_mirror,
 );
 criterion_main!(pipeline);

--- a/benches/tests/mirror.rs
+++ b/benches/tests/mirror.rs
@@ -1,0 +1,199 @@
+//! Sanity gate for the `pipeline` bench's `mirror` (`checkout --delete`) arms.
+//!
+//! The `mirror` criterion bench's headline is **zero-extraneous mirror ≈ plain
+//! checkout**: when nothing in the destination is extraneous, the exact-mirror
+//! prune (dest walk + `prune_set` + deletions) adds only negligible cost on top
+//! of `fetch_files`. The wall-clock bench *quantifies* that; this test pins it
+//! *qualitatively* using the SHIPPED `snapdir-core` public API:
+//!
+//! 1. A zero-extraneous prune set is EMPTY — the prune walk deletes nothing.
+//! 2. After the (no-op) prune, the materialized dest is byte-for-byte equal to a
+//!    plain checkout.
+//! 3. With planted extraneous files, the prune set is exactly those files (so
+//!    the `with_extraneous` arm measures real deletion work) and the dest again
+//!    equals a plain checkout afterward.
+//!
+//! Every test fn name contains `mirror` so `cargo test -p snapdir-benches mirror`
+//! selects exactly this suite. Runs natively — no valgrind.
+
+use std::os::unix::fs::PermissionsExt;
+use std::path::Path;
+
+use snapdir_benches::{bench_scenarios, deterministic_bytes, Scenario};
+use snapdir_core::mirror::{prune_set, DestEntry};
+use snapdir_core::store::Store;
+use snapdir_core::{walk, Blake3Hasher, Manifest, PathType, WalkOptions};
+use snapdir_stores::{FileStore, MaterializeMode};
+use tempfile::TempDir;
+
+fn materialize(scenario: &Scenario) -> TempDir {
+    let tmp = TempDir::new().expect("create temp dir");
+    scenario
+        .materialize(tmp.path())
+        .expect("materialize scenario");
+    tmp
+}
+
+fn walk_manifest(root: &Path) -> Manifest {
+    walk(root, &WalkOptions::default(), &Blake3Hasher::new()).expect("walk scenario")
+}
+
+fn fresh_dir() -> TempDir {
+    TempDir::new().expect("create scratch dir")
+}
+
+/// Walks `dir` into the `./`-prefixed [`DestEntry`] listing `prune_set` expects
+/// (dirs end `/`), relative to `root`. Mirrors the bench's `collect_dest_entries`.
+fn collect_dest_entries(root: &Path, dir: &Path, out: &mut Vec<DestEntry>) {
+    for entry in std::fs::read_dir(dir).expect("read dest dir") {
+        let entry = entry.expect("dest dir entry");
+        let path = entry.path();
+        let meta = std::fs::symlink_metadata(&path).expect("stat dest entry");
+        let rel = path
+            .strip_prefix(root)
+            .expect("dest entry under root")
+            .to_string_lossy()
+            .into_owned();
+        if meta.file_type().is_dir() {
+            out.push(DestEntry::new(format!("./{rel}/"), PathType::Directory));
+            collect_dest_entries(root, &path, out);
+        } else {
+            out.push(DestEntry::new(format!("./{rel}"), PathType::File));
+        }
+    }
+}
+
+/// The exact-mirror prune step (faithful copy of the bench's `mirror_prune`).
+fn mirror_prune(manifest: &Manifest, dest: &Path) {
+    let mut entries = Vec::new();
+    collect_dest_entries(dest, dest, &mut entries);
+    let prune = prune_set(manifest, &entries, &[]);
+    for path in &prune {
+        let rel = path.strip_prefix("./").unwrap_or(path);
+        let rel = rel.strip_suffix('/').unwrap_or(rel);
+        let target = dest.join(rel);
+        let meta = match std::fs::symlink_metadata(&target) {
+            Ok(m) => m,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+            Err(e) => panic!("stat {}: {e}", target.display()),
+        };
+        if meta.file_type().is_dir() {
+            std::fs::remove_dir(&target).expect("remove extraneous dir");
+        } else {
+            std::fs::remove_file(&target).expect("remove extraneous path");
+        }
+    }
+}
+
+/// A sorted snapshot of the dest's `(path, type)` keys.
+fn dest_keys(root: &Path) -> Vec<DestEntry> {
+    let mut v = Vec::new();
+    collect_dest_entries(root, root, &mut v);
+    v.sort_by(|a, b| a.path.cmp(&b.path));
+    v
+}
+
+fn bench_scenario(name: &str) -> Scenario {
+    bench_scenarios()
+        .into_iter()
+        .find(|s| s.name == name)
+        .expect("named bench scenario exists")
+}
+
+/// A zero-extraneous mirror prunes NOTHING and leaves the dest identical to a
+/// plain checkout — the `mirror` bench's `zero_extraneous ≈ checkout` headline.
+#[test]
+fn zero_extraneous_mirror_equals_plain_checkout() {
+    let scenario = bench_scenario("many_small_bench");
+    let source = materialize(&scenario);
+    let manifest = walk_manifest(source.path());
+
+    let store_dir = fresh_dir();
+    let store = FileStore::from_root(store_dir.path());
+    store.push(&manifest, source.path()).expect("seed push");
+
+    // Plain checkout.
+    let plain = fresh_dir();
+    store
+        .fetch_files_with_mode(&manifest, plain.path(), MaterializeMode::Auto)
+        .expect("plain checkout");
+    let plain_keys = dest_keys(plain.path());
+
+    // Mirror checkout (fetch + prune) with NOTHING extraneous.
+    let mirrored = fresh_dir();
+    store
+        .fetch_files_with_mode(&manifest, mirrored.path(), MaterializeMode::Auto)
+        .expect("mirror checkout");
+
+    // The prune set is empty: the prune walk does no deletion work.
+    let mut entries = Vec::new();
+    collect_dest_entries(mirrored.path(), mirrored.path(), &mut entries);
+    let prune = prune_set(&manifest, &entries, &[]);
+    assert!(
+        prune.is_empty(),
+        "zero-extraneous mirror must prune nothing, got {prune:?}"
+    );
+
+    mirror_prune(&manifest, mirrored.path());
+    assert_eq!(
+        plain_keys,
+        dest_keys(mirrored.path()),
+        "zero-extraneous mirror must equal a plain checkout"
+    );
+}
+
+/// With planted extraneous files, the prune set is EXACTLY those files and the
+/// dest equals a plain checkout afterward — the `with_extraneous` arm's contract.
+#[test]
+fn mirror_prunes_exactly_the_planted_extraneous() {
+    // A small BENCH scenario for a fast, representative tree.
+    let scenario = bench_scenario("deep_nest_bench");
+    let source = materialize(&scenario);
+    let manifest = walk_manifest(source.path());
+
+    let store_dir = fresh_dir();
+    let store = FileStore::from_root(store_dir.path());
+    store.push(&manifest, source.path()).expect("seed push");
+
+    let plain = fresh_dir();
+    store
+        .fetch_files_with_mode(&manifest, plain.path(), MaterializeMode::Auto)
+        .expect("plain checkout");
+    let plain_keys = dest_keys(plain.path());
+
+    let mirrored = fresh_dir();
+    store
+        .fetch_files_with_mode(&manifest, mirrored.path(), MaterializeMode::Auto)
+        .expect("mirror checkout");
+
+    // Plant a handful of extraneous files in a fresh subdir.
+    let extra = mirrored.path().join("extra");
+    std::fs::create_dir_all(&extra).expect("mkdir extra");
+    let content = deterministic_bytes(64);
+    let mut planted = Vec::new();
+    for i in 0..8u32 {
+        let target = extra.join(format!("stale{i:03}.bin"));
+        std::fs::write(&target, &content).expect("write extraneous");
+        std::fs::set_permissions(&target, PermissionsExt::from_mode(0o644)).expect("chmod");
+        planted.push(format!("./extra/stale{i:03}.bin"));
+    }
+
+    let mut entries = Vec::new();
+    collect_dest_entries(mirrored.path(), mirrored.path(), &mut entries);
+    let mut prune = prune_set(&manifest, &entries, &[]);
+    prune.sort();
+    let mut expected = planted.clone();
+    expected.push("./extra/".to_owned());
+    expected.sort();
+    assert_eq!(
+        prune, expected,
+        "prune set must be exactly the planted extraneous paths (+ their dir)"
+    );
+
+    mirror_prune(&manifest, mirrored.path());
+    assert_eq!(
+        plain_keys,
+        dest_keys(mirrored.path()),
+        "after pruning the extraneous files the dest must equal a plain checkout"
+    );
+}

--- a/crates/snapdir-cli/src/cli.rs
+++ b/crates/snapdir-cli/src/cli.rs
@@ -35,9 +35,9 @@ use snapdir_core::{
 };
 use snapdir_stores::{
     is_hex64, limits, read_pack, resolve_adapter, write_pack_with_format, Adapter, B2Store,
-    Durability, ExternalStore, FileSink, FileStore, GcsStore, PackFormat, PackReadReport, PackSink,
-    RetryPolicy, S3Store, SplitStore, StreamSink, StreamStore, TransferAdaptivePolicy,
-    TransferConfig, DEFAULT_ZSTD_LEVEL, WIRE_CAPS, WIRE_VERSION,
+    Durability, ExternalStore, FileSink, FileStore, GcsStore, MaterializeMode, PackFormat,
+    PackReadReport, PackSink, RetryPolicy, S3Store, SplitStore, StreamSink, StreamStore,
+    TransferAdaptivePolicy, TransferConfig, DEFAULT_ZSTD_LEVEL, WIRE_CAPS, WIRE_VERSION,
 };
 
 /// Upper bound for the adaptive concurrency ceiling (`--max-jobs` / `--jobs`
@@ -244,6 +244,39 @@ pub struct TransferArgs {
     pub dryrun: bool,
 }
 
+/// The exact-mirror family: the `--delete` + `--exclude` flags attached ONLY to
+/// `checkout`/`pull` (Phase 32). Kept disjoint from [`TransferArgs`] /
+/// [`WalkArgs`] (no field-name overlap) so each command flattens exactly the
+/// groups it needs without a clap collision; `checkout`/`pull` flatten
+/// [`TransferArgs`] + [`MirrorArgs`].
+///
+/// `--exclude` lives here (not on `WalkArgs`) because `checkout`/`pull` do NOT
+/// flatten `WalkArgs` — they take no walk — and the prune-side excludes are a
+/// distinct concern (regex protect-patterns over the DEST tree) from the
+/// walk-side `--exclude`. The patterns are extended-regex (grep `-E`), matching
+/// the core `ExcludeMatcher` / `prune_set` contract.
+#[derive(Debug, Default, Args)]
+pub struct MirrorArgs {
+    /// Prune the destination to an EXACT mirror: remove anything not in the
+    /// snapshot's manifest. Refuses dangerous destinations (/, $HOME, the cache
+    /// dir, a store path) even with --force.
+    #[arg(long)]
+    pub delete: bool,
+
+    /// With --delete, PROTECT destination paths matching the extended-regex
+    /// PATTERN from pruning (repeatable / comma-delimited).
+    // Mirrors the walk-side `--exclude` shape: repeated occurrences and
+    // comma-delimited values are OR-combined; the patterns are extended-regex
+    // (the same primitive as the core `ExcludeMatcher`/`prune_set`).
+    #[arg(
+        long,
+        value_name = "PATTERN",
+        action = clap::ArgAction::Append,
+        value_delimiter = ','
+    )]
+    pub exclude: Vec<String>,
+}
+
 /// The `defaults` reporting family: the CONFIG knobs `snapdir defaults` resolves
 /// and reports (with a `flag`/`env`/`default` source tag). It deliberately
 /// mirrors only the resolvable subset of [`TransferArgs`] — the store/cache/
@@ -413,6 +446,7 @@ pub struct Resolved {
     pub objects_store: Option<String>,
     pub id: Option<String>,
     pub exclude: Vec<String>,
+    pub delete: bool,
     pub linked: bool,
     pub force: bool,
     pub purge: bool,
@@ -616,6 +650,10 @@ pub enum Command {
         #[command(flatten)]
         transfer: TransferArgs,
 
+        /// Mirror flags (`--delete`, `--exclude`).
+        #[command(flatten)]
+        mirror: MirrorArgs,
+
         /// Destination directory.
         path: Option<PathBuf>,
     },
@@ -625,6 +663,10 @@ pub enum Command {
         /// Transfer flags (`--id`, `--cache-dir`, `--linked`, …).
         #[command(flatten)]
         transfer: TransferArgs,
+
+        /// Mirror flags (`--delete`, `--exclude`).
+        #[command(flatten)]
+        mirror: MirrorArgs,
 
         /// Destination directory.
         dir: Option<PathBuf>,
@@ -708,6 +750,12 @@ pub enum Command {
         /// colocated store. Distinct from the global `--objects-store`.
         #[arg(long, value_name = "URI")]
         to_objects: Option<String>,
+        /// Make the dest store an exact mirror of the source's manifest set:
+        /// after the copy-in, prune dest manifests not present in the source.
+        /// Objects are NEVER deleted. Requires a local file:// destination (an
+        /// object/remote dest is refused). Honors --dryrun.
+        #[arg(long)]
+        delete: bool,
     },
 
     /// Compare two sides, each a set of manifests, reporting file-level
@@ -907,10 +955,28 @@ impl Cli {
                 merge_walk(&mut globals, walk);
                 merge_transfer(&mut globals, transfer);
             }
-            Command::Fetch { transfer }
-            | Command::Pull { transfer, .. }
-            | Command::Checkout { transfer, .. }
-            | Command::Sync { transfer, .. } => merge_transfer(&mut globals, transfer),
+            Command::Fetch { transfer } => {
+                merge_transfer(&mut globals, transfer);
+            }
+            // `sync` carries the transfer group PLUS its own `--delete` mirror
+            // flag (manifest-set mirror of the dest to the source set).
+            Command::Sync {
+                transfer, delete, ..
+            } => {
+                merge_transfer(&mut globals, transfer);
+                globals.delete = *delete;
+            }
+            // `checkout`/`pull` also carry the exact-mirror group (`--delete` +
+            // the prune-side `--exclude`), folded alongside the transfer flags.
+            Command::Pull {
+                transfer, mirror, ..
+            }
+            | Command::Checkout {
+                transfer, mirror, ..
+            } => {
+                merge_transfer(&mut globals, transfer);
+                merge_mirror(&mut globals, mirror);
+            }
             // `defaults` folds its config group so its `--cache-dir`/`--jobs`/
             // `--store`/… overrides resolve (and report `flag`) like a real run.
             Command::Defaults { config } => merge_defaults(&mut globals, config),
@@ -963,6 +1029,13 @@ fn merge_transfer(g: &mut Resolved, t: &TransferArgs) {
     g.force = t.force;
     g.keep = t.keep;
     g.dryrun = t.dryrun;
+}
+
+/// Folds a parsed [`MirrorArgs`] group (`--delete` + the prune-side
+/// `--exclude`) into the resolved config. Only `checkout`/`pull` carry it.
+fn merge_mirror(g: &mut Resolved, m: &MirrorArgs) {
+    g.delete = m.delete;
+    g.exclude.clone_from(&m.exclude);
 }
 
 /// Folds a parsed [`DefaultsArgs`] group into the resolved config so `defaults`
@@ -1811,13 +1884,25 @@ impl Ctx {
     fn checkout_inner(&self, dir: Option<&Path>, meter: Option<&Arc<Meter>>) -> Result<()> {
         let id = self.require_id()?;
         let dest = resolve_root(dir).context("resolving checkout destination")?;
-        // Under --dryrun: skip materializing the destination tree and restoring
-        // permissions — both write to the destination. The notice is emitted
-        // before the cache manifest read so `pull --dryrun` (whose `fetch` leg
-        // is itself a dry no-op and therefore leaves the cache unpopulated)
-        // composes into a clean, write-free no-op rather than failing on a
-        // missing cached manifest.
-        if self.globals.dryrun {
+        // FIRST, before ANY store/manifest lookup or deletion: the unconditional
+        // dangerous-dest refusal (only when mirroring). `--force` does NOT bypass
+        // it; firing here means the refusal is the surfaced failure even for a
+        // shape-valid-but-bogus id, and no deletion has happened yet.
+        if self.globals.delete {
+            self.guard_dangerous_dest(&dest)?;
+        }
+        // Resolve the materialize mode, enforcing the `--linked`-against-a-remote
+        // refusal at the CLI seam — BEFORE any materialization, so no partial
+        // dest is written.
+        let mode = self.materialize_mode()?;
+        // Under --dryrun WITHOUT --delete: skip materializing the destination
+        // tree and restoring permissions — both write to the destination. The
+        // notice is emitted before the cache manifest read so `pull --dryrun`
+        // (whose `fetch` leg is itself a dry no-op and therefore leaves the
+        // cache unpopulated) composes into a clean, write-free no-op rather than
+        // failing on a missing cached manifest. With --delete the dryrun must
+        // LIST the prune set, which needs the manifest, so it falls through.
+        if self.globals.dryrun && !self.globals.delete {
             if !self.globals.quiet {
                 eprintln!(
                     "dry-run: would check out {id} to {} (no writes performed)",
@@ -1830,6 +1915,11 @@ impl Ctx {
         let manifest = cache.get_manifest(id).with_context(|| {
             format!("manifest {id} not found locally; did you forget to fetch it?")
         })?;
+        // --delete --dryrun: list the prune set and write/remove NOTHING (no
+        // materialize, no restore_permissions). `prune_dest` handles the listing.
+        if self.globals.dryrun {
+            return self.prune_dest(&manifest, &dest);
+        }
         // Pre-flight the object pool so a checkout that cannot complete fails
         // with a message that locates the gap by FILE PATH (from the manifest),
         // not the bare object-not-found hash the store would surface mid-copy.
@@ -1848,14 +1938,37 @@ impl Ctx {
             m.set_total(total_object_bytes(&manifest));
         }
         cache
-            .fetch_files(&manifest, &dest)
+            .fetch_files_with_mode(&manifest, &dest, mode)
             .with_context(|| format!("checking out snapshot {id} to {}", dest.display()))?;
-        restore_permissions(&manifest, &dest)?;
+        // Restore per-entry permissions for the Auto (real-inode) materialize.
+        // In Linked mode the file entries are symlinks into the shared 0444
+        // objects (intentionally hardened, read-only); chmod-ing them would
+        // follow into and re-mode the shared store object, so it is skipped.
+        if mode == MaterializeMode::Auto {
+            restore_permissions(&manifest, &dest)?;
+        }
+        // After the normal materialize, prune the destination to an exact mirror
+        // when `--delete` is set. The pruned set is everything the dest holds
+        // that the manifest does not; deepest-first removal keeps dirs empty.
+        if self.globals.delete {
+            self.prune_dest(&manifest, &dest)?;
+        }
         Ok(())
     }
 
     /// `snapdir pull` = fetch + checkout.
     fn run_pull(&self, path: Option<&Path>) -> Result<()> {
+        // Refuse BEFORE the fetch leg so no partial dest is materialized and the
+        // refusal is the surfaced failure (not a downstream store error):
+        //   * `--linked` against a remote store has no local object to point at;
+        //   * `--delete` onto a dangerous dest is unconditionally refused.
+        // Both checks are repeated inside `checkout_inner`; doing them here too
+        // keeps the network/fetch leg from running for a doomed `pull`.
+        let _ = self.materialize_mode()?;
+        if self.globals.delete {
+            let dest = resolve_root(path).context("resolving pull destination")?;
+            self.guard_dangerous_dest(&dest)?;
+        }
         // Banner ONCE for the whole pull, then run the two legs without their
         // own banners (`fetch_inner`/`checkout_inner`) so `pull --verbose`
         // emits exactly one transfer-config line. ONE reporter spans the whole
@@ -2643,6 +2756,51 @@ impl Ctx {
             m.set_phase(Phase::Transfer);
         }
 
+        // `--delete` upgrades the additive copy-in to a manifest-set MIRROR:
+        // after the copy-in, dest manifests absent from the SOURCE set are
+        // pruned (objects are NEVER deleted). The stores layer refuses an
+        // object/remote dest up front via `supports_mirror()`, surfaced here as
+        // a clear non-zero-exit error. Without `--delete`, behavior is unchanged
+        // (plain additive `sync_snapshot`). The mirror path folds a `SyncReport`,
+        // so both paths report the same copy-in counters; the mirror adds the
+        // manifests-pruned accounting on top.
+        if self.globals.delete {
+            let report = snapdir_stores::sync_snapshot_mirror(
+                &*from_store,
+                &*to_store,
+                id,
+                &config,
+                self.globals.dryrun,
+                meter.as_deref(),
+            );
+            // Clear the live line before ANY stdout/stderr summary write.
+            reporter.finish();
+            let report = report
+                .with_context(|| format!("mirroring snapshot {id} from {from_url} to {to_url}"))?;
+            let sync = &report.sync;
+            if sync.dry_run {
+                if !self.globals.quiet {
+                    eprintln!(
+                        "dry-run: would copy {} object(s) and prune {} manifest(s) for {id}",
+                        sync.objects_copied, report.manifests_pruned
+                    );
+                }
+            } else {
+                // Scriptable id-on-stdout contract (matches push/stage).
+                println!("{id}");
+                if !self.globals.quiet {
+                    eprintln!(
+                        "mirrored {id}: {} copied, {} skipped ({} bytes), {} manifest(s) pruned",
+                        sync.objects_copied,
+                        sync.objects_skipped,
+                        sync.bytes_copied,
+                        report.manifests_pruned
+                    );
+                }
+            }
+            return Ok(());
+        }
+
         let report = snapdir_stores::sync_snapshot(
             &*from_store,
             &*to_store,
@@ -3007,15 +3165,189 @@ impl Ctx {
         Ok(self.cache_store()?.with_meter(meter))
     }
 
+    /// Resolves the [`MaterializeMode`] for a checkout/pull, enforcing the
+    /// `--linked`-against-a-remote-store refusal at the CLI/router seam.
+    ///
+    /// `--linked` symlinks each dest file into the LOCAL content-addressed
+    /// object — only meaningful when the source store is local. Against a
+    /// non-local store (`s3://`/`gs://`/`b2://`/`ssh://`/`sftp://`/any
+    /// non-`file://` scheme) there is no local object to point at, so `--linked`
+    /// is a HARD ERROR here, BEFORE any materialization — never a silent
+    /// fall-back to copies. A bare `--store` of an absolute path, a `file://`
+    /// URL, or NO `--store` (checkout from the local cache) is local.
+    ///
+    /// # Errors
+    /// Returns an error when `--linked` is combined with a non-local `--store`.
+    fn materialize_mode(&self) -> Result<MaterializeMode> {
+        if !self.globals.linked {
+            return Ok(MaterializeMode::Auto);
+        }
+        if let Some(store_url) = self.globals.store.as_deref() {
+            if !store_url_is_local(store_url) {
+                anyhow::bail!(
+                    "snapdir: --linked cannot be used with the remote store {store_url}: \
+                     symlinks point at LOCAL content-addressed objects, which a remote \
+                     store does not provide; drop --linked (objects are copied) or use a \
+                     local file:// store"
+                );
+            }
+        }
+        Ok(MaterializeMode::Linked)
+    }
+
+    /// HARD-REFUSES an exact-mirror `--delete` against a dangerous destination,
+    /// UNCONDITIONALLY (`--force` does NOT bypass). Fires BEFORE any deletion and
+    /// BEFORE the manifest/store lookup, so the refusal is the failure surfaced.
+    ///
+    /// `dest` is the already-resolved (absolute, lexically-normalized) checkout
+    /// destination. The guard compares the CANONICAL real path of `dest` against
+    /// the canonical real paths of the protected locations — the filesystem root
+    /// `/`, `$HOME`, the cache dir (explicit `$SNAPDIR_CACHE_DIR` AND the default
+    /// `${XDG_CACHE_HOME:-$HOME/.cache}/snapdir`), and any configured store root
+    /// (`--store` and `--objects-store`, for local `file://`/path stores) — so a
+    /// trailing slash, a `.` segment, or a symlinked alias still trips the guard.
+    /// A location that does not exist on disk falls back to its
+    /// lexically-normalized form so the comparison still fires.
+    ///
+    /// # Errors
+    /// Returns an error (the refusal) when `dest` resolves to a protected path.
+    fn guard_dangerous_dest(&self, dest: &Path) -> Result<()> {
+        let dest_key = canonical_key(dest);
+
+        let mut guarded: Vec<(PathBuf, &'static str)> = Vec::new();
+        guarded.push((canonical_key(Path::new("/")), "the filesystem root"));
+        if let Ok(home) = std::env::var("HOME") {
+            if !home.is_empty() {
+                guarded.push((canonical_key(Path::new(&home)), "your home directory"));
+            }
+        }
+        // The cache dir holds the content-addressable objects; pruning it would
+        // corrupt the cache. Guard the resolved cache dir (which already honors
+        // explicit `--cache-dir`/`$SNAPDIR_CACHE_DIR` else the XDG default).
+        guarded.push((
+            canonical_key(&self.cache_dir()),
+            "the object cache directory",
+        ));
+        // Also guard the DEFAULT cache location even when an explicit cache dir
+        // is configured, so the default is never prunable.
+        guarded.push((
+            canonical_key(&default_cache_dir()),
+            "the object cache directory",
+        ));
+        // The store(s) hold the snapshot's manifests/objects; mirror-pruning the
+        // store would destroy it. Guard both the manifest store and the object
+        // pool roots (only the local ones resolve to a real path).
+        for url in [
+            self.globals.store.as_deref(),
+            self.globals.objects_store.as_deref(),
+        ]
+        .into_iter()
+        .flatten()
+        {
+            if store_url_is_local(url) {
+                guarded.push((canonical_key(&store_root_path(url)), "the snapshot store"));
+            }
+        }
+
+        for (path, label) in guarded {
+            if path == dest_key {
+                anyhow::bail!(
+                    "snapdir: refusing to mirror-delete {} — it is {label}; \
+                     --delete only prunes a checkout destination (this guard is \
+                     unconditional and is NOT bypassed by --force)",
+                    dest.display()
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Prunes the destination tree to an EXACT mirror of `manifest`: removes
+    /// every dest path NOT in the manifest, deepest-first, honoring the
+    /// prune-side `--exclude` protect-patterns. Under `--dryrun` it LISTS the
+    /// deletion set (one path per line, to stdout) and removes NOTHING.
+    ///
+    /// The dest walk is content-free (no hashing): each entry is recorded by
+    /// `(./`-prefixed path, type) via `symlink_metadata` so a symlink is an
+    /// ENTRY and is NEVER followed. The pure [`snapdir_core::mirror::prune_set`]
+    /// decides what is extraneous; this method only walks + unlinks. Every prune
+    /// path is dest-relative, so nothing outside the dest root is ever touched.
+    ///
+    /// A dest that does not exist yet is a no-op (a plain checkout has nothing to
+    /// prune).
+    ///
+    /// # Errors
+    /// Returns an error when the dest walk or a removal fails.
+    fn prune_dest(&self, manifest: &Manifest, dest: &Path) -> Result<()> {
+        if !dest.exists() {
+            return Ok(());
+        }
+        let mut entries = Vec::new();
+        collect_dest_entries(dest, dest, &mut entries)
+            .with_context(|| format!("walking checkout destination {}", dest.display()))?;
+
+        let exclude_refs: Vec<&str> = self.globals.exclude.iter().map(String::as_str).collect();
+        let prune = snapdir_core::mirror::prune_set(manifest, &entries, &exclude_refs);
+
+        if self.globals.dryrun {
+            // List the exact deletion set and remove nothing. Paths are the
+            // verbatim `./`-prefixed dest-relative keys `prune_set` returned.
+            let mut out = std::io::stdout().lock();
+            for path in &prune {
+                writeln!(out, "would delete: {path}")
+                    .context("writing the dry-run deletion list")?;
+            }
+            return Ok(());
+        }
+
+        for path in &prune {
+            // `prune_set` returns dest-relative `./`-prefixed keys (dirs end
+            // `/`); join under the dest root only. Deepest-first ordering
+            // guarantees a directory is empty by the time we reach it.
+            let rel = path.strip_prefix("./").unwrap_or(path);
+            let rel = rel.strip_suffix('/').unwrap_or(rel);
+            let target = dest.join(rel);
+            // Use symlink_metadata so a symlink (even one pointing OUTSIDE the
+            // dest) is classified by the LINK itself and unlinked, never
+            // followed into a recursive delete of its target.
+            let meta = match std::fs::symlink_metadata(&target) {
+                Ok(m) => m,
+                // Already gone (e.g. a parent removed it): idempotent no-op.
+                Err(e) if e.kind() == std::io::ErrorKind::NotFound => continue,
+                Err(e) => return Err(e).with_context(|| format!("stat'ing {}", target.display())),
+            };
+            if meta.file_type().is_dir() {
+                std::fs::remove_dir(&target).with_context(|| {
+                    format!("removing extraneous directory {}", target.display())
+                })?;
+            } else {
+                // A regular file OR a symlink: `remove_file` unlinks the entry
+                // itself (for a symlink, the link — NOT its target).
+                std::fs::remove_file(&target)
+                    .with_context(|| format!("removing extraneous path {}", target.display()))?;
+            }
+        }
+        Ok(())
+    }
+
     /// Resolves the cache directory: `--cache-dir`, else
     /// `${XDG_CACHE_HOME:-$HOME/.cache}/snapdir` (the oracle default).
     fn cache_dir(&self) -> PathBuf {
         if let Some(dir) = &self.globals.cache_dir {
             return dir.clone();
         }
-        let home = std::env::var("HOME").unwrap_or_default();
-        let base = std::env::var("XDG_CACHE_HOME").unwrap_or_else(|_| format!("{home}/.cache"));
-        PathBuf::from(format!("{base}/snapdir"))
+        // Commands that flatten `WalkArgs` (`id`/`manifest`) do NOT carry a
+        // `--cache-dir`/env field, so `globals.cache_dir` is unset for them even
+        // when `$SNAPDIR_CACHE_DIR` is exported. Honor the env directly here so
+        // the resolved cache matches the one `push`/`pull` wrote to — required
+        // for the linked-mode fast path to recognize a symlink whose target is a
+        // cache object (and correct independently of that path).
+        if let Some(dir) = std::env::var_os("SNAPDIR_CACHE_DIR") {
+            if !dir.is_empty() {
+                return PathBuf::from(dir);
+            }
+        }
+        default_cache_dir()
     }
 
     /// Returns the manifest's file objects that are ABSENT from the cache at
@@ -3062,6 +3394,7 @@ impl Ctx {
             path,
             absolute,
             no_follow,
+            checksum_bin,
             exclude,
             "resolving manifest path",
         )?;
@@ -3102,8 +3435,14 @@ impl Ctx {
         exclude: &[String],
         meter: Option<&Meter>,
     ) -> Result<(Manifest, std::collections::HashMap<PathBuf, CopyGuard>)> {
-        let (root, options) =
-            self.resolve_walk(path, absolute, no_follow, exclude, "resolving stage path")?;
+        let (root, options) = self.resolve_walk(
+            path,
+            absolute,
+            no_follow,
+            checksum_bin,
+            exclude,
+            "resolving stage path",
+        )?;
 
         match checksum_bin {
             None | Some("b3sum") => {
@@ -3130,6 +3469,7 @@ impl Ctx {
         path: Option<&Path>,
         absolute: bool,
         no_follow: bool,
+        checksum_bin: Option<&str>,
         exclude: &[String],
         context: &'static str,
     ) -> Result<(PathBuf, WalkOptions)> {
@@ -3163,11 +3503,47 @@ impl Ctx {
         } else {
             PathMode::Relative
         };
+        // Linked-mode checksum-reuse fast path. A `--linked` checkout's dest
+        // entries are symlinks into a LOCAL content-addressed `.objects/` pool
+        // whose sharded path mechanically encodes the file's BLAKE3, so a
+        // re-snapshot can recover each checksum from the symlink target's object
+        // path WITHOUT reading the bytes (core's `recover_object_key`).
+        //
+        // Eligibility (gated here so core stays env-pure): the requested
+        // checksum must be the store's addressing algorithm — plain, non-keyed
+        // BLAKE3. A non-default `--checksum-bin` (md5sum/sha256sum) or a keyed
+        // `SNAPDIR_MANIFEST_CONTEXT` makes the embedded hash the WRONG algorithm
+        // → leave the roots empty so core re-hashes content normally.
+        let plain_blake3 = matches!(checksum_bin, None | Some("b3sum"))
+            && std::env::var("SNAPDIR_MANIFEST_CONTEXT").map_or(true, |c| c.is_empty());
+        // The strict override forces a content re-hash (and, with the roots
+        // hinted, an integrity ERROR on a corrupt object). It is inert without
+        // eligible entries, so roots are still populated below.
+        let verify_linked_objects =
+            plain_blake3 && std::env::var("SNAPDIR_VERIFY_COPIES").as_deref() == Ok("1");
+        let object_store_roots = if plain_blake3 {
+            // The known LOCAL object-store roots `--linked` symlinks may point
+            // into: the resolved cache-dir store (`pull --linked` symlinks point
+            // into `<cache>/.objects/`) plus the local `--store`/`$SNAPDIR_STORE`
+            // root when local. Each root is a `<store-root>` dir (containing
+            // `.objects/`), exactly what `recover_object_key` strips against.
+            let mut roots = vec![self.cache_dir()];
+            if let Some(url) = self.globals.store.as_deref() {
+                if store_url_is_local(url) {
+                    roots.push(store_root_path(url));
+                }
+            }
+            roots
+        } else {
+            Vec::new()
+        };
         let options = WalkOptions {
             follow,
             path_mode,
             exclude: matcher,
             walk_jobs: self.globals.walk_jobs,
+            object_store_roots,
+            verify_linked_objects,
         };
         Ok((root, options))
     }
@@ -3629,6 +4005,81 @@ impl Drop for ScratchDir {
 /// This is purely lexical: it does **not** call `.canonicalize()`, so symlinks
 /// and `..` keep their existing semantics and the not-found error path is
 /// preserved (the path need not exist yet for some commands).
+/// Whether a `--store` URL routes to a LOCAL filesystem store — i.e. a
+/// `file://` URL or a bare absolute path (no `<scheme>://`). Everything else
+/// (`s3://`/`gs://`/`b2://`/`ssh://`/`sftp://`/any other scheme) is remote.
+///
+/// Used by the `--linked` remote-refusal and the store-path dangerous-dest
+/// guard (which only resolves a real path for a local store).
+fn store_url_is_local(store_url: &str) -> bool {
+    if store_url.starts_with("file:") {
+        return true;
+    }
+    // A bare absolute path has no `<scheme>://` separator.
+    !store_url.contains("://")
+}
+
+/// The on-disk root of a LOCAL store URL (a `file://` URL or a bare path),
+/// reusing the stores layer's `FileStore::new(..).root()` parse so the CLI
+/// never re-implements the `file:`-scheme normalization. Only meaningful for a
+/// URL [`store_url_is_local`] accepted.
+fn store_root_path(store_url: &str) -> PathBuf {
+    FileStore::new(store_url).root().to_path_buf()
+}
+
+/// The DEFAULT cache directory: `${XDG_CACHE_HOME:-$HOME/.cache}/snapdir` —
+/// independent of any explicit `--cache-dir`/`$SNAPDIR_CACHE_DIR`. Used by the
+/// dangerous-dest guard so the default cache location is always protected.
+fn default_cache_dir() -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_default();
+    let base = std::env::var("XDG_CACHE_HOME").unwrap_or_else(|_| format!("{home}/.cache"));
+    PathBuf::from(format!("{base}/snapdir"))
+}
+
+/// A comparison key for a path: its CANONICAL real path when it exists on disk
+/// (so a trailing slash, a `.` segment, or a symlinked alias all collapse to
+/// the same key), else its lexically-normalized form (so a not-yet-existing
+/// dangerous target — e.g. a store root that the test tore down — still
+/// compares equal to its guarded twin).
+fn canonical_key(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| lexically_normalize_root(path))
+}
+
+/// Recursively records the destination tree's entries as [`DestEntry`] values
+/// for [`snapdir_core::mirror::prune_set`]: each path is rendered `./`-prefixed
+/// (relative to `root`) with directories ending `/`, matching the manifest
+/// convention. Entries are recorded via `symlink_metadata` (lstat), so a
+/// symlink is recorded as a NON-directory entry and is NEVER descended into —
+/// the prune step unlinks the link itself, never following it out of the dest.
+fn collect_dest_entries(
+    root: &Path,
+    dir: &Path,
+    out: &mut Vec<snapdir_core::mirror::DestEntry>,
+) -> std::io::Result<()> {
+    use snapdir_core::mirror::DestEntry;
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        let meta = std::fs::symlink_metadata(&path)?;
+        let ft = meta.file_type();
+        // Render the dest-relative path the manifest way: `./` + components.
+        let rel = path
+            .strip_prefix(root)
+            .expect("dest child is under the dest root");
+        let rel_str = rel.to_string_lossy();
+        if ft.is_dir() {
+            out.push(DestEntry::new(format!("./{rel_str}/"), PathType::Directory));
+            // Recurse into real directories only (NOT a symlink to a dir).
+            collect_dest_entries(root, &path, out)?;
+        } else {
+            // A regular file OR a symlink: a single non-directory entry. A
+            // symlink is recorded by the LINK, not its target, and not followed.
+            out.push(DestEntry::new(format!("./{rel_str}"), PathType::File));
+        }
+    }
+    Ok(())
+}
+
 fn resolve_root(path: Option<&Path>) -> Result<PathBuf> {
     let raw = match path {
         Some(p) => p.to_path_buf(),

--- a/crates/snapdir-cli/tests/cmd/help-checkout.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-checkout.trycmd
@@ -99,6 +99,12 @@ Options:
       --dryrun
           Run without making any changes
 
+      --delete
+          Prune the destination to an EXACT mirror: remove anything not in the snapshot's manifest. Refuses dangerous destinations (/, $HOME, the cache dir, a store path) even with --force
+
+      --exclude <PATTERN>
+          With --delete, PROTECT destination paths matching the extended-regex PATTERN from pruning (repeatable / comma-delimited)
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-pull.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-pull.trycmd
@@ -99,6 +99,12 @@ Options:
       --dryrun
           Run without making any changes
 
+      --delete
+          Prune the destination to an EXACT mirror: remove anything not in the snapshot's manifest. Refuses dangerous destinations (/, $HOME, the cache dir, a store path) even with --force
+
+      --exclude <PATTERN>
+          With --delete, PROTECT destination paths matching the extended-regex PATTERN from pruning (repeatable / comma-delimited)
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/cmd/help-sync.trycmd
+++ b/crates/snapdir-cli/tests/cmd/help-sync.trycmd
@@ -109,6 +109,9 @@ Options:
       --to-objects <URI>
           Explicit DESTINATION object pool URI (split dest): objects are written here while manifests go to `--to`. Absent => `--to` is a plain colocated store. Distinct from the global `--objects-store`
 
+      --delete
+          Make the dest store an exact mirror of the source's manifest set: after the copy-in, prune dest manifests not present in the source. Objects are NEVER deleted. Requires a local file:// destination (an object/remote dest is refused). Honors --dryrun
+
   -h, --help
           Print help (see a summary with '-h')
 

--- a/crates/snapdir-cli/tests/mirror_checkout_cli.rs
+++ b/crates/snapdir-cli/tests/mirror_checkout_cli.rs
@@ -1,0 +1,942 @@
+//! ADVERSARY black-box spec suite (`assert_cmd`) for `checkout`/`pull` exact-mirror
+//! `--delete` + `--exclude`, and the carried-forward remote-source `--linked`
+//! refusal. Phase 32.
+//!
+//! AUTHORED FROM SPEC ONLY — no `--delete`/mirror implementation was read (none
+//! exists yet). These tests are EXPECTED TO FAIL until the impl lands; they pin
+//! the contract and must NOT be weakened to go green.
+//!
+//! Assumed CLI surface (stated in the handoff): `checkout`/`pull` gain two new
+//! flags on the transfer family — `--delete` (a bool: prune the destination to
+//! an EXACT mirror of the manifest, removing anything not in the manifest) and
+//! `--exclude <PATTERN>` (repeatable / comma-delimited, extended-regex like the
+//! core `ExcludeMatcher`, protecting a matching otherwise-extraneous path from
+//! pruning). The store URI is supplied via `--store <uri>` / `$SNAPDIR_STORE`,
+//! the snapshot via `--id <id>`, and the destination directory is the trailing
+//! positional arg. `--dryrun` lists the deletion set and removes nothing.
+//!
+//! SAFETY: the dangerous-dest tests (`/`, `$HOME`, cache dir, store path) are
+//! scoped via an env'd `HOME`/`XDG_CACHE_HOME`/`SNAPDIR_CACHE_DIR` pointing at
+//! tempdirs and sentinel files placed OUTSIDE the dest. They assert the command
+//! REFUSES (non-zero exit) and that the sentinel survives. They are designed so
+//! that even a buggy impl cannot delete a real `$HOME` or `/`, because `HOME`
+//! is redirected to a tempdir for the `$HOME` case and the `/` case relies on
+//! the refusal firing before any deletion (a sentinel under the env'd HOME is
+//! asserted intact). No test ever points a real prune at `/` or the real home.
+
+use std::fs;
+use std::os::unix::fs::{symlink, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+
+/// Unique temp dir under the OS temp root, removed by the caller on drop.
+fn temp_dir(tag: &str) -> PathBuf {
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "snapdir-mirror-{tag}-{}-{:?}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// A fresh `snapdir` command with the cache pinned and the developer's env
+/// scrubbed: `SNAPDIR_STORE`/`SNAPDIR_OBJECTS_STORE` removed so leakage cannot
+/// mask a bug, and `HOME`/`XDG_CACHE_HOME` redirected at the given `home` temp
+/// so the "default cache dir" / "$HOME" computations resolve INSIDE the test
+/// sandbox (never the real home).
+fn snapdir(cache: &Path, home: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("snapdir").expect("snapdir binary built");
+    cmd.env("SNAPDIR_CACHE_DIR", cache);
+    cmd.env("HOME", home);
+    cmd.env("XDG_CACHE_HOME", home.join(".cache"));
+    cmd.env_remove("SNAPDIR_STORE");
+    cmd.env_remove("SNAPDIR_OBJECTS_STORE");
+    cmd
+}
+
+/// Runs `snapdir <args>`, asserts success, returns trimmed stdout.
+fn ok_stdout(mut cmd: Command, args: &[&str]) -> String {
+    let out = cmd.args(args).output().expect("run snapdir");
+    assert!(
+        out.status.success(),
+        "snapdir {args:?} failed ({:?})\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8(out.stdout).unwrap().trim_end().to_owned()
+}
+
+/// Build a tiny deterministic source tree (stable perms so a checkout
+/// re-manifests to the same id) and return it.
+fn build_src(tag: &str) -> PathBuf {
+    let src = temp_dir(tag);
+    fs::write(src.join("a.txt"), b"hello").unwrap();
+    fs::set_permissions(src.join("a.txt"), fs::Permissions::from_mode(0o644)).unwrap();
+    fs::create_dir(src.join("sub")).unwrap();
+    fs::set_permissions(src.join("sub"), fs::Permissions::from_mode(0o755)).unwrap();
+    fs::write(src.join("sub").join("b.txt"), b"world!!").unwrap();
+    fs::set_permissions(
+        src.join("sub").join("b.txt"),
+        fs::Permissions::from_mode(0o644),
+    )
+    .unwrap();
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o755)).unwrap();
+    src
+}
+
+/// Push `src` into a fresh `file://` store and return `(store_url, id)`.
+fn push_to_store(src: &Path, cache: &Path, home: &Path, store: &Path) -> (String, String) {
+    let store_url = format!("file://{}", store.display());
+    let src_str = src.to_string_lossy().into_owned();
+    let id = ok_stdout(
+        snapdir(cache, home),
+        &["push", "--store", &store_url, &src_str],
+    );
+    assert_eq!(id.len(), 64, "push must print a 64-hex id");
+    (store_url, id)
+}
+
+/// Best-effort recursive cleanup of test scratch dirs.
+fn cleanup(dirs: &[&Path]) {
+    for d in dirs {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// PRUNING — extraneous content is removed, nested + idempotent + no-op cases.
+// ---------------------------------------------------------------------------
+
+/// SPEC: `--delete` prunes an extraneous top-level file from the dest, making it
+/// an exact mirror of the manifest; in-manifest files survive untouched.
+#[test]
+fn delete_prunes_extraneous_top_level_file() {
+    let src = build_src("prune-top-src");
+    let store = temp_dir("prune-top-store");
+    let dest = temp_dir("prune-top-dest");
+    let cache = temp_dir("prune-top-cache");
+    let home = temp_dir("prune-top-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+
+    // First plain checkout to populate the dest, then add an extraneous file.
+    let dest_str = dest.to_string_lossy().into_owned();
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["pull", "--store", &store_url, "--id", &id, &dest_str],
+    );
+    fs::write(dest.join("EXTRANEOUS.txt"), b"junk").unwrap();
+    assert!(dest.join("EXTRANEOUS.txt").exists());
+
+    // Re-checkout WITH --delete: the extraneous file must be pruned; the
+    // in-manifest files must remain.
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["checkout", "--id", &id, "--delete", &dest_str],
+    );
+    assert!(
+        !dest.join("EXTRANEOUS.txt").exists(),
+        "--delete must prune the extraneous file to make an exact mirror"
+    );
+    assert_eq!(fs::read(dest.join("a.txt")).unwrap(), b"hello");
+    assert_eq!(
+        fs::read(dest.join("sub").join("b.txt")).unwrap(),
+        b"world!!"
+    );
+    // And the mirror re-manifests back to the source id.
+    assert_eq!(ok_stdout(snapdir(&cache, &home), &["id", &dest_str]), id);
+
+    cleanup(&[&src, &store, &dest, &cache, &home]);
+}
+
+/// SPEC: nested extraneous directories are removed deepest-first (the prune-set
+/// is deepest-first), so a populated extraneous subtree is fully gone.
+#[test]
+fn delete_prunes_nested_extraneous_dirs_deepest_first() {
+    let src = build_src("prune-nest-src");
+    let store = temp_dir("prune-nest-store");
+    let dest = temp_dir("prune-nest-dest");
+    let cache = temp_dir("prune-nest-cache");
+    let home = temp_dir("prune-nest-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["pull", "--store", &store_url, "--id", &id, &dest_str],
+    );
+    // A non-empty extraneous nested subtree.
+    fs::create_dir_all(dest.join("junk").join("deep")).unwrap();
+    fs::write(dest.join("junk").join("deep").join("x"), b"x").unwrap();
+    fs::write(dest.join("junk").join("y"), b"y").unwrap();
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["checkout", "--id", &id, "--delete", &dest_str],
+    );
+    assert!(
+        !dest.join("junk").exists(),
+        "the entire extraneous subtree must be removed deepest-first"
+    );
+    assert_eq!(ok_stdout(snapdir(&cache, &home), &["id", &dest_str]), id);
+
+    cleanup(&[&src, &store, &dest, &cache, &home]);
+}
+
+/// SPEC: `--delete` is idempotent — a second `--delete` run over an
+/// already-exact mirror succeeds (exit 0) and removes nothing further.
+#[test]
+fn delete_is_idempotent_on_exact_mirror() {
+    let src = build_src("idem-src");
+    let store = temp_dir("idem-store");
+    let dest = temp_dir("idem-dest");
+    let cache = temp_dir("idem-cache");
+    let home = temp_dir("idem-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["pull", "--store", &store_url, "--id", &id, &dest_str],
+    );
+    // Two consecutive --delete runs; both must succeed and the second is a no-op.
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["checkout", "--id", &id, "--delete", &dest_str],
+    );
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["checkout", "--id", &id, "--delete", &dest_str],
+    );
+    assert_eq!(ok_stdout(snapdir(&cache, &home), &["id", &dest_str]), id);
+
+    cleanup(&[&src, &store, &dest, &cache, &home]);
+}
+
+/// SPEC: a dest that already EXACTLY matches the manifest yields no deletions
+/// (the prune-set is empty); the checkout succeeds and the mirror is intact.
+#[test]
+fn delete_no_op_when_dest_already_matches() {
+    let src = build_src("match-src");
+    let store = temp_dir("match-store");
+    let dest = temp_dir("match-dest");
+    let cache = temp_dir("match-cache");
+    let home = temp_dir("match-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    // Checkout WITH --delete straight onto an empty dest, then again: a freshly
+    // materialized dest already matches, so --delete prunes nothing.
+    ok_stdout(
+        snapdir(&cache, &home),
+        &[
+            "pull", "--store", &store_url, "--id", &id, "--delete", &dest_str,
+        ],
+    );
+    assert_eq!(fs::read(dest.join("a.txt")).unwrap(), b"hello");
+    assert_eq!(
+        fs::read(dest.join("sub").join("b.txt")).unwrap(),
+        b"world!!"
+    );
+    assert_eq!(ok_stdout(snapdir(&cache, &home), &["id", &dest_str]), id);
+
+    cleanup(&[&src, &store, &dest, &cache, &home]);
+}
+
+// ---------------------------------------------------------------------------
+// DRYRUN — lists deletions, removes nothing.
+// ---------------------------------------------------------------------------
+
+/// SPEC: `--delete --dryrun` LISTS the exact deletion set (on stdout or stderr)
+/// and deletes NOTHING — the extraneous file must still exist afterward.
+#[test]
+fn delete_dryrun_lists_deletions_and_removes_nothing() {
+    let src = build_src("dry-src");
+    let store = temp_dir("dry-store");
+    let dest = temp_dir("dry-dest");
+    let cache = temp_dir("dry-cache");
+    let home = temp_dir("dry-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["pull", "--store", &store_url, "--id", &id, &dest_str],
+    );
+    fs::write(dest.join("WOULD_DELETE.txt"), b"junk").unwrap();
+
+    let out = snapdir(&cache, &home)
+        .args(["checkout", "--id", &id, "--delete", "--dryrun", &dest_str])
+        .output()
+        .expect("run snapdir");
+    assert!(
+        out.status.success(),
+        "dryrun checkout --delete should succeed; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        combined.contains("WOULD_DELETE.txt"),
+        "--dryrun must LIST the exact path it would delete; got: {combined}"
+    );
+    assert!(
+        dest.join("WOULD_DELETE.txt").exists(),
+        "--dryrun must NOT actually delete anything"
+    );
+
+    cleanup(&[&src, &store, &dest, &cache, &home]);
+}
+
+// ---------------------------------------------------------------------------
+// DEST-ABSENT — behaves as a plain checkout (nothing to prune, no error).
+// ---------------------------------------------------------------------------
+
+/// SPEC: when the dest does not exist yet, `--delete` is a plain checkout — the
+/// tree is materialized, nothing is pruned, and there is no error.
+#[test]
+fn delete_with_absent_dest_is_plain_checkout() {
+    let src = build_src("absent-src");
+    let store = temp_dir("absent-store");
+    let cache = temp_dir("absent-cache");
+    let home = temp_dir("absent-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+
+    // A dest path that does NOT exist (parent exists, leaf absent).
+    let parent = temp_dir("absent-parent");
+    let dest = parent.join("not-yet");
+    assert!(!dest.exists());
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &[
+            "pull", "--store", &store_url, "--id", &id, "--delete", &dest_str,
+        ],
+    );
+    assert_eq!(fs::read(dest.join("a.txt")).unwrap(), b"hello");
+    assert_eq!(ok_stdout(snapdir(&cache, &home), &["id", &dest_str]), id);
+
+    cleanup(&[&src, &store, &parent, &cache, &home]);
+}
+
+// ---------------------------------------------------------------------------
+// EXCLUDE — protects matching extraneous paths; non-matching siblings still pruned.
+// ---------------------------------------------------------------------------
+
+/// SPEC: `--exclude <glob>` PROTECTS an otherwise-extraneous matching path from
+/// pruning, while a non-matching extraneous sibling IS still pruned.
+#[test]
+fn delete_exclude_protects_match_but_prunes_sibling() {
+    let src = build_src("excl-src");
+    let store = temp_dir("excl-store");
+    let dest = temp_dir("excl-dest");
+    let cache = temp_dir("excl-cache");
+    let home = temp_dir("excl-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["pull", "--store", &store_url, "--id", &id, &dest_str],
+    );
+    // Two extraneous files: one matches the exclude (protected), one does not.
+    fs::write(dest.join("keep.log"), b"protected").unwrap();
+    fs::write(dest.join("drop.tmp"), b"prunable").unwrap();
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &[
+            "checkout",
+            "--id",
+            &id,
+            "--delete",
+            "--exclude",
+            // Extended-regex (core ExcludeMatcher): match the .log path.
+            "keep\\.log",
+            &dest_str,
+        ],
+    );
+    assert!(
+        dest.join("keep.log").exists(),
+        "--exclude must PROTECT the matching extraneous path from pruning"
+    );
+    assert!(
+        !dest.join("drop.tmp").exists(),
+        "a non-matching extraneous sibling must still be pruned"
+    );
+
+    cleanup(&[&src, &store, &dest, &cache, &home]);
+}
+
+// ---------------------------------------------------------------------------
+// SYMLINK ESCAPE — a dest symlink to OUTSIDE the dest root is unlinked, not
+// followed; nothing outside the dest root is ever deleted.
+// ---------------------------------------------------------------------------
+
+/// SPEC: an extraneous symlink in the dest pointing OUTSIDE the dest root is
+/// removed-not-followed: the link itself is unlinked, but its external target
+/// (and the file inside it) survives — nothing outside the dest root is deleted.
+#[test]
+fn delete_removes_escaping_symlink_without_following_it() {
+    let src = build_src("link-src");
+    let store = temp_dir("link-store");
+    let dest = temp_dir("link-dest");
+    let cache = temp_dir("link-cache");
+    let home = temp_dir("link-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["pull", "--store", &store_url, "--id", &id, &dest_str],
+    );
+
+    // An external directory OUTSIDE the dest, with a canary file inside it.
+    let outside = temp_dir("link-outside");
+    let canary = outside.join("CANARY.txt");
+    fs::write(&canary, b"must survive").unwrap();
+
+    // An extraneous symlink in the dest that escapes to the external dir.
+    let escape = dest.join("escape");
+    symlink(&outside, &escape).unwrap();
+    assert!(escape.symlink_metadata().unwrap().file_type().is_symlink());
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["checkout", "--id", &id, "--delete", &dest_str],
+    );
+
+    // The link itself was unlinked...
+    assert!(
+        escape.symlink_metadata().is_err(),
+        "the escaping symlink must be unlinked"
+    );
+    // ...but the external target dir and its canary are untouched (the link was
+    // removed, not followed into a recursive delete of the target).
+    assert!(
+        canary.exists(),
+        "deleting must NOT follow the symlink: the external target must survive"
+    );
+    assert!(outside.exists(), "the external dir itself must survive");
+
+    cleanup(&[&src, &store, &dest, &cache, &home, &outside]);
+}
+
+// ---------------------------------------------------------------------------
+// HARD-REFUSE dangerous dests — non-zero exit, nothing deleted, NO --force bypass.
+// ---------------------------------------------------------------------------
+
+/// Asserts a `checkout --delete <dest>` (optionally with `--force`) REFUSES:
+/// non-zero exit, and a sentinel placed under the dest survives. Used for every
+/// dangerous-dest case so the refusal is proven to fire BEFORE any deletion.
+fn assert_refuses_dangerous(cache: &Path, home: &Path, dest: &Path, with_force: bool) {
+    let dest_str = dest.to_string_lossy().into_owned();
+    // A sentinel inside the dangerous dest: if the impl wrongly pruned, this
+    // would vanish. The refusal must fire first, so it MUST survive.
+    let sentinel = dest.join("DO_NOT_DELETE.sentinel");
+    fs::create_dir_all(dest).ok();
+    fs::write(&sentinel, b"sentinel").unwrap();
+
+    let id = "0".repeat(64); // shape-valid; the refusal must precede any lookup.
+    let mut args = vec!["checkout", "--id"];
+    args.push(&id);
+    args.push("--delete");
+    if with_force {
+        args.push("--force");
+    }
+    args.push(&dest_str);
+
+    let out = snapdir(cache, home)
+        .args(&args)
+        .output()
+        .expect("run snapdir");
+    assert!(
+        !out.status.success(),
+        "checkout --delete on dangerous dest {} (force={with_force}) MUST refuse with non-zero exit",
+        dest.display()
+    );
+    assert!(
+        sentinel.exists(),
+        "the refusal must fire BEFORE any deletion: sentinel under {} must survive (force={with_force})",
+        dest.display()
+    );
+}
+
+/// SPEC: `--delete` HARD-REFUSES dest = `$HOME` (non-zero exit, nothing deleted),
+/// and `--force` does NOT bypass the refusal. HOME is env-redirected to a temp
+/// dir so a buggy impl cannot touch the real home.
+#[test]
+fn delete_refuses_home_dir_even_with_force() {
+    let cache = temp_dir("home-cache");
+    let home = temp_dir("home-home"); // env'd HOME -> this temp dir
+                                      // dest == the env'd $HOME
+    assert_refuses_dangerous(&cache, &home, &home, false);
+    assert_refuses_dangerous(&cache, &home, &home, true);
+    cleanup(&[&cache, &home]);
+}
+
+/// SPEC: `--delete` HARD-REFUSES dest = `/` (filesystem root): non-zero exit,
+/// nothing deleted, no `--force` bypass. We do NOT place a sentinel at real `/`;
+/// the refusal must fire on the path identity alone, so we only assert the
+/// non-zero exit (a buggy impl that DID prune `/` would also be caught by CI's
+/// inability to write `/`, but the contract is the refusal itself).
+#[test]
+fn delete_refuses_filesystem_root_even_with_force() {
+    let cache = temp_dir("root-cache");
+    let home = temp_dir("root-home");
+    for force in [false, true] {
+        let mut args = vec!["checkout", "--id"];
+        let id = "0".repeat(64);
+        args.push(&id);
+        args.push("--delete");
+        if force {
+            args.push("--force");
+        }
+        args.push("/");
+        let out = snapdir(&cache, &home)
+            .args(&args)
+            .output()
+            .expect("run snapdir");
+        assert!(
+            !out.status.success(),
+            "checkout --delete / (force={force}) MUST hard-refuse with non-zero exit"
+        );
+    }
+    cleanup(&[&cache, &home]);
+}
+
+/// SPEC: `--delete` HARD-REFUSES dest = the cache dir (`$SNAPDIR_CACHE_DIR`):
+/// non-zero exit, nothing deleted, no `--force` bypass. The cache dir holds the
+/// content-addressable objects — pruning it would corrupt the cache.
+#[test]
+fn delete_refuses_cache_dir_even_with_force() {
+    let cache = temp_dir("cachedir-cache");
+    let home = temp_dir("cachedir-home");
+    // dest == the explicitly-configured SNAPDIR_CACHE_DIR.
+    assert_refuses_dangerous(&cache, &home, &cache, false);
+    assert_refuses_dangerous(&cache, &home, &cache, true);
+    cleanup(&[&cache, &home]);
+}
+
+/// SPEC: `--delete` HARD-REFUSES dest = the default cache dir
+/// (`$XDG_CACHE_HOME/snapdir`) too — not just the explicit `--cache-dir`. The
+/// default location must be guarded identically.
+#[test]
+fn delete_refuses_default_cache_dir_even_with_force() {
+    let home = temp_dir("defcache-home");
+    // The default cache dir derived from the env'd XDG_CACHE_HOME.
+    let default_cache = home.join(".cache").join("snapdir");
+    fs::create_dir_all(&default_cache).unwrap();
+    // Use a SEPARATE explicit cache so the dest equals the DEFAULT location, not
+    // the configured one — but env the same HOME/XDG so the default resolves
+    // inside the sandbox. We pass the default cache as dest while leaving
+    // SNAPDIR_CACHE_DIR pointed elsewhere is not possible via snapdir(); instead
+    // run with the default cache as both the resolved cache and the dest.
+    let mut cmd = Command::cargo_bin("snapdir").expect("snapdir binary built");
+    cmd.env("HOME", &home);
+    cmd.env("XDG_CACHE_HOME", home.join(".cache"));
+    cmd.env_remove("SNAPDIR_CACHE_DIR");
+    cmd.env_remove("SNAPDIR_STORE");
+    let sentinel = default_cache.join("DO_NOT_DELETE.sentinel");
+    fs::write(&sentinel, b"sentinel").unwrap();
+    let id = "0".repeat(64);
+    let dest_str = default_cache.to_string_lossy().into_owned();
+    let out = cmd
+        .args(["checkout", "--id", &id, "--delete", "--force", &dest_str])
+        .output()
+        .expect("run snapdir");
+    assert!(
+        !out.status.success(),
+        "checkout --delete on the DEFAULT cache dir must hard-refuse (no --force bypass)"
+    );
+    assert!(sentinel.exists(), "default cache dir must not be pruned");
+    cleanup(&[&home]);
+}
+
+/// SPEC: `--delete` HARD-REFUSES dest = a store path (the local `file://` store
+/// backing this run): non-zero exit, nothing deleted, no `--force` bypass. The
+/// dest must never be allowed to mirror-prune the very store it reads from.
+#[test]
+fn delete_refuses_store_path_even_with_force() {
+    let src = build_src("storepath-src");
+    let store = temp_dir("storepath-store");
+    let cache = temp_dir("storepath-cache");
+    let home = temp_dir("storepath-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+
+    // dest == the store's on-disk root. The store holds .objects/.manifests; a
+    // mirror-prune of it would destroy the store. Sentinel = the landed manifest.
+    let manifest_key = store.join(format!(
+        ".manifests/{}/{}/{}/{}",
+        &id[0..3],
+        &id[3..6],
+        &id[6..9],
+        &id[9..]
+    ));
+    assert!(manifest_key.is_file(), "precondition: manifest landed");
+    let store_str = store.to_string_lossy().into_owned();
+
+    for force in [false, true] {
+        let mut args = vec!["checkout", "--store", &store_url, "--id", &id, "--delete"];
+        if force {
+            args.push("--force");
+        }
+        args.push(&store_str);
+        let out = snapdir(&cache, &home)
+            .args(&args)
+            .output()
+            .expect("run snapdir");
+        assert!(
+            !out.status.success(),
+            "checkout --delete onto the store path (force={force}) MUST hard-refuse"
+        );
+        assert!(
+            manifest_key.is_file(),
+            "the store's manifest must survive the refusal (force={force})"
+        );
+    }
+
+    cleanup(&[&src, &store, &cache, &home]);
+}
+
+// ---------------------------------------------------------------------------
+// CARRIED FROM materialize-modes: `--linked` against a REMOTE object source is
+// a HARD ERROR at the CLI/router layer (can't symlink to a remote object).
+// ---------------------------------------------------------------------------
+
+/// SPEC (carried): `checkout --linked` against a NON-LOCAL store
+/// (`s3://`/`gs://`/`b2://`/`ssh://`/`sftp://`) is a HARD ERROR at the CLI —
+/// clear message, non-zero exit, no partial dest written. Pinned across every
+/// remote scheme.
+#[test]
+fn linked_against_remote_store_is_a_hard_error() {
+    let cache = temp_dir("linkremote-cache");
+    let home = temp_dir("linkremote-home");
+    let parent = temp_dir("linkremote-parent");
+
+    for (i, remote) in [
+        "s3://bucket/prefix",
+        "gs://bucket/prefix",
+        "b2://bucket/prefix",
+        "ssh://host/srv/store",
+        "sftp://host/srv/store",
+    ]
+    .iter()
+    .enumerate()
+    {
+        let dest = parent.join(format!("dest-{i}"));
+        let dest_str = dest.to_string_lossy().into_owned();
+        let id = "0".repeat(64);
+        let out = snapdir(&cache, &home)
+            .args([
+                "checkout", "--store", remote, "--id", &id, "--linked", &dest_str,
+            ])
+            .output()
+            .expect("run snapdir");
+        assert!(
+            !out.status.success(),
+            "checkout --linked against remote {remote} MUST be a hard error"
+        );
+        assert!(
+            !dest.exists() || fs::read_dir(&dest).map_or(true, |mut d| d.next().is_none()),
+            "no partial dest tree may be materialized for remote {remote}"
+        );
+    }
+
+    cleanup(&[&cache, &home, &parent]);
+}
+
+/// SPEC (carried): `pull --linked` against a remote store is likewise a hard
+/// error at the CLI (pull = fetch + checkout; the linked-from-remote refusal
+/// must surface, not silently fall back to copies).
+#[test]
+fn pull_linked_against_remote_store_is_a_hard_error() {
+    let cache = temp_dir("pulllink-cache");
+    let home = temp_dir("pulllink-home");
+    let parent = temp_dir("pulllink-parent");
+    let dest = parent.join("dest");
+    let dest_str = dest.to_string_lossy().into_owned();
+    let id = "0".repeat(64);
+
+    let out = snapdir(&cache, &home)
+        .args([
+            "pull",
+            "--store",
+            "s3://bucket/prefix",
+            "--id",
+            &id,
+            "--linked",
+            &dest_str,
+        ])
+        .output()
+        .expect("run snapdir");
+    assert!(
+        !out.status.success(),
+        "pull --linked against a remote store MUST be a hard error"
+    );
+
+    cleanup(&[&cache, &home, &parent]);
+}
+
+// ---------------------------------------------------------------------------
+// IMPL-REVEALED (review-phase additions). The impl made `--linked` from a LOCAL
+// store symlink each file entry into the shared 0444 content object, and SKIP
+// `restore_permissions` in Linked mode (re-chmod'ing the link would follow into
+// and corrupt the shared object). It also canonicalizes the dangerous-dest key.
+// These cases pin those now-visible branches. All remain black-box assert_cmd.
+// ---------------------------------------------------------------------------
+
+/// REVIEW: local `--linked` happy path. `checkout --linked` from a LOCAL
+/// `file://` store into a FRESH dir materializes each file entry as a SYMLINK
+/// (not a real-inode copy), the linked file reads the correct content, and the
+/// shared object the link points at is read-only `0444`. Pins the impl's
+/// `MaterializeMode::Linked` wiring for a local source.
+#[test]
+fn linked_local_checkout_creates_symlinks_to_readonly_objects() {
+    let src = build_src("linkok-src");
+    let store = temp_dir("linkok-store");
+    let dest = temp_dir("linkok-dest");
+    let cache = temp_dir("linkok-cache");
+    let home = temp_dir("linkok-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    // `--linked` against the LOCAL file:// store must succeed (local objects to
+    // point at) and materialize symlinks, not copies. `pull --linked` = fetch
+    // (populate the cache with manifest + objects) + linked checkout in one.
+    ok_stdout(
+        snapdir(&cache, &home),
+        &[
+            "pull", "--store", &store_url, "--id", &id, "--linked", &dest_str,
+        ],
+    );
+
+    let a = dest.join("a.txt");
+    let a_meta = a.symlink_metadata().expect("a.txt exists");
+    assert!(
+        a_meta.file_type().is_symlink(),
+        "--linked must materialize a.txt as a SYMLINK, not a real-inode copy"
+    );
+    let b = dest.join("sub").join("b.txt");
+    assert!(
+        b.symlink_metadata().unwrap().file_type().is_symlink(),
+        "--linked must materialize the nested sub/b.txt as a symlink too"
+    );
+
+    // The linked files read the correct content (the link resolves into the
+    // shared object).
+    assert_eq!(fs::read(&a).unwrap(), b"hello");
+    assert_eq!(fs::read(&b).unwrap(), b"world!!");
+
+    // The shared object the link points at is read-only `0444` (hardened so a
+    // write THROUGH the link cannot corrupt the shared bytes). The link target
+    // is the object on disk; follow it and assert its real mode.
+    let target = fs::canonicalize(&a).expect("resolve linked target");
+    let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o444,
+        "the shared linked object must be read-only 0444 (got {mode:o})"
+    );
+
+    cleanup(&[&src, &store, &dest, &cache, &home]);
+}
+
+/// REVIEW: confirms the impl's `restore_permissions`-skip in Linked mode is
+/// CORRECT — a linked checkout must NOT chmod the shared object up to the
+/// manifest's writable (`0644`) mode. The source `a.txt` is `0644`; were the
+/// CLI to run `restore_permissions` in Linked mode it would follow the link and
+/// re-mode the shared `0444` object to `0644`, corrupting it for every other
+/// link. We pin that the resolved target stays `0444` and is NOT the manifest's
+/// `0644`.
+#[test]
+fn linked_checkout_does_not_rechmod_shared_object_to_manifest_mode() {
+    let src = build_src("linkperm-src"); // a.txt is 0644 in the source/manifest
+    let store = temp_dir("linkperm-store");
+    let dest = temp_dir("linkperm-dest");
+    let cache = temp_dir("linkperm-cache");
+    let home = temp_dir("linkperm-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &[
+            "pull", "--store", &store_url, "--id", &id, "--linked", &dest_str,
+        ],
+    );
+
+    let target = fs::canonicalize(dest.join("a.txt")).expect("resolve linked target");
+    let mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        mode, 0o444,
+        "Linked mode must SKIP restore_permissions: the shared object stays 0444 \
+         and must NOT be chmod'd to the manifest's writable 0644 (got {mode:o})"
+    );
+    assert_ne!(
+        mode, 0o644,
+        "the shared object must NOT be re-moded to the manifest's writable mode"
+    );
+
+    cleanup(&[&src, &store, &dest, &cache, &home]);
+}
+
+/// REVIEW: `--linked --delete` interaction. A linked checkout that also prunes
+/// must remove the extraneous dest entry while LEAVING the materialized symlinks
+/// (which are in-manifest) intact and still readable. Pins the
+/// `checkout_inner` branch where Linked materialize is followed by `prune_dest`.
+#[test]
+fn linked_with_delete_prunes_extraneous_but_keeps_links() {
+    let src = build_src("linkdel-src");
+    let store = temp_dir("linkdel-store");
+    let dest = temp_dir("linkdel-dest");
+    let cache = temp_dir("linkdel-cache");
+    let home = temp_dir("linkdel-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    // First a linked pull (populate cache + materialize links), then drop an
+    // extraneous file alongside.
+    ok_stdout(
+        snapdir(&cache, &home),
+        &[
+            "pull", "--store", &store_url, "--id", &id, "--linked", &dest_str,
+        ],
+    );
+    fs::write(dest.join("EXTRA_LINKED.txt"), b"junk").unwrap();
+
+    // Re-run linked WITH --delete: prune the extraneous file, keep the links.
+    ok_stdout(
+        snapdir(&cache, &home),
+        &[
+            "checkout", "--store", &store_url, "--id", &id, "--linked", "--delete", &dest_str,
+        ],
+    );
+    assert!(
+        !dest.join("EXTRA_LINKED.txt").exists(),
+        "--linked --delete must prune the extraneous file"
+    );
+    assert!(
+        dest.join("a.txt")
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "the in-manifest link must survive the prune"
+    );
+    assert_eq!(fs::read(dest.join("a.txt")).unwrap(), b"hello");
+
+    cleanup(&[&src, &store, &dest, &cache, &home]);
+}
+
+/// REVIEW (guard canonicalization alias): the dangerous-dest guard compares the
+/// CANONICAL real path, so `$HOME` given with a trailing slash AND `$HOME/.`
+/// (both canonicalize to `$HOME`) must STILL be hard-refused. A purely lexical
+/// guard would miss these aliases. HOME is env-redirected to a tempdir, so a
+/// buggy impl cannot touch the real home; a sentinel proves nothing was pruned.
+#[test]
+fn delete_refuses_home_canonicalization_aliases_even_with_force() {
+    let cache = temp_dir("alias-cache");
+    let home = temp_dir("alias-home");
+    let sentinel = home.join("DO_NOT_DELETE.sentinel");
+    fs::write(&sentinel, b"sentinel").unwrap();
+
+    let home_str = home.to_string_lossy().into_owned();
+    // Aliases that all canonicalize to the env'd HOME.
+    for alias in [format!("{home_str}/"), format!("{home_str}/."), {
+        // A symlink that resolves to HOME — a canonicalizing guard must follow
+        // it; a lexical-only guard would not.
+        let parent = home.parent().unwrap();
+        let link = parent.join(format!("home-alias-{}", std::process::id()));
+        fs::remove_file(&link).ok();
+        symlink(&home, &link).unwrap();
+        link.to_string_lossy().into_owned()
+    }] {
+        let id = "0".repeat(64);
+        let out = snapdir(&cache, &home)
+            .args(["checkout", "--id", &id, "--delete", "--force", &alias])
+            .output()
+            .expect("run snapdir");
+        assert!(
+            !out.status.success(),
+            "checkout --delete onto a canonicalization-alias of $HOME ({alias}) \
+             MUST hard-refuse (canonical guard, no --force bypass)"
+        );
+        assert!(
+            sentinel.exists(),
+            "the refusal must fire before any deletion for alias {alias}"
+        );
+    }
+
+    // Clean up the symlink alias we created under home's parent.
+    let parent = home.parent().unwrap();
+    fs::remove_file(parent.join(format!("home-alias-{}", std::process::id()))).ok();
+    cleanup(&[&cache, &home]);
+}
+
+/// REVIEW (exclude regex semantics): `--exclude` is EXTENDED-REGEX (confirmed by
+/// the impl, resolving the gate's glob-vs-regex ambiguity). A regex METACHAR
+/// pattern protects as a regex (a `.` matches any char; an alternation matches
+/// either), and MULTIPLE `--exclude` flags ALL apply (each is its own protect
+/// pattern). A non-matching extraneous sibling is still pruned.
+#[test]
+fn delete_exclude_regex_metachars_and_multiple_flags_all_apply() {
+    let src = build_src("exclre-src");
+    let store = temp_dir("exclre-store");
+    let dest = temp_dir("exclre-dest");
+    let cache = temp_dir("exclre-cache");
+    let home = temp_dir("exclre-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["pull", "--store", &store_url, "--id", &id, &dest_str],
+    );
+    // Three extraneous files. `keep1.log` is protected by an alternation regex,
+    // `keepX.cfg` by a metachar (`.` = any char) regex via a SECOND --exclude,
+    // and `drop.bin` matches neither and must be pruned.
+    fs::write(dest.join("keep1.log"), b"a").unwrap();
+    fs::write(dest.join("keepX.cfg"), b"b").unwrap();
+    fs::write(dest.join("drop.bin"), b"c").unwrap();
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &[
+            "checkout",
+            "--id",
+            &id,
+            "--delete",
+            // Extended-regex alternation: protect either *.log or *.bak.
+            "--exclude",
+            "(keep1\\.log|keep1\\.bak)",
+            // SECOND --exclude, regex metachar `.` = any single char.
+            "--exclude",
+            "keep.\\.cfg",
+            &dest_str,
+        ],
+    );
+    assert!(
+        dest.join("keep1.log").exists(),
+        "the alternation-regex --exclude must protect keep1.log"
+    );
+    assert!(
+        dest.join("keepX.cfg").exists(),
+        "the SECOND --exclude (metachar regex) must ALSO apply and protect keepX.cfg"
+    );
+    assert!(
+        !dest.join("drop.bin").exists(),
+        "a sibling matching NEITHER exclude must still be pruned"
+    );
+
+    cleanup(&[&src, &store, &dest, &cache, &home]);
+}

--- a/crates/snapdir-cli/tests/mirror_durability.rs
+++ b/crates/snapdir-cli/tests/mirror_durability.rs
@@ -1,0 +1,1007 @@
+//! KEYSTONE DURABILITY SUITE for the exact-mirror (`--delete`) + materialization
+//! modes feature (Phase 32, gate `mirror-durability-review`).
+//!
+//! This is a CONSOLIDATED keystone gate, NOT a spec-tests/impl/review triple: the
+//! whole feature is BUILT and per-cluster verified. This suite pins the single
+//! durability promise the operator named — a long-running process that is holding
+//! a destination file OPEN must keep working through a mirror — across EVERY
+//! materialization mode, plus the no-shared-store-corruption invariants. Every
+//! test here is EXPECTED TO PASS against the shipped code. If a keystone assertion
+//! fails, that is a REAL BUG: it is left failing and reported for the PM to reopen
+//! the offending lane. No assertion is ever weakened to go green.
+//!
+//! ## The durability promise, restated
+//! POSIX binds an open fd to the underlying INODE, so the original bytes survive
+//! an unlink / rename / atomic swap of the path UNTIL the fd closes. The five
+//! invariants pinned below:
+//!
+//!   1. HELD-OPEN FD SURVIVES `--delete` REMOVAL (in-place path), DEFAULT + LINKED.
+//!      A dest file is opened, then a `checkout --delete <OTHER snapshot>` prunes
+//!      or replaces it in place; the still-open fd keeps reading the ORIGINAL
+//!      bytes (inode retention). Driven through the CLI (`assert_cmd`), which uses
+//!      the in-place prune path.
+//!   2. HELD-OPEN FD SURVIVES THE ATOMIC STAGED SWAP, ALL ZERO-COPY MODES. The
+//!      atomic swap is a stores primitive (`FileStore::fetch_files_atomic`); the
+//!      CLI does not route through it yet, so this calls the stores API directly:
+//!      open a dest file, swap a DIFFERENT snapshot into the same dest (Auto on a
+//!      CoW host + Linked on any FS); the held fd reads ORIGINAL bytes, a fresh
+//!      open of the path reads NEW content.
+//!   3. SYMLINK-MODE WRITE IS BLOCKED (no shared-store corruption). A `--linked`
+//!      dest file is a symlink to a `0444` store object; writing THROUGH it fails
+//!      (PermissionDenied) and the store object's bytes stay byte-identical and
+//!      still BLAKE3-verify.
+//!   4. REFLINK-MODE WRITE LEAVES THE SOURCE OBJECT BYTE-IDENTICAL (CoW
+//!      independence). In default mode, editing a materialized dest file does NOT
+//!      change the source store/cache object (the write breaks CoW). Gated on CoW
+//!      capability; the no-corruption invariant is asserted on EVERY host.
+//!   5. ZERO EXTRA BYTE COPIES on the zero-copy paths. reflink (CoW) copies no
+//!      file bytes — `clonefile_hits()` advances; symlinks are links, not copies.
+//!
+//! ## CoW gating
+//! macOS dev is APFS (clone fires); Linux CI runs an ext4 leg (NO reflink) and a
+//! Btrfs leg (real FICLONE). The "reflink actually fired" assertions are GATED on
+//! a clone-capable host (macOS always; Linux only under `SNAPDIR_REFLINK_TEST_DIR`,
+//! mirroring `crates/snapdir-stores/tests/reflink.rs`). The held-fd survival, the
+//! symlink-write-blocked, and the no-corruption invariants are asserted on EVERY
+//! host — symlink (`Linked`) staging is zero-copy on any filesystem, so those legs
+//! run unconditionally.
+//!
+//! ## Mixed harness
+//! Invariants 1, 3, 4, 5(symlink) drive the shipped CLI via `assert_cmd` (the
+//! in-place `--delete` / `--linked` paths). Invariant 2 and 5(reflink) call
+//! `snapdir_stores` directly (`fetch_files_atomic` / `clonefile_hits`). Both live
+//! in this one file (the test crate depends on `snapdir-stores` + `snapdir-core`).
+
+#![cfg(unix)]
+// Wiring (shape only, no assertion change): silence the workspace `-D warnings`
+// pedantic clippy lints on this adversary-authored suite, exactly as the sibling
+// `mirror_*` suites do. `doc_markdown` fires on the prose invariant docstrings
+// (method/path names without backticks); `cast_possible_truncation` on the
+// `len as u32` deterministic-content generators. Pure shape; no test logic
+// affected.
+#![allow(clippy::doc_markdown, clippy::cast_possible_truncation)]
+
+use std::collections::HashSet;
+use std::fs;
+use std::io::Read as _;
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+use assert_cmd::prelude::*;
+
+use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
+use snapdir_core::merkle::{directory_checksum, Blake3Hasher, Hasher};
+use snapdir_core::snapshot_id;
+use snapdir_core::store::{object_path, Store};
+use snapdir_stores::{clonefile_hits, FileStore, MaterializeMode, StreamStore};
+
+// ===========================================================================
+// Shared scaffolding (no dev-deps beyond assert_cmd; mirrors the sibling CLI +
+// stores suites so the harness is familiar and the cleanup is hardened-tree-safe).
+// ===========================================================================
+
+/// Unique temp dir under `parent`, removed (with the 0444 tree un-hardened first)
+/// by the caller via [`cleanup`]. A global counter keeps names unique across the
+/// process so parallel `#[test]`s never collide.
+fn temp_under(parent: &Path, tag: &str) -> PathBuf {
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    let mut dir = parent.to_path_buf();
+    dir.push(format!(
+        "snapdir-durability-{tag}-{}-{n}",
+        std::process::id()
+    ));
+    let _ = fs::remove_dir_all(&dir);
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// Unique temp dir under the OS temp root.
+fn temp_dir(tag: &str) -> PathBuf {
+    temp_under(&std::env::temp_dir(), tag)
+}
+
+/// Recursively restore `u+w` so a hardened (`0444`) linked tree / store can be
+/// removed; never chases a symlink during teardown.
+fn restore_writable(root: &Path) {
+    if let Ok(md) = fs::symlink_metadata(root) {
+        if md.file_type().is_symlink() {
+            return;
+        }
+        let mut perms = md.permissions();
+        let mode = perms.mode();
+        perms.set_mode(mode | 0o700);
+        let _ = fs::set_permissions(root, perms);
+        if md.is_dir() {
+            if let Ok(rd) = fs::read_dir(root) {
+                for e in rd.flatten() {
+                    restore_writable(&e.path());
+                }
+            }
+        }
+    }
+}
+
+/// Best-effort recursive cleanup of test scratch dirs (un-hardening first so a
+/// `0444` linked store / dest tears down cleanly).
+fn cleanup(dirs: &[&Path]) {
+    for d in dirs {
+        restore_writable(d);
+        let _ = fs::remove_dir_all(d);
+    }
+}
+
+/// Process-global lock guarding `SNAPDIR_CLONEFILE` + the process-global
+/// `clonefile_hits()` counter. Any test that toggles the knob or compares a
+/// counter delta MUST hold this for its whole body. Mirrors the stores suites.
+fn env_lock() -> MutexGuard<'static, ()> {
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// RAII guard that sets/clears `SNAPDIR_CLONEFILE` and restores the prior value
+/// on drop. The caller must already hold [`env_lock`].
+struct CloneEnv {
+    prev: Option<String>,
+}
+
+impl CloneEnv {
+    fn set(value: Option<&str>) -> Self {
+        let prev = std::env::var("SNAPDIR_CLONEFILE").ok();
+        match value {
+            Some(v) => std::env::set_var("SNAPDIR_CLONEFILE", v),
+            None => std::env::remove_var("SNAPDIR_CLONEFILE"),
+        }
+        Self { prev }
+    }
+}
+
+impl Drop for CloneEnv {
+    fn drop(&mut self) {
+        match &self.prev {
+            Some(v) => std::env::set_var("SNAPDIR_CLONEFILE", v),
+            None => std::env::remove_var("SNAPDIR_CLONEFILE"),
+        }
+    }
+}
+
+// --- CLI harness (assert_cmd) ----------------------------------------------
+
+/// A fresh `snapdir` command with the cache pinned and the dev env scrubbed:
+/// `SNAPDIR_STORE`/`SNAPDIR_OBJECTS_STORE` removed so leakage can't mask a bug,
+/// `HOME`/`XDG_CACHE_HOME` redirected inside the sandbox. Mirrors the sibling
+/// CLI suites exactly.
+fn snapdir(cache: &Path, home: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("snapdir").expect("snapdir binary built");
+    cmd.env("SNAPDIR_CACHE_DIR", cache);
+    cmd.env("HOME", home);
+    cmd.env("XDG_CACHE_HOME", home.join(".cache"));
+    cmd.env_remove("SNAPDIR_STORE");
+    cmd.env_remove("SNAPDIR_OBJECTS_STORE");
+    cmd.env_remove("SNAPDIR_VERIFY_COPIES");
+    cmd.env_remove("SNAPDIR_MANIFEST_CONTEXT");
+    cmd
+}
+
+/// Runs `snapdir <args>`, asserts success, returns trimmed stdout.
+fn ok_stdout(mut cmd: Command, args: &[&str]) -> String {
+    let out = cmd.args(args).output().expect("run snapdir");
+    assert!(
+        out.status.success(),
+        "snapdir {args:?} failed ({:?})\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8(out.stdout).unwrap().trim_end().to_owned()
+}
+
+/// Pushes a directory tree into a fresh `file://` store via the CLI, returning
+/// `(store_url, id)`. Used by the in-place `--delete` / `--linked` legs so the
+/// path under test is the SHIPPED router, not a stores back door.
+fn cli_push(src: &Path, cache: &Path, home: &Path, store: &Path) -> (String, String) {
+    let store_url = format!("file://{}", store.display());
+    let src_str = src.to_string_lossy().into_owned();
+    let id = ok_stdout(
+        snapdir(cache, home),
+        &["push", "--store", &store_url, &src_str],
+    );
+    assert_eq!(id.len(), 64, "push must print a 64-hex id");
+    (store_url, id)
+}
+
+/// Writes one file `rel` with `content` + octal `mode` under `src` (creating
+/// parents). The source dir itself is left at a stable `0755`.
+fn write_file(src: &Path, rel: &str, content: &[u8], mode: u32) {
+    let target = src.join(rel);
+    if let Some(parent) = target.parent() {
+        fs::create_dir_all(parent).unwrap();
+    }
+    fs::write(&target, content).unwrap();
+    fs::set_permissions(&target, fs::Permissions::from_mode(mode)).unwrap();
+}
+
+// --- stores harness (direct API) -------------------------------------------
+
+/// Writes a real source tree under `src` and returns the matching `Manifest`
+/// plus its snapshot id, content-addressed under the NON-keyed `Blake3Hasher`
+/// the file store files objects under. Mirrors the stores suites' `build_tree`.
+fn build_tree(src: &Path, files: &[(&str, &[u8], &str)]) -> (Manifest, String) {
+    let hasher = Blake3Hasher::new();
+    let mut manifest = Manifest::new();
+
+    let mut file_sums: Vec<String> = Vec::new();
+    for (rel, content, mode) in files {
+        let target = src.join(rel);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&target, content).unwrap();
+        let perms = fs::Permissions::from_mode(u32::from_str_radix(mode, 8).unwrap());
+        fs::set_permissions(&target, perms).unwrap();
+        let sum = hasher.hash_hex(content);
+        file_sums.push(sum.clone());
+        manifest.push(ManifestEntry::new(
+            PathType::File,
+            *mode,
+            sum,
+            content.len() as u64,
+            format!("./{rel}"),
+        ));
+    }
+
+    let root_sum = directory_checksum(file_sums.iter().map(String::as_str), &hasher);
+    let root_size: u64 = files.iter().map(|(_, c, _)| c.len() as u64).sum();
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        root_size,
+        "./",
+    ));
+
+    manifest.sort();
+    let id = snapshot_id(&manifest, &hasher);
+    (manifest, id)
+}
+
+/// On-disk sharded path of an object blob under `root`.
+fn object_disk(root: &Path, checksum: &str) -> PathBuf {
+    root.join(object_path(checksum))
+}
+
+/// Counts the regular files under `<root>/.objects`.
+fn count_objects(root: &Path) -> usize {
+    fn walk(dir: &Path, acc: &mut usize) {
+        if let Ok(rd) = fs::read_dir(dir) {
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    walk(&p, acc);
+                } else if p.is_file() {
+                    *acc += 1;
+                }
+            }
+        }
+    }
+    let mut n = 0;
+    walk(&root.join(".objects"), &mut n);
+    n
+}
+
+/// Honors the same env contract `reflink.rs` uses: `SNAPDIR_REFLINK_TEST_DIR`
+/// set ⇒ `Some` (place src + store + dest under it so a clone can fire), unset ⇒
+/// `None`.
+fn reflink_root() -> Option<PathBuf> {
+    match std::env::var("SNAPDIR_REFLINK_TEST_DIR") {
+        Ok(dir) if !dir.is_empty() => {
+            let p = PathBuf::from(dir);
+            p.is_dir().then_some(p)
+        }
+        _ => None,
+    }
+}
+
+/// macOS (APFS) is always clone-capable; Linux only under a reflink root.
+fn reflink_capable() -> bool {
+    cfg!(target_os = "macos") || reflink_root().is_some()
+}
+
+/// The parent under which to co-locate src + store + dest so a clone can fire.
+fn coloc_parent() -> PathBuf {
+    reflink_root().unwrap_or_else(std::env::temp_dir)
+}
+
+// ###########################################################################
+// INVARIANT 1 — HELD-OPEN FD SURVIVES `--delete` REMOVAL (in-place path), ALL
+// MODES. Driven through the SHIPPED CLI (`assert_cmd`), which prunes in place via
+// `snapdir_core::mirror::prune_set` + remove. A process holds a dest file open;
+// a `checkout --delete <OTHER snapshot>` then removes/replaces that path; the
+// still-open fd must keep reading the ORIGINAL bytes (POSIX inode retention).
+// ###########################################################################
+
+/// Builds two single-file snapshots V1/V2 (same dest path `data.bin`, different
+/// content) into one `file://` store and returns
+/// `(store_url, id1, id2, v1, v2, store, cache, home)`. The caller owns the temp
+/// roots and cleans them up.
+#[allow(clippy::type_complexity)]
+fn two_snapshots_one_path(
+    tag: &str,
+) -> (
+    String,
+    String,
+    String,
+    Vec<u8>,
+    Vec<u8>,
+    PathBuf,
+    PathBuf,
+    PathBuf,
+) {
+    let store = temp_dir(&format!("{tag}-store"));
+    let cache = temp_dir(&format!("{tag}-cache"));
+    let home = temp_dir(&format!("{tag}-home"));
+
+    // >64 KiB so the read can be split across the prune (head before, tail after).
+    let v1: Vec<u8> = (0..(96 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    let v2: Vec<u8> = (0..(96 * 1024u32))
+        .map(|i| ((i * 7 + 3) % 251) as u8)
+        .collect();
+    assert_ne!(
+        v1, v2,
+        "V1 and V2 must differ for the test to be meaningful"
+    );
+
+    let src1 = temp_dir(&format!("{tag}-src1"));
+    fs::set_permissions(&src1, fs::Permissions::from_mode(0o755)).unwrap();
+    write_file(&src1, "data.bin", &v1, 0o644);
+    let (store_url, id1) = cli_push(&src1, &cache, &home, &store);
+
+    let src2 = temp_dir(&format!("{tag}-src2"));
+    fs::set_permissions(&src2, fs::Permissions::from_mode(0o755)).unwrap();
+    // A DIFFERENT layout: data.bin replaced + an EXTRA file that --delete-into-V2
+    // would prune nothing of, but the V1->V2 swap replaces data.bin's content.
+    write_file(&src2, "data.bin", &v2, 0o644);
+    let (_u2, id2) = cli_push(&src2, &cache, &home, &store);
+
+    let _ = fs::remove_dir_all(&src1);
+    let _ = fs::remove_dir_all(&src2);
+    (store_url, id1, id2, v1, v2, store, cache, home)
+}
+
+#[test]
+fn held_open_fd_survives_in_place_delete_default_mode_cli() {
+    // INVARIANT 1 (default/reflink-or-copy): a dest file opened before a CLI
+    // `checkout --delete <V2>` keeps reading the ORIGINAL (V1) inode bytes after
+    // V2 is materialized in place over the same path. POSIX: open() binds the fd
+    // to the V1 inode; the in-place replace (prune + re-materialize) unlinks the
+    // old name but the inode survives until the fd closes.
+    let (store_url, id1, id2, v1, v2, store, cache, home) =
+        two_snapshots_one_path("held-delete-default");
+    let dest = temp_dir("held-delete-default-dest");
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    // Lay V1 into the dest (default/Auto materialize) via the shipped CLI.
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["pull", "--store", &store_url, "--id", &id1, &dest_str],
+    );
+    let data_path = dest.join("data.bin");
+    assert_eq!(fs::read(&data_path).unwrap(), v1, "dest must hold V1 first");
+
+    // Open the V1 file and read the FIRST half BEFORE the mutation (binding the
+    // fd to the V1 inode). Auto mode is a real independent inode, so open() lands
+    // directly on it.
+    let mut fd = fs::File::open(&data_path).expect("open dest data.bin before --delete");
+    let mut head = vec![0u8; v1.len() / 2];
+    fd.read_exact(&mut head)
+        .expect("read V1 head before mutate");
+    assert_eq!(
+        head,
+        &v1[..v1.len() / 2],
+        "head read before mutate must be V1"
+    );
+
+    // Now swap V2 into the SAME dest via `pull --delete` (fetch V2 into the cache
+    // then the in-place prune + re-materialize path; `checkout` alone reads only
+    // the local cache and would not have V2's manifest). --delete makes the dest
+    // an exact mirror of V2.
+    ok_stdout(
+        snapdir(&cache, &home),
+        &[
+            "pull", "--store", &store_url, "--id", &id2, "--delete", &dest_str,
+        ],
+    );
+
+    // The PATH now resolves to V2 ...
+    assert_eq!(
+        fs::read(&data_path).expect("read dest path after --delete"),
+        v2,
+        "after checkout --delete the dest PATH must resolve to V2 content"
+    );
+
+    // ... but the still-open fd keeps reading the ORIGINAL (V1) bytes.
+    let mut tail = vec![0u8; v1.len() - v1.len() / 2];
+    fd.read_exact(&mut tail)
+        .expect("the held-open fd must keep reading V1 bytes across the in-place --delete");
+    assert_eq!(
+        tail,
+        &v1[v1.len() / 2..],
+        "KEYSTONE (default/in-place): the fd opened before `checkout --delete` MUST keep \
+         reading the ORIGINAL (V1) inode bytes — long-running processes are never disrupted"
+    );
+
+    cleanup(&[&store, &cache, &home, &dest]);
+}
+
+#[test]
+fn held_open_fd_survives_in_place_delete_linked_mode_cli() {
+    // INVARIANT 1 (--linked/symlink): a dest file opened before a CLI
+    // `checkout --linked --delete <V2>` keeps reading the ORIGINAL (V1) bytes.
+    // The V1 dest entry is a symlink to the V1 0444 object; open() follows it and
+    // binds the fd to the V1 OBJECT inode. The in-place replace re-points the
+    // dest symlink at the V2 object, but the V1 object inode survives behind the
+    // held fd.
+    let (store_url, id1, id2, v1, v2, store, cache, home) =
+        two_snapshots_one_path("held-delete-linked");
+    let dest = temp_dir("held-delete-linked-dest");
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    // Linked pull = fetch (prime the cache with manifest + objects so the symlinks
+    // resolve) + linked checkout.
+    ok_stdout(
+        snapdir(&cache, &home),
+        &[
+            "pull", "--store", &store_url, "--id", &id1, "--linked", &dest_str,
+        ],
+    );
+    let data_path = dest.join("data.bin");
+    assert!(
+        data_path
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "linked V1 dest entry must be a symlink"
+    );
+    assert_eq!(
+        fs::read(&data_path).unwrap(),
+        v1,
+        "linked dest must read V1 first"
+    );
+
+    // Open the V1 link (open() follows the symlink to the V1 object inode) and
+    // read the first half before the mutation.
+    let mut fd = fs::File::open(&data_path).expect("open linked dest before --delete");
+    let mut head = vec![0u8; v1.len() / 2];
+    fd.read_exact(&mut head)
+        .expect("read V1 head before mutate");
+    assert_eq!(
+        head,
+        &v1[..v1.len() / 2],
+        "linked head before mutate must be V1"
+    );
+
+    // Swap V2 in via `pull --linked --delete` (fetch V2 into the cache, then
+    // re-point the dest symlink at the V2 object; `checkout` alone reads only the
+    // local cache and would not have V2's manifest).
+    ok_stdout(
+        snapdir(&cache, &home),
+        &[
+            "pull", "--store", &store_url, "--id", &id2, "--linked", "--delete", &dest_str,
+        ],
+    );
+
+    // The PATH now resolves to the V2 object ...
+    assert!(
+        data_path
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "after the linked --delete the dest entry must still be a symlink"
+    );
+    assert_eq!(
+        fs::read(&data_path).expect("read linked dest path after --delete"),
+        v2,
+        "after checkout --linked --delete the dest PATH must resolve to V2 content"
+    );
+
+    // ... but the still-open fd keeps reading the ORIGINAL (V1) object bytes.
+    let mut tail = vec![0u8; v1.len() - v1.len() / 2];
+    fd.read_exact(&mut tail)
+        .expect("the held-open fd must keep reading V1 object bytes across the linked --delete");
+    assert_eq!(
+        tail,
+        &v1[v1.len() / 2..],
+        "KEYSTONE (linked/in-place): the fd opened before `checkout --linked --delete` MUST keep \
+         reading the ORIGINAL (V1) OBJECT inode bytes even as the dest symlink is re-pointed at V2"
+    );
+
+    cleanup(&[&store, &cache, &home, &dest]);
+}
+
+// ###########################################################################
+// INVARIANT 2 — HELD-OPEN FD SURVIVES THE ATOMIC STAGED SWAP, ALL ZERO-COPY
+// MODES. The atomic swap is the stores primitive `fetch_files_atomic` (the CLI
+// does not route through it yet); we call it directly. Open a dest file, swap a
+// DIFFERENT snapshot into the same dest; the held fd reads ORIGINAL bytes, a
+// fresh open reads NEW content. Linked runs on ANY FS; Auto is gated on CoW.
+// ###########################################################################
+
+/// Builds V1/V2 single-file snapshots (path `data.bin`, differing content) into
+/// ONE `FileStore` under `parent`, returning `(store, store_dir, m1, v1, m2, v2)`.
+#[allow(clippy::type_complexity)]
+fn store_two_snapshots(
+    parent: &Path,
+    tag: &str,
+    len: usize,
+) -> (FileStore, PathBuf, Manifest, Vec<u8>, Manifest, Vec<u8>) {
+    let v1: Vec<u8> = (0..len as u32).map(|i| (i % 251) as u8).collect();
+    let v2: Vec<u8> = (0..len as u32)
+        .map(|i| ((i * 11 + 5) % 251) as u8)
+        .collect();
+    assert_ne!(v1, v2);
+
+    let store_dir = temp_under(parent, &format!("{tag}-store"));
+    let store = FileStore::from_root(store_dir.clone());
+
+    let src1 = temp_under(parent, &format!("{tag}-src1"));
+    let (m1, _i1) = build_tree(&src1, &[("data.bin", v1.as_slice(), "644")]);
+    store.push(&m1, &src1).expect("push v1");
+
+    let src2 = temp_under(parent, &format!("{tag}-src2"));
+    let (m2, _i2) = build_tree(&src2, &[("data.bin", v2.as_slice(), "644")]);
+    store.push(&m2, &src2).expect("push v2");
+
+    let _ = fs::remove_dir_all(&src1);
+    let _ = fs::remove_dir_all(&src2);
+    (store, store_dir, m1, v1, m2, v2)
+}
+
+#[test]
+fn held_open_fd_survives_atomic_swap_linked_mode() {
+    // INVARIANT 2 (atomic swap, Linked): an fd opened on a dest file BEFORE
+    // `fetch_files_atomic(.., Linked)` swaps a DIFFERENT snapshot into the same
+    // dest keeps reading the ORIGINAL bytes (the old tree is renamed aside; the
+    // object inode survives). Linked is zero-copy on any FS, so this runs
+    // unconditionally.
+    let parent = coloc_parent();
+    let (store, store_dir, m1, v1, m2, v2) =
+        store_two_snapshots(&parent, "atomic-linked", 80 * 1024);
+    let dest = temp_under(&parent, "atomic-linked-dest");
+
+    store
+        .fetch_files_atomic(&m1, &dest, MaterializeMode::Linked)
+        .expect("initial atomic swap (V1, Linked) must succeed");
+    let data_path = dest.join("data.bin");
+
+    // Open V1 + read the first half before the swap (open() follows the link to
+    // the V1 object inode).
+    let mut fd = fs::File::open(&data_path).expect("open dest before swap");
+    let mut head = vec![0u8; v1.len() / 2];
+    fd.read_exact(&mut head).expect("read V1 head before swap");
+    assert_eq!(head, &v1[..v1.len() / 2]);
+
+    store
+        .fetch_files_atomic(&m2, &dest, MaterializeMode::Linked)
+        .expect("atomic swap (V2, Linked) over the held-open dest must succeed");
+
+    // A FRESH open of the path resolves to V2 ...
+    assert_eq!(
+        fs::read(&data_path).expect("fresh read after swap"),
+        v2,
+        "after the atomic swap a fresh open of the dest PATH must resolve to V2 content"
+    );
+    // ... the held fd keeps reading the ORIGINAL (V1) object bytes.
+    let mut tail = vec![0u8; v1.len() - v1.len() / 2];
+    fd.read_exact(&mut tail)
+        .expect("the held-open fd must keep reading V1 bytes across the Linked atomic swap");
+    assert_eq!(
+        tail,
+        &v1[v1.len() / 2..],
+        "KEYSTONE (atomic/Linked): the fd opened before the atomic swap MUST keep reading the \
+         ORIGINAL (V1) object inode bytes across the swap"
+    );
+
+    cleanup(&[&store_dir, &dest]);
+}
+
+#[test]
+fn held_open_fd_survives_atomic_swap_auto_cow() {
+    // INVARIANT 2 (atomic swap, Auto/reflink): same held-fd durability on the
+    // editable Auto (reflink) path. GATED on a clone-capable host — Auto atomic
+    // on a non-CoW target is a hard error (zero-copy-only), so the swap could not
+    // run there anyway.
+    if !reflink_capable() {
+        eprintln!(
+            "SKIP held_open_fd_survives_atomic_swap_auto_cow: no clone-capable FS \
+             (Auto atomic requires zero-copy/CoW; set SNAPDIR_REFLINK_TEST_DIR on Linux)"
+        );
+        return;
+    }
+
+    let parent = coloc_parent();
+
+    let _g = env_lock();
+    let _e = CloneEnv::set(None); // reflink enabled where supported
+
+    let (store, store_dir, m1, v1, m2, v2) = store_two_snapshots(&parent, "atomic-auto", 80 * 1024);
+    let dest = temp_under(&parent, "atomic-auto-dest");
+
+    store
+        .fetch_files_atomic(&m1, &dest, MaterializeMode::Auto)
+        .expect("initial atomic swap (V1, Auto) must succeed on a CoW host");
+    let data_path = dest.join("data.bin");
+    // Auto entries are real independent inodes (not symlinks).
+    assert!(
+        data_path.symlink_metadata().unwrap().file_type().is_file(),
+        "atomic Auto dest entry must be a regular file (editable), not a symlink"
+    );
+
+    let mut fd = fs::File::open(&data_path).expect("open dest before swap");
+    let mut head = vec![0u8; v1.len() / 2];
+    fd.read_exact(&mut head).expect("read V1 head before swap");
+    assert_eq!(head, &v1[..v1.len() / 2]);
+
+    store
+        .fetch_files_atomic(&m2, &dest, MaterializeMode::Auto)
+        .expect("atomic swap (V2, Auto) over the held-open dest must succeed");
+
+    assert_eq!(
+        fs::read(&data_path).expect("fresh read after swap"),
+        v2,
+        "after the Auto atomic swap a fresh open must resolve to V2 content"
+    );
+    let mut tail = vec![0u8; v1.len() - v1.len() / 2];
+    fd.read_exact(&mut tail)
+        .expect("the held-open fd must keep reading V1 bytes across the Auto atomic swap");
+    assert_eq!(
+        tail,
+        &v1[v1.len() / 2..],
+        "KEYSTONE (atomic/Auto): the fd opened before the atomic swap MUST keep reading the \
+         ORIGINAL (V1) inode bytes across the reflink swap"
+    );
+
+    cleanup(&[&store_dir, &dest]);
+}
+
+// ###########################################################################
+// INVARIANT 3 — SYMLINK-MODE WRITE IS BLOCKED (no shared-store corruption).
+// A `--linked` dest file is a symlink to a `0444` store object; writing THROUGH
+// it fails (PermissionDenied), and the store object stays byte-identical AND
+// still BLAKE3-verifies. Driven through the shipped `pull --linked` CLI.
+// ###########################################################################
+
+#[test]
+fn linked_write_through_is_blocked_and_object_stays_intact_and_verifies_cli() {
+    // INVARIANT 3: a `pull --linked` dest entry is a symlink to a 0444 store
+    // object. Writing THROUGH the link must FAIL with PermissionDenied, and the
+    // underlying store object's bytes must stay byte-identical and still verify
+    // (no shared-store corruption through the link).
+    let content = b"shared-object-must-not-be-corruptible-through-the-link\n".to_vec();
+
+    let store = temp_dir("linkwrite-store");
+    let cache = temp_dir("linkwrite-cache");
+    let home = temp_dir("linkwrite-home");
+    let dest = temp_dir("linkwrite-dest");
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    let src = temp_dir("linkwrite-src");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o755)).unwrap();
+    write_file(&src, "doc.txt", &content, 0o644);
+    let (store_url, id) = cli_push(&src, &cache, &home, &store);
+
+    // Linked pull: prime the cache (manifest + objects) so the symlinks resolve.
+    ok_stdout(
+        snapdir(&cache, &home),
+        &[
+            "pull", "--store", &store_url, "--id", &id, "--linked", &dest_str,
+        ],
+    );
+
+    let link = dest.join("doc.txt");
+    assert!(
+        link.symlink_metadata().unwrap().file_type().is_symlink(),
+        "linked dest entry must be a symlink for the write-through to target the object"
+    );
+
+    // The object the link resolves to is read-only 0444.
+    let target = fs::canonicalize(&link).expect("resolve linked target");
+    let target_mode = fs::metadata(&target).unwrap().permissions().mode() & 0o777;
+    assert_eq!(
+        target_mode, 0o444,
+        "the shared linked object must be read-only 0444 (got {target_mode:o})"
+    );
+
+    // Writing THROUGH the link must FAIL with PermissionDenied (the 0444 object).
+    let write_res = fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(&link)
+        .and_then(|mut f| {
+            use std::io::Write as _;
+            f.write_all(b"CORRUPTION")
+        });
+    assert!(
+        write_res.is_err(),
+        "writing through a linked (0444) dest file MUST fail — the store object must not be \
+         corruptible through the link; got Ok(())"
+    );
+    assert_eq!(
+        write_res.unwrap_err().kind(),
+        std::io::ErrorKind::PermissionDenied,
+        "the write-through failure must be a permission error (0444 object)"
+    );
+
+    // The shared object's bytes are UNCHANGED after the blocked write ...
+    assert_eq!(
+        fs::read(&target).expect("object still readable"),
+        content,
+        "the store object bytes must be byte-identical after the blocked write-through"
+    );
+    // ... and it still BLAKE3-verifies through the store's read-time backstop.
+    let sum = Blake3Hasher::new().hash_hex(&content);
+    let store_obj = FileStore::from_root(store.clone());
+    assert_eq!(
+        store_obj
+            .get_object(&sum)
+            .expect("object verifies via get_object"),
+        content,
+        "the store object must still BLAKE3-verify (get_object) after the blocked write-through"
+    );
+
+    cleanup(&[&store, &cache, &home, &dest, &src]);
+}
+
+// ###########################################################################
+// INVARIANT 4 — REFLINK-MODE WRITE LEAVES THE SOURCE OBJECT BYTE-IDENTICAL (CoW
+// independence). In default mode, editing a materialized dest file does NOT
+// change the source store/cache object (the write breaks CoW). The reflink-fired
+// assertion is gated on CoW capability; the no-corruption invariant is asserted
+// on EVERY host. Driven through the shipped `pull` (default/Auto) CLI.
+// ###########################################################################
+
+#[test]
+fn default_mode_dest_edit_leaves_source_object_byte_identical_cli() {
+    // INVARIANT 4: a default-mode (Auto) `pull` materializes an INDEPENDENT,
+    // EDITABLE dest inode (reflink-on-CoW else copy). Editing it (a CoW break on a
+    // reflink FS) must leave BOTH the store object AND the primed cache object
+    // byte-identical — no shared-object corruption. A >256 KiB payload so a
+    // reflink shares real extents and a CoW-break bug would surface.
+    let content: Vec<u8> = (0..(300 * 1024u32)).map(|i| (i % 251) as u8).collect();
+
+    // Co-locate store/cache/dest so a clone can actually fire where supported.
+    let parent = coloc_parent();
+    let store = temp_under(&parent, "cowedit-store");
+    let cache = temp_under(&parent, "cowedit-cache");
+    let home = temp_under(&parent, "cowedit-home");
+    let dest = temp_under(&parent, "cowedit-dest");
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    let src = temp_under(&parent, "cowedit-src");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o755)).unwrap();
+    write_file(&src, "editable.bin", &content, 0o644);
+
+    let _g = env_lock();
+    let _e = CloneEnv::set(None); // reflink enabled where supported
+
+    let (store_url, id) = cli_push(&src, &cache, &home, &store);
+
+    // Default-mode pull (no --linked): the dest file is a real editable inode
+    // (a reflink clone on a CoW host, else a plain copy — INVARIANT 5a proves the
+    // reflink path itself fires via the stores primitive; here we pin the
+    // no-corruption invariant which holds on either path).
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["pull", "--store", &store_url, "--id", &id, &dest_str],
+    );
+
+    let dest_file = dest.join("editable.bin");
+    let dmeta = dest_file.symlink_metadata().expect("dest file metadata");
+    assert!(
+        dmeta.file_type().is_file(),
+        "default-mode dest entry must be a regular editable file, never a symlink"
+    );
+
+    let sum = Blake3Hasher::new().hash_hex(&content);
+    let store_object = object_disk(&store, &sum);
+    // The dest file is an INDEPENDENT inode from the store object.
+    let ometa = store_object
+        .symlink_metadata()
+        .expect("store object metadata");
+    assert_ne!(
+        (dmeta.dev(), dmeta.ino()),
+        (ometa.dev(), ometa.ino()),
+        "default-mode dest file must be an INDEPENDENT inode, not the store object itself"
+    );
+
+    // EDIT the dest file (a CoW break on a reflink FS): writing must SUCCEED
+    // (it is the editable mode, manifest 0644).
+    let mut edited = content.clone();
+    edited[0] ^= 0xff;
+    edited[content.len() / 2] ^= 0xff;
+    edited[content.len() - 1] ^= 0xff;
+    fs::write(&dest_file, &edited).expect("default-mode dest file must be editable/writable");
+
+    // KEYSTONE: the SOURCE store object's bytes are UNCHANGED after the edit ...
+    assert_eq!(
+        fs::read(&store_object).expect("store object still readable"),
+        content,
+        "editing the reflinked/copied dest file must NOT change the source STORE object bytes \
+         (CoW break / independent inode)"
+    );
+    let store_handle = FileStore::from_root(store.clone());
+    assert_eq!(
+        store_handle
+            .get_object(&sum)
+            .expect("store object verifies"),
+        content,
+        "the store object must still BLAKE3-verify after the dest file was edited"
+    );
+
+    // ... and the CACHE object the pull primed is ALSO byte-identical (the cache
+    // is the other shared content-addressed pool a CoW break could corrupt).
+    let cache_object = object_disk(&cache, &sum);
+    if cache_object.exists() {
+        assert_eq!(
+            fs::read(&cache_object).expect("cache object readable"),
+            content,
+            "editing the dest file must NOT change the primed CACHE object bytes either"
+        );
+    }
+
+    // The edit actually landed on the independent dest inode.
+    assert_eq!(
+        fs::read(&dest_file).expect("read edited dest"),
+        edited,
+        "the edit must have landed on the independent dest inode"
+    );
+
+    cleanup(&[&store, &cache, &home, &dest, &src]);
+}
+
+// ###########################################################################
+// INVARIANT 5 — ZERO EXTRA BYTE COPIES on the zero-copy paths.
+//   (5a) reflink (CoW): `clonefile_hits()` advances — no file bytes duplicated.
+//   (5b) symlink (--linked): dest entries are LINKS, not copies, and no object is
+//        duplicated into the store/cache pool.
+// 5a is gated on a clone-capable host; 5b runs on any FS.
+// ###########################################################################
+
+#[test]
+fn reflink_materialize_copies_zero_bytes_clonefile_hits_advances() {
+    // INVARIANT 5a: on a CoW host a default-mode atomic materialize REFLINKS the
+    // staged files (CopyMethod::Cloned) — clonefile_hits() must advance, proving
+    // ZERO bytes of the >256 KiB object were duplicated. GATED on a clone-capable
+    // host (on a copy-only host there is no clone to count). Uses the stores
+    // primitive directly so the counter delta is attributable to this swap alone
+    // (under env_lock).
+    if !reflink_capable() {
+        eprintln!(
+            "SKIP reflink_materialize_copies_zero_bytes_clonefile_hits_advances: \
+             no clone-capable FS (set SNAPDIR_REFLINK_TEST_DIR on Linux)"
+        );
+        return;
+    }
+
+    let big: Vec<u8> = (0..(300 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    let parent = coloc_parent();
+
+    let _g = env_lock();
+    let _e = CloneEnv::set(None);
+
+    let store_dir = temp_under(&parent, "zerocopy-reflink-store");
+    let store = FileStore::from_root(store_dir.clone());
+    let src = temp_under(&parent, "zerocopy-reflink-src");
+    let (manifest, _id) = build_tree(&src, &[("big.bin", big.as_slice(), "644")]);
+    store.push(&manifest, &src).expect("push big object");
+
+    let dest = temp_under(&parent, "zerocopy-reflink-dest");
+    let before = clonefile_hits();
+    store
+        .fetch_files_atomic(&manifest, &dest, MaterializeMode::Auto)
+        .expect("Auto atomic materialize on a CoW host must succeed");
+    let after = clonefile_hits();
+
+    assert!(
+        after > before,
+        "INVARIANT 5a: reflink materialization must clone (CopyMethod::Cloned), copying ZERO \
+         file bytes — clonefile_hits() must advance: {before} -> {after}"
+    );
+    // The materialized dest entry is a real (independent) file holding the bytes.
+    assert_eq!(
+        fs::read(dest.join("big.bin")).expect("read materialized big.bin"),
+        big,
+        "the reflinked dest file must hold the source content"
+    );
+    // No object was duplicated into the store pool by the clone.
+    assert_eq!(
+        count_objects(&store_dir),
+        1,
+        "a reflink materialize must not duplicate objects into the store"
+    );
+
+    cleanup(&[&store_dir, &dest, &src]);
+}
+
+#[test]
+fn linked_materialize_is_symlinks_not_copies_zero_byte_duplication_cli() {
+    // INVARIANT 5b: a `pull --linked` materializes SYMLINKS (links, not byte
+    // copies) into the local objects, on ANY filesystem. Every file entry is a
+    // symlink resolving to the shared object, and NO object is duplicated into
+    // the store or the primed cache (zero-copy). Driven through the shipped CLI.
+    let store = temp_dir("zerocopy-linked-store");
+    let cache = temp_dir("zerocopy-linked-cache");
+    let home = temp_dir("zerocopy-linked-home");
+    let dest = temp_dir("zerocopy-linked-dest");
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    // A mixed tree: a >256 KiB object, a tiny file, a 0-byte file, a nested path.
+    let big: Vec<u8> = (0..(300 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    let files: Vec<(&str, Vec<u8>, u32)> = vec![
+        ("big.bin", big, 0o644),
+        ("tiny.txt", b"hello\n".to_vec(), 0o644),
+        ("empty", Vec::new(), 0o644),
+        (
+            "nested/deep/leaf.bin",
+            vec![0u8, 1, 2, 3, 255, 254, 0],
+            0o600,
+        ),
+    ];
+
+    let src = temp_dir("zerocopy-linked-src");
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o755)).unwrap();
+    for (rel, content, mode) in &files {
+        write_file(&src, rel, content, *mode);
+    }
+    let (store_url, id) = cli_push(&src, &cache, &home, &store);
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &[
+            "pull", "--store", &store_url, "--id", &id, "--linked", &dest_str,
+        ],
+    );
+
+    let hasher = Blake3Hasher::new();
+    let mut distinct: HashSet<String> = HashSet::new();
+    for (rel, content, _mode) in &files {
+        let link = dest.join(rel);
+        assert!(
+            link.symlink_metadata().unwrap().file_type().is_symlink(),
+            "INVARIANT 5b: linked dest entry {rel} MUST be a symlink (zero-copy), not a fresh copy"
+        );
+        assert_eq!(
+            &fs::read(&link).unwrap(),
+            content,
+            "reading through the linked entry {rel} must return the source content"
+        );
+        distinct.insert(hasher.hash_hex(content));
+    }
+
+    // ZERO byte duplication: the store pool holds exactly the distinct objects —
+    // the links carry no object bytes of their own.
+    assert_eq!(
+        count_objects(&store),
+        distinct.len(),
+        "INVARIANT 5b: linked materialization is zero-copy — it must NOT duplicate objects into \
+         the store ({} distinct expected)",
+        distinct.len()
+    );
+    // The primed cache pool likewise holds at most the distinct objects (no
+    // per-link byte copy leaked into the cache).
+    assert!(
+        count_objects(&cache) <= distinct.len(),
+        "INVARIANT 5b: a linked pull must not duplicate object bytes into the cache pool either \
+         (cache objects {} must be <= distinct {})",
+        count_objects(&cache),
+        distinct.len()
+    );
+
+    cleanup(&[&store, &cache, &home, &dest, &src]);
+}

--- a/crates/snapdir-cli/tests/mirror_linked_fastpath.rs
+++ b/crates/snapdir-cli/tests/mirror_linked_fastpath.rs
@@ -1,0 +1,903 @@
+//! ADVERSARY black-box spec suite (`assert_cmd`) for the **linked-mode
+//! checksum-reuse fast path** (Phase 32, gate `mirror-linked-fastpath-spec-tests`).
+//!
+//! AUTHORED FROM SPEC ONLY. The fast path does NOT exist yet — no implementation
+//! was read (none exists). Authored from the locked design
+//! (`.gatesmith/reviews/mirror-linked-fastpath.md`) + the SPEC + the EXISTING
+//! public CLI surface (the `--linked` checkout wiring already landed). These
+//! tests are EXPECTED TO FAIL until the fast path lands; they pin the contract
+//! and must NOT be weakened to go green.
+//!
+//! ## The fast path, restated
+//! In `--linked` mode a checkout's dest entries are SYMLINKS into a local
+//! `file://` store's content-addressed `.objects/<sharded>` pool, whose path
+//! mechanically encodes the file's BLAKE3. A re-snapshot (`snapdir id` /
+//! `manifest`) of a linked tree can RECOVER each file's checksum directly from
+//! the symlink target's object path — WITHOUT reading or hashing the content.
+//!
+//! Eligibility (ALL): entry is a symlink whose canonical target is an object in
+//! a KNOWN local store, AND plain non-keyed BLAKE3, AND not
+//! `SNAPDIR_VERIFY_COPIES=1`. Fallbacks: wrong/keyed algo, escaped/non-object
+//! target, strict-verify → re-hash; dangling → typed error (no panic).
+//!
+//! CHECKSUM-ONLY: the recovered value is the content CHECKSUM only; the walk
+//! still records the symlink's OWN lstat mode+size, so a linked re-snapshot does
+//! NOT reproduce the original source snapshot id. These tests therefore NEVER
+//! assert `id <linked-tree> == source-snapshot-id`.
+//!
+//! ## Assumed/observed CLI surface (see handoff)
+//! - **Keystone toggle:** default `snapdir id <linked-tree>` = recover-from-path
+//!   (fast path); `SNAPDIR_VERIFY_COPIES=1 snapdir id <linked-tree>` = force a
+//!   content re-hash. On a healthy store the two outputs are byte-identical.
+//! - **No-read proof:** corrupt an object's BYTES while keeping its FILENAME (=
+//!   its original address). Default `id` still emits the original checksum (read
+//!   the path, not the garbage); `SNAPDIR_VERIFY_COPIES=1 id` READS the garbage,
+//!   detects content != address, and ERRORS (non-zero, names the object/file).
+//! - **Wrong/keyed algo:** `snapdir id` does NOT expose `--checksum-bin` (only
+//!   `snapdir manifest` does). So the non-BLAKE3 case uses `snapdir manifest
+//!   --checksum-bin md5sum <linked-tree>` (must re-hash → reads the garbage →
+//!   ERRORS), and the keyed case uses `SNAPDIR_MANIFEST_CONTEXT=<key> snapdir id
+//!   <linked-tree>` (keyed BLAKE3 != the store's plain-BLAKE3 address → must
+//!   re-hash → reads the garbage → ERRORS). Flagged in the handoff.
+//! - A linked tree is built by `push`ing a small tree to a local `file://` store
+//!   then `pull --store <file://> --id <id> --linked <dest>`.
+//!
+//! ## Garbage injection vs 0444
+//! Linked objects are `0444` (read-only). To overwrite an object's bytes while
+//! keeping its filename, the test chmods the object writable (scoped to the
+//! tempdir store's `.objects/` ONLY), truncates+writes garbage, restores nothing
+//! (the tempdir is discarded). All injection is on the per-test tempdir store.
+
+use std::fs;
+use std::os::unix::fs::{symlink, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+
+/// Unique temp dir under the OS temp root, removed by the caller on drop.
+fn temp_dir(tag: &str) -> PathBuf {
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "snapdir-linkfast-{tag}-{}-{:?}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// A fresh `snapdir` command with the cache pinned and the developer's env
+/// scrubbed so leakage can't mask a bug: `SNAPDIR_STORE`/`SNAPDIR_OBJECTS_STORE`
+/// removed, `SNAPDIR_VERIFY_COPIES`/`SNAPDIR_MANIFEST_CONTEXT` removed (each test
+/// re-adds them explicitly when exercising those knobs), and `HOME`/
+/// `XDG_CACHE_HOME` redirected inside the sandbox.
+fn snapdir(cache: &Path, home: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("snapdir").expect("snapdir binary built");
+    cmd.env("SNAPDIR_CACHE_DIR", cache);
+    cmd.env("HOME", home);
+    cmd.env("XDG_CACHE_HOME", home.join(".cache"));
+    cmd.env_remove("SNAPDIR_STORE");
+    cmd.env_remove("SNAPDIR_OBJECTS_STORE");
+    cmd.env_remove("SNAPDIR_VERIFY_COPIES");
+    cmd.env_remove("SNAPDIR_MANIFEST_CONTEXT");
+    cmd
+}
+
+/// Runs `snapdir <args>`, asserts success, returns trimmed stdout.
+fn ok_stdout(mut cmd: Command, args: &[&str]) -> String {
+    let out = cmd.args(args).output().expect("run snapdir");
+    assert!(
+        out.status.success(),
+        "snapdir {args:?} failed ({:?})\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8(out.stdout).unwrap().trim_end().to_owned()
+}
+
+/// Build a tiny deterministic source tree (stable perms) and return it.
+fn build_src(tag: &str) -> PathBuf {
+    let src = temp_dir(tag);
+    fs::write(src.join("a.txt"), b"hello").unwrap();
+    fs::set_permissions(src.join("a.txt"), fs::Permissions::from_mode(0o644)).unwrap();
+    fs::create_dir(src.join("sub")).unwrap();
+    fs::set_permissions(src.join("sub"), fs::Permissions::from_mode(0o755)).unwrap();
+    fs::write(src.join("sub").join("b.txt"), b"world!!").unwrap();
+    fs::set_permissions(
+        src.join("sub").join("b.txt"),
+        fs::Permissions::from_mode(0o644),
+    )
+    .unwrap();
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o755)).unwrap();
+    src
+}
+
+/// Push `src` into a fresh `file://` store and return `(store_url, id)`.
+fn push_to_store(src: &Path, cache: &Path, home: &Path, store: &Path) -> (String, String) {
+    let store_url = format!("file://{}", store.display());
+    let src_str = src.to_string_lossy().into_owned();
+    let id = ok_stdout(
+        snapdir(cache, home),
+        &["push", "--store", &store_url, &src_str],
+    );
+    assert_eq!(id.len(), 64, "push must print a 64-hex id");
+    (store_url, id)
+}
+
+/// Push `src` then `pull --linked` it into a fresh `dest`, returning
+/// `(store_url, id, dest)`. The dest entries become symlinks into the store's
+/// `.objects/` pool — the precondition for the fast path.
+fn build_linked_tree(
+    tag: &str,
+    src: &Path,
+    cache: &Path,
+    home: &Path,
+    store: &Path,
+) -> (String, String, PathBuf) {
+    let (store_url, id) = push_to_store(src, cache, home, store);
+    let dest = temp_dir(&format!("{tag}-dest"));
+    let dest_str = dest.to_string_lossy().into_owned();
+    ok_stdout(
+        snapdir(cache, home),
+        &[
+            "pull", "--store", &store_url, "--id", &id, "--linked", &dest_str,
+        ],
+    );
+    // Sanity: the dest really is a linked tree (symlinks), else the rest of the
+    // suite would not be exercising the fast path at all.
+    assert!(
+        dest.join("a.txt")
+            .symlink_metadata()
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "precondition: --linked checkout must materialize symlinks (got a non-symlink a.txt)"
+    );
+    (store_url, id, dest)
+}
+
+/// Overwrite the BYTES of a content object while KEEPING its filename (= its
+/// original BLAKE3 address). Resolves the symlink at `dest/<rel>` to its target
+/// object in the tempdir store, chmods it writable (scoped to this tempdir
+/// store), truncates, and writes `garbage`. Returns the object's on-disk path.
+fn corrupt_object_keep_name(dest: &Path, rel: &str, garbage: &[u8]) -> PathBuf {
+    let link = dest.join(rel);
+    let target = fs::canonicalize(&link).expect("resolve linked object target");
+    // Objects are 0444; relax just this object so we can rewrite its bytes.
+    fs::set_permissions(&target, fs::Permissions::from_mode(0o644))
+        .expect("relax object perms in tempdir store");
+    fs::write(&target, garbage).expect("inject garbage into the object (filename preserved)");
+    target
+}
+
+/// Best-effort recursive cleanup of test scratch dirs.
+fn cleanup(dirs: &[&Path]) {
+    for d in dirs {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+/// REVIEW helper: asserts `manifest_text` is a well-formed snapdir manifest whose
+/// FILE rows (`F`) carry a checksum of exactly `checksum_hex_len` lowercase-hex
+/// chars. Every non-empty, non-comment line must be `<F|D> <perms> <checksum>
+/// <size> <path>` (5 whitespace columns; paths may contain spaces, so the path
+/// column is the remainder). Used to prove the md5 re-hash produced a real,
+/// structurally-valid md5 manifest — not a stale/garbage echo of the fast path.
+fn is_well_formed_file_manifest(manifest_text: &str, checksum_hex_len: usize) -> bool {
+    let mut saw_file = false;
+    for line in manifest_text.lines() {
+        if line.is_empty() || line.starts_with('#') {
+            continue;
+        }
+        let cols: Vec<&str> = line.splitn(5, ' ').collect();
+        if cols.len() != 5 {
+            return false;
+        }
+        let (ty, _perms, checksum, size, _path) = (cols[0], cols[1], cols[2], cols[3], cols[4]);
+        if ty != "F" && ty != "D" {
+            return false;
+        }
+        if size.parse::<u64>().is_err() {
+            return false;
+        }
+        if ty == "F" {
+            saw_file = true;
+            let is_hex = checksum.len() == checksum_hex_len
+                && checksum
+                    .bytes()
+                    .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b));
+            if !is_hex {
+                return false;
+            }
+        }
+    }
+    saw_file
+}
+
+/// REVIEW helper: returns the md5 hex of `content` as computed by snapdir ITSELF
+/// (the frozen `--checksum-bin md5sum` oracle) over a throwaway one-file real
+/// tree. Keeps the test free of any md5 implementation / dependency of its own
+/// while still pinning that the corrupted bytes were actually read. The single
+/// FILE row's checksum column is the md5 of `content`.
+fn md5_of_bytes_via_snapdir(cache: &Path, home: &Path, tag: &str, content: &[u8]) -> String {
+    let dir = temp_dir(tag);
+    fs::write(dir.join("only.bin"), content).unwrap();
+    fs::set_permissions(dir.join("only.bin"), fs::Permissions::from_mode(0o644)).unwrap();
+    let dir_str = dir.to_string_lossy().into_owned();
+    let manifest = ok_stdout(
+        snapdir(cache, home),
+        &["manifest", "--checksum-bin", "md5sum", &dir_str],
+    );
+    let md5 = manifest
+        .lines()
+        .find(|l| l.starts_with("F "))
+        .and_then(|l| l.split(' ').nth(2))
+        .expect("md5 manifest must have a FILE row with a checksum")
+        .to_owned();
+    assert_eq!(md5.len(), 32, "md5sum checksum column must be 32-hex");
+    cleanup(&[&dir]);
+    md5
+}
+
+// ===========================================================================
+// KEYSTONE — default fast path == strict re-hash path on a HEALTHY store.
+// ===========================================================================
+
+/// SPEC (KEYSTONE): on a healthy store, default `snapdir id <linked-tree>` (fast
+/// path, recover-from-path) is BYTE-IDENTICAL to `SNAPDIR_VERIFY_COPIES=1 snapdir
+/// id <linked-tree>` (forced content re-hash). The recovered checksum equals the
+/// hashed checksum, so the two manifests/ids match exactly.
+#[test]
+fn keystone_default_id_equals_strict_verify_id_on_healthy_store() {
+    let src = build_src("keystone-src");
+    let store = temp_dir("keystone-store");
+    let cache = temp_dir("keystone-cache");
+    let home = temp_dir("keystone-home");
+    let (_url, _id, dest) = build_linked_tree("keystone", &src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    // Default (recover-from-object-path fast path).
+    let fast = ok_stdout(snapdir(&cache, &home), &["id", &dest_str]);
+
+    // Strict (force a content re-hash through every symlink).
+    let mut strict_cmd = snapdir(&cache, &home);
+    strict_cmd.env("SNAPDIR_VERIFY_COPIES", "1");
+    let strict = ok_stdout(strict_cmd, &["id", &dest_str]);
+
+    assert_eq!(
+        fast, strict,
+        "KEYSTONE: the fast path's id must be byte-identical to the strict re-hash \
+         id on a healthy store"
+    );
+    assert_eq!(fast.len(), 64, "id must be a 64-hex snapshot id");
+
+    cleanup(&[&src, &store, &cache, &home, &dest]);
+}
+
+/// SPEC (KEYSTONE, manifest-level): not just the id but the full MANIFEST is
+/// identical between the default fast path and the strict re-hash, since the
+/// recovered checksum must equal the hashed checksum for EVERY eligible entry.
+#[test]
+fn keystone_default_manifest_equals_strict_verify_manifest() {
+    let src = build_src("keymani-src");
+    let store = temp_dir("keymani-store");
+    let cache = temp_dir("keymani-cache");
+    let home = temp_dir("keymani-home");
+    let (_url, _id, dest) = build_linked_tree("keymani", &src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    let fast = ok_stdout(snapdir(&cache, &home), &["manifest", &dest_str]);
+
+    let mut strict_cmd = snapdir(&cache, &home);
+    strict_cmd.env("SNAPDIR_VERIFY_COPIES", "1");
+    let strict = ok_stdout(strict_cmd, &["manifest", &dest_str]);
+
+    assert_eq!(
+        fast, strict,
+        "the fast-path manifest must be byte-identical to the strict re-hash manifest"
+    );
+
+    cleanup(&[&src, &store, &cache, &home, &dest]);
+}
+
+// ===========================================================================
+// PROVE NO CONTENT READ — corrupt object bytes, keep filename (= address).
+// ===========================================================================
+
+/// SPEC (no-read proof): after a linked checkout, OVERWRITE an object's bytes
+/// with garbage while KEEPING its filename (its original hash). Default `snapdir
+/// id <linked-tree>` STILL emits the ORIGINAL checksum (it read the path, not the
+/// garbage) — its id is unchanged from the pre-corruption id.
+#[test]
+fn default_id_unchanged_after_object_bytes_corrupted_keeping_name() {
+    let src = build_src("noread-src");
+    let store = temp_dir("noread-store");
+    let cache = temp_dir("noread-cache");
+    let home = temp_dir("noread-home");
+    let (_url, _id, dest) = build_linked_tree("noread", &src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    // The id BEFORE corruption (fast path, healthy store).
+    let before = ok_stdout(snapdir(&cache, &home), &["id", &dest_str]);
+
+    // Corrupt a.txt's object bytes but keep its filename (= its BLAKE3 address).
+    corrupt_object_keep_name(&dest, "a.txt", b"GARBAGE-NOT-HELLO-XXXXXXXXXXXXXXXX");
+
+    // Default fast path reads the PATH, not the garbage → id is unchanged.
+    let after = ok_stdout(snapdir(&cache, &home), &["id", &dest_str]);
+    assert_eq!(
+        after, before,
+        "the default fast path must recover the checksum from the object PATH and \
+         NOT read the corrupted bytes — the id must be unchanged"
+    );
+
+    cleanup(&[&src, &store, &cache, &home, &dest]);
+}
+
+/// SPEC (no-read proof, strict side): `SNAPDIR_VERIFY_COPIES=1 snapdir id
+/// <linked-tree>` against the SAME garbage-injected object READS the bytes,
+/// detects content != address, and ERRORS (non-zero exit, naming the offending
+/// file/object). This is the strict counterpart that proves the default path
+/// truly avoided the read.
+#[test]
+fn strict_verify_id_errors_on_corrupted_object_naming_it() {
+    let src = build_src("strictbad-src");
+    let store = temp_dir("strictbad-store");
+    let cache = temp_dir("strictbad-cache");
+    let home = temp_dir("strictbad-home");
+    let (_url, _id, dest) = build_linked_tree("strictbad", &src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    let target = corrupt_object_keep_name(&dest, "a.txt", b"GARBAGE-NOT-HELLO-YYYYYYYYYYYYYY");
+
+    let mut strict_cmd = snapdir(&cache, &home);
+    strict_cmd.env("SNAPDIR_VERIFY_COPIES", "1");
+    let out = strict_cmd
+        .args(["id", &dest_str])
+        .output()
+        .expect("run snapdir");
+    assert!(
+        !out.status.success(),
+        "SNAPDIR_VERIFY_COPIES=1 must READ the bytes, detect the content/address \
+         mismatch, and FAIL with non-zero exit"
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let target_name = target.file_name().unwrap().to_string_lossy();
+    assert!(
+        combined.contains("a.txt") || combined.contains(target_name.as_ref()),
+        "the strict-verify error must name the offending file/object; got: {combined}"
+    );
+
+    cleanup(&[&src, &store, &cache, &home, &dest]);
+}
+
+// ===========================================================================
+// WRONG / KEYED ALGO disables the fast path → re-hash → reads garbage → ERROR.
+// ===========================================================================
+
+/// SPEC (wrong algo): a non-default `--checksum-bin` (md5sum) makes the embedded
+/// BLAKE3 the WRONG algorithm, so the fast path is ineligible and content must be
+/// re-hashed. NOTE: `snapdir id` does NOT expose `--checksum-bin`; only `snapdir
+/// manifest` does. The fast path is DISABLED for md5 (it cannot recover an md5
+/// from a BLAKE3-addressed path), so the bytes are RE-HASHED: `snapdir manifest
+/// --checksum-bin md5sum <linked-tree>` SUCCEEDS and emits an md5 manifest that
+/// reflects the object's ACTUAL (corrupted) content — it must NOT echo the stale
+/// BLAKE3 fast-path output. Per the locked design, wrong-algo merely re-hashes;
+/// it does NOT error.
+#[test]
+fn wrong_checksum_bin_disables_fastpath_and_rehashes_corrupted_object() {
+    let src = build_src("md5-src");
+    let store = temp_dir("md5-store");
+    let cache = temp_dir("md5-cache");
+    let home = temp_dir("md5-home");
+    let (_url, _id, dest) = build_linked_tree("md5", &src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    // The plain-BLAKE3 fast-path id over the HEALTHY tree (what a wrongly-fired
+    // fast path would echo). Captured before corruption.
+    let blake3_fast = ok_stdout(snapdir(&cache, &home), &["id", &dest_str]);
+    assert_eq!(blake3_fast.len(), 64);
+
+    let garbage: &[u8] = b"GARBAGE-FOR-MD5-PATHWAY-ZZZZZZZZ";
+    corrupt_object_keep_name(&dest, "a.txt", garbage);
+
+    // md5sum mode cannot recover a checksum from the BLAKE3 object path: the fast
+    // path is DISABLED, so it RE-HASHES the (now corrupted) content and SUCCEEDS,
+    // emitting an md5 manifest that reflects the actual bytes — NOT the stale
+    // BLAKE3 fast-path output.
+    let md5_manifest = ok_stdout(
+        snapdir(&cache, &home),
+        &["manifest", "--checksum-bin", "md5sum", &dest_str],
+    );
+    assert!(
+        !md5_manifest.contains(&blake3_fast),
+        "a non-BLAKE3 --checksum-bin must DISABLE the fast path and re-hash; the md5 \
+         manifest must NOT echo the stale BLAKE3 fast-path id; manifest:\n{md5_manifest}"
+    );
+
+    // STRENGTHENED (review): the correction claims SUCCESS + a re-hash that
+    // actually READS the corrupted bytes. Prove all three:
+    //  (1) the output is a well-formed manifest (every line = 5 space-separated
+    //      columns; the checksum column is exactly 32-hex md5 for FILE rows);
+    //  (2) the md5 of the CORRUPTED bytes is PRESENT (content was truly read —
+    //      not the healthy "hello" md5, not the BLAKE3 address);
+    //  (3) the md5 of the ORIGINAL bytes ("hello") is ABSENT.
+    // The expected md5 hexes are derived from snapdir ITSELF (oracle md5sum) over
+    // real one-file trees, so the test carries no md5 implementation of its own
+    // and no extra dependency.
+    assert!(
+        is_well_formed_file_manifest(&md5_manifest, 32),
+        "md5 manifest must be well-formed with 32-hex checksum columns; got:\n{md5_manifest}"
+    );
+    let md5_corrupt = md5_of_bytes_via_snapdir(&cache, &home, "md5-corrupt", garbage);
+    let md5_original = md5_of_bytes_via_snapdir(&cache, &home, "md5-original", b"hello");
+    assert_ne!(
+        md5_corrupt, md5_original,
+        "sanity: corrupted and original content must have distinct md5s"
+    );
+    assert!(
+        md5_manifest.contains(&md5_corrupt),
+        "the md5 re-hash must reflect the CORRUPTED content (proving the fast path was \
+         disabled and the bytes were actually read); expected md5 {md5_corrupt} in:\n{md5_manifest}"
+    );
+    assert!(
+        !md5_manifest.contains(&md5_original),
+        "the md5 manifest must NOT contain the ORIGINAL content's md5 — the corrupted \
+         bytes were read, not a stale/cached value; manifest:\n{md5_manifest}"
+    );
+
+    cleanup(&[&src, &store, &cache, &home, &dest]);
+}
+
+/// SPEC (wrong algo, positive): even on a HEALTHY store, `snapdir manifest
+/// --checksum-bin md5sum <linked-tree>` must NOT contain the store's plain
+/// BLAKE3 object addresses (which would betray the fast path firing for the wrong
+/// algorithm). The emitted checksums must be md5 (32 hex), recomputed from
+/// content — not the 64-hex BLAKE3 the object path encodes.
+#[test]
+fn wrong_checksum_bin_does_not_emit_blake3_object_address() {
+    let src = build_src("md5pos-src");
+    let store = temp_dir("md5pos-store");
+    let cache = temp_dir("md5pos-cache");
+    let home = temp_dir("md5pos-home");
+    let (_url, blake3_id, dest) = build_linked_tree("md5pos", &src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    // The plain-BLAKE3 address of a.txt's content ("hello"), recovered from the
+    // healthy store path. The md5 manifest must NOT contain it.
+    let blake3_a = {
+        let target = fs::canonicalize(dest.join("a.txt")).unwrap();
+        // The object's filename + its three shard segments reconstruct the hash;
+        // simplest CLI-observable proxy: the default fast-path id is pure BLAKE3.
+        // We only need *a* known BLAKE3 hex string from this tree to assert it is
+        // absent from the md5 manifest.
+        let _ = target;
+        ok_stdout(snapdir(&cache, &home), &["id", &dest_str])
+    };
+    assert_eq!(blake3_a.len(), 64);
+    assert_eq!(blake3_id.len(), 64);
+
+    let md5_manifest = ok_stdout(
+        snapdir(&cache, &home),
+        &["manifest", "--checksum-bin", "md5sum", &dest_str],
+    );
+    // md5 checksums are 32-hex; the BLAKE3-flavored fast-path id (64-hex) must not
+    // leak into the md5 manifest (that would mean the fast path wrongly fired).
+    assert!(
+        !md5_manifest.contains(&blake3_a),
+        "md5 manifest must NOT contain the BLAKE3 fast-path id — the fast path must \
+         be disabled for a non-BLAKE3 algorithm; manifest:\n{md5_manifest}"
+    );
+
+    cleanup(&[&src, &store, &cache, &home, &dest]);
+}
+
+/// SPEC (keyed algo): a keyed `SNAPDIR_MANIFEST_CONTEXT` makes the manifest's
+/// checksum keyed-BLAKE3, which differs from the store's plain-BLAKE3 address, so
+/// the fast path is ineligible and content must be re-hashed. The keyed re-hash
+/// SUCCEEDS and reflects the object's ACTUAL (corrupted) content, so its id
+/// DIFFERS from the plain-BLAKE3 fast-path output — it must NOT echo the stale
+/// plain address. Per the locked design, keyed-algo merely re-hashes; it does
+/// NOT error.
+#[test]
+fn keyed_manifest_context_disables_fastpath_and_rehashes_corrupted_object() {
+    let src = build_src("keyed-src");
+    let store = temp_dir("keyed-store");
+    let cache = temp_dir("keyed-cache");
+    let home = temp_dir("keyed-home");
+    let (_url, _id, dest) = build_linked_tree("keyed", &src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    // The plain-BLAKE3 fast-path id over the HEALTHY tree (what a wrongly-fired
+    // fast path would echo). Captured before corruption.
+    let plain_fast = ok_stdout(snapdir(&cache, &home), &["id", &dest_str]);
+    assert_eq!(plain_fast.len(), 64);
+
+    // STRENGTHENED (review): the keyed id over the HEALTHY tree BEFORE corruption.
+    // The fast path is disabled for a keyed context, so this run already re-hashes
+    // the (healthy) content with the key. We capture it to prove that, AFTER
+    // corruption, the SAME keyed run produces a DIFFERENT id — i.e. it genuinely
+    // re-read the bytes each time rather than recovering a fixed address.
+    let mut keyed_healthy_cmd = snapdir(&cache, &home);
+    keyed_healthy_cmd.env("SNAPDIR_MANIFEST_CONTEXT", "some-keyed-context");
+    let keyed_healthy = ok_stdout(keyed_healthy_cmd, &["id", &dest_str]);
+    assert_eq!(
+        keyed_healthy.len(),
+        64,
+        "keyed id must be a 64-hex snapshot id"
+    );
+
+    corrupt_object_keep_name(&dest, "a.txt", b"GARBAGE-FOR-KEYED-CONTEXT-QQQQQQ");
+
+    // The keyed run cannot recover the plain address from the object path: the
+    // fast path is DISABLED, so it RE-HASHES the (now corrupted) content with the
+    // key and SUCCEEDS, emitting a keyed id that reflects the actual bytes — NOT
+    // the stale plain-BLAKE3 fast-path output.
+    let mut cmd = snapdir(&cache, &home);
+    cmd.env("SNAPDIR_MANIFEST_CONTEXT", "some-keyed-context");
+    let keyed = ok_stdout(cmd, &["id", &dest_str]);
+    assert_eq!(keyed.len(), 64, "keyed id must be a 64-hex snapshot id");
+    assert_ne!(
+        keyed, plain_fast,
+        "a keyed SNAPDIR_MANIFEST_CONTEXT must DISABLE the fast path (keyed BLAKE3 != \
+         the store's plain-BLAKE3 address) and re-hash; the keyed id must NOT echo the \
+         stale plain-BLAKE3 fast-path id"
+    );
+    // The KEYSTONE of the correction: corruption changed the keyed id, proving the
+    // keyed run actually READ the (now garbage) content instead of recovering a
+    // fixed object address from the path. A fast path firing wrongly here would
+    // have yielded the SAME id before and after corruption.
+    assert_ne!(
+        keyed, keyed_healthy,
+        "the keyed id over the CORRUPTED tree must differ from the keyed id over the \
+         HEALTHY tree — proving the keyed run re-read the bytes (fast path truly \
+         disabled), not recovered a stale address"
+    );
+
+    cleanup(&[&src, &store, &cache, &home, &dest]);
+}
+
+/// SPEC (keyed algo, divergence): on a HEALTHY store, a keyed
+/// `SNAPDIR_MANIFEST_CONTEXT` id must DIFFER from the default plain-BLAKE3
+/// fast-path id — proving the keyed run re-hashed with the key rather than
+/// recovering the plain address from the object path.
+#[test]
+fn keyed_manifest_context_id_differs_from_plain_fastpath_id() {
+    let src = build_src("keyeddiv-src");
+    let store = temp_dir("keyeddiv-store");
+    let cache = temp_dir("keyeddiv-cache");
+    let home = temp_dir("keyeddiv-home");
+    let (_url, _id, dest) = build_linked_tree("keyeddiv", &src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    let plain = ok_stdout(snapdir(&cache, &home), &["id", &dest_str]);
+
+    let mut keyed_cmd = snapdir(&cache, &home);
+    keyed_cmd.env("SNAPDIR_MANIFEST_CONTEXT", "another-keyed-context");
+    let keyed = ok_stdout(keyed_cmd, &["id", &dest_str]);
+
+    assert_ne!(
+        plain, keyed,
+        "a keyed-context id must DIFFER from the plain fast-path id (keyed re-hash, \
+         not plain-address recovery)"
+    );
+
+    cleanup(&[&src, &store, &cache, &home, &dest]);
+}
+
+// ===========================================================================
+// ESCAPED / NON-OBJECT symlink → normal hash, never trusted.
+// ===========================================================================
+
+/// SPEC (escaped target): a dest symlink pointing OUTSIDE any store object (to an
+/// arbitrary file) is hashed NORMALLY, never treated as a recoverable object. We
+/// prove the content is read by giving the escaped target known bytes and
+/// asserting the linked-tree id equals the id of an equivalent REAL-FILE tree
+/// with the same content+symlink-mode — i.e. the checksum came from the content,
+/// not from any (absent) object path.
+#[test]
+fn escaped_non_object_symlink_is_hashed_normally_not_trusted() {
+    let src = build_src("escape-src");
+    let store = temp_dir("escape-store");
+    let cache = temp_dir("escape-cache");
+    let home = temp_dir("escape-home");
+    let (_url, _id, dest) = build_linked_tree("escape", &src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    // An arbitrary external file OUTSIDE any store, with known content.
+    let outside = temp_dir("escape-outside");
+    let ext_file = outside.join("external.bin");
+    fs::write(&ext_file, b"ESCAPED-CONTENT").unwrap();
+
+    // Add an extraneous dest symlink that escapes to the external file. This is
+    // NOT an object path, so the fast path must hash its (followed) content.
+    let escape_link = dest.join("escape.bin");
+    symlink(&ext_file, &escape_link).unwrap();
+
+    // The default id must succeed (the escaped link is hashed normally, the
+    // in-store links recover from path). Compare against SNAPDIR_VERIFY_COPIES=1:
+    // for the escaped entry both paths hash content, so a healthy store keeps the
+    // two ids identical — proving the escaped link was hashed, not trusted as an
+    // object, in BOTH modes.
+    let fast = ok_stdout(snapdir(&cache, &home), &["id", &dest_str]);
+
+    let mut strict_cmd = snapdir(&cache, &home);
+    strict_cmd.env("SNAPDIR_VERIFY_COPIES", "1");
+    let strict = ok_stdout(strict_cmd, &["id", &dest_str]);
+
+    assert_eq!(
+        fast, strict,
+        "an escaped (non-object) symlink must be HASHED normally in the default path \
+         too, so its id matches the strict re-hash id"
+    );
+
+    cleanup(&[&src, &store, &cache, &home, &dest, &outside]);
+}
+
+// ===========================================================================
+// DANGLING symlink → typed error, no panic.
+// ===========================================================================
+
+/// SPEC (dangling): after a linked checkout, REMOVE the target object so the dest
+/// symlink dangles. `snapdir id <linked-tree>` must FAIL with a clear typed error
+/// (non-zero exit, naming the path) — never a panic / SIGABRT / SIGSEGV.
+#[test]
+fn dangling_symlink_is_typed_error_not_panic() {
+    let src = build_src("dangle-src");
+    let store = temp_dir("dangle-store");
+    let cache = temp_dir("dangle-cache");
+    let home = temp_dir("dangle-home");
+    let (_url, _id, dest) = build_linked_tree("dangle", &src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    // Remove the target object so dest/a.txt dangles. Objects are 0444; relax the
+    // parent dir if needed, then unlink the object (scoped to the tempdir store).
+    let target = fs::canonicalize(dest.join("a.txt")).expect("resolve target");
+    if let Some(parent) = target.parent() {
+        fs::set_permissions(parent, fs::Permissions::from_mode(0o755)).ok();
+    }
+    fs::remove_file(&target).expect("remove the linked object → dangling symlink");
+    assert!(
+        dest.join("a.txt").symlink_metadata().is_ok(),
+        "the dest symlink itself must still exist (only its target was removed)"
+    );
+
+    let out = snapdir(&cache, &home)
+        .args(["id", &dest_str])
+        .output()
+        .expect("run snapdir");
+    assert!(
+        !out.status.success(),
+        "a dangling linked object must FAIL with a typed error (non-zero exit)"
+    );
+    // Must be a clean error exit, not a crash: assert it terminated via exit code
+    // (Some(code)), never killed by a signal (None on Unix => terminated by signal).
+    assert!(
+        out.status.code().is_some(),
+        "dangling symlink must produce a typed error, NOT a panic/SIGABRT/SIGSEGV \
+         (process was killed by a signal: {:?})",
+        out.status
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        combined.contains("a.txt") || combined.to_lowercase().contains("no such file"),
+        "the dangling-symlink error should name the offending path; got: {combined}"
+    );
+    assert!(
+        !combined.contains("panicked"),
+        "the failure must be a typed error, not a Rust panic; got: {combined}"
+    );
+
+    cleanup(&[&src, &store, &cache, &home, &dest]);
+}
+
+// ===========================================================================
+// CHECKSUM-ONLY honesty — the linked re-snapshot id is NOT the source id.
+// ===========================================================================
+
+/// SPEC (checksum-only): the fast path is CHECKSUM-ONLY. `snapdir id
+/// <linked-tree>` records the SYMLINK's own lstat mode+size (not the target's),
+/// so it must NOT reproduce the original source snapshot id. We pin that it
+/// DIFFERS (mode/size of a symlink != the original file), guarding against an
+/// over-claim that a linked re-snapshot round-trips the source id.
+#[test]
+fn linked_resnapshot_id_differs_from_source_snapshot_id() {
+    let src = build_src("creuse-src");
+    let store = temp_dir("creuse-store");
+    let cache = temp_dir("creuse-cache");
+    let home = temp_dir("creuse-home");
+
+    // The original source snapshot id (real files, real modes/sizes).
+    let src_str = src.to_string_lossy().into_owned();
+    let source_id = ok_stdout(snapdir(&cache, &home), &["id", &src_str]);
+
+    let (_url, pushed_id, dest) = build_linked_tree("creuse", &src, &cache, &home, &store);
+    assert_eq!(
+        pushed_id, source_id,
+        "precondition: the pushed snapshot id equals the real-file source id"
+    );
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    // The linked re-snapshot must NOT equal the source id: symlink lstat mode+size
+    // differ from the original files. The fast path is checksum-only.
+    let linked_id = ok_stdout(snapdir(&cache, &home), &["id", &dest_str]);
+    assert_ne!(
+        linked_id, source_id,
+        "CHECKSUM-ONLY: a linked re-snapshot must NOT reproduce the source snapshot \
+         id (symlink mode/size differ from the original files)"
+    );
+
+    cleanup(&[&src, &store, &cache, &home, &dest]);
+}
+
+// ===========================================================================
+// REVIEW-ADDED (impl-revealed) — the now-visible core/cli wiring exposes the
+// `manifest` keystone (not just `id`), mixed trees, and the strict-verify
+// integrity error on the `manifest` command path.
+// ===========================================================================
+
+/// REVIEW (no-read proof, MANIFEST level): the staged suite proves the default
+/// fast path doesn't read content for `snapdir id`; the impl recovers the
+/// checksum identically for the `manifest` command (both go through the same
+/// `resolve_walk`/`object_store_roots` wiring). Corrupt an object's bytes while
+/// keeping its filename (= its address): the default `snapdir manifest
+/// <linked-tree>` is UNCHANGED (it read the path, not the garbage).
+#[test]
+fn default_manifest_unchanged_after_object_bytes_corrupted_keeping_name() {
+    let src = build_src("manifest-noread-src");
+    let store = temp_dir("manifest-noread-store");
+    let cache = temp_dir("manifest-noread-cache");
+    let home = temp_dir("manifest-noread-home");
+    let (_url, _id, dest) = build_linked_tree("manifest-noread", &src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    let before = ok_stdout(snapdir(&cache, &home), &["manifest", &dest_str]);
+
+    corrupt_object_keep_name(&dest, "a.txt", b"GARBAGE-MANIFEST-NOREAD-WWWWWWWW");
+
+    let after = ok_stdout(snapdir(&cache, &home), &["manifest", &dest_str]);
+    assert_eq!(
+        after, before,
+        "the default fast path must recover EACH file's checksum from the object PATH \
+         for `manifest` too — the corrupted bytes must not be read, so the manifest is \
+         byte-identical"
+    );
+
+    cleanup(&[&src, &store, &cache, &home, &dest]);
+}
+
+/// REVIEW (strict-verify integrity, MANIFEST level): the staged strict test
+/// drives `id`; the impl raises `WalkError::LinkedObjectIntegrity` from the same
+/// walk regardless of the front-end command. `SNAPDIR_VERIFY_COPIES=1 snapdir
+/// manifest <linked-tree>` against a garbage-injected object READS the bytes,
+/// detects content != address, and ERRORS (non-zero, names the file) — never a
+/// stale manifest, never a panic.
+#[test]
+fn strict_verify_manifest_errors_on_corrupted_object_naming_it() {
+    let src = build_src("strictman-src");
+    let store = temp_dir("strictman-store");
+    let cache = temp_dir("strictman-cache");
+    let home = temp_dir("strictman-home");
+    let (_url, _id, dest) = build_linked_tree("strictman", &src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    let target = corrupt_object_keep_name(&dest, "a.txt", b"GARBAGE-STRICT-MANIFEST-VVVVVVVV");
+
+    let mut strict_cmd = snapdir(&cache, &home);
+    strict_cmd.env("SNAPDIR_VERIFY_COPIES", "1");
+    let out = strict_cmd
+        .args(["manifest", &dest_str])
+        .output()
+        .expect("run snapdir");
+    assert!(
+        !out.status.success(),
+        "SNAPDIR_VERIFY_COPIES=1 manifest must READ the bytes, detect the \
+         content/address mismatch, and FAIL with non-zero exit"
+    );
+    assert!(
+        out.status.code().is_some(),
+        "strict-verify mismatch must be a typed error, NOT a signal kill; got: {:?}",
+        out.status
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let target_name = target.file_name().unwrap().to_string_lossy();
+    assert!(
+        combined.contains("a.txt") || combined.contains(target_name.as_ref()),
+        "the strict-verify error must name the offending file/object; got: {combined}"
+    );
+    assert!(
+        !combined.contains("panicked"),
+        "the failure must be a typed error, not a Rust panic; got: {combined}"
+    );
+
+    cleanup(&[&src, &store, &cache, &home, &dest]);
+}
+
+/// REVIEW (mixed tree): a tree where SOME entries are recoverable in-store
+/// symlinks and ANOTHER is a real (non-symlink) file must be handled per-entry —
+/// the fast-path eligibility is decided per symlink, not for the whole walk. On
+/// a healthy store the default id (fast path for the linked entries, normal hash
+/// for the real file) is byte-identical to `SNAPDIR_VERIFY_COPIES=1` (every entry
+/// re-hashed). This pins that adding a non-symlink sibling does not break the
+/// per-entry decision and the two paths still agree.
+#[test]
+fn mixed_linked_and_real_tree_default_equals_strict() {
+    let src = build_src("mixed-src");
+    let store = temp_dir("mixed-store");
+    let cache = temp_dir("mixed-cache");
+    let home = temp_dir("mixed-home");
+    let (_url, _id, dest) = build_linked_tree("mixed", &src, &cache, &home, &store);
+
+    // Add a REAL regular file alongside the linked entries (not a symlink, so it
+    // is hashed normally in BOTH modes).
+    let real = dest.join("real.txt");
+    fs::write(&real, b"a genuine non-linked regular file").unwrap();
+    fs::set_permissions(&real, fs::Permissions::from_mode(0o644)).unwrap();
+    let dest_str = dest.to_string_lossy().into_owned();
+
+    let fast = ok_stdout(snapdir(&cache, &home), &["id", &dest_str]);
+
+    let mut strict_cmd = snapdir(&cache, &home);
+    strict_cmd.env("SNAPDIR_VERIFY_COPIES", "1");
+    let strict = ok_stdout(strict_cmd, &["id", &dest_str]);
+
+    assert_eq!(
+        fast, strict,
+        "a mixed linked+real tree must produce the same id under the default fast path \
+         and the strict re-hash on a healthy store (per-entry eligibility)"
+    );
+    assert_eq!(fast.len(), 64);
+
+    cleanup(&[&src, &store, &cache, &home, &dest]);
+}
+
+/// REVIEW (canonicalization / `..` in the symlink target): `recover_object_key`
+/// lexically folds `.`/`..` before testing the target against the store root. A
+/// linked tree whose object symlinks are still well-formed object addresses after
+/// folding must take the fast path. We exercise the recover path against a tree
+/// reached through a `..`-containing dest path (the dest is addressed via its
+/// parent + `..`), proving the lexical normalization in `recover_object_key`
+/// doesn't reject a legitimately-rooted object and the id still matches strict.
+#[test]
+fn dest_addressed_with_dotdot_still_fast_paths_and_matches_strict() {
+    let src = build_src("dotdot-src");
+    let store = temp_dir("dotdot-store");
+    let cache = temp_dir("dotdot-cache");
+    let home = temp_dir("dotdot-home");
+    let (_url, _id, dest) = build_linked_tree("dotdot", &src, &cache, &home, &store);
+
+    // Re-address the dest through a `..` hop: <dest>/sub/.. == <dest>.
+    let via_dotdot = dest.join("sub").join("..");
+    let via_dotdot_str = via_dotdot.to_string_lossy().into_owned();
+
+    let fast = ok_stdout(snapdir(&cache, &home), &["id", &via_dotdot_str]);
+
+    let mut strict_cmd = snapdir(&cache, &home);
+    strict_cmd.env("SNAPDIR_VERIFY_COPIES", "1");
+    let strict = ok_stdout(strict_cmd, &["id", &via_dotdot_str]);
+
+    assert_eq!(
+        fast, strict,
+        "a dest addressed via a `..` hop must still fast-path (lexical normalization \
+         in recover_object_key) and match the strict re-hash on a healthy store"
+    );
+    assert_eq!(fast.len(), 64);
+
+    cleanup(&[&src, &store, &cache, &home, &dest]);
+}

--- a/crates/snapdir-cli/tests/mirror_safety.rs
+++ b/crates/snapdir-cli/tests/mirror_safety.rs
@@ -1,0 +1,846 @@
+//! ADVERSARY destructive-safety KEYSTONE suite for `checkout`/`pull --delete`
+//! (Phase 32). This consolidates and goes DEEPER than `mirror_checkout_cli.rs`
+//! on the ONE thing that matters most: `--delete` must NEVER destroy anything it
+//! is not mandated to. The exact-mirror `--delete` feature is FULLY BUILT; these
+//! tests must PASS against the shipped binary. If a safety assertion FAILS, that
+//! is a REAL DESTRUCTIVE BUG — the failing test is left in place and the impl
+//! gate (`mirror-checkout-cli-impl`) is reopened. NONE of these may be weakened
+//! to go green.
+//!
+//! The destructive-safety invariants pinned (each `#[test]` names its invariant):
+//!   1. NEVER delete anything OUTSIDE the dest root (the cardinal rule): a dest
+//!      symlink escaping to an external file/dir is removed AS A LINK; the
+//!      external target + its contents survive byte-identical (canaries).
+//!   2. The escaping symlink IS removed (extraneous) but UNLINKED, not followed —
+//!      the prune-set walk must not descend out of the dest.
+//!   3. HARD-REFUSE dangerous dests with NO `--force` bypass, deleting nothing:
+//!      `/`, `$HOME`, the cache dir(s), and a store path; canonicalization
+//!      aliases (trailing `/`, `/.`, symlink-to-guarded) all refuse.
+//!   4. `--exclude` is honored: a matching extraneous path is protected; a
+//!      non-matching sibling is still pruned.
+//!   5. Nothing deleted on refusal (all-or-nothing on the guard); `--dryrun
+//!      --delete` deletes nothing while listing.
+//!   6. Adversarial extras: a symlink LOOP doesn't hang/panic; a dest symlink to
+//!      a guarded dir is removed as a link, not followed into it; a deeply nested
+//!      extraneous tree is pruned without escaping.
+//!
+//! SAFETY OF THE SUITE ITSELF: every dangerous-dest run env-redirects
+//! `HOME`/`XDG_CACHE_HOME`/`SNAPDIR_CACHE_DIR` to per-test tempdirs, so even a
+//! buggy impl that ignored the guard could only ever touch a sandbox, never the
+//! real `$HOME` or cache. The `/` case asserts ONLY the refusal (it never writes
+//! to or targets real `/`). Canaries are placed liberally OUTSIDE every dest and
+//! their byte-for-byte survival is asserted after the prune.
+
+#![cfg(unix)]
+
+use std::fs;
+use std::os::unix::fs::{symlink, PermissionsExt};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use assert_cmd::prelude::*;
+
+/// Unique temp dir under the OS temp root, removed by the caller on drop.
+fn temp_dir(tag: &str) -> PathBuf {
+    let mut dir = std::env::temp_dir();
+    dir.push(format!(
+        "snapdir-safety-{tag}-{}-{:?}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    ));
+    fs::create_dir_all(&dir).expect("create temp dir");
+    dir
+}
+
+/// A fresh `snapdir` command with the cache pinned and the developer's env
+/// scrubbed. `HOME`/`XDG_CACHE_HOME` are redirected at `home` so the default
+/// cache / `$HOME` computations resolve INSIDE the sandbox (never the real
+/// home), and `SNAPDIR_STORE`/`SNAPDIR_OBJECTS_STORE` are removed so leakage
+/// cannot mask a bug.
+fn snapdir(cache: &Path, home: &Path) -> Command {
+    let mut cmd = Command::cargo_bin("snapdir").expect("snapdir binary built");
+    cmd.env("SNAPDIR_CACHE_DIR", cache);
+    cmd.env("HOME", home);
+    cmd.env("XDG_CACHE_HOME", home.join(".cache"));
+    cmd.env_remove("SNAPDIR_STORE");
+    cmd.env_remove("SNAPDIR_OBJECTS_STORE");
+    cmd
+}
+
+/// Runs `snapdir <args>`, asserts success, returns trimmed stdout.
+fn ok_stdout(mut cmd: Command, args: &[&str]) -> String {
+    let out = cmd.args(args).output().expect("run snapdir");
+    assert!(
+        out.status.success(),
+        "snapdir {args:?} failed ({:?})\nstderr: {}",
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr),
+    );
+    String::from_utf8(out.stdout).unwrap().trim_end().to_owned()
+}
+
+/// Build a tiny deterministic source tree (stable perms so a checkout
+/// re-manifests to the same id) and return it.
+fn build_src(tag: &str) -> PathBuf {
+    let src = temp_dir(tag);
+    fs::write(src.join("a.txt"), b"hello").unwrap();
+    fs::set_permissions(src.join("a.txt"), fs::Permissions::from_mode(0o644)).unwrap();
+    fs::create_dir(src.join("sub")).unwrap();
+    fs::set_permissions(src.join("sub"), fs::Permissions::from_mode(0o755)).unwrap();
+    fs::write(src.join("sub").join("b.txt"), b"world!!").unwrap();
+    fs::set_permissions(
+        src.join("sub").join("b.txt"),
+        fs::Permissions::from_mode(0o644),
+    )
+    .unwrap();
+    fs::set_permissions(&src, fs::Permissions::from_mode(0o755)).unwrap();
+    src
+}
+
+/// Push `src` into a fresh `file://` store and return `(store_url, id)`.
+fn push_to_store(src: &Path, cache: &Path, home: &Path, store: &Path) -> (String, String) {
+    let store_url = format!("file://{}", store.display());
+    let src_str = src.to_string_lossy().into_owned();
+    let id = ok_stdout(
+        snapdir(cache, home),
+        &["push", "--store", &store_url, &src_str],
+    );
+    assert_eq!(id.len(), 64, "push must print a 64-hex id");
+    (store_url, id)
+}
+
+/// Materialize the snapshot into `dest` (plain checkout), then return its
+/// dest-string. Used to set up an exact mirror that we then perturb.
+fn pull_into(dest: &Path, store_url: &str, id: &str, cache: &Path, home: &Path) -> String {
+    let dest_str = dest.to_string_lossy().into_owned();
+    ok_stdout(
+        snapdir(cache, home),
+        &["pull", "--store", store_url, "--id", id, &dest_str],
+    );
+    dest_str
+}
+
+/// Best-effort recursive cleanup of test scratch dirs.
+fn cleanup(dirs: &[&Path]) {
+    for d in dirs {
+        fs::remove_dir_all(d).ok();
+    }
+}
+
+/// Recursively snapshot a tree as a sorted list of `(relpath, kind, bytes)`,
+/// where kind is "f" (file, with bytes), "d" (dir), "l" (symlink, bytes = the
+/// link target). Used to assert an OUTSIDE-the-dest canary tree is BYTE-IDENTICAL
+/// before and after a prune.
+fn snapshot_tree(root: &Path) -> Vec<(String, &'static str, Vec<u8>)> {
+    fn walk(root: &Path, dir: &Path, out: &mut Vec<(String, &'static str, Vec<u8>)>) {
+        let mut entries: Vec<_> = fs::read_dir(dir)
+            .unwrap()
+            .map(|e| e.unwrap().path())
+            .collect();
+        entries.sort();
+        for path in entries {
+            let rel = path
+                .strip_prefix(root)
+                .unwrap()
+                .to_string_lossy()
+                .into_owned();
+            let meta = fs::symlink_metadata(&path).unwrap();
+            let ft = meta.file_type();
+            if ft.is_symlink() {
+                let target = fs::read_link(&path).unwrap();
+                out.push((rel, "l", target.as_os_str().as_encoded_bytes().to_vec()));
+            } else if ft.is_dir() {
+                out.push((rel, "d", Vec::new()));
+                walk(root, &path, out);
+            } else {
+                out.push((rel, "f", fs::read(&path).unwrap()));
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(root, root, &mut out);
+    out
+}
+
+// ===========================================================================
+// INVARIANT 1 + 2 — NEVER delete outside the dest root; escaping symlink is
+// removed-AS-A-LINK, never followed. Canaries outside the dest prove survival.
+// ===========================================================================
+
+/// INVARIANT 1/2: an extraneous dest symlink → an EXTERNAL FILE (absolute target)
+/// is unlinked, but the external file survives byte-identical. Canary proves the
+/// target was not deleted-through-the-link.
+#[test]
+fn escaping_symlink_to_external_file_absolute_is_unlinked_target_survives() {
+    let src = build_src("ext-file-abs-src");
+    let store = temp_dir("ext-file-abs-store");
+    let dest = temp_dir("ext-file-abs-dest");
+    let cache = temp_dir("ext-file-abs-cache");
+    let home = temp_dir("ext-file-abs-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = pull_into(&dest, &store_url, &id, &cache, &home);
+
+    // A canary file OUTSIDE the dest, with known bytes.
+    let outside = temp_dir("ext-file-abs-outside");
+    let canary = outside.join("CANARY.txt");
+    fs::write(&canary, b"external file must survive byte-identical").unwrap();
+    let before = fs::read(&canary).unwrap();
+
+    // Extraneous dest symlink escaping to that external file (ABSOLUTE target).
+    let escape = dest.join("escape-file");
+    symlink(&canary, &escape).unwrap();
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["checkout", "--id", &id, "--delete", &dest_str],
+    );
+
+    assert!(
+        escape.symlink_metadata().is_err(),
+        "the escaping symlink must be unlinked (it is extraneous)"
+    );
+    assert!(
+        canary.exists(),
+        "external canary FILE must survive --delete"
+    );
+    assert_eq!(
+        fs::read(&canary).unwrap(),
+        before,
+        "external canary FILE must be byte-identical (not deleted through the link)"
+    );
+
+    cleanup(&[&src, &store, &dest, &cache, &home, &outside]);
+}
+
+/// INVARIANT 1/2: an extraneous dest symlink → an EXTERNAL DIRECTORY is unlinked;
+/// `--delete` must NOT recurse INTO it and delete its contents. The whole
+/// external subtree (a canary file + a nested canary) survives byte-identical.
+#[test]
+fn escaping_symlink_to_external_dir_does_not_recurse_or_delete_contents() {
+    let src = build_src("ext-dir-src");
+    let store = temp_dir("ext-dir-store");
+    let dest = temp_dir("ext-dir-dest");
+    let cache = temp_dir("ext-dir-cache");
+    let home = temp_dir("ext-dir-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = pull_into(&dest, &store_url, &id, &cache, &home);
+
+    // A populated external directory OUTSIDE the dest.
+    let outside = temp_dir("ext-dir-outside");
+    fs::write(outside.join("CANARY.txt"), b"top canary").unwrap();
+    fs::create_dir(outside.join("nested")).unwrap();
+    fs::write(outside.join("nested").join("DEEP.txt"), b"deep canary").unwrap();
+    let before = snapshot_tree(&outside);
+
+    // Extraneous dest symlink escaping to that external DIRECTORY.
+    let escape = dest.join("escape-dir");
+    symlink(&outside, &escape).unwrap();
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["checkout", "--id", &id, "--delete", &dest_str],
+    );
+
+    assert!(
+        escape.symlink_metadata().is_err(),
+        "the escaping dir-symlink must be unlinked"
+    );
+    assert!(outside.exists(), "external directory must survive");
+    assert_eq!(
+        snapshot_tree(&outside),
+        before,
+        "the external directory's ENTIRE contents must survive byte-identical \
+         (--delete must NOT follow the symlink and recurse into it)"
+    );
+
+    cleanup(&[&src, &store, &dest, &cache, &home, &outside]);
+}
+
+/// INVARIANT 1/2: a RELATIVE escaping symlink (`../../<outside>`) is unlinked;
+/// the external target survives. A relative-path escape must be just as safe as
+/// an absolute one.
+#[test]
+fn escaping_symlink_relative_traversal_is_unlinked_target_survives() {
+    // Use a shared parent so a `..`-relative link can address an external file.
+    let parent = temp_dir("rel-parent");
+    let src = build_src("rel-src");
+    let store = temp_dir("rel-store");
+    let dest = parent.join("dest");
+    fs::create_dir(&dest).unwrap();
+    let cache = temp_dir("rel-cache");
+    let home = temp_dir("rel-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+
+    // Materialize the mirror into the nested dest.
+    let dest_str = dest.to_string_lossy().into_owned();
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["pull", "--store", &store_url, "--id", &id, &dest_str],
+    );
+
+    // A canary sibling of `dest` (outside it), addressed via `..`.
+    let canary = parent.join("OUTSIDE_CANARY.txt");
+    fs::write(&canary, b"relative escape must not reach me").unwrap();
+    let before = fs::read(&canary).unwrap();
+
+    // Extraneous RELATIVE escaping symlink: dest/escape-rel -> ../OUTSIDE_CANARY.txt
+    let escape = dest.join("escape-rel");
+    symlink(Path::new("../OUTSIDE_CANARY.txt"), &escape).unwrap();
+    // Sanity: it resolves to the canary.
+    assert_eq!(fs::read(&escape).unwrap(), before);
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["checkout", "--id", &id, "--delete", &dest_str],
+    );
+
+    assert!(
+        escape.symlink_metadata().is_err(),
+        "the relative escaping symlink must be unlinked"
+    );
+    assert!(
+        canary.exists(),
+        "the `..`-addressed external canary must survive"
+    );
+    assert_eq!(
+        fs::read(&canary).unwrap(),
+        before,
+        "a `..`-traversal escape must NOT delete the external target"
+    );
+
+    cleanup(&[&src, &store, &cache, &home, &parent]);
+}
+
+/// INVARIANT 1/2: a `..`-traversal escaping symlink to an external DIRECTORY is
+/// unlinked, not followed; the external dir's contents survive. Combines the
+/// `..`-traversal and dir-recursion attack vectors.
+#[test]
+fn escaping_symlink_dotdot_to_external_dir_does_not_recurse() {
+    let parent = temp_dir("dotdot-parent");
+    let src = build_src("dotdot-src");
+    let store = temp_dir("dotdot-store");
+    let dest = parent.join("dest");
+    fs::create_dir(&dest).unwrap();
+    let cache = temp_dir("dotdot-cache");
+    let home = temp_dir("dotdot-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = dest.to_string_lossy().into_owned();
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["pull", "--store", &store_url, "--id", &id, &dest_str],
+    );
+
+    // An external dir sibling of dest, with contents, addressed via `..`.
+    let outside = parent.join("outside_dir");
+    fs::create_dir(&outside).unwrap();
+    fs::write(outside.join("KEEP.txt"), b"keep me").unwrap();
+    let before = snapshot_tree(&outside);
+
+    let escape = dest.join("escape-dotdot-dir");
+    symlink(Path::new("../outside_dir"), &escape).unwrap();
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["checkout", "--id", &id, "--delete", &dest_str],
+    );
+
+    assert!(escape.symlink_metadata().is_err(), "link unlinked");
+    assert_eq!(
+        snapshot_tree(&outside),
+        before,
+        "a `..`-to-dir escape must NOT recurse and delete the external dir's contents"
+    );
+
+    cleanup(&[&src, &store, &cache, &home, &parent]);
+}
+
+// ===========================================================================
+// INVARIANT 3 + 5 — HARD-REFUSE dangerous dests (no `--force` bypass), nothing
+// deleted; the dest tree is byte-identical to before the refusal.
+// ===========================================================================
+
+/// Plants a sentinel + an extra junk subtree inside `dest`, snapshots it, runs
+/// `checkout --delete [--force] <dest>` (expecting REFUSAL), and asserts: the
+/// command exits non-zero AND the dest tree is BYTE-IDENTICAL (nothing deleted —
+/// the guard fired before any prune, all-or-nothing). `extra_args` lets a case
+/// add `--store`/`--id` as needed.
+fn assert_refuses_and_dest_unchanged(cmd: Command, dest: &Path, dest_arg: &str, args: &[&str]) {
+    // Plant a sentinel AND an extraneous junk subtree: if the impl wrongly
+    // pruned (treated this as a normal mirror), the junk would vanish. The
+    // refusal must fire first, so the WHOLE tree must be byte-identical.
+    let sentinel = dest.join("DO_NOT_DELETE.sentinel");
+    fs::write(&sentinel, b"sentinel").unwrap();
+    fs::create_dir_all(dest.join("junk").join("deep")).unwrap();
+    fs::write(dest.join("junk").join("deep").join("x"), b"x").unwrap();
+    let before = snapshot_tree(dest);
+
+    let mut cmd = cmd;
+    let out = cmd.args(args).arg(dest_arg).output().expect("run snapdir");
+    assert!(
+        !out.status.success(),
+        "checkout --delete on dangerous dest {} (args {args:?}) MUST refuse non-zero",
+        dest.display()
+    );
+    assert!(
+        sentinel.exists(),
+        "the sentinel under {} must survive the refusal",
+        dest.display()
+    );
+    assert_eq!(
+        snapshot_tree(dest),
+        before,
+        "NOTHING may be deleted on a guard refusal — dest {} must be byte-identical",
+        dest.display()
+    );
+}
+
+/// INVARIANT 3/5: dest = `$HOME` is hard-refused with AND without `--force`;
+/// nothing deleted. HOME is env-redirected to a tempdir, so even a buggy bypass
+/// can only touch the sandbox.
+#[test]
+fn refuses_home_dest_no_force_bypass_nothing_deleted() {
+    let cache = temp_dir("home-cache");
+    let home = temp_dir("home-home");
+    let id = "0".repeat(64);
+    assert_refuses_and_dest_unchanged(
+        snapdir(&cache, &home),
+        &home,
+        &home.to_string_lossy(),
+        &["checkout", "--id", &id, "--delete"],
+    );
+    assert_refuses_and_dest_unchanged(
+        snapdir(&cache, &home),
+        &home,
+        &home.to_string_lossy(),
+        &["checkout", "--id", &id, "--delete", "--force"],
+    );
+    cleanup(&[&cache, &home]);
+}
+
+/// INVARIANT 3: dest = `/` is hard-refused with AND without `--force`. We NEVER
+/// write to or place a sentinel at real `/`; the refusal must fire on path
+/// identity alone, so we assert ONLY the non-zero exit.
+#[test]
+fn refuses_filesystem_root_no_force_bypass() {
+    let cache = temp_dir("root-cache");
+    let home = temp_dir("root-home");
+    let id = "0".repeat(64);
+    for force in [false, true] {
+        let mut cmd = snapdir(&cache, &home);
+        cmd.args(["checkout", "--id", &id, "--delete"]);
+        if force {
+            cmd.arg("--force");
+        }
+        let out = cmd.arg("/").output().expect("run snapdir");
+        assert!(
+            !out.status.success(),
+            "checkout --delete / (force={force}) MUST hard-refuse"
+        );
+    }
+    cleanup(&[&cache, &home]);
+}
+
+/// INVARIANT 3/5: dest = the explicit cache dir (`$SNAPDIR_CACHE_DIR`) is
+/// hard-refused (no `--force` bypass); the cache (content-addressable objects)
+/// is untouched.
+#[test]
+fn refuses_explicit_cache_dir_no_force_bypass_nothing_deleted() {
+    let cache = temp_dir("cachedir-cache");
+    let home = temp_dir("cachedir-home");
+    let id = "0".repeat(64);
+    assert_refuses_and_dest_unchanged(
+        snapdir(&cache, &home),
+        &cache,
+        &cache.to_string_lossy(),
+        &["checkout", "--id", &id, "--delete"],
+    );
+    assert_refuses_and_dest_unchanged(
+        snapdir(&cache, &home),
+        &cache,
+        &cache.to_string_lossy(),
+        &["checkout", "--id", &id, "--delete", "--force"],
+    );
+    cleanup(&[&cache, &home]);
+}
+
+/// INVARIANT 3/5: dest = the DEFAULT cache dir (`$XDG_CACHE_HOME/snapdir`) is
+/// guarded too, even when an explicit `SNAPDIR_CACHE_DIR` points elsewhere. A
+/// sentinel in the default cache survives; `--force` does not bypass.
+#[test]
+fn refuses_default_cache_dir_no_force_bypass_nothing_deleted() {
+    let home = temp_dir("defcache-home");
+    let explicit_cache = temp_dir("defcache-explicit"); // a DIFFERENT explicit cache
+    let default_cache = home.join(".cache").join("snapdir");
+    fs::create_dir_all(&default_cache).unwrap();
+    let id = "0".repeat(64);
+
+    // snapdir() pins SNAPDIR_CACHE_DIR to `explicit_cache`, while XDG_CACHE_HOME
+    // resolves the DEFAULT to `default_cache` — so dest == the default location,
+    // not the configured one. The guard must still refuse it.
+    assert_refuses_and_dest_unchanged(
+        snapdir(&explicit_cache, &home),
+        &default_cache,
+        &default_cache.to_string_lossy(),
+        &["checkout", "--id", &id, "--delete", "--force"],
+    );
+    cleanup(&[&home, &explicit_cache]);
+}
+
+/// INVARIANT 3/5: dest = a local store's on-disk root is hard-refused (no
+/// `--force` bypass). The store holds `.manifests`/`.objects`; mirror-pruning it
+/// would destroy the snapshot. The landed manifest + the whole store tree
+/// survive byte-identical.
+#[test]
+fn refuses_store_path_no_force_bypass_nothing_deleted() {
+    let src = build_src("storepath-src");
+    let store = temp_dir("storepath-store");
+    let cache = temp_dir("storepath-cache");
+    let home = temp_dir("storepath-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+
+    let manifest_key = store.join(format!(
+        ".manifests/{}/{}/{}/{}",
+        &id[0..3],
+        &id[3..6],
+        &id[6..9],
+        &id[9..]
+    ));
+    assert!(manifest_key.is_file(), "precondition: manifest landed");
+    let store_str = store.to_string_lossy().into_owned();
+    let before = snapshot_tree(&store);
+
+    for force in [false, true] {
+        let mut cmd = snapdir(&cache, &home);
+        cmd.args(["checkout", "--store", &store_url, "--id", &id, "--delete"]);
+        if force {
+            cmd.arg("--force");
+        }
+        let out = cmd.arg(&store_str).output().expect("run snapdir");
+        assert!(
+            !out.status.success(),
+            "checkout --delete onto the store path (force={force}) MUST hard-refuse"
+        );
+        assert!(
+            manifest_key.is_file(),
+            "the store's manifest must survive (force={force})"
+        );
+        assert_eq!(
+            snapshot_tree(&store),
+            before,
+            "the ENTIRE store tree must be byte-identical after the refusal (force={force})"
+        );
+    }
+
+    cleanup(&[&src, &store, &cache, &home]);
+}
+
+// --- INVARIANT 3: canonicalization aliases all refuse (no lexical bypass) ---
+
+/// INVARIANT 3: a guarded dest reached via a CANONICALIZATION ALIAS still
+/// refuses — `$HOME` with a trailing `/`, with `/.`, and via a symlink that
+/// resolves to `$HOME`. A lexical-only guard would miss these. HOME is
+/// env-redirected; a sentinel proves nothing was pruned.
+#[test]
+fn refuses_home_canonicalization_aliases_no_force_bypass() {
+    let cache = temp_dir("alias-cache");
+    let home = temp_dir("alias-home");
+    let sentinel = home.join("DO_NOT_DELETE.sentinel");
+    fs::write(&sentinel, b"sentinel").unwrap();
+    let before = snapshot_tree(&home);
+
+    let home_str = home.to_string_lossy().into_owned();
+    let link = home
+        .parent()
+        .unwrap()
+        .join(format!("home-alias-{}", std::process::id()));
+    fs::remove_file(&link).ok();
+    symlink(&home, &link).unwrap();
+
+    let aliases = [
+        format!("{home_str}/"),
+        format!("{home_str}/."),
+        link.to_string_lossy().into_owned(),
+    ];
+    let id = "0".repeat(64);
+    for alias in &aliases {
+        let out = snapdir(&cache, &home)
+            .args(["checkout", "--id", &id, "--delete", "--force", alias])
+            .output()
+            .expect("run snapdir");
+        assert!(
+            !out.status.success(),
+            "checkout --delete onto a canonicalization-alias of $HOME ({alias}) MUST refuse"
+        );
+        assert!(sentinel.exists(), "sentinel must survive alias {alias}");
+        assert_eq!(
+            snapshot_tree(&home),
+            before,
+            "nothing deleted via $HOME alias {alias}"
+        );
+    }
+
+    fs::remove_file(&link).ok();
+    cleanup(&[&cache, &home]);
+}
+
+/// INVARIANT 3/6: a dest that is itself a SYMLINK resolving to a guarded dir
+/// (e.g. `link -> $HOME`) is refused via canonicalization and is NOT followed
+/// into `$HOME` to delete its contents. HOME is env-redirected; a sentinel in
+/// the (sandbox) home survives, and the home tree is byte-identical.
+#[test]
+fn refuses_dest_symlink_to_guarded_home_not_followed() {
+    let cache = temp_dir("symguard-cache");
+    let home = temp_dir("symguard-home");
+    let sentinel = home.join("DO_NOT_DELETE.sentinel");
+    fs::write(&sentinel, b"sentinel").unwrap();
+    fs::create_dir(home.join("private")).unwrap();
+    fs::write(home.join("private").join("secret"), b"secret").unwrap();
+    let before = snapshot_tree(&home);
+
+    // A symlink (outside home) that points AT the guarded home.
+    let link_parent = temp_dir("symguard-linkparent");
+    let link = link_parent.join("dest-link");
+    symlink(&home, &link).unwrap();
+    let link_str = link.to_string_lossy().into_owned();
+    let id = "0".repeat(64);
+
+    let out = snapdir(&cache, &home)
+        .args(["checkout", "--id", &id, "--delete", "--force", &link_str])
+        .output()
+        .expect("run snapdir");
+    assert!(
+        !out.status.success(),
+        "a dest symlink resolving to $HOME MUST be refused (canonicalized guard)"
+    );
+    assert!(sentinel.exists(), "home sentinel must survive");
+    assert_eq!(
+        snapshot_tree(&home),
+        before,
+        "the guarded home tree must be byte-identical (not followed/deleted)"
+    );
+
+    cleanup(&[&cache, &home, &link_parent]);
+}
+
+// ===========================================================================
+// INVARIANT 4 — `--exclude` honored: matching extraneous protected; sibling pruned.
+// ===========================================================================
+
+/// INVARIANT 4: an extraneous path matching `--exclude` is PROTECTED, while a
+/// non-matching extraneous sibling is still pruned. (Extended-regex semantics.)
+#[test]
+fn exclude_protects_match_but_prunes_nonmatching_sibling() {
+    let src = build_src("excl-src");
+    let store = temp_dir("excl-store");
+    let dest = temp_dir("excl-dest");
+    let cache = temp_dir("excl-cache");
+    let home = temp_dir("excl-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = pull_into(&dest, &store_url, &id, &cache, &home);
+
+    fs::write(dest.join("keep.log"), b"protected").unwrap();
+    fs::write(dest.join("drop.tmp"), b"prunable").unwrap();
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &[
+            "checkout",
+            "--id",
+            &id,
+            "--delete",
+            "--exclude",
+            "keep\\.log",
+            &dest_str,
+        ],
+    );
+    assert!(
+        dest.join("keep.log").exists(),
+        "--exclude must PROTECT the matching extraneous path"
+    );
+    assert!(
+        !dest.join("drop.tmp").exists(),
+        "a non-matching extraneous sibling must still be pruned"
+    );
+
+    cleanup(&[&src, &store, &dest, &cache, &home]);
+}
+
+// ===========================================================================
+// INVARIANT 5 — `--dryrun --delete` deletes nothing while listing.
+// ===========================================================================
+
+/// INVARIANT 5: `--delete --dryrun` LISTS the deletion set and removes NOTHING —
+/// the extraneous file (and a nested junk subtree) survive byte-identical.
+#[test]
+fn dryrun_delete_lists_and_removes_nothing() {
+    let src = build_src("dry-src");
+    let store = temp_dir("dry-store");
+    let dest = temp_dir("dry-dest");
+    let cache = temp_dir("dry-cache");
+    let home = temp_dir("dry-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = pull_into(&dest, &store_url, &id, &cache, &home);
+
+    fs::write(dest.join("WOULD_DELETE.txt"), b"junk").unwrap();
+    fs::create_dir_all(dest.join("junkdir").join("deep")).unwrap();
+    fs::write(dest.join("junkdir").join("deep").join("z"), b"z").unwrap();
+    let before = snapshot_tree(&dest);
+
+    let out = snapdir(&cache, &home)
+        .args(["checkout", "--id", &id, "--delete", "--dryrun", &dest_str])
+        .output()
+        .expect("run snapdir");
+    assert!(
+        out.status.success(),
+        "dryrun checkout --delete should succeed; stderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let combined = format!(
+        "{}{}",
+        String::from_utf8_lossy(&out.stdout),
+        String::from_utf8_lossy(&out.stderr)
+    );
+    assert!(
+        combined.contains("WOULD_DELETE.txt"),
+        "--dryrun must LIST the path it would delete; got: {combined}"
+    );
+    assert_eq!(
+        snapshot_tree(&dest),
+        before,
+        "--dryrun --delete must delete NOTHING (dest byte-identical)"
+    );
+
+    cleanup(&[&src, &store, &dest, &cache, &home]);
+}
+
+// ===========================================================================
+// INVARIANT 6 — adversarial extras: symlink loop, deep nested prune.
+// ===========================================================================
+
+/// INVARIANT 6: a SYMLINK LOOP among extraneous dest entries does not hang or
+/// panic the prune — the loop links are unlinked, the command completes, and the
+/// in-manifest mirror survives. A naive symlink-following walk would loop
+/// forever; the prune lstat's entries and never follows them.
+#[test]
+fn symlink_loop_in_dest_does_not_hang_or_panic() {
+    let src = build_src("loop-src");
+    let store = temp_dir("loop-store");
+    let dest = temp_dir("loop-dest");
+    let cache = temp_dir("loop-cache");
+    let home = temp_dir("loop-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = pull_into(&dest, &store_url, &id, &cache, &home);
+
+    // A mutual symlink loop among extraneous entries: loopA -> loopB -> loopA.
+    let a = dest.join("loopA");
+    let b = dest.join("loopB");
+    symlink("loopB", &a).unwrap();
+    symlink("loopA", &b).unwrap();
+    // And a self-loop dir-symlink for good measure.
+    let selfl = dest.join("selfloop");
+    symlink("selfloop", &selfl).unwrap();
+
+    // Must terminate (no hang) and succeed.
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["checkout", "--id", &id, "--delete", &dest_str],
+    );
+
+    assert!(a.symlink_metadata().is_err(), "loopA unlinked");
+    assert!(b.symlink_metadata().is_err(), "loopB unlinked");
+    assert!(selfl.symlink_metadata().is_err(), "selfloop unlinked");
+    // The in-manifest mirror survives + still re-manifests to the source id.
+    assert_eq!(fs::read(dest.join("a.txt")).unwrap(), b"hello");
+    assert_eq!(ok_stdout(snapdir(&cache, &home), &["id", &dest_str]), id);
+
+    cleanup(&[&src, &store, &dest, &cache, &home]);
+}
+
+/// INVARIANT 6: a DEEPLY NESTED extraneous tree is pruned entirely (deepest-first,
+/// no escaping), and crucially an escaping symlink BURIED deep inside that
+/// extraneous tree does not cause the prune to follow it out of the dest — an
+/// external canary survives.
+#[test]
+fn deep_nested_extraneous_tree_pruned_without_escaping() {
+    let src = build_src("deep-src");
+    let store = temp_dir("deep-store");
+    let dest = temp_dir("deep-dest");
+    let cache = temp_dir("deep-cache");
+    let home = temp_dir("deep-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = pull_into(&dest, &store_url, &id, &cache, &home);
+
+    // A deep extraneous subtree under the dest.
+    let mut deep = dest.join("junk");
+    for seg in ["l1", "l2", "l3", "l4", "l5"] {
+        deep = deep.join(seg);
+    }
+    fs::create_dir_all(&deep).unwrap();
+    fs::write(deep.join("leaf"), b"leaf").unwrap();
+
+    // An external canary + a buried escaping symlink pointing at it.
+    let outside = temp_dir("deep-outside");
+    let canary = outside.join("CANARY.txt");
+    fs::write(&canary, b"deep escape must not reach me").unwrap();
+    symlink(&canary, deep.join("buried-escape")).unwrap();
+
+    ok_stdout(
+        snapdir(&cache, &home),
+        &["checkout", "--id", &id, "--delete", &dest_str],
+    );
+
+    assert!(
+        !dest.join("junk").exists(),
+        "the whole deep extraneous subtree must be pruned"
+    );
+    assert!(canary.exists(), "the external canary must survive");
+    assert_eq!(
+        fs::read(&canary).unwrap(),
+        b"deep escape must not reach me",
+        "a buried escaping symlink must NOT be followed out of the dest"
+    );
+    // The mirror is intact.
+    assert_eq!(ok_stdout(snapdir(&cache, &home), &["id", &dest_str]), id);
+
+    cleanup(&[&src, &store, &dest, &cache, &home, &outside]);
+}
+
+/// INVARIANT 1 (pull parity): the `pull --delete` path enforces the same
+/// outside-dest safety — an escaping symlink is unlinked, the external canary
+/// survives. (`pull` = fetch + checkout; the guard/prune must apply on both.)
+#[test]
+fn pull_delete_escaping_symlink_target_survives() {
+    let src = build_src("pull-esc-src");
+    let store = temp_dir("pull-esc-store");
+    let dest = temp_dir("pull-esc-dest");
+    let cache = temp_dir("pull-esc-cache");
+    let home = temp_dir("pull-esc-home");
+    let (store_url, id) = push_to_store(&src, &cache, &home, &store);
+    let dest_str = pull_into(&dest, &store_url, &id, &cache, &home);
+
+    let outside = temp_dir("pull-esc-outside");
+    let canary = outside.join("CANARY.txt");
+    fs::write(&canary, b"pull must not delete me").unwrap();
+    let escape = dest.join("escape");
+    symlink(&outside, &escape).unwrap();
+
+    // Re-run via PULL with --delete.
+    ok_stdout(
+        snapdir(&cache, &home),
+        &[
+            "pull", "--store", &store_url, "--id", &id, "--delete", &dest_str,
+        ],
+    );
+
+    assert!(escape.symlink_metadata().is_err(), "escaping link unlinked");
+    assert!(
+        canary.exists(),
+        "external canary must survive pull --delete"
+    );
+    assert_eq!(fs::read(&canary).unwrap(), b"pull must not delete me");
+
+    cleanup(&[&src, &store, &dest, &cache, &home, &outside]);
+}

--- a/crates/snapdir-cli/tests/sync_command.rs
+++ b/crates/snapdir-cli/tests/sync_command.rs
@@ -227,3 +227,105 @@ fn sync_cmd_dryrun_writes_nothing() {
         "dry-run sync must not write to the destination store"
     );
 }
+
+/// `sync --delete` between two `file://` stores makes the dest an exact mirror of
+/// the SOURCE's manifest set: it copies the synced id in AND prunes a dest
+/// manifest that the source does not hold. Objects are never deleted (owned
+/// exhaustively by the stores adversary suite; here we just confirm the CLI
+/// wiring prunes the extraneous manifest and the summary reports it).
+#[test]
+fn sync_cmd_delete_prunes_extraneous_dest_manifest() {
+    let cache = TempDir::new().unwrap();
+    let src_a = TempDir::new().unwrap();
+    let src_b = TempDir::new().unwrap();
+    let store_a = TempDir::new().unwrap();
+    let store_b = TempDir::new().unwrap();
+    build_tree(&src_a);
+    src_b.child("only-b.txt").write_str("extraneous").unwrap();
+
+    let a_str = src_a.path().to_string_lossy().into_owned();
+    let b_str = src_b.path().to_string_lossy().into_owned();
+    let a_url = format!("file://{}", store_a.path().display());
+    let b_url = format!("file://{}", store_b.path().display());
+
+    // Source A holds one snapshot; dest B holds a DIFFERENT snapshot absent from A.
+    let id_a = stdout_ok(cache.path(), &["push", "--store", &a_url, &a_str]);
+    let id_b = stdout_ok(cache.path(), &["push", "--store", &b_url, &b_str]);
+    assert_ne!(id_a, id_b);
+
+    let manifest_b = store_b.path().join(".manifests");
+    let extraneous = walk_find_manifest(&manifest_b, &id_b);
+    assert!(extraneous.exists(), "dest must hold id_b before the mirror");
+
+    // sync --delete A -> B: copy id_a in, prune id_b (absent from A's set).
+    let out = snapdir(cache.path())
+        .args([
+            "sync", "--delete", "--id", &id_a, "--from", &a_url, "--to", &b_url,
+        ])
+        .output()
+        .expect("run snapdir sync --delete");
+    assert!(
+        out.status.success(),
+        "mirror sync must succeed\nstderr: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stderr = String::from_utf8(out.stderr).unwrap();
+    assert!(
+        stderr.contains(&format!("mirrored {id_a}")) && stderr.contains("1 manifest(s) pruned"),
+        "mirror summary must report the pruned manifest:\n{stderr}"
+    );
+    assert!(
+        !extraneous.exists(),
+        "the dest manifest absent from the source set must be pruned"
+    );
+    assert!(
+        walk_find_manifest(&manifest_b, &id_a).exists(),
+        "the synced id must be present in the dest after the mirror"
+    );
+}
+
+/// `sync --delete` to an object/remote (`gs://`) destination is refused with a
+/// clear, actionable non-zero-exit error: the stores capability gate
+/// (`supports_mirror()`) fires before any write. (The plain additive `sync`
+/// to such a dest is a separate path; here we only confirm `--delete` is gated.)
+#[test]
+fn sync_cmd_delete_remote_dest_errors_clearly() {
+    let cache = TempDir::new().unwrap();
+    let src = TempDir::new().unwrap();
+    let store_a = TempDir::new().unwrap();
+    build_tree(&src);
+
+    let src_str = src.path().to_string_lossy().into_owned();
+    let a_url = format!("file://{}", store_a.path().display());
+    let id = stdout_ok(cache.path(), &["push", "--store", &a_url, &src_str]);
+
+    snapdir(cache.path())
+        .args([
+            "sync",
+            "--delete",
+            "--id",
+            &id,
+            "--from",
+            &a_url,
+            "--to",
+            "gs://example-bucket/path",
+        ])
+        .assert()
+        .failure()
+        .stderr(
+            predicate::str::contains("mirror unsupported").and(predicate::str::contains(
+                "requires a local file:// destination",
+            )),
+        );
+}
+
+/// Locates the on-disk manifest path for `id` under a `file://` store's
+/// `.manifests/` dir, using the frozen `3/3/3/rest` shard layout, so a test can
+/// assert presence / absence after a mirror prune.
+fn walk_find_manifest(manifests_root: &Path, id: &str) -> std::path::PathBuf {
+    manifests_root
+        .join(&id[0..3])
+        .join(&id[3..6])
+        .join(&id[6..9])
+        .join(&id[9..])
+}

--- a/crates/snapdir-core/src/hash_file.rs
+++ b/crates/snapdir-core/src/hash_file.rs
@@ -106,6 +106,25 @@ pub trait HashFile {
     fn hash_file_hex_seq(&self, path: &Path) -> io::Result<(String, u64)> {
         self.hash_file_hex(path)
     }
+
+    /// Whether this hasher's digest is the SAME algorithm a snapdir object
+    /// store addresses its objects by — i.e. plain, non-keyed BLAKE3.
+    ///
+    /// This gates the linked-mode checksum-reuse fast path
+    /// ([`recover`](crate::recover)): a symlink target's object path encodes the
+    /// object's plain-BLAKE3 key, so its checksum can only be RECOVERED from the
+    /// path (instead of hashing the content) when the active hasher would itself
+    /// produce that same plain-BLAKE3 digest. For every other hasher — keyed
+    /// BLAKE3 ([`Blake3KeyedHasher`]), MD5 ([`Md5Hasher`]), SHA-256
+    /// ([`Sha256Hasher`]) — the embedded key is the WRONG algorithm, so the
+    /// default returns `false` and the walk re-hashes the content.
+    ///
+    /// The decision is driven by the concrete hasher TYPE, not by hardcoding an
+    /// algorithm name at the call site: only [`Blake3Hasher`] overrides this to
+    /// `true`. It is a pure, const-cheap predicate with no I/O.
+    fn recovers_object_keys(&self) -> bool {
+        false
+    }
 }
 
 /// Memory-maps `path` into `hasher` with `update_mmap`, guarded against a
@@ -164,6 +183,14 @@ impl HashFile for Blake3Hasher {
         // distinct trait method is kept because `walk.rs` selects it for its
         // oversubscription guard; the output is byte-identical either way.
         blake3_hash_file(blake3::Hasher::new(), path)
+    }
+
+    fn recovers_object_keys(&self) -> bool {
+        // Plain, non-keyed BLAKE3 IS the algorithm a snapdir object store
+        // addresses its objects by, so its checksum can be recovered from the
+        // symlink target's object path. (Keyed BLAKE3, MD5 and SHA-256 keep the
+        // trait default of `false`.)
+        true
     }
 }
 

--- a/crates/snapdir-core/src/lib.rs
+++ b/crates/snapdir-core/src/lib.rs
@@ -23,7 +23,9 @@ pub mod excludes;
 pub mod hash_file;
 pub mod manifest;
 pub mod merkle;
+pub mod mirror;
 pub mod progress;
+pub mod recover;
 pub mod resources;
 #[cfg(unix)]
 pub mod sigbus;
@@ -45,6 +47,7 @@ pub use merkle::{
     Sha256Hasher,
 };
 pub use progress::{Meter, MeterSnapshot, Phase};
+pub use recover::recover_object_key;
 pub use resources::{resident_set_bytes, total_ram_bytes, CpuSampler};
 pub use store::{manifest_path, object_path, Store, StoreError, MANIFESTS_DIR, OBJECTS_DIR};
 pub use walk::{walk, walk_with_guards, walk_with_meter, PathMode, WalkError, WalkOptions};

--- a/crates/snapdir-core/src/mirror.rs
+++ b/crates/snapdir-core/src/mirror.rs
@@ -1,0 +1,117 @@
+//! Pure exact-mirror prune-set computation (Phase 32: `--delete`).
+//!
+//! Given a target [`Manifest`] and a listing of the destination tree's
+//! paths + types ([`DestEntry`]), [`prune_set`] returns the *extraneous* dest
+//! paths — those present in the dest but ABSENT from the manifest — in
+//! deepest-first deletion order. This is exactly the set `--delete` must remove
+//! to make the destination an exact mirror of the manifest.
+//!
+//! This module is **pure** and content-free, by design:
+//!
+//! - It NEVER reads or hashes object content; the manifest's `checksum`/`size`
+//!   fields are irrelevant to the keep/prune decision. The keep/prune key is a
+//!   path's `(path, path_type)` only, encoded by the trailing-slash convention
+//!   shared with [`ManifestEntry`](crate::ManifestEntry): a file `./p` and a
+//!   directory `./p/` are DISTINCT keys, so a file↔directory type change at a
+//!   path surfaces the dest form as extraneous (to be replaced).
+//! - It performs NO I/O and takes no object-store handle; the destination
+//!   walk that produces `dest_entries` is a later (cli) gate's job.
+//!
+//! The set-difference approach mirrors the dest-side `Added` classification of
+//! [`crate diff`](../../snapdir_cli/diff/index.html) (a dest path not keyed by
+//! the manifest == extraneous), re-implemented standalone here so `snapdir-core`
+//! carries no dependency on `snapdir-cli`.
+
+use std::collections::BTreeSet;
+
+use crate::excludes::ExcludeMatcher;
+use crate::{Manifest, PathType};
+
+/// A single destination-tree entry: its path (verbatim, `./`-prefixed like a
+/// manifest path; directories end with `/`) and its on-disk type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DestEntry {
+    /// The dest path, verbatim. Directories end with `/`, files do not.
+    pub path: String,
+    /// The on-disk type of the entry.
+    pub path_type: PathType,
+}
+
+impl DestEntry {
+    /// Builds a [`DestEntry`] from a path and its type.
+    #[must_use]
+    pub fn new(path: impl Into<String>, path_type: PathType) -> Self {
+        Self {
+            path: path.into(),
+            path_type,
+        }
+    }
+}
+
+/// Computes the extraneous dest paths in DEEPEST-FIRST deletion order.
+///
+/// The prune-set is every [`DestEntry`] whose path key is NOT present in the
+/// manifest, minus the destination root `./` (which mirrors the manifest target
+/// and is never pruned), minus any path PROTECTED by an exclude.
+///
+/// Keep/prune keys on `(path, path_type)` only — the trailing-slash convention
+/// distinguishes a file `./p` from a directory `./p/`, so a file↔directory type
+/// change yields the dest form as extraneous. Content (`checksum`/`size`) is
+/// never consulted, and no object pool is required.
+///
+/// `excludes` are extended-regex patterns (grep `-E` semantics, the same
+/// primitive as [`ExcludeMatcher`]): an extraneous path matching ANY exclude is
+/// PROTECTED — removed from the prune-set. Excludes only ever REMOVE entries;
+/// they never resurrect a kept (in-manifest) path. An invalid regex pattern
+/// simply protects nothing (it cannot match), keeping the function total.
+///
+/// The returned order is deepest-first: across the whole set, every descendant
+/// precedes its ancestors, so a caller can unlink children before `rmdir`-ing
+/// their parent directories. The order is deterministic and idempotent.
+#[must_use]
+pub fn prune_set(
+    manifest: &Manifest,
+    dest_entries: &[DestEntry],
+    excludes: &[&str],
+) -> Vec<String> {
+    // The set of manifest path keys (verbatim, trailing-`/` for dirs). A dest
+    // path is KEPT iff its exact key (including the type-distinguishing trailing
+    // slash) is in this set.
+    let kept: BTreeSet<&str> = manifest.entries().iter().map(|e| e.path.as_str()).collect();
+
+    // Compile the exclude patterns once. An invalid pattern is skipped (it
+    // protects nothing), keeping `prune_set` total and panic-free.
+    let matchers: Vec<ExcludeMatcher> = excludes
+        .iter()
+        .filter_map(|p| ExcludeMatcher::new(p).ok())
+        .collect();
+    let is_protected = |path: &str| matchers.iter().any(|m| m.is_excluded(path));
+
+    let mut extraneous: Vec<&str> = dest_entries
+        .iter()
+        .map(|d| d.path.as_str())
+        // The mirror root is never pruned/emitted.
+        .filter(|p| *p != "./")
+        // Extraneous = dest path key absent from the manifest.
+        .filter(|p| !kept.contains(p))
+        // `--exclude` is a one-way PROTECT: drop matching paths from the set.
+        .filter(|p| !is_protected(p))
+        .collect();
+
+    // Deepest-first deletion order: sort by descending path-segment depth so a
+    // descendant always precedes its ancestors; break ties by path (byte order)
+    // for a deterministic, idempotent result.
+    extraneous.sort_by(|a, b| depth(b).cmp(&depth(a)).then_with(|| a.cmp(b)));
+
+    extraneous.into_iter().map(str::to_owned).collect()
+}
+
+/// The directory depth of a path: the number of path separators, ignoring a
+/// single trailing `/` (which marks a directory rather than adding depth).
+///
+/// `./` is depth 1, `./a` and `./a/` are depth 1 (a child of root rendered at
+/// the top level), `./a/b` and `./a/b/` are depth 2, etc. Sorting by descending
+/// depth places any descendant strictly after a shorter ancestor prefix.
+fn depth(path: &str) -> usize {
+    path.trim_end_matches('/').matches('/').count()
+}

--- a/crates/snapdir-core/src/recover.rs
+++ b/crates/snapdir-core/src/recover.rs
@@ -1,0 +1,159 @@
+//! Linked-mode checksum-reuse fast path: recover a file's content checksum from
+//! the object-store path its symlink points at, *without reading the bytes*.
+//!
+//! In `--linked` mode a checkout's destination entries are symlinks into a local
+//! content-addressed object store whose layout mechanically encodes the file's
+//! BLAKE3 digest:
+//!
+//! ```text
+//! <store-root>/.objects/<h[0..3]>/<h[3..6]>/<h[6..9]>/<h[9..]>
+//! ```
+//!
+//! (the exact inverse of the frozen [`object_path`](crate::store::object_path) /
+//! `sharded_path` split). A re-snapshot (`snapdir id` / `manifest`) of such a
+//! tree can therefore RECOVER each file's checksum directly from the symlink
+//! target's object path, never reading or hashing the object's content — the
+//! whole point of the fast path.
+//!
+//! This module is **pure** (string/path parsing only — no I/O of its own) and
+//! **dormant by default**: it is consulted only when the [`walk`](crate::walk)
+//! caller supplies a non-empty object-store-roots hint
+//! ([`WalkOptions::object_store_roots`](crate::walk::WalkOptions::object_store_roots))
+//! AND the active hasher reports it recovers object keys
+//! ([`HashFile::recovers_object_keys`](crate::hash_file::HashFile::recovers_object_keys),
+//! true only for plain, non-keyed BLAKE3 — the store's addressing algorithm).
+//! With no hint every existing call site behaves byte-identically.
+//!
+//! ## Trust boundary (no trust, no panic)
+//!
+//! Recovery is attempted only for a target that **lexically resolves under a
+//! hinted root** as a well-formed `.objects/3/3/3/rest` object path whose four
+//! shard segments concatenate to a valid 64-hex key. A target that escaped the
+//! store, has the wrong shard shape, or is not 64-hex yields [`None`] (the
+//! caller falls back to a normal followed-symlink content hash). Whether the
+//! object actually EXISTS (dangling vs present) is decided by the caller via a
+//! cheap `exists()` check, so a dangling object becomes a typed
+//! [`WalkError`](crate::walk::WalkError) rather than a silent drop or a panic.
+
+use std::path::{Component, Path, PathBuf};
+
+use crate::store::OBJECTS_DIR;
+
+/// Returns `true` iff `s` is exactly 64 lowercase hex characters — the shape of
+/// a snapdir BLAKE3 object key / snapshot id. (Mirrors the `is_hex64` predicate
+/// used by the store layer; kept local so `snapdir-core` has no dependency on
+/// the stores crate.)
+#[must_use]
+fn is_hex64(s: &str) -> bool {
+    s.len() == 64
+        && s.bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+/// Lexically normalizes `path` by folding `.` and `..` components, WITHOUT
+/// touching the filesystem.
+///
+/// Used to canonicalize a symlink target enough to test it against the hinted
+/// store roots even when the target object is MISSING (a `fs::canonicalize`
+/// would fail on a dangling target — we must still recognize that the dangling
+/// target *was* an object path so the caller can raise a typed error rather than
+/// silently dropping it). For symlink targets snapdir's `--linked` checkout
+/// emits — absolute paths into a store's `.objects/` — no symlink components
+/// remain to be followed, so the lexical fold matches the real canonical path.
+fn lexically_normalize(path: &Path) -> PathBuf {
+    let mut out = PathBuf::new();
+    for comp in path.components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => {
+                // Pop a trailing normal component; keep `..` only when there is
+                // nothing to pop (a path that climbs above its anchor).
+                if matches!(out.components().next_back(), Some(Component::Normal(_))) {
+                    out.pop();
+                } else {
+                    out.push("..");
+                }
+            }
+            other => out.push(other.as_os_str()),
+        }
+    }
+    out
+}
+
+/// Resolves a symlink target (as read by `read_link`, possibly relative to the
+/// link's parent directory) to an absolute, lexically-normalized path.
+fn resolve_target(link_parent: &Path, target: &Path) -> PathBuf {
+    let joined = if target.is_absolute() {
+        target.to_path_buf()
+    } else {
+        link_parent.join(target)
+    };
+    lexically_normalize(&joined)
+}
+
+/// Recovers the 64-hex object key encoded by a symlink target's object path, if
+/// the target is a well-formed object under one of the hinted store `roots`.
+///
+/// `link_parent` is the directory containing the symlink (used to resolve a
+/// relative `target`). `target` is the raw symlink target (`fs::read_link`).
+/// `roots` are the local store roots the caller hinted (each a `<store-root>`
+/// directory that holds a `.objects/` pool); an empty slice always yields
+/// [`None`] (the fast path is dormant).
+///
+/// Returns `Some(key)` only when the resolved target is exactly
+/// `<root>/.objects/<3>/<3>/<3>/<rest>` for some hinted `root`, the three shard
+/// segments are 3 chars each, and their concatenation with the trailing segment
+/// is a valid 64-hex key. Otherwise (escaped the store, wrong shard shape, non-
+/// hex, …) returns [`None`] and the caller hashes the followed content normally.
+///
+/// This performs **no filesystem I/O** and never panics: it is pure path
+/// parsing. The caller decides present-vs-dangling separately.
+#[must_use]
+pub fn recover_object_key(link_parent: &Path, target: &Path, roots: &[PathBuf]) -> Option<String> {
+    if roots.is_empty() {
+        return None;
+    }
+    let resolved = resolve_target(link_parent, target);
+
+    for root in roots {
+        let root = lexically_normalize(root);
+        let Ok(rel) = resolved.strip_prefix(&root) else {
+            continue;
+        };
+        // The remainder under the root must be exactly the sharded object
+        // layout: `.objects / s0 / s1 / s2 / rest` (five components). Anything
+        // else (not under `.objects`, wrong depth, an extra nested level) is not
+        // a clean object address and is rejected.
+        let comps: Vec<&std::ffi::OsStr> = rel
+            .components()
+            .map(|c| match c {
+                Component::Normal(s) => Some(s),
+                _ => None,
+            })
+            .collect::<Option<Vec<_>>>()?;
+        if comps.len() != 5 {
+            continue;
+        }
+        if comps[0] != OBJECTS_DIR {
+            continue;
+        }
+        let (Some(s0), Some(s1), Some(s2), Some(rest)) = (
+            comps[1].to_str(),
+            comps[2].to_str(),
+            comps[3].to_str(),
+            comps[4].to_str(),
+        ) else {
+            continue;
+        };
+        // The frozen `sharded_path` split is `[0..3] / [3..6] / [6..9] / [9..]`,
+        // so the three shard dirs are exactly 3 chars each.
+        if s0.len() != 3 || s1.len() != 3 || s2.len() != 3 {
+            continue;
+        }
+        let key = format!("{s0}{s1}{s2}{rest}");
+        if is_hex64(&key) {
+            return Some(key);
+        }
+    }
+    None
+}

--- a/crates/snapdir-core/src/walk.rs
+++ b/crates/snapdir-core/src/walk.rs
@@ -105,6 +105,58 @@ pub struct WalkOptions {
     /// oversubscribing the bounded pool, otherwise BLAKE3's intra-file `rayon`
     /// path is allowed so spare cores still help a lone big file.
     pub walk_jobs: Option<usize>,
+
+    /// Optional local **object-store roots** hint enabling the linked-mode
+    /// checksum-reuse fast path. Defaults to **empty** (the fast path is
+    /// DORMANT — every existing call site is byte-identical).
+    ///
+    /// When non-empty AND the active hasher reports
+    /// [`recovers_object_keys`](crate::hash_file::HashFile::recovers_object_keys)
+    /// (true only for plain, non-keyed BLAKE3), a **symlink-to-file** whose
+    /// canonical target is a valid object under one of these roots'
+    /// `.objects/<3>/<3>/<3>/<rest>` layout has its content checksum
+    /// **recovered from the path** (via [`recover_object_key`](crate::recover::recover_object_key))
+    /// instead of being read and hashed — the recovered key is byte-identical to
+    /// the hash the content would produce on a healthy store. Eligibility is
+    /// per-entry; ineligible symlinks fall back to a normal followed-content
+    /// hash, and a target whose object is MISSING (dangling) raises a typed
+    /// [`WalkError::DanglingLinkedObject`].
+    ///
+    /// The CLI passes the store root(s) here regardless of strict-verify; the
+    /// strict override is carried by [`verify_linked_objects`](WalkOptions::verify_linked_objects)
+    /// instead (so a strict run still recognizes a dangling object and still
+    /// re-hashes-and-ERRORS on a corrupted one). For the non-default-algo /
+    /// keyed cases the CLI leaves this empty so the content is re-hashed. Each
+    /// root is a `<store-root>` directory holding a `.objects/` pool (the path
+    /// `FileStore` materializes linked symlinks into).
+    pub object_store_roots: Vec<PathBuf>,
+
+    /// **Strict-verify override** for the linked-mode fast path. Defaults to
+    /// **`false`** — the fast path TRUSTS the object's address (recovers the
+    /// checksum from the symlink target's path WITHOUT reading the bytes), which
+    /// is the byte-identical default behavior.
+    ///
+    /// When `true` AND an entry would otherwise take the fast path (the same
+    /// eligibility the recover path uses: a symlink whose canonical target is a
+    /// valid object under a hinted [`object_store_roots`](WalkOptions::object_store_roots)
+    /// root, with a hasher that
+    /// [`recovers_object_keys`](crate::hash_file::HashFile::recovers_object_keys)),
+    /// the walk does NOT trust the address: it **reads + hashes the content**
+    /// (`H'`), recovers the address (`H`) from the object path, and compares. On
+    /// a match it records `H` (correct). On a mismatch it returns a typed
+    /// [`WalkError::LinkedObjectIntegrity`] naming the offending symlink and its
+    /// object — the store's content no longer matches the address it is filed
+    /// under. This is the `SNAPDIR_VERIFY_COPIES=1` re-hash-and-error keystone.
+    ///
+    /// This flag ONLY affects entries that WOULD have taken the fast path.
+    /// Ineligible entries (wrong / keyed algo, escaped the store, non-linked)
+    /// are unaffected and hash normally — `true` here never turns those into an
+    /// error. A dangling target still raises
+    /// [`WalkError::DanglingLinkedObject`] regardless of this flag.
+    ///
+    /// The CLI sets this to `true` when `SNAPDIR_VERIFY_COPIES=1`; core stays
+    /// pure / env-free — this bool is the seam.
+    pub verify_linked_objects: bool,
 }
 
 /// Errors raised while walking the filesystem.
@@ -160,6 +212,49 @@ pub enum WalkError {
     FileChangedDuringWalk {
         /// The path of the file that changed mid-hash.
         path: PathBuf,
+    },
+
+    /// A linked-mode fast-path symlink pointed at an object under a hinted
+    /// store root, but the object is **missing** (dangling): the checkout's
+    /// backing object was GC'd / removed. The fast path will neither silently
+    /// drop the entry nor read garbage — it surfaces this typed error naming the
+    /// symlink (and its target), so an in-flux / pruned store fails cleanly
+    /// instead of panicking. (Only ever raised when the object-store-roots hint
+    /// is active; without the hint a dangling symlink is dropped as before,
+    /// matching `find -L`.)
+    #[error(
+        "linked object missing (dangling symlink into the store): {path:?} -> {target:?}; \
+         the backing object was removed/GC'd"
+    )]
+    DanglingLinkedObject {
+        /// The dest symlink whose target object is missing.
+        path: PathBuf,
+        /// The resolved object path the symlink pointed at.
+        target: PathBuf,
+    },
+
+    /// Strict-verify (`SNAPDIR_VERIFY_COPIES=1`,
+    /// [`WalkOptions::verify_linked_objects`]) re-hashed a linked object's
+    /// CONTENT and found it no longer matches the address its object path is
+    /// filed under: the store is corrupt (the content was mutated while keeping
+    /// — or having been moved under — the wrong address). The fast path would
+    /// have trusted the address; strict-verify catches the integrity violation
+    /// and refuses to record a checksum that does not match the bytes. Only ever
+    /// raised when both the object-store-roots hint and `verify_linked_objects`
+    /// are active, and only for an entry that WOULD have taken the fast path.
+    #[error(
+        "linked object integrity check failed (content does not match its address): \
+         {path:?} -> {target:?}; addressed as {expected}, content hashes to {actual}"
+    )]
+    LinkedObjectIntegrity {
+        /// The dest symlink whose backing object's content is corrupt.
+        path: PathBuf,
+        /// The resolved object path the symlink pointed at.
+        target: PathBuf,
+        /// The hash recovered from the object's address (what it claims to be).
+        expected: String,
+        /// The hash of the object's actual content (what it really is).
+        actual: String,
     },
 
     /// A directory invariant expected during the bottom-up finalize pass was
@@ -397,11 +492,20 @@ fn walk_inner<H: Hasher + HashFile + Sync>(
     // file's absolute working-tree path (what a store later clones from).
     let mut guards: HashMap<PathBuf, CopyGuard> = HashMap::new();
     let mut guard_sink = capture_guards.then_some(&mut guards);
+    // Linked-mode fast path is enabled only when a store-root hint was supplied
+    // AND the active hasher's digest matches the store's addressing algorithm
+    // (plain, non-keyed BLAKE3 — see `HashFile::recovers_object_keys`). Computed
+    // once; passed down so per-entry symlink handling can recover a checksum
+    // from the object path instead of reading the content. When `false` (the
+    // default — empty hint) discovery is byte-identical to before.
+    let recover_keys = !options.object_store_roots.is_empty() && hasher.recovers_object_keys();
     discover_dir(
         root,
         &root_str,
         root_permissions,
         options,
+        recover_keys,
+        hasher,
         &mut dirs,
         &mut pending,
         &mut guard_sink,
@@ -491,11 +595,14 @@ fn walk_inner<H: Hasher + HashFile + Sync>(
 /// directory), recording its direct files and child directories, then recurses
 /// into each child directory.
 #[allow(clippy::too_many_arguments)] // internal recursion carrying walk state + the discovery meter
-fn discover_dir(
+#[allow(clippy::too_many_lines)] // one cohesive readdir loop: per-entry exclude/follow/type + fast-path
+fn discover_dir<H: Hasher + HashFile + Sync>(
     dir: &Path,
     abs_path: &str,
     permissions: String,
     options: &WalkOptions,
+    recover_keys: bool,
+    hasher: &H,
     dirs: &mut BTreeMap<String, DirRecord>,
     pending: &mut Vec<PendingHash>,
     guards: &mut Option<&mut HashMap<PathBuf, CopyGuard>>,
@@ -552,6 +659,17 @@ fn discover_dir(
                 // file or directory, so it is omitted. Surface real I/O errors
                 // on non-symlink entries.
                 if is_symlink && (e.kind() == io::ErrorKind::NotFound || is_loop_error(&e)) {
+                    // LINKED-MODE FAST PATH: a dangling symlink whose target IS a
+                    // recoverable object under a hinted store root is NOT a
+                    // benign broken link to silently drop — the checkout's
+                    // backing object was removed/GC'd. Surface a typed error
+                    // (never a panic, never a silent drop). Otherwise a broken
+                    // symlink is dropped exactly as before, matching `find -L`.
+                    if let Some(err) =
+                        dangling_linked_object(recover_keys, &e, dir, &entry_path, options)
+                    {
+                        return Err(err);
+                    }
                     continue;
                 }
                 return Err(WalkError::io(&entry_path, e));
@@ -573,6 +691,8 @@ fn discover_dir(
                 &entry_abs,
                 own_permissions,
                 options,
+                recover_keys,
+                hasher,
                 dirs,
                 pending,
                 guards,
@@ -610,6 +730,53 @@ fn discover_dir(
                 meter.object_discovered();
             }
 
+            // LINKED-MODE FAST PATH (dormant unless `recover_keys`): for a
+            // symlink-to-file whose target is an object under a hinted store
+            // root, RECOVER the content checksum from the object path instead of
+            // reading + hashing the bytes. The recovered key is byte-identical
+            // to the content hash on a healthy store, so the manifest/id is
+            // unchanged from the read path — but no content is read. SIZE still
+            // comes from the symlink's own `lstat` (checksum-only fast path), so
+            // a linked re-snapshot does NOT reproduce the source id. Ineligible
+            // symlinks (escaped / non-object target) fall through to the normal
+            // followed-content hash below; a MISSING object (dangling) is a
+            // typed error, never a panic or a silent drop.
+            if recover_keys && is_symlink {
+                // The target object is already known to exist here: `target_meta`
+                // stat'd through the link successfully above, so this is NOT a
+                // dangling link (the dangling case is caught earlier and turned
+                // into `WalkError::DanglingLinkedObject`). `read_link` + pure
+                // path parsing recover the key; no content is read.
+                if let Some(key) = std::fs::read_link(&entry_path).ok().and_then(|t| {
+                    crate::recover::recover_object_key(dir, &t, &options.object_store_roots)
+                }) {
+                    // STRICT-VERIFY override (`SNAPDIR_VERIFY_COPIES=1`): when
+                    // `verify_linked_objects` is set, do NOT trust the address —
+                    // re-hash the content and ERROR on a mismatch (corrupt store).
+                    // On the default path (`false`) the recovered `key` is trusted
+                    // and recorded WITHOUT reading the bytes. Either way the
+                    // checksum-to-record is resolved here.
+                    let checksum = if options.verify_linked_objects {
+                        verify_linked_checksum(hasher, dir, &entry_path, key)?
+                    } else {
+                        key
+                    };
+                    // Record the (recovered or verified) checksum directly. No
+                    // `PendingHash` is queued; SIZE is still the symlink's own
+                    // `lstat` length (checksum-only fast path).
+                    record.files.push(FileRecord {
+                        abs_path: entry_abs,
+                        permissions: own_permissions,
+                        checksum,
+                        size: link_meta.len(),
+                    });
+                    if let Some(meter) = meter {
+                        meter.object_finished();
+                    }
+                    continue;
+                }
+            }
+
             let file_index = record.files.len();
             record.files.push(FileRecord {
                 abs_path: entry_abs,
@@ -631,6 +798,82 @@ fn discover_dir(
 
     dirs.insert(record.abs_path.clone(), record);
     Ok(())
+}
+
+/// Decides whether a broken symlink (`metadata` returned `NotFound`) is a
+/// dangling LINKED object that must surface a typed
+/// [`WalkError::DanglingLinkedObject`], rather than being silently dropped.
+///
+/// Returns `Some(err)` only when the linked-mode fast path is active
+/// (`recover_keys`), the failure was `NotFound` (not a symlink loop), and the
+/// symlink's target lexically resolves to a recoverable object under a hinted
+/// store root. Otherwise `None` (the caller drops the broken link as `find -L`
+/// does). Pure aside from one `read_link`; never reads content, never panics.
+fn dangling_linked_object(
+    recover_keys: bool,
+    err: &io::Error,
+    link_parent: &Path,
+    entry_path: &Path,
+    options: &WalkOptions,
+) -> Option<WalkError> {
+    if !recover_keys || err.kind() != io::ErrorKind::NotFound {
+        return None;
+    }
+    let target = std::fs::read_link(entry_path).ok()?;
+    crate::recover::recover_object_key(link_parent, &target, &options.object_store_roots)?;
+    Some(WalkError::DanglingLinkedObject {
+        path: entry_path.to_path_buf(),
+        target,
+    })
+}
+
+/// Strict-verify a fast-path-eligible linked object: re-hash its CONTENT and
+/// confirm it matches the address (`expected`) recovered from the object path.
+///
+/// Only called for an entry that WOULD take the fast path (eligible symlink,
+/// recoverable object key) when [`WalkOptions::verify_linked_objects`] is set —
+/// the `SNAPDIR_VERIFY_COPIES=1` keystone. It reads + hashes the bytes the
+/// default fast path deliberately skips, then:
+/// - on a **match** returns the verified checksum (identical to `expected`), so
+///   the caller records a checksum proven against the content;
+/// - on a **mismatch** returns [`WalkError::LinkedObjectIntegrity`] naming the
+///   symlink, its target object, the claimed address and the actual content
+///   hash — the store filed bytes under the wrong address (corruption), and the
+///   walk refuses to trust it.
+///
+/// A genuine read/IO fault on the content surfaces as [`WalkError::Io`].
+fn verify_linked_checksum<H: HashFile>(
+    hasher: &H,
+    link_parent: &Path,
+    entry_path: &Path,
+    expected: String,
+) -> Result<String, WalkError> {
+    let (actual, _len) = hasher
+        .hash_file_hex(entry_path)
+        .map_err(|e| WalkError::io(entry_path, e))?;
+    if actual == expected {
+        return Ok(actual);
+    }
+    let target = std::fs::read_link(entry_path).map_or_else(
+        |_| entry_path.to_path_buf(),
+        |t| resolve_link_target(link_parent, &t),
+    );
+    Err(WalkError::LinkedObjectIntegrity {
+        path: entry_path.to_path_buf(),
+        target,
+        expected,
+        actual,
+    })
+}
+
+/// Resolves a (possibly relative) symlink target against the link's parent
+/// directory, for the human-facing `target` field of an integrity error.
+fn resolve_link_target(link_parent: &Path, target: &Path) -> PathBuf {
+    if target.is_absolute() {
+        target.to_path_buf()
+    } else {
+        link_parent.join(target)
+    }
 }
 
 /// Hashes every [`PendingHash`] in parallel inside a bounded, scoped

--- a/crates/snapdir-core/tests/mirror_prune_set.rs
+++ b/crates/snapdir-core/tests/mirror_prune_set.rs
@@ -1,0 +1,880 @@
+//! ADVERSARY black-box spec-tests for the PURE exact-mirror prune-set
+//! (Phase 32: `--delete` for checkout/pull/sync).
+//!
+//! These tests pin the CONTRACT for computing the *extraneous* set: given a
+//! target [`Manifest`] and a listing of the destination tree's paths + types,
+//! the prune-set is the set of destination paths that are present in the dest
+//! but ABSENT from the manifest — i.e. exactly what `--delete` must remove to
+//! make the dest an exact mirror of the manifest.
+//!
+//! Authored from the gate SPEC alone, with ZERO visibility into the (not yet
+//! existing) implementation. They will NOT compile/pass until the
+//! `mirror-prune-set-impl` gate lands the `snapdir_core::mirror` module.
+//!
+//! ## Assumed public API (the core impl lane must honor or re-point)
+//!
+//! ```ignore
+//! pub mod mirror {
+//!     /// A single destination-tree entry: its path (verbatim, `./`-prefixed
+//!     /// like a manifest path; directories end with `/`) and its on-disk type.
+//!     #[derive(Debug, Clone, PartialEq, Eq)]
+//!     pub struct DestEntry {
+//!         pub path: String,
+//!         pub path_type: snapdir_core::PathType,
+//!     }
+//!     impl DestEntry {
+//!         pub fn new(path: impl Into<String>, path_type: snapdir_core::PathType) -> Self;
+//!     }
+//!
+//!     /// Computes the extraneous dest paths in DEEPEST-FIRST deletion order.
+//!     ///
+//!     /// PURE + I/O-light: compares manifest entries (path+type) against the
+//!     /// dest listing. NEVER reads/hashes object content; works with no
+//!     /// `.objects/` pool present. `excludes` are extended-regex patterns
+//!     /// (grep -E semantics, same as `snapdir_core::excludes::ExcludeMatcher`):
+//!     /// an extraneous path matching ANY exclude is PROTECTED (omitted).
+//!     pub fn prune_set(
+//!         manifest: &snapdir_core::Manifest,
+//!         dest_entries: &[DestEntry],
+//!         excludes: &[&str],
+//!     ) -> Vec<String>;
+//! }
+//! ```
+//!
+//! NOTE for the impl lane: the SPEC writes `--exclude <glob>`, but the only
+//! exclude primitive `snapdir-core` exposes is the extended-regex
+//! `excludes::ExcludeMatcher` (grep -E -v). These tests therefore use exclude
+//! patterns that read identically as a literal substring AND as a regex (plain
+//! path fragments, no metacharacters), so the assertions hold whichever
+//! matching primitive the impl wires in. If the impl chooses a different
+//! exclude type, re-point the type — do NOT weaken the protect/keep assertions.
+
+use snapdir_core::mirror::{prune_set, DestEntry};
+use snapdir_core::{Manifest, PathType};
+
+// ---------------------------------------------------------------------------
+// Test helpers (NOT under test): build manifests + dest listings tersely.
+// ---------------------------------------------------------------------------
+
+/// A manifest file entry line. Checksums/sizes are deliberately BOGUS — the
+/// prune-set must never consult them (it keys on path + type only).
+fn mf(path: &str) -> String {
+    format!("F 600 deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef 0 {path}")
+}
+
+/// A manifest directory entry line (path must end with `/`).
+fn md(path: &str) -> String {
+    format!("D 700 deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef 0 {path}")
+}
+
+/// Parse manifest text from a slice of lines.
+fn manifest(lines: &[String]) -> Manifest {
+    Manifest::parse(&lines.join("\n")).expect("test manifest parses")
+}
+
+/// Convenience: a dest file entry.
+fn df(path: &str) -> DestEntry {
+    DestEntry::new(path, PathType::File)
+}
+
+/// Convenience: a dest directory entry (path should end with `/`).
+fn dd(path: &str) -> DestEntry {
+    DestEntry::new(path, PathType::Directory)
+}
+
+/// True iff `set` is in valid deepest-first deletion order: for every pair
+/// where `a` is an ancestor path of `b` (b starts with a, both dirs), `b`
+/// (the descendant) must appear BEFORE `a`. Proves children unlink before
+/// parents so an `rmdir` of a non-empty dir never happens.
+fn is_deepest_first(set: &[String]) -> bool {
+    for (i, ancestor) in set.iter().enumerate() {
+        // Only directory paths can be ancestors (they end with '/').
+        if !ancestor.ends_with('/') {
+            continue;
+        }
+        for (j, descendant) in set.iter().enumerate() {
+            if i == j {
+                continue;
+            }
+            // `descendant` lives under `ancestor` and is not the ancestor itself.
+            if descendant.starts_with(ancestor.as_str()) && descendant != ancestor {
+                // The descendant must be removed first => earlier index.
+                if j > i {
+                    return false;
+                }
+            }
+        }
+    }
+    true
+}
+
+// ===========================================================================
+// CORE CONTRACT: extraneous = in dest, not in manifest
+// ===========================================================================
+
+#[test]
+fn extraneous_is_dest_paths_absent_from_manifest() {
+    // SPEC: "Extraneous = in dest, not in manifest."
+    let m = manifest(&[md("./"), mf("./keep.txt")]);
+    let dest = vec![dd("./"), df("./keep.txt"), df("./extra.txt")];
+    let set = prune_set(&m, &dest, &[]);
+    assert!(
+        set.contains(&"./extra.txt".to_string()),
+        "a dest path absent from the manifest must be extraneous; got {set:?}"
+    );
+    assert!(
+        !set.contains(&"./keep.txt".to_string()),
+        "a dest path present in the manifest must NOT be pruned; got {set:?}"
+    );
+    assert!(
+        !set.contains(&"./".to_string()),
+        "the root, present in the manifest, must never be pruned; got {set:?}"
+    );
+}
+
+#[test]
+fn manifest_path_kept_even_when_content_differs() {
+    // SPEC: "A path present in the manifest is kept (never pruned), regardless
+    // of content differences (content repair is materialize's job, not
+    // prune's)." The dest file at ./same has a different (in-tree) content than
+    // the manifest, but since prune ignores content it must NOT be extraneous.
+    let m = manifest(&[md("./"), mf("./same")]);
+    // Same path + same type; prune does not look at checksum/size at all.
+    let dest = vec![dd("./"), df("./same")];
+    let set = prune_set(&m, &dest, &[]);
+    assert!(
+        set.is_empty(),
+        "a path in both manifest and dest is never pruned regardless of content; got {set:?}"
+    );
+}
+
+// ===========================================================================
+// PURITY / I/O-LIGHTNESS: no object pool required
+// ===========================================================================
+
+#[test]
+fn prune_set_computes_with_no_objects_pool_present() {
+    // SPEC: "the prune-set is computable with no `.objects` pool present" — the
+    // computation is PURE: it never reads/hashes object content. We prove this
+    // by feeding bogus checksums and never providing any store/objects path to
+    // the function: its signature takes only (manifest, dest_entries, excludes).
+    let m = manifest(&[md("./"), mf("./a.txt")]);
+    let dest = vec![dd("./"), df("./a.txt"), df("./b.txt")];
+    // No store, no .objects/, nothing on disk — just data structures.
+    let set = prune_set(&m, &dest, &[]);
+    assert_eq!(
+        set,
+        vec!["./b.txt".to_string()],
+        "prune-set must be derivable purely from path+type listings; got {set:?}"
+    );
+}
+
+#[test]
+fn prune_set_ignores_checksum_field_entirely() {
+    // SPEC: content is never consulted. Two manifests differing ONLY by the
+    // (bogus) checksum of an entry yield the identical prune-set, proving the
+    // checksum field is not part of the keep/prune decision.
+    let dest = vec![dd("./"), df("./keep"), df("./drop")];
+
+    let m1 = manifest(&[md("./"), mf("./keep")]);
+    let weird = "F 600 0000000000000000000000000000000000000000000000000000000000000000 999 ./keep";
+    let m2 = Manifest::parse(&format!("{}\n{weird}", md("./"))).expect("parses");
+
+    let s1 = prune_set(&m1, &dest, &[]);
+    let s2 = prune_set(&m2, &dest, &[]);
+    assert_eq!(
+        s1, s2,
+        "prune-set must not depend on checksum/size; {s1:?} vs {s2:?}"
+    );
+    assert_eq!(s1, vec!["./drop".to_string()]);
+}
+
+// ===========================================================================
+// FILE <-> DIR TYPE CHANGE: replaced, not kept (both directions)
+// ===========================================================================
+
+#[test]
+fn manifest_file_but_dest_dir_is_extraneous_replace_not_keep() {
+    // SPEC: "if the manifest has path `p` as a File but the dest has `p` as a
+    // Directory ... `p` (the dest form) is extraneous and must be in the
+    // prune-set (so materialize can replace it with the correct type)."
+    // Manifest: p is a File. Dest: p/ is a Directory (with a child).
+    let m = manifest(&[md("./"), mf("./p")]);
+    let dest = vec![dd("./"), dd("./p/"), df("./p/child")];
+    let set = prune_set(&m, &dest, &[]);
+    // The dest directory ./p/ (and its child) must be pruned: the manifest
+    // wants a File at p, so the directory form is extraneous.
+    assert!(
+        set.contains(&"./p/".to_string()),
+        "dest dir ./p/ where manifest has file ./p must be pruned (type change); got {set:?}"
+    );
+    assert!(
+        set.contains(&"./p/child".to_string()),
+        "the child under the to-be-replaced dir must also be pruned; got {set:?}"
+    );
+}
+
+#[test]
+fn manifest_dir_but_dest_file_is_extraneous_replace_not_keep() {
+    // SPEC (other direction): manifest has `p` as a Directory, dest has `p` as
+    // a File => the dest file is extraneous (must be replaced by the dir).
+    let m = manifest(&[md("./"), md("./p/"), mf("./p/inside")]);
+    let dest = vec![dd("./"), df("./p")];
+    let set = prune_set(&m, &dest, &[]);
+    assert!(
+        set.contains(&"./p".to_string()),
+        "dest file ./p where manifest has dir ./p/ must be pruned (type change); got {set:?}"
+    );
+}
+
+#[test]
+fn type_change_pruned_even_when_path_string_matches_modulo_trailing_slash() {
+    // SPEC corollary: the dest dir entry (`./p/`) and the manifest file entry
+    // (`./p`) are NOT the same path key — the trailing slash distinguishes
+    // type. The dir form is extraneous; nothing in the manifest "saves" it.
+    let m = manifest(&[md("./"), mf("./p")]);
+    let dest = vec![dd("./"), dd("./p/")];
+    let set = prune_set(&m, &dest, &[]);
+    assert_eq!(
+        set,
+        vec!["./p/".to_string()],
+        "the dir form ./p/ is extraneous against a file ./p; got {set:?}"
+    );
+}
+
+// ===========================================================================
+// DEEPEST-FIRST ORDERING for nested extraneous trees
+// ===========================================================================
+
+#[test]
+fn nested_extraneous_tree_is_ordered_deepest_first() {
+    // SPEC: "Nested directories must be ordered deepest-first ... a nested
+    // extraneous tree yields a deletion order with descendants before their
+    // ancestors." Manifest is just the root; the whole ./junk/ subtree is extra.
+    let m = manifest(&[md("./")]);
+    let dest = vec![
+        dd("./"),
+        dd("./junk/"),
+        dd("./junk/deep/"),
+        df("./junk/deep/leaf.txt"),
+        df("./junk/top.txt"),
+    ];
+    let set = prune_set(&m, &dest, &[]);
+    assert!(
+        is_deepest_first(&set),
+        "removal order must unlink descendants before ancestors; got {set:?}"
+    );
+    // Concretely: the deepest leaf precedes ./junk/deep/ which precedes ./junk/.
+    let pos = |p: &str| set.iter().position(|x| x == p).expect("present in set");
+    assert!(pos("./junk/deep/leaf.txt") < pos("./junk/deep/"));
+    assert!(pos("./junk/deep/") < pos("./junk/"));
+    assert!(pos("./junk/top.txt") < pos("./junk/"));
+}
+
+#[test]
+fn sibling_subtrees_each_internally_deepest_first() {
+    // SPEC reinforcement: multiple independent extraneous subtrees each obey
+    // deepest-first internally (cross-subtree order is unconstrained, so we
+    // only assert the ancestor/descendant invariant via the helper).
+    let m = manifest(&[md("./")]);
+    let dest = vec![
+        dd("./"),
+        dd("./x/"),
+        df("./x/x1"),
+        dd("./y/"),
+        dd("./y/yy/"),
+        df("./y/yy/y2"),
+    ];
+    let set = prune_set(&m, &dest, &[]);
+    assert!(
+        is_deepest_first(&set),
+        "each subtree must be deepest-first; got {set:?}"
+    );
+}
+
+// ===========================================================================
+// EMPTY EXTRANEOUS DIRECTORIES are included
+// ===========================================================================
+
+#[test]
+fn empty_extraneous_directory_is_included() {
+    // SPEC: "Empty extraneous directories are included in the prune-set."
+    let m = manifest(&[md("./"), mf("./keep")]);
+    let dest = vec![dd("./"), df("./keep"), dd("./emptydir/")];
+    let set = prune_set(&m, &dest, &[]);
+    assert!(
+        set.contains(&"./emptydir/".to_string()),
+        "an empty extraneous directory must be pruned; got {set:?}"
+    );
+}
+
+#[test]
+fn nested_empty_extraneous_dirs_ordered_deepest_first() {
+    // SPEC: empty dirs included AND deepest-first. A chain of empty dirs with
+    // no files at the bottom must still order child before parent.
+    let m = manifest(&[md("./")]);
+    let dest = vec![dd("./"), dd("./a/"), dd("./a/b/"), dd("./a/b/c/")];
+    let set = prune_set(&m, &dest, &[]);
+    assert!(
+        is_deepest_first(&set),
+        "empty-dir chain must be deepest-first; got {set:?}"
+    );
+    let pos = |p: &str| set.iter().position(|x| x == p).expect("present");
+    assert!(pos("./a/b/c/") < pos("./a/b/"));
+    assert!(pos("./a/b/") < pos("./a/"));
+}
+
+// ===========================================================================
+// EXCLUDE: matching extraneous paths are PROTECTED (opt-out)
+// ===========================================================================
+
+#[test]
+fn exclude_protects_matching_extraneous_path() {
+    // SPEC: "an extraneous path that matches an exclude pattern is PROTECTED,
+    // i.e. NOT pruned." `./protected.log` would be extraneous but is excluded;
+    // `./pruned.tmp` is extraneous and NOT excluded => still pruned.
+    let m = manifest(&[md("./"), mf("./keep")]);
+    let dest = vec![
+        dd("./"),
+        df("./keep"),
+        df("./protected.log"),
+        df("./pruned.tmp"),
+    ];
+    let set = prune_set(&m, &dest, &["protected.log"]);
+    assert!(
+        !set.contains(&"./protected.log".to_string()),
+        "an excluded extraneous path must be protected (not pruned); got {set:?}"
+    );
+    assert!(
+        set.contains(&"./pruned.tmp".to_string()),
+        "a non-excluded extraneous path must still be pruned; got {set:?}"
+    );
+}
+
+#[test]
+fn exclude_does_not_resurrect_a_manifest_path() {
+    // SPEC corollary: excludes only REMOVE from the prune-set; a kept (in
+    // manifest) path was never in the set, so an exclude that matches it is a
+    // no-op — the set is unchanged.
+    let m = manifest(&[md("./"), mf("./keep")]);
+    let dest = vec![dd("./"), df("./keep"), df("./drop")];
+    let with = prune_set(&m, &dest, &["keep"]);
+    let without = prune_set(&m, &dest, &[]);
+    assert_eq!(
+        with, without,
+        "excluding a path that is already kept changes nothing; {with:?} vs {without:?}"
+    );
+    assert_eq!(with, vec!["./drop".to_string()]);
+}
+
+#[test]
+fn multiple_excludes_all_apply() {
+    // SPEC: each --exclude pattern protects matching extraneous paths. Two
+    // patterns protect two different files; a third unmatched file is pruned.
+    let m = manifest(&[md("./")]);
+    let dest = vec![
+        dd("./"),
+        df("./a.keepme"),
+        df("./b.keepme2"),
+        df("./c.gone"),
+    ];
+    let set = prune_set(&m, &dest, &["keepme", "keepme2"]);
+    assert!(!set.contains(&"./a.keepme".to_string()), "got {set:?}");
+    assert!(!set.contains(&"./b.keepme2".to_string()), "got {set:?}");
+    assert!(set.contains(&"./c.gone".to_string()), "got {set:?}");
+}
+
+#[test]
+fn exclude_protecting_dir_protects_whole_subtree_paths_that_match() {
+    // SPEC: excludes operate on each path; a pattern matching a directory
+    // segment protects every dest path under it that the regex also matches.
+    // Using the segment fragment "node_modules" (matches the dir and its
+    // children, since the regex matches anywhere in the path).
+    let m = manifest(&[md("./")]);
+    let dest = vec![
+        dd("./"),
+        dd("./node_modules/"),
+        df("./node_modules/pkg/index.js"),
+        df("./build.tmp"),
+    ];
+    let set = prune_set(&m, &dest, &["node_modules"]);
+    assert!(
+        !set.iter().any(|p| p.contains("node_modules")),
+        "every node_modules path must be protected; got {set:?}"
+    );
+    assert!(
+        set.contains(&"./build.tmp".to_string()),
+        "the non-matching extraneous file must still be pruned; got {set:?}"
+    );
+}
+
+// ===========================================================================
+// IDEMPOTENCY / DEGENERATE INPUTS
+// ===========================================================================
+
+#[test]
+fn dest_exactly_equals_manifest_yields_empty_prune_set() {
+    // SPEC: "dest exactly equals manifest -> empty prune-set."
+    let m = manifest(&[md("./"), md("./a/"), mf("./a/f"), mf("./r")]);
+    let dest = vec![dd("./"), dd("./a/"), df("./a/f"), df("./r")];
+    let set = prune_set(&m, &dest, &[]);
+    assert!(
+        set.is_empty(),
+        "exact mirror must produce no deletions; got {set:?}"
+    );
+}
+
+#[test]
+fn empty_dest_yields_empty_prune_set() {
+    // SPEC: "dest empty -> empty prune-set." Nothing on disk => nothing to remove.
+    let m = manifest(&[md("./"), mf("./a"), mf("./b")]);
+    let set = prune_set(&m, &[], &[]);
+    assert!(
+        set.is_empty(),
+        "an empty dest can have nothing extraneous; got {set:?}"
+    );
+}
+
+#[test]
+fn empty_manifest_with_nonempty_dest_prunes_everything_except_root() {
+    // SPEC: "manifest empty + dest non-empty -> all dest paths extraneous."
+    // The root ./ is special: an empty manifest still implies the dest root
+    // exists as the mirror target. We assert all NON-root dest paths are
+    // extraneous; whether the bare root is itself listed is asserted by the
+    // root-specific test below. Here we use a manifest with only the root.
+    let m = manifest(&[md("./")]);
+    let dest = vec![dd("./"), df("./a"), dd("./d/"), df("./d/e")];
+    let set = prune_set(&m, &dest, &[]);
+    assert!(set.contains(&"./a".to_string()), "got {set:?}");
+    assert!(set.contains(&"./d/".to_string()), "got {set:?}");
+    assert!(set.contains(&"./d/e".to_string()), "got {set:?}");
+    assert!(
+        !set.contains(&"./".to_string()),
+        "the mirror root ./ (present in manifest) must never be pruned; got {set:?}"
+    );
+    assert!(is_deepest_first(&set), "got {set:?}");
+}
+
+#[test]
+fn totally_empty_manifest_and_empty_dest_is_empty() {
+    // SPEC degenerate corner: both empty => empty.
+    let m = Manifest::new();
+    let set = prune_set(&m, &[], &[]);
+    assert!(set.is_empty(), "nothing in, nothing out; got {set:?}");
+}
+
+#[test]
+fn idempotent_across_repeated_calls() {
+    // SPEC: idempotency / re-runs. Calling twice on the same inputs yields the
+    // identical ordered result (no hidden state, stable order).
+    let m = manifest(&[md("./"), mf("./keep")]);
+    let dest = vec![dd("./"), df("./keep"), dd("./x/"), df("./x/y"), df("./z")];
+    let a = prune_set(&m, &dest, &[]);
+    let b = prune_set(&m, &dest, &[]);
+    assert_eq!(a, b, "prune-set must be deterministic and order-stable");
+}
+
+#[test]
+fn manifest_directory_also_in_dest_is_kept() {
+    // SPEC: "Directories in the manifest that also exist in the dest are kept."
+    let m = manifest(&[md("./"), md("./shared/"), mf("./shared/f")]);
+    let dest = vec![dd("./"), dd("./shared/"), df("./shared/f")];
+    let set = prune_set(&m, &dest, &[]);
+    assert!(
+        !set.contains(&"./shared/".to_string()),
+        "a directory present in both manifest and dest must be kept; got {set:?}"
+    );
+    assert!(set.is_empty(), "got {set:?}");
+}
+
+// ===========================================================================
+// UNICODE / SPACE / DOT-PREFIXED PATHS
+// ===========================================================================
+
+#[test]
+fn unicode_and_space_and_dot_prefixed_extraneous_paths_handled() {
+    // SPEC: "unicode / space / dot-prefixed paths handled." Each extraneous
+    // path with awkward bytes must still be detected as extraneous and kept
+    // verbatim (no normalization) in the output.
+    let m = manifest(&[md("./"), mf("./keep")]);
+    let dest = vec![
+        dd("./"),
+        df("./keep"),
+        df("./naïve café.txt"),     // unicode + space
+        df("./a file with spaces"), // spaces
+        df("./.hidden"),            // dot-prefixed (not the ./ prefix)
+        df("./日本語.txt"),         // unicode file name
+    ];
+    let set = prune_set(&m, &dest, &[]);
+    assert!(set.contains(&"./naïve café.txt".to_string()), "got {set:?}");
+    assert!(
+        set.contains(&"./a file with spaces".to_string()),
+        "got {set:?}"
+    );
+    assert!(set.contains(&"./.hidden".to_string()), "got {set:?}");
+    assert!(set.contains(&"./日本語.txt".to_string()), "got {set:?}");
+}
+
+#[test]
+fn dot_prefixed_file_present_in_manifest_is_kept() {
+    // SPEC: dot-prefixed paths are ordinary paths — one in the manifest is kept.
+    let m = manifest(&[md("./"), mf("./.config")]);
+    let dest = vec![dd("./"), df("./.config"), df("./.junk")];
+    let set = prune_set(&m, &dest, &[]);
+    assert!(
+        !set.contains(&"./.config".to_string()),
+        "dotfile in manifest kept; got {set:?}"
+    );
+    assert!(
+        set.contains(&"./.junk".to_string()),
+        "extraneous dotfile pruned; got {set:?}"
+    );
+}
+
+#[test]
+fn space_bearing_path_is_keyed_verbatim_not_split() {
+    // SPEC corollary + manifest-format note: the path field may contain spaces
+    // and is keyed verbatim. A space-bearing path present in the manifest is
+    // kept; only the truly-extraneous space-bearing path is pruned.
+    let m = manifest(&[md("./"), mf("./keep me.txt")]);
+    let dest = vec![dd("./"), df("./keep me.txt"), df("./drop me.txt")];
+    let set = prune_set(&m, &dest, &[]);
+    assert!(!set.contains(&"./keep me.txt".to_string()), "got {set:?}");
+    assert!(set.contains(&"./drop me.txt".to_string()), "got {set:?}");
+}
+
+// ===========================================================================
+// MIXED REALISTIC SCENARIO (everything at once)
+// ===========================================================================
+
+#[test]
+fn mixed_scenario_keep_replace_prune_exclude_ordered() {
+    // SPEC integration: a single call exercising keep, type-change-replace,
+    // nested-extraneous deepest-first, empty-dir, and exclude-protect together.
+    let m = manifest(&[
+        md("./"),
+        mf("./keep.txt"), // present in dest, same type => kept
+        md("./libdir/"),  // present in dest as dir => kept
+        mf("./libdir/lib.rs"),
+        mf("./becomes_file"), // manifest says File; dest has it as a dir => replace
+    ]);
+    let dest = vec![
+        dd("./"),
+        df("./keep.txt"),
+        dd("./libdir/"),
+        df("./libdir/lib.rs"),
+        dd("./becomes_file/"),      // type change -> prune the dir form
+        df("./becomes_file/stale"), // its child -> prune
+        dd("./trash/"),             // wholly extraneous subtree
+        dd("./trash/sub/"),
+        df("./trash/sub/x"),
+        dd("./emptyextra/"),    // empty extraneous dir
+        df("./protected.keep"), // extraneous but excluded => protected
+    ];
+    let set = prune_set(&m, &dest, &["protected.keep"]);
+
+    // Kept paths absent from the prune-set.
+    for kept in [
+        "./",
+        "./keep.txt",
+        "./libdir/",
+        "./libdir/lib.rs",
+        "./protected.keep",
+    ] {
+        assert!(
+            !set.contains(&kept.to_string()),
+            "{kept} must be kept; got {set:?}"
+        );
+    }
+    // Pruned paths present.
+    for pruned in [
+        "./becomes_file/",
+        "./becomes_file/stale",
+        "./trash/",
+        "./trash/sub/",
+        "./trash/sub/x",
+        "./emptyextra/",
+    ] {
+        assert!(
+            set.contains(&pruned.to_string()),
+            "{pruned} must be pruned; got {set:?}"
+        );
+    }
+    // Ordering invariant holds across the whole set.
+    assert!(
+        is_deepest_first(&set),
+        "whole-set deletion order must be deepest-first; got {set:?}"
+    );
+}
+
+// ===========================================================================
+// REVIEW-GATE ADDITIONS (impl now visible: excludes are extended-regex via
+// `snapdir_core::excludes::ExcludeMatcher` = `Regex::is_match`, UNANCHORED;
+// invalid regex protects nothing; keep/prune keys on the verbatim path string
+// only — `path_type` is never consulted; symlinks are ordinary path entries).
+// All assertions below remain BLACK-BOX against the public `mirror` API.
+// ===========================================================================
+
+#[test]
+fn exclude_regex_dot_metachar_matches_any_char_not_just_literal_dot() {
+    // IMPL-REVEALED: excludes are extended-regex (`Regex::is_match`), so `.` is
+    // the any-char metacharacter, NOT a literal dot. The pattern `protected.log`
+    // therefore protects BOTH `./protectedXlog` (`.`==`X`) and `./protected.log`
+    // (`.`==`.`). Pin this so a future "treat excludes as literals" change is
+    // caught: a metachar pattern protects the wider regex language, not just the
+    // literal string. (Documents the contract; does not over/under-protect a
+    // path the regex genuinely does not match.)
+    let m = manifest(&[md("./")]);
+    let dest = vec![
+        dd("./"),
+        df("./protected.log"), // literal dot — matches `protected.log`
+        df("./protectedXlog"), // `.` metachar matches the `X`
+        df("./protectedlog"),  // NO char between `protected` and `log` => no match
+    ];
+    let set = prune_set(&m, &dest, &["protected.log"]);
+    assert!(
+        !set.contains(&"./protected.log".to_string()),
+        "literal-dot path protected by regex `.`; got {set:?}"
+    );
+    assert!(
+        !set.contains(&"./protectedXlog".to_string()),
+        "regex `.` is any-char, so protectedXlog is also protected; got {set:?}"
+    );
+    assert!(
+        set.contains(&"./protectedlog".to_string()),
+        "no char to fill `.` => no match => still pruned; got {set:?}"
+    );
+}
+
+#[test]
+fn exclude_unanchored_matches_substring_anywhere_in_path() {
+    // IMPL-REVEALED: `ExcludeMatcher::is_excluded` is an UNANCHORED `is_match`,
+    // so a bare fragment matches as a substring anywhere — including across the
+    // `./` prefix and path segments. Pin that `node_modules` protects the dir,
+    // its children, AND a deeper-nested occurrence, while a sibling that merely
+    // shares a prefix substring (`node`) is also caught (documents substring,
+    // not segment, semantics) — but an unrelated path is pruned.
+    let m = manifest(&[md("./")]);
+    let dest = vec![
+        dd("./"),
+        dd("./node_modules/"),
+        df("./node_modules/pkg/index.js"),
+        df("./src/vendor/node_modules/x"), // nested occurrence matches too
+        df("./node_extra"),                // shares `node` only, NOT `node_modules`
+        df("./build.tmp"),
+    ];
+    let set = prune_set(&m, &dest, &["node_modules"]);
+    assert!(
+        !set.iter().any(|p| p.contains("node_modules")),
+        "every path containing node_modules (any depth) protected; got {set:?}"
+    );
+    assert!(
+        set.contains(&"./node_extra".to_string()),
+        "`node_extra` does not contain `node_modules` => pruned; got {set:?}"
+    );
+    assert!(
+        set.contains(&"./build.tmp".to_string()),
+        "unrelated extraneous file still pruned; got {set:?}"
+    );
+}
+
+#[test]
+fn exclude_anchored_pattern_respects_anchors() {
+    // IMPL-REVEALED: extended-regex anchors `^`/`$` work. `^\\./top$` (anchored
+    // to the whole path) protects exactly `./top` and nothing else; a path that
+    // merely contains `top` as a substring is NOT protected by the anchored
+    // pattern. Pin anchored vs unanchored distinction so excludes are not
+    // silently treated as always-substring.
+    let m = manifest(&[md("./")]);
+    let dest = vec![
+        dd("./"),
+        df("./top"),     // exact match for the anchored pattern
+        df("./topmost"), // contains `top` but anchored `$` rejects it
+        df("./sub/top"), // contains `top` but anchored `^\./top` rejects it
+    ];
+    let set = prune_set(&m, &dest, &[r"^\./top$"]);
+    assert!(
+        !set.contains(&"./top".to_string()),
+        "anchored pattern protects exactly ./top; got {set:?}"
+    );
+    assert!(
+        set.contains(&"./topmost".to_string()),
+        "anchored `$` => ./topmost NOT protected, pruned; got {set:?}"
+    );
+    assert!(
+        set.contains(&"./sub/top".to_string()),
+        "anchored `^\\./top` => ./sub/top NOT protected, pruned; got {set:?}"
+    );
+}
+
+#[test]
+fn invalid_exclude_regex_protects_nothing() {
+    // IMPL-REVEALED: `prune_set` compiles each pattern via `ExcludeMatcher::new`
+    // and SKIPS any that fail to compile (`filter_map(... .ok())`), so an invalid
+    // regex protects NOTHING and the function stays total/panic-free. Pin that an
+    // unbalanced bracket `[` (invalid ERE) silently protects nothing — the
+    // extraneous path is still pruned exactly as if no exclude were given.
+    let m = manifest(&[md("./"), mf("./keep")]);
+    let dest = vec![dd("./"), df("./keep"), df("./drop")];
+    let with_bad = prune_set(&m, &dest, &["["]); // unbalanced bracket: invalid
+    let without = prune_set(&m, &dest, &[]);
+    assert_eq!(
+        with_bad, without,
+        "an invalid regex protects nothing (skipped); {with_bad:?} vs {without:?}"
+    );
+    assert_eq!(
+        with_bad,
+        vec!["./drop".to_string()],
+        "extraneous ./drop still pruned despite the bad pattern; got {with_bad:?}"
+    );
+}
+
+#[test]
+fn invalid_exclude_does_not_suppress_other_valid_excludes() {
+    // IMPL-REVEALED corollary: with a mix of one invalid and one valid pattern,
+    // the invalid one is skipped but the valid one STILL protects its match —
+    // the bad pattern neither panics nor disables the good one.
+    let m = manifest(&[md("./")]);
+    let dest = vec![dd("./"), df("./safe.keep"), df("./gone")];
+    let set = prune_set(&m, &dest, &["(", "safe.keep"]); // first invalid, second valid
+    assert!(
+        !set.contains(&"./safe.keep".to_string()),
+        "valid pattern still protects despite a preceding invalid one; got {set:?}"
+    );
+    assert!(
+        set.contains(&"./gone".to_string()),
+        "unmatched extraneous path still pruned; got {set:?}"
+    );
+}
+
+#[test]
+fn symlink_dest_entry_classified_by_path_presence_not_followed() {
+    // IMPL-REVEALED + spec/_shared symlink note: `PathType` has only File/Dir, so
+    // a dest symlink surfaces as an ordinary path entry. The keep/prune decision
+    // keys ONLY on the verbatim path string vs the manifest — the impl never
+    // stats, follows, or resolves a symlink target. A symlink whose path is
+    // ABSENT from the manifest is extraneous (pruned); one whose path IS in the
+    // manifest is kept — regardless of what it points at.
+    let m = manifest(&[md("./"), mf("./linked_in")]);
+    let dest = vec![
+        dd("./"),
+        df("./linked_in"), // a symlink occupying a path the manifest keeps
+        df("./dangling"),  // a symlink path absent from the manifest => extraneous
+    ];
+    let set = prune_set(&m, &dest, &[]);
+    assert!(
+        !set.contains(&"./linked_in".to_string()),
+        "a symlink at a kept path is kept (not followed); got {set:?}"
+    );
+    assert_eq!(
+        set,
+        vec!["./dangling".to_string()],
+        "a symlink path absent from the manifest is extraneous by path alone; got {set:?}"
+    );
+}
+
+#[test]
+fn symlink_to_dir_without_trailing_slash_is_distinct_key_from_manifest_dir() {
+    // IMPL-REVEALED: the trailing-slash convention is the type key. A dest symlink
+    // recorded as a file `./p` (no trailing slash) is a DISTINCT key from a
+    // manifest directory `./p/`. So a symlink-as-file at ./p where the manifest
+    // has a real dir ./p/ is extraneous (must be replaced) — the symlink is not
+    // specially "followed" into the directory to make it match.
+    let m = manifest(&[md("./"), md("./p/"), mf("./p/inside")]);
+    let dest = vec![dd("./"), df("./p")]; // a symlink, recorded as a file key
+    let set = prune_set(&m, &dest, &[]);
+    assert_eq!(
+        set,
+        vec!["./p".to_string()],
+        "symlink-as-file ./p is extraneous vs manifest dir ./p/; got {set:?}"
+    );
+}
+
+#[test]
+fn duplicate_dest_entries_for_same_extraneous_path_both_emitted_verbatim() {
+    // IMPL-REVEALED edge: `prune_set` maps dest entries 1:1 (no dedup pass) before
+    // sorting. Pin the behavior on a degenerate duplicate input so a future
+    // dedup/refactor must be a deliberate, reviewed change rather than silent.
+    // The path is emitted once per dest entry; both are the same extraneous key.
+    let m = manifest(&[md("./")]);
+    let dest = vec![dd("./"), df("./dup"), df("./dup")];
+    let set = prune_set(&m, &dest, &[]);
+    assert!(
+        set.contains(&"./dup".to_string()),
+        "the extraneous duplicate path must be present; got {set:?}"
+    );
+    assert_eq!(
+        set.iter().filter(|p| *p == "./dup").count(),
+        2,
+        "current impl emits one entry per dest listing (no dedup); got {set:?}"
+    );
+}
+
+#[test]
+fn ordering_stable_under_adversarial_input_permutation() {
+    // IMPL-REVEALED: deepest-first is achieved by sort (descending depth, byte-
+    // order tie-break), so the OUTPUT must be identical regardless of the INPUT
+    // ordering. Feed the same nested extraneous tree in two scrambled orders and
+    // assert byte-identical results AND the deepest-first invariant for both.
+    let m = manifest(&[md("./")]);
+    let forward = vec![
+        dd("./"),
+        dd("./a/"),
+        dd("./a/b/"),
+        df("./a/b/leaf"),
+        df("./a/top"),
+        df("./z"),
+    ];
+    let scrambled = vec![
+        df("./z"),
+        df("./a/b/leaf"),
+        dd("./"),
+        df("./a/top"),
+        dd("./a/b/"),
+        dd("./a/"),
+    ];
+    let s1 = prune_set(&m, &forward, &[]);
+    let s2 = prune_set(&m, &scrambled, &[]);
+    assert_eq!(
+        s1, s2,
+        "output order must be independent of input order; {s1:?} vs {s2:?}"
+    );
+    assert!(is_deepest_first(&s1), "got {s1:?}");
+    assert!(is_deepest_first(&s2), "got {s2:?}");
+}
+
+#[test]
+fn equal_depth_extraneous_paths_break_ties_in_byte_order() {
+    // IMPL-REVEALED: among same-depth siblings (no ancestor/descendant relation),
+    // the impl tie-breaks by ascending byte order for determinism. Pin that the
+    // top-level siblings come out byte-sorted so the order is fully specified
+    // (not merely "some deterministic order").
+    let m = manifest(&[md("./")]);
+    let dest = vec![dd("./"), df("./c"), df("./a"), df("./b")];
+    let set = prune_set(&m, &dest, &[]);
+    assert_eq!(
+        set,
+        vec!["./a".to_string(), "./b".to_string(), "./c".to_string()],
+        "equal-depth siblings emit in ascending byte order; got {set:?}"
+    );
+}
+
+#[test]
+fn trailing_slash_directory_and_same_named_file_both_extraneous_distinct_keys() {
+    // IMPL-REVEALED corner: if the dest somehow lists BOTH `./p` (file) and
+    // `./p/` (dir) and the manifest has neither, both are distinct extraneous
+    // keys and BOTH are pruned; the file (depth 1) and the dir (depth 1) are
+    // independent. Pin that neither suppresses the other.
+    let m = manifest(&[md("./")]);
+    let dest = vec![dd("./"), df("./p"), dd("./p/")];
+    let set = prune_set(&m, &dest, &[]);
+    assert!(
+        set.contains(&"./p".to_string()),
+        "file ./p pruned; got {set:?}"
+    );
+    assert!(
+        set.contains(&"./p/".to_string()),
+        "dir ./p/ pruned; got {set:?}"
+    );
+    assert_eq!(set.len(), 2, "both distinct keys pruned; got {set:?}");
+}

--- a/crates/snapdir-stores/src/file_store.rs
+++ b/crates/snapdir-stores/src/file_store.rs
@@ -79,6 +79,27 @@ pub struct FileStore {
     copy_guards: HashMap<PathBuf, CopyGuard>,
 }
 
+/// How a manifest's file entries are written into a destination by
+/// [`FileStore::fetch_files_with_mode`].
+///
+/// [`MaterializeMode::Auto`] is the historical default: each file is a real,
+/// independent, editable inode (a `CoW` reflink where the filesystem supports
+/// it, else a plain byte copy). [`MaterializeMode::Linked`] is the zero-copy
+/// thin store-view: each file entry is a symlink into the local
+/// content-addressed object, and those objects are hardened to `0444` so the
+/// shared bytes cannot be corrupted through the link.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum MaterializeMode {
+    /// Reflink-or-copy into an INDEPENDENT, EDITABLE dest inode (today's
+    /// default). Byte-for-byte [`Store::fetch_files`].
+    Auto,
+    /// Symlink each file entry into the LOCAL `.objects/<sharded>` object for
+    /// its checksum (zero-copy); the linked objects are hardened to `0444`
+    /// (read-only). Directories are still materialized as real directories.
+    Linked,
+}
+
 /// How [`copy_file`] actually moved the bytes — the trust input to whether
 /// [`persist`] may skip its post-copy re-hash.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -204,6 +225,216 @@ impl FileStore {
     /// Absolute on-disk path of a manifest given its snapshot id.
     fn manifest_disk_path(&self, id: &str) -> PathBuf {
         self.root.join(manifest_path(id))
+    }
+
+    /// Materializes `manifest` into `dest` using an explicit
+    /// [`MaterializeMode`].
+    ///
+    /// * [`MaterializeMode::Auto`] is byte-for-byte [`Store::fetch_files`]
+    ///   (reflink-or-copy into independent, editable inodes).
+    /// * [`MaterializeMode::Linked`] writes each file entry as a symlink into
+    ///   the LOCAL content-addressed object for its checksum (zero-copy) and
+    ///   hardens those objects to `0444`; directories are real directories.
+    ///   A required object that is not resolvable to a real LOCAL store object
+    ///   is a hard [`StoreError::ObjectNotFound`] (no dangling symlink is
+    ///   left). Symlinking to a remote object is impossible — the genuine
+    ///   non-local-source refusal lives at the CLI/router layer; this method
+    ///   only ever links to the local `.objects` pool.
+    pub fn fetch_files_with_mode(
+        &self,
+        manifest: &Manifest,
+        dest: &Path,
+        mode: MaterializeMode,
+    ) -> Result<(), StoreError> {
+        match mode {
+            // Auto is the historical default — delegate to the unchanged
+            // trait method so it stays byte-for-byte today's behavior.
+            MaterializeMode::Auto => self.fetch_files(manifest, dest),
+            MaterializeMode::Linked => self.fetch_files_linked(manifest, dest),
+        }
+    }
+
+    /// Materializes `manifest` into `dest` via an **atomic staged swap**: the
+    /// complete destination tree is built fresh in a sibling *staging*
+    /// directory (reflink clones under [`MaterializeMode::Auto`] on a `CoW`
+    /// filesystem; symlinks into the local `.objects` pool under
+    /// [`MaterializeMode::Linked`]) and then swapped into place with a pair of
+    /// `rename`s. Because staging is rebuilt from the manifest, the swapped-in
+    /// `dest` is an EXACT mirror with no extraneous entries.
+    ///
+    /// The swap is `rename(dest -> dest.old-<tmp>)` then
+    /// `rename(staging -> dest)` then best-effort removal of the old tree. A
+    /// file descriptor held open on an old `dest` file keeps reading the
+    /// ORIGINAL inode's bytes across the swap (POSIX), so long-running readers
+    /// are never disrupted. If `dest` is absent, the staging dir is simply
+    /// renamed into place (plain materialize, no error).
+    ///
+    /// This path is **zero-copy only**. Under [`MaterializeMode::Auto`] it
+    /// consults [`cow_reflink_supported`] for `dest`'s filesystem first; if the
+    /// target is NOT reflink-capable (e.g. `SNAPDIR_CLONEFILE=0` or a non-CoW
+    /// filesystem), staging in `Auto` mode would duplicate every byte, so it
+    /// returns a typed [`StoreError::Backend`] rather than silently byte-copying
+    /// — and `dest` is left byte-for-byte untouched (no partial apply, no
+    /// leftover staging/`dest.old` sibling). [`MaterializeMode::Linked`] is
+    /// zero-copy on ANY filesystem (symlinks), so it is never refused on that
+    /// ground.
+    ///
+    /// **Swap-or-nothing:** if staging fails partway (e.g. a manifest object is
+    /// missing from the pool), `dest` is touched only by the final rename, which
+    /// never runs — the original tree remains byte-for-byte intact and the
+    /// partial staging dir is cleaned up.
+    ///
+    /// # Errors
+    ///
+    /// - [`StoreError::Backend`] if `Auto` is requested on a non-CoW target
+    ///   (zero-copy refusal).
+    /// - Any error surfaced by [`fetch_files_with_mode`](Self::fetch_files_with_mode)
+    ///   while building the staging tree (e.g. [`StoreError::ObjectNotFound`]).
+    /// - [`StoreError::Io`] on a filesystem failure during the swap itself.
+    #[cfg(unix)]
+    pub fn fetch_files_atomic(
+        &self,
+        manifest: &Manifest,
+        dest: &Path,
+        mode: MaterializeMode,
+    ) -> Result<(), StoreError> {
+        // Zero-copy guard (mode-aware): Auto staging on a non-CoW target would
+        // byte-copy every object, which this path refuses. Linked staging is
+        // symlinks (zero-copy on any FS), so it is never refused here. Probe
+        // BEFORE creating any staging sibling so a refusal leaves no residue and
+        // `dest` untouched.
+        if matches!(mode, MaterializeMode::Auto) && !cow_reflink_supported(dest)? {
+            return Err(StoreError::Backend {
+                message: format!(
+                    "atomic swap unavailable: {} has no copy-on-write (reflink); \
+                     refusing to duplicate bytes (zero-copy only)",
+                    dest.display()
+                ),
+                source: None,
+            });
+        }
+
+        // The staging dir must be a sibling of `dest` (same filesystem) so the
+        // final rename is atomic and reflinks/hardlinks stay same-FS. Mirror a
+        // plain checkout: create `dest`'s parent if it is missing.
+        let parent = match dest.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p.to_path_buf(),
+            // `dest` is a bare name / filesystem root — stage under cwd's `.`.
+            _ => PathBuf::from("."),
+        };
+        fs::create_dir_all(&parent)?;
+        let staging = temp_sibling(&parent.join(".snapdir-staging"));
+        // A leftover staging dir from a crashed prior run must not block us.
+        let _ = fs::remove_dir_all(&staging);
+        fs::create_dir_all(&staging)?;
+
+        // Build the COMPLETE tree into staging. On ANY failure, remove the
+        // partial staging dir and propagate — `dest` is never touched, so the
+        // original tree stays byte-for-byte intact (swap-or-nothing).
+        if let Err(err) = self.fetch_files_with_mode(manifest, &staging, mode) {
+            restore_writable_tree(&staging);
+            let _ = fs::remove_dir_all(&staging);
+            return Err(err);
+        }
+
+        // Swap atomically. If `dest` is absent there is no original to rename
+        // aside — a single rename of staging into place is the whole operation.
+        match fs::symlink_metadata(dest) {
+            Ok(_) => {
+                // `dest` exists: rename it aside, swap staging in, drop the old.
+                let old = temp_sibling(&parent.join(".snapdir-dest-old"));
+                let _ = fs::remove_dir_all(&old);
+                if let Err(err) = fs::rename(dest, &old) {
+                    restore_writable_tree(&staging);
+                    let _ = fs::remove_dir_all(&staging);
+                    return Err(StoreError::Io(err));
+                }
+                if let Err(err) = fs::rename(&staging, dest) {
+                    // Roll back: restore the original tree, drop staging.
+                    let _ = fs::rename(&old, dest);
+                    restore_writable_tree(&staging);
+                    let _ = fs::remove_dir_all(&staging);
+                    return Err(StoreError::Io(err));
+                }
+                // The old tree is renamed aside; held-open fds keep reading its
+                // inodes. Drop it best-effort (Linked checkouts harden objects
+                // to 0444, but the dest entries are symlinks/dirs, so removal of
+                // the swapped-aside tree only unlinks links + dirs).
+                restore_writable_tree(&old);
+                let _ = fs::remove_dir_all(&old);
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => {
+                // Dest-absent: plain materialize — just rename staging in.
+                if let Err(err) = fs::rename(&staging, dest) {
+                    restore_writable_tree(&staging);
+                    let _ = fs::remove_dir_all(&staging);
+                    return Err(StoreError::Io(err));
+                }
+            }
+            Err(e) => {
+                restore_writable_tree(&staging);
+                let _ = fs::remove_dir_all(&staging);
+                return Err(StoreError::Io(e));
+            }
+        }
+
+        Ok(())
+    }
+
+    /// `--linked` materialization: directories become real directories and
+    /// each file entry becomes a `0444`-hardened, atomically-created symlink
+    /// into the local `.objects` pool. Zero-copy: no object is duplicated.
+    #[cfg(unix)]
+    fn fetch_files_linked(&self, manifest: &Manifest, dest: &Path) -> Result<(), StoreError> {
+        for entry in manifest.entries() {
+            let rel = strip_leading_dot_slash(&entry.path);
+            let target = dest.join(rel);
+            match entry.path_type {
+                PathType::Directory => {
+                    fs::create_dir_all(&target)?;
+                }
+                PathType::File => {
+                    if let Some(parent) = target.parent() {
+                        fs::create_dir_all(parent)?;
+                    }
+                    let object = self.object_disk_path(&entry.checksum);
+                    // The object must resolve to a real LOCAL store object — a
+                    // missing object is the stores-API analogue of a non-local
+                    // / unreachable source. Hard-error BEFORE creating any link
+                    // so no dangling symlink is ever left behind.
+                    if !object.exists() {
+                        return Err(StoreError::ObjectNotFound {
+                            checksum: entry.checksum.clone(),
+                        });
+                    }
+                    // Read-only-enforce the shared object (0444) so a write
+                    // THROUGH the link fails and the shared bytes cannot be
+                    // corrupted. Never re-chmod the object to the (writable)
+                    // manifest mode.
+                    harden_object_readonly(&object)?;
+                    // Atomic symlink: temp-sibling symlink + rename, mirroring
+                    // `persist`'s temp+rename discipline, so an idempotent
+                    // re-run never trips on an existing link.
+                    atomic_symlink(&object, &target)?;
+                    if let Some(m) = self.meter.as_deref() {
+                        m.object_started();
+                        m.object_finished();
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Linked materialization is unix-only (it relies on symlinks + `0444`
+    /// hardening). On non-unix targets it surfaces a typed [`StoreError`].
+    #[cfg(not(unix))]
+    fn fetch_files_linked(&self, _manifest: &Manifest, _dest: &Path) -> Result<(), StoreError> {
+        Err(StoreError::Backend {
+            message: "linked materialization is unsupported on this platform (no symlinks)"
+                .to_owned(),
+            source: None,
+        })
     }
 
     /// Copies a batch of `(source, target, expected_checksum)` jobs through
@@ -596,6 +827,25 @@ impl StreamStore for FileStore {
             id,
             &Blake3Hasher::new(),
         )
+    }
+
+    fn supports_mirror(&self) -> bool {
+        // A local `file://` store can delete a manifest file atomically — it is
+        // the only backend that supports the manifest-set mirror (`sync --delete`).
+        true
+    }
+
+    fn delete_manifest(&self, id: &str) -> Result<(), StoreError> {
+        // Remove ONLY the sharded `.manifests/<id>` manifest file; NO object is
+        // ever touched (object GC is out of scope). Removing an already-absent
+        // manifest is idempotent (`Ok(())`), matching the listing/dedup
+        // discipline elsewhere.
+        let path = self.manifest_disk_path(id);
+        match fs::remove_file(&path) {
+            Ok(()) => Ok(()),
+            Err(err) if err.kind() == io::ErrorKind::NotFound => Ok(()),
+            Err(err) => Err(StoreError::Io(err)),
+        }
     }
 
     fn list_manifest_ids(&self) -> Result<Vec<String>, StoreError> {
@@ -1118,6 +1368,79 @@ fn try_clonefile(source: &Path, target: &Path) -> Result<bool, StoreError> {
     Ok(true)
 }
 
+/// Hardens a local store object to `0444` (read-only for everyone) so a write
+/// THROUGH a symlinked dest file fails (`PermissionDenied`) and the shared
+/// object bytes cannot be corrupted. Idempotent — re-running over an already
+/// `0444` object is a no-op.
+///
+/// Unlinking the object still only needs write on its PARENT shard directory
+/// (not the object itself), so a `0444` object stays GC-able. The clone
+/// fast-path opens the object `O_RDONLY`, so `clonefile`/`FICLONE` read a
+/// `0444` source fine.
+#[cfg(unix)]
+fn harden_object_readonly(object: &Path) -> Result<(), StoreError> {
+    use std::os::unix::fs::PermissionsExt;
+    let meta = fs::metadata(object)?;
+    let mut perms = meta.permissions();
+    if perms.mode() & 0o7777 != 0o444 {
+        perms.set_mode(0o444);
+        fs::set_permissions(object, perms)?;
+    }
+    Ok(())
+}
+
+/// Atomically (re)points `link` at `target` via a temp-sibling symlink +
+/// rename, mirroring [`persist`]'s temp+rename discipline. A `rename` over an
+/// existing path replaces it atomically, so an idempotent re-run never trips on
+/// an existing link.
+#[cfg(unix)]
+fn atomic_symlink(target: &Path, link: &Path) -> Result<(), StoreError> {
+    let tmp = temp_sibling(link);
+    // A leftover temp from a crashed prior run must not block us.
+    let _ = fs::remove_file(&tmp);
+    std::os::unix::fs::symlink(target, &tmp)?;
+    // `fs::rename` replaces an existing destination atomically (including an
+    // existing symlink from a prior linked checkout).
+    if let Err(err) = fs::rename(&tmp, link) {
+        let _ = fs::remove_file(&tmp);
+        return Err(StoreError::Io(err));
+    }
+    Ok(())
+}
+
+/// Ahead-of-time probe: does the filesystem hosting `dest` support a zero-copy
+/// `CoW` reflink (`clonefile` on macOS / `FICLONE` on Linux)?
+///
+/// It trial-clones a tiny temp file into a sibling of `dest` (same directory,
+/// so the probe runs on the SAME filesystem the real materialization will use,
+/// avoiding an `EXDEV` false negative) and reports whether the copy came back
+/// [`CopyMethod::Cloned`]. The probe temps are always cleaned up. Respects the
+/// `SNAPDIR_CLONEFILE` knob (a forced-off clone reports `false`). Used later by
+/// the atomic-swap path to decide its strategy ahead of time.
+///
+/// `dest` is the eventual destination path (need not exist yet); its PARENT
+/// directory is created if missing and is where the probe runs.
+pub fn cow_reflink_supported(dest: &Path) -> Result<bool, StoreError> {
+    let parent = dest.parent().unwrap_or(dest);
+    fs::create_dir_all(parent)?;
+
+    let probe_src = temp_sibling(&parent.join(".snapdir-cow-probe"));
+    let probe_dst = temp_sibling(&parent.join(".snapdir-cow-probe"));
+
+    // Tiny payload — a reflink shares extents regardless of size; a byte is
+    // enough to exercise the clone path.
+    if let Err(err) = fs::write(&probe_src, b"x") {
+        let _ = fs::remove_file(&probe_src);
+        return Err(StoreError::Io(err));
+    }
+
+    let result = copy_file(&probe_src, &probe_dst);
+    let _ = fs::remove_file(&probe_src);
+    let _ = fs::remove_file(&probe_dst);
+
+    Ok(matches!(result?, CopyMethod::Cloned))
+}
+
 /// Builds a unique temp sibling path for `target` (same directory, so the
 /// final rename stays on one filesystem). Uses pid + a process-monotonic
 /// counter so concurrent persists never collide.
@@ -1134,6 +1457,32 @@ fn temp_sibling(target: &Path) -> PathBuf {
     match target.parent() {
         Some(parent) => parent.join(tmp_name),
         None => PathBuf::from(tmp_name),
+    }
+}
+
+/// Best-effort restore of `u+rwx` on every directory under `root` (and `root`
+/// itself) so a hardened staging / swapped-aside tree can be torn down by
+/// `remove_dir_all` without an `EACCES` on a read-only directory. Files are
+/// left alone (unlinking them only needs a writable parent); symlinks are never
+/// chased. Used only on the atomic-swap cleanup paths.
+#[cfg(unix)]
+fn restore_writable_tree(root: &Path) {
+    use std::os::unix::fs::PermissionsExt;
+    let Ok(md) = fs::symlink_metadata(root) else {
+        return;
+    };
+    if md.file_type().is_symlink() {
+        return;
+    }
+    if md.is_dir() {
+        let mut perms = md.permissions();
+        perms.set_mode(perms.mode() | 0o700);
+        let _ = fs::set_permissions(root, perms);
+        if let Ok(rd) = fs::read_dir(root) {
+            for entry in rd.flatten() {
+                restore_writable_tree(&entry.path());
+            }
+        }
     }
 }
 

--- a/crates/snapdir-stores/src/lib.rs
+++ b/crates/snapdir-stores/src/lib.rs
@@ -79,7 +79,7 @@ pub use adaptive::{
     OpResult, OpSample,
 };
 pub use b2_store::B2Store;
-pub use file_store::{clonefile_hits, FileStore};
+pub use file_store::{clonefile_hits, cow_reflink_supported, FileStore, MaterializeMode};
 pub use gcs_store::{GcsLocation, GcsStore};
 pub use limits::{for_scheme, BackendLimits};
 pub use pack::{
@@ -97,7 +97,7 @@ pub use s3_store::{S3Location, S3Store};
 pub use shim::ExternalStore;
 pub use split::SplitStore;
 pub use stream::StreamStore;
-pub use sync::{sync_snapshot, SyncReport};
+pub use sync::{sync_snapshot, sync_snapshot_mirror, MirrorReport, SyncReport};
 pub use transfer::{
     classify_error, run_adaptive, run_concurrent, AdaptivePolicy as TransferAdaptivePolicy,
     BlockingRateLimiter, RateLimiter, TransferConfig,

--- a/crates/snapdir-stores/src/stream.rs
+++ b/crates/snapdir-stores/src/stream.rs
@@ -176,6 +176,42 @@ pub trait StreamStore: Store {
             source: None,
         })
     }
+
+    /// Whether this store can serve as the destination of a manifest-set
+    /// **mirror** (`sync --delete`): i.e. it can delete a manifest under its
+    /// `id` atomically/efficiently via [`delete_manifest`](Self::delete_manifest).
+    ///
+    /// The default is `false`: only the local [`FileStore`](crate::FileStore)
+    /// overrides this to `true`. Object/remote backends (S3/GCS/B2/SSH/external)
+    /// inherit `false`, so a mirror targeting them is refused up front by
+    /// [`sync_snapshot_mirror`](crate::sync_snapshot_mirror) before anything in
+    /// the destination is touched.
+    fn supports_mirror(&self) -> bool {
+        false
+    }
+
+    /// Deletes the manifest filed under `id`. **No object is ever touched** —
+    /// this removes ONLY the manifest entry. Garbage-collecting the objects a
+    /// pruned manifest referenced is out of scope (a future `snapdir gc`).
+    ///
+    /// The default implementation returns a [`StoreError::Backend`]
+    /// ("delete unsupported"): a store that cannot mirror-prune must not silently
+    /// succeed. The local [`FileStore`](crate::FileStore) overrides this to
+    /// remove the sharded `.manifests/<id>` file.
+    ///
+    /// # Errors
+    ///
+    /// - [`StoreError::Backend`] from the default impl (delete unsupported).
+    /// - [`StoreError::Io`] / [`StoreError::Backend`] on transport failure for
+    ///   a store that implements it.
+    fn delete_manifest(&self, id: &str) -> Result<(), StoreError> {
+        let _ = id;
+        Err(StoreError::Backend {
+            message: "delete unsupported: this store cannot delete a manifest (mirror unsupported)"
+                .to_owned(),
+            source: None,
+        })
+    }
 }
 
 /// Reconstructs a candidate 64-hex snapshot id from the shard segments of a

--- a/crates/snapdir-stores/src/sync.rs
+++ b/crates/snapdir-stores/src/sync.rs
@@ -254,6 +254,139 @@ pub fn sync_snapshot(
     })
 }
 
+/// Outcome of a [`sync_snapshot_mirror`] call: the underlying additive-sync
+/// counters PLUS the manifest-set prune accounting.
+///
+/// `sync` carries the [`SyncReport`] from the copy-in half (objects copied /
+/// skipped / bytes). `manifests_pruned` is the number of destination manifests
+/// that were absent from the SOURCE store's manifest set and were therefore
+/// deleted (or, in a dry run, that WOULD be deleted); `pruned_ids` is that exact
+/// id set. **No object is ever counted here because no object is ever deleted.**
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct MirrorReport {
+    /// The additive copy-in half's counters (objects copied/skipped, bytes,
+    /// dry-run flag). Folds [`SyncReport`] so callers keep the full picture.
+    pub sync: SyncReport,
+    /// Number of destination manifests pruned (absent from the source set). In a
+    /// dry run, the number that WOULD be pruned.
+    pub manifests_pruned: usize,
+    /// The exact id set pruned (or, in a dry run, that would be pruned).
+    pub pruned_ids: Vec<String>,
+}
+
+/// Objects copied source → dest by the copy-in half (mirrors
+/// [`SyncReport::objects_copied`]).
+impl MirrorReport {
+    /// Objects actually copied by the copy-in half (or, in a dry run, that would
+    /// be copied). Convenience pass-through to the folded [`SyncReport`].
+    #[must_use]
+    pub fn objects_copied(&self) -> usize {
+        self.sync.objects_copied
+    }
+
+    /// Objects skipped because the destination already held them. Convenience
+    /// pass-through to the folded [`SyncReport`].
+    #[must_use]
+    pub fn objects_skipped(&self) -> usize {
+        self.sync.objects_skipped
+    }
+}
+
+/// Copies one snapshot in (additive, manifest-last — exactly
+/// [`sync_snapshot`]), THEN mirrors the destination's manifest set to the
+/// SOURCE store's: every destination manifest **absent from the source set** is
+/// pruned via [`StreamStore::delete_manifest`]. This is the stores half of
+/// `snapdir sync --delete`.
+///
+/// # Manifest-set mirror, never object GC
+///
+/// After the copy-in, the prune set is
+/// `to.list_manifest_ids()` MINUS `from.list_manifest_ids()` — destination
+/// manifests that do not exist in the source store. Each is deleted with
+/// [`delete_manifest`](StreamStore::delete_manifest). **No object is ever
+/// deleted** (not a shared object a retained manifest still references, not even
+/// an orphan referenced only by a pruned manifest): reclaiming orphan objects is
+/// a future `snapdir gc`, never this path. The just-synced `id` is in the source
+/// set, so it is naturally retained — and explicitly guarded against deletion.
+///
+/// # Ordering / safety
+///
+/// The copy-in happens FIRST and in full (objects-then-manifest, manifest-last),
+/// so a healthy mirror with nothing to prune is byte-identical to a plain
+/// [`sync_snapshot`]. The prune runs only after the copy-in succeeds.
+///
+/// # Unsupported destination
+///
+/// If `to` does not [`supports_mirror`](StreamStore::supports_mirror) (every
+/// object/remote backend: S3/GCS/B2/SSH/external), this returns a typed
+/// [`StoreError::Backend`] up front and **changes NOTHING** in the destination —
+/// no copy-in, no delete.
+///
+/// # Dry run
+///
+/// `dry_run` computes and reports the prune set (and the would-copy counters)
+/// but writes/deletes nothing.
+///
+/// # Errors
+///
+/// - [`StoreError::Backend`] if `to` does not support mirroring (refused up
+///   front, destination untouched).
+/// - The first [`StoreError`] from the copy-in ([`sync_snapshot`]) or from
+///   listing/deleting a manifest.
+pub fn sync_snapshot_mirror(
+    from: &(dyn StreamStore + Sync),
+    to: &(dyn StreamStore + Sync),
+    id: &str,
+    config: &TransferConfig,
+    dry_run: bool,
+    meter: Option<&Meter>,
+) -> Result<MirrorReport, StoreError> {
+    // Refuse early on an unsupported (object/remote) destination: the capability
+    // gate must fire BEFORE any copy-in or delete, leaving the dest untouched.
+    if !to.supports_mirror() {
+        return Err(StoreError::Backend {
+            message: "mirror unsupported: the destination store cannot delete a manifest \
+                      (object/remote dest); `--delete` requires a local file:// destination"
+                .to_owned(),
+            source: None,
+        });
+    }
+
+    // Copy-in FIRST, in full (objects-then-manifest, manifest-last). A dry run
+    // copies nothing; a wet run lands the snapshot before any prune.
+    let sync = sync_snapshot(from, to, id, config, dry_run, meter)?;
+
+    // Compute the prune set: dest manifests ABSENT from the SOURCE store's set.
+    // The just-synced `id` is in the source set, so it is never in this set —
+    // but guard explicitly so no edge can classify it for deletion.
+    let source_ids: std::collections::HashSet<String> =
+        from.list_manifest_ids()?.into_iter().collect();
+    let dest_ids = to.list_manifest_ids()?;
+
+    let mut pruned_ids: Vec<String> = dest_ids
+        .into_iter()
+        .filter(|dest_id| dest_id != id && !source_ids.contains(dest_id))
+        .collect();
+    pruned_ids.sort();
+    pruned_ids.dedup();
+
+    // Dry run: report what WOULD be pruned, delete nothing.
+    if !dry_run {
+        for prune in &pruned_ids {
+            // Defense-in-depth: never delete the just-synced id (already excluded
+            // above; assert the invariant holds before any delete).
+            debug_assert_ne!(prune, id, "the just-synced id must never be pruned");
+            to.delete_manifest(prune)?;
+        }
+    }
+
+    Ok(MirrorReport {
+        sync,
+        manifests_pruned: pruned_ids.len(),
+        pruned_ids,
+    })
+}
+
 /// Adaptive store-to-store copy pass: pool sized to the policy `ceiling`, each
 /// object gated to the controller's live limit (effective concurrency ≤
 /// ceiling), every copy timed + classified + recorded via `copy_one`'s report

--- a/crates/snapdir-stores/tests/mirror_atomic_swap.rs
+++ b/crates/snapdir-stores/tests/mirror_atomic_swap.rs
@@ -1,0 +1,1338 @@
+//! Adversarial integration suite for the **atomic staged swap** (phase 32, gate
+//! `mirror-atomic-swap-spec-tests`).
+//!
+//! BLACK-BOX: authored from the gate SPEC + the operator-approved plan alone,
+//! with NO visibility into the atomic-swap implementation (it does NOT exist yet
+//! — `fetch_files` / `fetch_files_with_mode` materialize in place; there is no
+//! staged-swap path). It will NOT compile/pass until the stores-impl teammate
+//! moves this file into `crates/snapdir-stores/tests/mirror_atomic_swap.rs`,
+//! lands the staged-swap API + the non-zero-copy hard-error guard, and wires the
+//! staged cases. Do NOT weaken any assertion to make it green — if a behavior
+//! here fails against the landed impl, that is a real bug in the impl, not in
+//! this test.
+//!
+//! ## SPEC under test (Phase 32 atomic staged swap)
+//!
+//! Instead of materialize-in-place-then-prune, the store can build the COMPLETE
+//! destination tree in a sibling **staging** directory (reflink each file from
+//! `.objects/` on CoW, or symlink to objects in `--linked` mode), then
+//! atomically swap it into place: `rename(dest -> dest.old)` +
+//! `rename(staging -> dest)` + remove the old. The swapped-in dest is an EXACT
+//! mirror (built fresh from the manifest, no extraneous files), and a held-open
+//! fd on an old dest file keeps reading the OLD inode (POSIX) so long-running
+//! processes are never disrupted.
+//!
+//! ## HARD INVARIANTS this suite pins (must be PREVENTED, not discouraged)
+//!
+//!   (1) ZERO-COPY ONLY:
+//!       (1a) on a CoW/symlink path the staged swap copies ZERO bytes — the
+//!            staged/swapped-in files are reflink CLONES (CopyMethod::Cloned, so
+//!            clonefile_hits() advances) or SYMLINKS to objects, never fresh
+//!            byte-copies.
+//!       (1b) requesting an atomic swap on a plain-copy / non-CoW path (forced
+//!            via SNAPDIR_CLONEFILE=0, which `cow_reflink_supported` reports
+//!            false for) is a TYPED, non-panic HARD ERROR — it must NOT silently
+//!            byte-copy, and must NOT partially apply (dest unchanged).
+//!   (2) HELD-OPEN FD SURVIVES THE SWAP: a file opened in the dest BEFORE the
+//!       swap keeps reading the ORIGINAL bytes across the swap (the old tree is
+//!       renamed aside; the inode survives until the fd closes). The durability
+//!       keystone.
+//!   (3) SWAP-OR-NOTHING (atomicity): a failure injected MID-stage (BEFORE the
+//!       final rename) — here, a manifest referencing an object MISSING from the
+//!       pool, so staging fails partway — leaves the ORIGINAL dest FULLY INTACT
+//!       (no partial mirror, no half-swapped tree, no torn state) and returns a
+//!       typed error.
+//!   (4) CoW capability probe consulted: when `cow_reflink_supported(dest)`
+//!       reports false (SNAPDIR_CLONEFILE=0), an atomic request errors rather
+//!       than copying.
+//!
+//! ## Assumed (contracted) public API — impl lane MUST honor or re-point
+//!
+//! The atomic-swap API does NOT exist yet. This suite is authored against a
+//! PLAUSIBLE shape; the impl may RE-POINT the type/method names only (NOT weaken
+//! the contract). See the handoff "Assumed stores API" + "Real-bug report".
+//!
+//!   * `FileStore::fetch_files_atomic(&self, manifest: &Manifest, dest: &Path,
+//!        mode: MaterializeMode) -> Result<(), StoreError>` — builds the full
+//!     dest tree in a sibling staging dir (reflink on CoW / symlink under
+//!     `Linked`) and atomically swaps it into place. On a non-zero-copy target
+//!     (plain copy / non-CoW where `cow_reflink_supported` is false and mode is
+//!     NOT `Linked`) it returns a TYPED, non-panic `StoreError` (assumed a
+//!     plausible variant; the suite tolerates ANY non-`Io`/non-panic typed error
+//!     whose Display names the unsupported/atomic/copy condition via
+//!     `is_atomic_unsupported_like`, exactly as the materialize-modes suite did —
+//!     a bare `Io` or a panic is NOT acceptable).
+//!   * `MaterializeMode::{Auto, Linked}` + `snapdir_stores::clonefile_hits()` +
+//!     `snapdir_stores::cow_reflink_supported(dest)` already exist (materialize
+//!     modes). The atomic path MUST consult the CoW probe.
+//!
+//! If the impl decides the swap belongs behind an existing entry point + a flag
+//! instead of a new method, it must encode the SAME observable behavior and
+//! re-point these tests; that API-shape question is flagged in the handoff.
+//!
+//! ## Env / parallelism note
+//!
+//! `SNAPDIR_CLONEFILE` is process-global and Rust runs `#[test]`s multithreaded
+//! in one binary, so every test that toggles the knob or compares a
+//! `clonefile_hits()` delta holds a single process-wide `ENV_LOCK` for its whole
+//! body and RESTORES the prior value on drop. Mirrors `reflink.rs` /
+//! `mirror_materialize_modes.rs`.
+//!
+//! ## CoW gating
+//!
+//! CI / dev hosts vary: macOS dev is APFS (clone fires), Linux CI runs both an
+//! ext4 leg (NO reflink) and a Btrfs loopback leg (real FICLONE). So the
+//! "swap actually reflinked / fired" assertions are GATED on a clone-capable
+//! host (macOS always; Linux only when `SNAPDIR_REFLINK_TEST_DIR` is provided).
+//! The HARD-ERROR half (atomic on a forced-copy path, SNAPDIR_CLONEFILE=0), the
+//! held-fd survival, and the swap-or-nothing atomicity invariants are asserted
+//! on EVERY host (no reflink FS required) — symlink (`Linked`) staging is
+//! zero-copy on ANY filesystem, so the zero-copy + held-fd cases also run
+//! unconditionally in `Linked` mode.
+
+// Wiring (shape only, no assertion change): silence workspace `-D warnings`
+// clippy lints on this adversary-authored suite. The new method is a
+// contracted-symbol presence check; the skip matches + round-trip helpers are
+// intentional in the adversary's style.
+#![allow(
+    unused_imports,
+    clippy::type_complexity,
+    clippy::single_match_else,
+    clippy::single_match,
+    clippy::manual_let_else,
+    clippy::too_many_lines,
+    clippy::doc_markdown,
+    clippy::similar_names,
+    clippy::map_unwrap_or,
+    clippy::manual_assert,
+    clippy::cast_possible_truncation,
+    clippy::unnested_or_patterns,
+    dead_code
+)]
+
+use std::fs;
+use std::io::Read as _;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
+use snapdir_core::merkle::{directory_checksum, Blake3Hasher, Hasher};
+use snapdir_core::snapshot_id;
+use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
+
+// CONTRACTED symbols. `MaterializeMode` / `clonefile_hits` / `cow_reflink_supported`
+// exist (materialize-modes); `FileStore::fetch_files_atomic` is the ASSUMED
+// staged-swap entry point this suite calls (impl may re-point the name only).
+use snapdir_stores::{
+    clonefile_hits, cow_reflink_supported, FileStore, MaterializeMode, StreamStore,
+};
+
+// ---------------------------------------------------------------------------
+// Test scaffolding (no dev-dependencies; mirrors mirror_materialize_modes.rs /
+// reflink.rs).
+// ---------------------------------------------------------------------------
+
+/// A unique temp dir removed on drop. `new` places it under the system temp dir;
+/// `under` places it under an explicit parent (used to co-locate src + store +
+/// dest on a reflink root so a clone can actually fire — same-FS co-location).
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        Self::under(&std::env::temp_dir(), tag)
+    }
+
+    fn under(parent: &Path, tag: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = parent.join(format!(
+            "snapdir-atomic-swap-test-{}-{tag}-{n}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).expect("create temp dir");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        // A linked/atomic checkout makes objects 0444 and dest entries symlinks;
+        // restore writability defensively so a hardened tree (incl. any leftover
+        // staging/`dest.old` siblings the impl may create) tears down cleanly.
+        restore_writable(&self.path);
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+/// Recursively restore u+w on every dir/file under `root` so a hardened
+/// (`0444`) tree can be torn down by the TempDir drop without leaking temp dirs.
+#[cfg(unix)]
+fn restore_writable(root: &Path) {
+    if let Ok(md) = fs::symlink_metadata(root) {
+        if md.file_type().is_symlink() {
+            return; // never chase a symlink during cleanup
+        }
+        let mut perms = md.permissions();
+        let mode = perms.mode();
+        perms.set_mode(mode | 0o700);
+        let _ = fs::set_permissions(root, perms);
+        if md.is_dir() {
+            if let Ok(rd) = fs::read_dir(root) {
+                for e in rd.flatten() {
+                    restore_writable(&e.path());
+                }
+            }
+        }
+    }
+}
+#[cfg(not(unix))]
+fn restore_writable(_root: &Path) {}
+
+/// Process-global lock guarding `SNAPDIR_CLONEFILE` + the process-global
+/// `clonefile_hits()` counter. Any test that reads/sets the knob or compares a
+/// counter delta MUST hold this for its whole body.
+fn env_lock() -> MutexGuard<'static, ()> {
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// RAII guard that sets/clears `SNAPDIR_CLONEFILE` and restores the prior value
+/// on drop. The caller must already hold `env_lock()`.
+struct CloneEnv {
+    prev: Option<String>,
+}
+
+impl CloneEnv {
+    /// `Some("0")` disables the clone fast-path (forces `fs::copy` / non-CoW);
+    /// `None` leaves it default-enabled.
+    fn set(value: Option<&str>) -> Self {
+        let prev = std::env::var("SNAPDIR_CLONEFILE").ok();
+        match value {
+            Some(v) => std::env::set_var("SNAPDIR_CLONEFILE", v),
+            None => std::env::remove_var("SNAPDIR_CLONEFILE"),
+        }
+        Self { prev }
+    }
+}
+
+impl Drop for CloneEnv {
+    fn drop(&mut self) {
+        match &self.prev {
+            Some(v) => std::env::set_var("SNAPDIR_CLONEFILE", v),
+            None => std::env::remove_var("SNAPDIR_CLONEFILE"),
+        }
+    }
+}
+
+/// Writes a real source tree under `src` and returns the matching `Manifest`
+/// plus its snapshot id. `files` is `(relative path, content, octal-mode-str)`.
+/// A `D ./` root entry is synthesized so the manifest is a valid snapshot.
+/// Object addressing uses the NON-keyed `Blake3Hasher` (the content-address
+/// hasher the file store files objects under), exactly as the shipped tests do.
+fn build_tree(src: &Path, files: &[(&str, &[u8], &str)]) -> (Manifest, String) {
+    let hasher = Blake3Hasher::new();
+    let mut manifest = Manifest::new();
+
+    let mut file_sums: Vec<String> = Vec::new();
+    for (rel, content, mode) in files {
+        let target = src.join(rel);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&target, content).unwrap();
+        #[cfg(unix)]
+        {
+            let perms = fs::Permissions::from_mode(u32::from_str_radix(mode, 8).unwrap());
+            fs::set_permissions(&target, perms).unwrap();
+        }
+        let sum = hasher.hash_hex(content);
+        file_sums.push(sum.clone());
+        manifest.push(ManifestEntry::new(
+            PathType::File,
+            *mode,
+            sum,
+            content.len() as u64,
+            format!("./{rel}"),
+        ));
+    }
+
+    let root_sum = directory_checksum(file_sums.iter().map(String::as_str), &hasher);
+    let root_size: u64 = files.iter().map(|(_, c, _)| c.len() as u64).sum();
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        root_size,
+        "./",
+    ));
+
+    manifest.sort();
+    let id = snapshot_id(&manifest, &hasher);
+    (manifest, id)
+}
+
+/// Counts the regular files under `<root>/.objects`.
+fn count_objects(root: &Path) -> usize {
+    fn walk(dir: &Path, acc: &mut usize) {
+        if let Ok(rd) = fs::read_dir(dir) {
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    walk(&p, acc);
+                } else if p.is_file() {
+                    *acc += 1;
+                }
+            }
+        }
+    }
+    let mut n = 0;
+    walk(&root.join(".objects"), &mut n);
+    n
+}
+
+/// On-disk sharded path of an object blob under `root`.
+fn object_disk(root: &Path, checksum: &str) -> PathBuf {
+    root.join(object_path(checksum))
+}
+
+/// The unix mode bits (permission portion) of `path`, or `None` off-unix.
+#[cfg(unix)]
+fn mode_bits(path: &Path) -> Option<u32> {
+    Some(fs::metadata(path).ok()?.permissions().mode() & 0o7777)
+}
+#[cfg(not(unix))]
+fn mode_bits(_path: &Path) -> Option<u32> {
+    None
+}
+
+/// `true` iff `e` is a typed, non-`Io` refusal of the kind the impl MUST use for
+/// the "atomic on a non-zero-copy / non-CoW target" hard error. Tolerant of the
+/// exact variant name so the impl may re-point to `Unsupported`/`Backend`/a new
+/// variant — but a bare `Io` or a panic is NOT acceptable. The Display text must
+/// name the unsupported/atomic/copy/CoW condition.
+fn is_atomic_unsupported_like(e: &StoreError) -> bool {
+    if matches!(e, StoreError::Io(_)) {
+        return false;
+    }
+    if matches!(e, StoreError::Backend { .. }) {
+        return true;
+    }
+    let s = e.to_string().to_lowercase();
+    s.contains("unsupported")
+        || s.contains("not supported")
+        || s.contains("atomic")
+        || s.contains("copy-on-write")
+        || s.contains("copy on write")
+        || s.contains("cow")
+        || s.contains("reflink")
+        || s.contains("clone")
+        || s.contains("would copy")
+        || s.contains("byte copy")
+        || s.contains("byte-copy")
+        || s.contains("zero-copy")
+        || s.contains("zero copy")
+}
+
+/// `true` iff `e` is a typed, non-`Io`/non-panic error of the kind the impl MUST
+/// use for a MID-STAGE staging failure (a manifest object missing from the
+/// pool). `ObjectNotFound` is the natural shape; `Integrity` and `Backend` are
+/// also acceptable; a bare `Io` is tolerated here ONLY because a missing-object
+/// open can surface as `NotFound` Io — but the KEY assertion in that test is
+/// that the dest is UNCHANGED, not the error variant.
+fn is_typed_staging_failure(e: &StoreError) -> bool {
+    matches!(
+        e,
+        StoreError::ObjectNotFound { .. }
+            | StoreError::Integrity { .. }
+            | StoreError::Backend { .. }
+            | StoreError::Io(_)
+    )
+}
+
+/// A representative tree exercising boundary sizes + path shapes: a file LARGER
+/// than 256 KiB (so a reflink shares real extents and a byte-copy would be
+/// detectable), a tiny file, a 0-byte file, and a nested deep path.
+fn mixed_files() -> Vec<(&'static str, Vec<u8>, &'static str)> {
+    let big: Vec<u8> = (0..(300 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    vec![
+        ("big.bin", big, "644"),
+        ("tiny.txt", b"hello\n".to_vec(), "644"),
+        ("empty", Vec::new(), "644"),
+        (
+            "nested/deep/leaf.bin",
+            vec![0u8, 1, 2, 3, 255, 254, 0],
+            "600",
+        ),
+    ]
+}
+
+/// Pushes `files` into a fresh local store rooted under `parent` and returns
+/// `(store, store_dir, manifest, id, src_dir)`. `src_dir`/`store_dir` are kept
+/// alive by the caller (they own the temp roots).
+fn staged_store(
+    parent: &Path,
+    tag: &str,
+    files: &[(&str, &[u8], &str)],
+) -> (FileStore, TempDir, Manifest, String, TempDir) {
+    let store_dir = TempDir::under(parent, &format!("{tag}-store"));
+    let src = TempDir::under(parent, &format!("{tag}-src"));
+    let (manifest, id) = build_tree(src.path(), files);
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    store
+        .push(&manifest, src.path())
+        .expect("push to local store");
+    (store, store_dir, manifest, id, src)
+}
+
+/// Resolves a reflink-capable root for the Linux Btrfs CI leg, honoring the same
+/// env contract `reflink.rs` uses: `SNAPDIR_REFLINK_TEST_DIR` set => `Some`,
+/// unset => `None` (caller falls back to a plain temp root + copy path). macOS
+/// needs no such root (APFS clones under the system temp dir).
+fn reflink_root() -> Option<PathBuf> {
+    match std::env::var("SNAPDIR_REFLINK_TEST_DIR") {
+        Ok(dir) if !dir.is_empty() => {
+            let p = PathBuf::from(dir);
+            if p.is_dir() {
+                Some(p)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Whether THIS run can actually exercise the reflink fast-path: macOS (APFS) is
+/// always clone-capable; Linux only when a reflink root is provided.
+fn reflink_capable() -> bool {
+    cfg!(target_os = "macos") || reflink_root().is_some()
+}
+
+/// The parent dir under which to co-locate src+store+dest so a clone can fire.
+fn coloc_parent() -> PathBuf {
+    reflink_root().unwrap_or_else(std::env::temp_dir)
+}
+
+/// Recursively collect `(relative-path, kind, bytes-if-file)` for every entry
+/// under `root` (kind: 'd' dir, 'f' regular file, 'l' symlink). Used to prove a
+/// dest is UNCHANGED after a swap-or-nothing failure (exact-tree snapshot).
+#[cfg(unix)]
+fn tree_snapshot(root: &Path) -> Vec<(String, char, Option<Vec<u8>>)> {
+    fn walk(base: &Path, dir: &Path, acc: &mut Vec<(String, char, Option<Vec<u8>>)>) {
+        let rd = match fs::read_dir(dir) {
+            Ok(rd) => rd,
+            Err(_) => return,
+        };
+        for e in rd.flatten() {
+            let p = e.path();
+            let rel = p.strip_prefix(base).unwrap().to_string_lossy().into_owned();
+            let md = match fs::symlink_metadata(&p) {
+                Ok(m) => m,
+                Err(_) => continue,
+            };
+            let ft = md.file_type();
+            if ft.is_symlink() {
+                // record the LINK TARGET text, not the (followed) content
+                let tgt = fs::read_link(&p)
+                    .ok()
+                    .map(|t| t.into_os_string().into_vec_lossy());
+                acc.push((rel, 'l', tgt));
+            } else if ft.is_dir() {
+                acc.push((rel.clone(), 'd', None));
+                walk(base, &p, acc);
+            } else if ft.is_file() {
+                acc.push((rel, 'f', fs::read(&p).ok()));
+            }
+        }
+    }
+    let mut out = Vec::new();
+    walk(root, root, &mut out);
+    out.sort_by(|a, b| a.0.cmp(&b.0));
+    out
+}
+
+/// Tiny helper so `tree_snapshot` can stringify a symlink target portably.
+#[cfg(unix)]
+trait IntoVecLossy {
+    fn into_vec_lossy(self) -> Vec<u8>;
+}
+#[cfg(unix)]
+impl IntoVecLossy for std::ffi::OsString {
+    fn into_vec_lossy(self) -> Vec<u8> {
+        use std::os::unix::ffi::OsStringExt;
+        self.into_vec()
+    }
+}
+
+// ===========================================================================
+// CASE 1a — ZERO-COPY on a CoW host: an atomic swap in Auto mode on a
+// clone-capable filesystem clones (reflink) the staged files — clonefile_hits()
+// advances — so ZERO bytes are duplicated. GATED on a clone-capable host (else
+// the copy path can't be a clone and clause 1b covers the non-CoW refusal).
+// Spec clause (1a): "on a CoW path the swap copies ZERO bytes (assert via the
+// clonefile_hits() counter)".
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn atomic_swap_on_cow_is_zero_copy_reflink_counter_advances() {
+    // Spec clause (1a): an atomic staged swap on a CoW filesystem must build the
+    // staging tree by REFLINK (CopyMethod::Cloned) — clonefile_hits() must
+    // advance, proving no fresh byte-copy of the >256 KiB object occurred.
+    if !reflink_capable() {
+        eprintln!(
+            "SKIP atomic_swap_on_cow_is_zero_copy_reflink_counter_advances: \
+             no clone-capable FS on this host (set SNAPDIR_REFLINK_TEST_DIR on Linux)"
+        );
+        return;
+    }
+
+    let files_owned = mixed_files();
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let parent = coloc_parent();
+
+    let _g = env_lock();
+    let _e = CloneEnv::set(None); // clone fast-path enabled (reflink where supported)
+
+    let (store, store_dir, manifest, _id, _src) = staged_store(&parent, "zc-cow", &files);
+    let dest = TempDir::under(&parent, "zc-cow-dest");
+
+    let before = clonefile_hits();
+    store
+        .fetch_files_atomic(&manifest, dest.path(), MaterializeMode::Auto)
+        .expect("atomic swap on a CoW host must succeed");
+    let after = clonefile_hits();
+
+    // The swap must have reflinked at least the >256 KiB object — clones fired,
+    // not a silent byte-copy.
+    assert!(
+        after > before,
+        "atomic swap on a CoW host must reflink the staged files (CopyMethod::Cloned) — \
+         clonefile_hits() must advance, proving ZERO bytes were copied: {before} -> {after}"
+    );
+
+    // The swapped-in dest is an EXACT mirror: every manifest file is present with
+    // correct content + mode, and the dest entries are independent regular files
+    // (Auto mode is editable, never the thin link view).
+    for (rel, content, mode) in &files_owned {
+        let p = dest.path().join(rel);
+        let md = fs::symlink_metadata(&p).unwrap_or_else(|e| panic!("dest {rel} must exist: {e}"));
+        assert!(
+            md.file_type().is_file(),
+            "atomic Auto dest entry {rel} must be a regular file (editable), not a symlink"
+        );
+        assert_eq!(
+            &fs::read(&p).unwrap(),
+            content,
+            "swapped-in dest content for {rel} must equal the source"
+        );
+        assert_eq!(
+            mode_bits(&p),
+            Some(u32::from_str_radix(mode, 8).unwrap()),
+            "swapped-in dest {rel} must carry the manifest-recorded mode {mode}"
+        );
+    }
+
+    // The store object pool was not bloated by the swap (no duplicate objects).
+    let distinct: std::collections::HashSet<String> = files_owned
+        .iter()
+        .map(|(_, c, _)| Blake3Hasher::new().hash_hex(c))
+        .collect();
+    assert_eq!(
+        count_objects(store_dir.path()),
+        distinct.len(),
+        "the atomic swap must not duplicate objects into the store"
+    );
+}
+
+// ===========================================================================
+// CASE 1a' — ZERO-COPY under --linked on ANY filesystem: an atomic swap in
+// Linked mode stages SYMLINKS into the local objects, so it copies ZERO bytes on
+// every host (no reflink FS required). Runs UNCONDITIONALLY.
+// Spec clause (1a, symlink half): "on a symlink (--linked) path the swap copies
+// ZERO bytes — staged files are symlinks, not fresh copies".
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn atomic_swap_linked_mode_is_zero_copy_symlinks_on_any_fs() {
+    // Spec clause (1a, symlink): atomic swap in Linked mode must produce SYMLINKS
+    // into the local objects (zero bytes copied) on ANY filesystem, and the
+    // swapped-in dest must be an exact mirror reading correct content per entry.
+    let files_owned = mixed_files();
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let parent = coloc_parent();
+    let (store, store_dir, manifest, _id, _src) = staged_store(&parent, "zc-linked", &files);
+    let dest = TempDir::under(&parent, "zc-linked-dest");
+
+    store
+        .fetch_files_atomic(&manifest, dest.path(), MaterializeMode::Linked)
+        .expect("atomic swap in Linked mode must succeed against a LOCAL store");
+
+    let hasher = Blake3Hasher::new();
+    for (rel, content, _mode) in &files_owned {
+        let link = dest.path().join(rel);
+        let md = fs::symlink_metadata(&link)
+            .unwrap_or_else(|e| panic!("dest entry {rel} must exist after swap: {e}"));
+        assert!(
+            md.file_type().is_symlink(),
+            "atomic Linked dest entry {rel} MUST be a symlink (zero-copy), not a fresh copy"
+        );
+        // The link resolves to the LOCAL store object for this checksum.
+        let sum = hasher.hash_hex(content);
+        let want = object_disk(store_dir.path(), &sum)
+            .canonicalize()
+            .expect("store object must exist to be linked");
+        let got = fs::canonicalize(&link)
+            .unwrap_or_else(|e| panic!("symlink {rel} must resolve to the object: {e}"));
+        assert_eq!(
+            got, want,
+            "the swapped-in link for {rel} must point at the LOCAL store object, not a copy"
+        );
+        assert_eq!(
+            &fs::read(&link).unwrap(),
+            content,
+            "reading through the swapped-in link for {rel} must return the source content"
+        );
+    }
+
+    // KEYSTONE: zero-copy — no object was DUPLICATED into the store by the swap.
+    let distinct: std::collections::HashSet<String> = files_owned
+        .iter()
+        .map(|(_, c, _)| Blake3Hasher::new().hash_hex(c))
+        .collect();
+    assert_eq!(
+        count_objects(store_dir.path()),
+        distinct.len(),
+        "atomic Linked swap is zero-copy: it must NOT duplicate objects into the store"
+    );
+}
+
+// ===========================================================================
+// CASE 1b / 4 — ATOMIC ON NON-CoW IS A HARD ERROR. With SNAPDIR_CLONEFILE=0 the
+// dest is non-CoW (cow_reflink_supported reports false), so an atomic swap in
+// Auto mode would have to byte-copy the whole tree into staging — that is
+// FORBIDDEN. The request must return a TYPED, non-panic error, must NOT silently
+// byte-copy, and must NOT partially apply (dest unchanged). Runs on EVERY host.
+// Spec clause (1b)+(4): "atomic requested where it would duplicate bytes (plain
+// copy on non-CoW) is a HARD ERROR" + "when cow_reflink_supported reports false
+// an atomic request errors rather than copying".
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn atomic_swap_on_non_cow_is_typed_hard_error_no_byte_copy_no_partial_apply() {
+    // Spec clause (1b)+(4): atomic Auto on a forced non-CoW path (SNAPDIR_CLONEFILE=0,
+    // so cow_reflink_supported==false) must be a typed, non-panic HARD ERROR — it
+    // must NOT byte-copy and must NOT partially apply (the dest is untouched).
+    let files_owned = mixed_files();
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let _g = env_lock();
+    let _e = CloneEnv::set(Some("0")); // force the non-CoW (copy) path everywhere
+
+    // Use the system temp dir: SNAPDIR_CLONEFILE=0 guarantees non-CoW regardless
+    // of the underlying FS (the probe routes through the same copy_file machinery).
+    let parent = std::env::temp_dir();
+    let (store, _store_dir, manifest, _id, _src) = staged_store(&parent, "noncow", &files);
+    let dest = TempDir::under(&parent, "noncow-dest");
+
+    // Precondition: the CoW probe must report false under the forced-off knob.
+    assert!(
+        !cow_reflink_supported(dest.path()).expect("probe must not error on a writable dir"),
+        "precondition: SNAPDIR_CLONEFILE=0 must make cow_reflink_supported report false"
+    );
+
+    // Plant a sentinel in the dest so we can prove the failed atomic request left
+    // the ORIGINAL dest untouched (no partial apply, no clobber).
+    let sentinel = dest.path().join("ORIGINAL_SENTINEL.txt");
+    fs::write(&sentinel, b"original-dest-content").unwrap();
+    let dest_before = tree_snapshot(dest.path());
+
+    let before = clonefile_hits();
+    let res = store.fetch_files_atomic(&manifest, dest.path(), MaterializeMode::Auto);
+    let after = clonefile_hits();
+
+    let err = res.expect_err(
+        "atomic swap on a non-CoW (plain-copy) path MUST be a HARD ERROR — it would \
+         duplicate every byte into staging, which is forbidden; got Ok(())",
+    );
+    assert!(
+        is_atomic_unsupported_like(&err),
+        "the non-CoW atomic refusal must be a typed, non-panic StoreError naming the \
+         unsupported/atomic/copy condition (NOT a bare Io, NOT a panic), got {err:?}"
+    );
+
+    // No clone fired (the knob is off) AND — critically — no byte-copy staging
+    // happened: the dest must be byte-for-byte what it was before the request.
+    assert_eq!(
+        after, before,
+        "the refused atomic request must not have fired any clone: {before} -> {after}"
+    );
+    assert_eq!(
+        tree_snapshot(dest.path()),
+        dest_before,
+        "a refused atomic-on-non-CoW request must NOT partially apply — the original \
+         dest tree must be byte-for-byte unchanged (no half-staged copy swapped in)"
+    );
+    assert_eq!(
+        fs::read(&sentinel).expect("sentinel must survive"),
+        b"original-dest-content",
+        "the original dest file must be untouched after the refused atomic request"
+    );
+    // No leftover staging / dest.old siblings from a partial attempt.
+    let parent_of_dest = dest.path().parent().unwrap();
+    for e in fs::read_dir(parent_of_dest).unwrap().flatten() {
+        let name = e.file_name().to_string_lossy().into_owned();
+        let dest_name = dest
+            .path()
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .into_owned();
+        if name == dest_name {
+            continue;
+        }
+        assert!(
+            !(name.starts_with(&dest_name) && (name.contains(".old") || name.contains("stag"))),
+            "a refused atomic request must leave no staging/dest.old sibling: found {name}"
+        );
+    }
+}
+
+// ===========================================================================
+// CASE 2 — HELD-OPEN FD SURVIVES THE SWAP (durability keystone). A process opens
+// a dest file and reads PART of it; an atomic swap to a DIFFERENT snapshot then
+// runs; the still-open fd must keep reading the ORIGINAL bytes (the old inode
+// survives the rename-aside). Runs UNCONDITIONALLY in Linked mode (zero-copy on
+// any FS) so it never false-skips, and ADDITIONALLY in Auto on a CoW host.
+// Spec clause (2): "a held-open fd keeps reading old bytes across the swap".
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn held_open_fd_keeps_reading_old_bytes_across_atomic_swap_linked() {
+    // Spec clause (2): an fd opened on a dest file BEFORE an atomic swap keeps
+    // reading the ORIGINAL inode's bytes across the swap (POSIX: the swap renames
+    // the old tree aside; the inode survives until the fd closes). Linked mode so
+    // it is zero-copy on ANY filesystem and never false-skips.
+    let parent = coloc_parent();
+
+    // V1 (the snapshot first checked out into the dest) and V2 (a DIFFERENT
+    // snapshot swapped in). Same path "data.bin", different content/checksum.
+    let v1_content: Vec<u8> = (0..(64 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    let v1_files: Vec<(&str, &[u8], &str)> = vec![("data.bin", v1_content.as_slice(), "644")];
+    let v2_content: Vec<u8> = (0..(64 * 1024u32))
+        .map(|i| ((i * 7 + 3) % 251) as u8)
+        .collect();
+    let v2_files: Vec<(&str, &[u8], &str)> = vec![("data.bin", v2_content.as_slice(), "644")];
+    assert_ne!(
+        v1_content, v2_content,
+        "V1 and V2 must differ for the test to be meaningful"
+    );
+
+    // A single store holding BOTH snapshots' objects.
+    let store_dir = TempDir::under(&parent, "heldfd-store");
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    let src1 = TempDir::under(&parent, "heldfd-src1");
+    let (m1, _id1) = build_tree(src1.path(), &v1_files);
+    store.push(&m1, src1.path()).expect("push v1");
+    let src2 = TempDir::under(&parent, "heldfd-src2");
+    let (m2, _id2) = build_tree(src2.path(), &v2_files);
+    store.push(&m2, src2.path()).expect("push v2");
+
+    let dest = TempDir::under(&parent, "heldfd-dest");
+
+    // First atomic swap: lay down V1.
+    store
+        .fetch_files_atomic(&m1, dest.path(), MaterializeMode::Linked)
+        .expect("initial atomic swap (V1) must succeed");
+
+    let data_path = dest.path().join("data.bin");
+    // Open the V1 file and read the FIRST half BEFORE the swap (binding the fd to
+    // the V1 inode / object). Follow the link explicitly: open() follows symlinks,
+    // so the fd binds to the underlying V1 object inode.
+    let mut fd = fs::File::open(&data_path).expect("open dest data.bin before swap");
+    let mut head = vec![0u8; v1_content.len() / 2];
+    fd.read_exact(&mut head)
+        .expect("read first half before swap");
+    assert_eq!(
+        head,
+        &v1_content[..v1_content.len() / 2],
+        "the first half read before the swap must be V1 content"
+    );
+
+    // Now atomically swap V2 into the SAME dest.
+    store
+        .fetch_files_atomic(&m2, dest.path(), MaterializeMode::Linked)
+        .expect("atomic swap (V2) over the held-open dest must succeed");
+
+    // The path now reflects V2 ...
+    assert_eq!(
+        fs::read(&data_path).expect("read dest path after swap"),
+        v2_content,
+        "after the swap the dest PATH must resolve to V2 content"
+    );
+
+    // ... but the still-open fd keeps reading the ORIGINAL (V1) bytes: read the
+    // REMAINING half from the same fd and assert it is V1's second half.
+    let mut tail = vec![0u8; v1_content.len() - v1_content.len() / 2];
+    fd.read_exact(&mut tail)
+        .expect("the held-open fd must keep reading V1 bytes across the swap");
+    assert_eq!(
+        tail,
+        &v1_content[v1_content.len() / 2..],
+        "KEYSTONE: the fd opened before the swap MUST keep reading the ORIGINAL (V1) \
+         inode bytes across the atomic swap — long-running processes are never disrupted"
+    );
+}
+
+#[cfg(unix)]
+#[test]
+fn held_open_fd_keeps_reading_old_bytes_across_atomic_swap_auto_cow() {
+    // Spec clause (2, Auto/reflink half): same held-fd durability on the editable
+    // Auto (reflink) path. GATED on a clone-capable host (Auto on non-CoW is a
+    // hard error per clause 1b, so the swap could not run there anyway).
+    if !reflink_capable() {
+        eprintln!(
+            "SKIP held_open_fd_keeps_reading_old_bytes_across_atomic_swap_auto_cow: \
+             no clone-capable FS (Auto atomic requires zero-copy/CoW)"
+        );
+        return;
+    }
+
+    let parent = coloc_parent();
+
+    let v1_content: Vec<u8> = (0..(80 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    let v1_files: Vec<(&str, &[u8], &str)> = vec![("data.bin", v1_content.as_slice(), "644")];
+    let v2_content: Vec<u8> = (0..(80 * 1024u32))
+        .map(|i| ((i * 11 + 5) % 251) as u8)
+        .collect();
+    let v2_files: Vec<(&str, &[u8], &str)> = vec![("data.bin", v2_content.as_slice(), "644")];
+    assert_ne!(v1_content, v2_content);
+
+    let _g = env_lock();
+    let _e = CloneEnv::set(None); // reflink enabled
+
+    let store_dir = TempDir::under(&parent, "heldfd-auto-store");
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    let src1 = TempDir::under(&parent, "heldfd-auto-src1");
+    let (m1, _id1) = build_tree(src1.path(), &v1_files);
+    store.push(&m1, src1.path()).expect("push v1");
+    let src2 = TempDir::under(&parent, "heldfd-auto-src2");
+    let (m2, _id2) = build_tree(src2.path(), &v2_files);
+    store.push(&m2, src2.path()).expect("push v2");
+
+    let dest = TempDir::under(&parent, "heldfd-auto-dest");
+    store
+        .fetch_files_atomic(&m1, dest.path(), MaterializeMode::Auto)
+        .expect("initial atomic swap (V1, Auto) must succeed");
+
+    let data_path = dest.path().join("data.bin");
+    let mut fd = fs::File::open(&data_path).expect("open dest before swap");
+    let mut head = vec![0u8; v1_content.len() / 2];
+    fd.read_exact(&mut head)
+        .expect("read first half before swap");
+    assert_eq!(head, &v1_content[..v1_content.len() / 2]);
+
+    store
+        .fetch_files_atomic(&m2, dest.path(), MaterializeMode::Auto)
+        .expect("atomic swap (V2, Auto) over the held-open dest must succeed");
+
+    assert_eq!(
+        fs::read(&data_path).expect("read after swap"),
+        v2_content,
+        "after the swap the dest PATH must resolve to V2 content"
+    );
+    let mut tail = vec![0u8; v1_content.len() - v1_content.len() / 2];
+    fd.read_exact(&mut tail)
+        .expect("the held-open fd must keep reading V1 bytes across the Auto swap");
+    assert_eq!(
+        tail,
+        &v1_content[v1_content.len() / 2..],
+        "KEYSTONE (Auto/reflink): the fd opened before the swap MUST keep reading the \
+         ORIGINAL (V1) bytes across the atomic swap"
+    );
+}
+
+// ===========================================================================
+// CASE 3 — SWAP-OR-NOTHING (atomicity). A mid-stage failure (a manifest
+// referencing an object MISSING from the pool, so staging fails partway BEFORE
+// the final rename) must leave the ORIGINAL dest FULLY INTACT — no partial
+// mirror, no half-swapped tree, no torn state — and return a typed error. Built
+// from an OBSERVABLE failure (missing object), not a private fault-injection
+// hook. Runs UNCONDITIONALLY in Linked mode (zero-copy on any FS).
+// Spec clause (3): "a simulated mid-stage failure leaves the original dest
+// intact (swap-or-nothing)".
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn mid_stage_failure_leaves_original_dest_intact_swap_or_nothing() {
+    // Spec clause (3): a staging failure injected MID-stage (a manifest object
+    // missing from the pool) must leave the ORIGINAL dest byte-for-byte intact
+    // (no partial/half-swapped tree) and return a typed error — swap-or-nothing.
+    let parent = coloc_parent();
+
+    // V1 is a healthy, fully-present snapshot we first lay into the dest.
+    let v1_files: Vec<(&str, &[u8], &str)> = vec![
+        ("keep.txt", b"V1-keep-content\n".as_slice(), "644"),
+        ("sub/inner.bin", b"V1-inner\n".as_slice(), "600"),
+    ];
+
+    // V2 is the snapshot we ATTEMPT to swap in — but one of its objects will be
+    // MISSING from the pool, so staging must fail partway.
+    let present_content = b"V2-present-object\n".to_vec();
+    let missing_content = b"V2-OBJECT-THAT-WILL-BE-REMOVED\n".to_vec();
+    let v2_files: Vec<(&str, &[u8], &str)> = vec![
+        ("keep.txt", present_content.as_slice(), "644"),
+        ("ghost.bin", missing_content.as_slice(), "644"),
+        ("sub/inner.bin", present_content.as_slice(), "600"),
+    ];
+
+    let store_dir = TempDir::under(&parent, "son-store");
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+
+    let src1 = TempDir::under(&parent, "son-src1");
+    let (m1, _id1) = build_tree(src1.path(), &v1_files);
+    store.push(&m1, src1.path()).expect("push v1");
+
+    let src2 = TempDir::under(&parent, "son-src2");
+    let (m2, _id2) = build_tree(src2.path(), &v2_files);
+    store.push(&m2, src2.path()).expect("push v2");
+
+    // Lay V1 into the dest via a healthy atomic swap; capture an EXACT snapshot.
+    let dest = TempDir::under(&parent, "son-dest");
+    store
+        .fetch_files_atomic(&m1, dest.path(), MaterializeMode::Linked)
+        .expect("initial atomic swap (V1) must succeed");
+    // Reading through the V1 links must yield V1 content before we break V2.
+    assert_eq!(
+        fs::read(dest.path().join("keep.txt")).unwrap(),
+        b"V1-keep-content\n",
+        "precondition: dest holds V1 keep.txt before the failed swap"
+    );
+    let dest_before = tree_snapshot(dest.path());
+
+    // OBSERVABLE mid-stage failure: remove V2's ghost.bin object from the pool so
+    // staging V2 fails partway (after staging keep.txt / sub, before the final
+    // rename). No private hook — just a missing object.
+    let ghost_sum = Blake3Hasher::new().hash_hex(&missing_content);
+    let ghost_obj = object_disk(store_dir.path(), &ghost_sum);
+    let _ = fs::set_permissions(&ghost_obj, fs::Permissions::from_mode(0o644)); // in case hardened
+    fs::remove_file(&ghost_obj).expect("remove V2's ghost object to force a mid-stage failure");
+
+    // Attempt the V2 swap — it must FAIL.
+    let res = store.fetch_files_atomic(&m2, dest.path(), MaterializeMode::Linked);
+    let err = res.expect_err(
+        "an atomic swap whose staging references a MISSING object must FAIL (never \
+         half-swap a partial tree)",
+    );
+    assert!(
+        is_typed_staging_failure(&err),
+        "the mid-stage failure must surface as a typed StoreError (ObjectNotFound / \
+         Integrity / Backend / Io), not a panic, got {err:?}"
+    );
+
+    // KEYSTONE: the ORIGINAL dest (V1) is byte-for-byte intact — no partial V2
+    // tree, no half-swapped state, no leftover ghost.bin, no torn directory.
+    assert_eq!(
+        tree_snapshot(dest.path()),
+        dest_before,
+        "swap-or-nothing: a mid-stage staging failure must leave the ORIGINAL dest \
+         byte-for-byte intact (no partial/half-swapped V2 tree)"
+    );
+    assert_eq!(
+        fs::read(dest.path().join("keep.txt")).expect("V1 keep.txt must survive"),
+        b"V1-keep-content\n",
+        "the original V1 keep.txt must be unchanged after the failed V2 swap"
+    );
+    assert!(
+        !dest.path().join("ghost.bin").exists(),
+        "no V2 entry (ghost.bin) may appear in the dest after a failed swap"
+    );
+
+    // No leftover staging / dest.old sibling from the aborted swap.
+    let parent_of_dest = dest.path().parent().unwrap();
+    let dest_name = dest
+        .path()
+        .file_name()
+        .unwrap()
+        .to_string_lossy()
+        .into_owned();
+    for e in fs::read_dir(parent_of_dest).unwrap().flatten() {
+        let name = e.file_name().to_string_lossy().into_owned();
+        if name == dest_name {
+            continue;
+        }
+        assert!(
+            !(name.starts_with(&dest_name) && (name.contains(".old") || name.contains("stag"))),
+            "a failed atomic swap must not leave a staging/dest.old sibling behind: {name}"
+        );
+    }
+}
+
+// ===========================================================================
+// CASE 3b — DEST-ABSENT atomic swap: a swap into a non-existent dest is a plain
+// materialize (no original to preserve) and SUCCEEDS, producing the exact tree.
+// Pins that the swap machinery handles the "nothing to rename aside" edge.
+// Spec clause (adversary exhaustiveness): dest-absent => plain checkout.
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn atomic_swap_into_absent_dest_is_plain_materialize() {
+    // Spec clause (dest-absent): an atomic swap whose dest does not yet exist must
+    // succeed (there is no original tree to rename aside) and produce the exact
+    // mirror. Linked mode so it is zero-copy on any FS.
+    let files: Vec<(&str, &[u8], &str)> = vec![
+        ("a.txt", b"alpha\n".as_slice(), "644"),
+        ("d/b.bin", b"beta\n".as_slice(), "600"),
+    ];
+
+    let parent = coloc_parent();
+    let (store, store_dir, manifest, _id, _src) = staged_store(&parent, "absent", &files);
+
+    // A dest PATH that does not exist yet (under a real, existing parent).
+    let host = TempDir::under(&parent, "absent-host");
+    let dest = host.path().join("not-created-yet");
+    assert!(!dest.exists(), "precondition: dest must be absent");
+
+    store
+        .fetch_files_atomic(&manifest, &dest, MaterializeMode::Linked)
+        .expect("atomic swap into an absent dest must succeed (plain materialize)");
+
+    assert!(dest.is_dir(), "the dest must have been created");
+    assert_eq!(
+        fs::read(dest.join("a.txt")).expect("a.txt"),
+        b"alpha\n",
+        "absent-dest swap must produce a.txt with the source content"
+    );
+    assert_eq!(
+        fs::read(dest.join("d/b.bin")).expect("d/b.bin"),
+        b"beta\n",
+        "absent-dest swap must produce the nested d/b.bin with the source content"
+    );
+    // Still zero-copy (no object duplication into the store).
+    let _ = store_dir; // keep the store alive
+}
+
+// ###########################################################################
+// IMPL-REVEALED CASES (review gate `mirror-atomic-swap-review`)
+//
+// Added after reading the landed impl (`FileStore::fetch_files_atomic`): the
+// staged spec-suite above proved zero-copy / held-fd / swap-or-nothing /
+// dest-absent. The impl now reveals concrete sibling-naming + a two-rename swap
+// + a dest-exists rename-aside branch; the cases below pin behaviors the
+// staged suite did NOT cover. NONE weaken anything above.
+// ###########################################################################
+
+/// Returns the names of any sibling of `dest` (under its parent) that looks
+/// like an atomic-swap scratch artifact: a `.snapdir-staging*`, a
+/// `.snapdir-dest-old*`, or anything that starts with the dest's own basename
+/// and carries `.old` / `stag`. Used to prove NO scratch residue survives.
+#[cfg(unix)]
+fn swap_scratch_siblings(dest: &Path) -> Vec<String> {
+    let parent = dest.parent().unwrap();
+    let dest_name = dest.file_name().unwrap().to_string_lossy().into_owned();
+    let mut out = Vec::new();
+    if let Ok(rd) = fs::read_dir(parent) {
+        for e in rd.flatten() {
+            let name = e.file_name().to_string_lossy().into_owned();
+            if name == dest_name {
+                continue;
+            }
+            let looks_like_swap_scratch = name.starts_with(".snapdir-staging")
+                || name.starts_with(".snapdir-dest-old")
+                || (name.starts_with(&dest_name)
+                    && (name.contains(".old") || name.contains("stag")));
+            if looks_like_swap_scratch {
+                out.push(name);
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+// ===========================================================================
+// CASE R1 — dest.old / STAGING CLEANUP AFTER A *SUCCESSFUL* SWAP. The impl does
+// `rename(dest -> .snapdir-dest-old-<tmp>)` + `rename(staging -> dest)` +
+// best-effort `remove_dir_all(old)`. The staged suite only checked residue on
+// FAILURE paths; this pins that a SUCCESSFUL swap over an existing dest leaves
+// NO `.snapdir-dest-old*` / `.snapdir-staging*` sibling behind. Linked mode so
+// it runs on any FS. (Impl branch: the dest-exists rename-aside arm.)
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn successful_swap_over_existing_dest_leaves_no_old_or_staging_sibling() {
+    let parent = coloc_parent();
+
+    let v1_files: Vec<(&str, &[u8], &str)> = vec![("data.bin", b"V1-content\n".as_slice(), "644")];
+    let v2_files: Vec<(&str, &[u8], &str)> = vec![("data.bin", b"V2-content\n".as_slice(), "644")];
+
+    let store_dir = TempDir::under(&parent, "cleanup-store");
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    let src1 = TempDir::under(&parent, "cleanup-src1");
+    let (m1, _i1) = build_tree(src1.path(), &v1_files);
+    store.push(&m1, src1.path()).expect("push v1");
+    let src2 = TempDir::under(&parent, "cleanup-src2");
+    let (m2, _i2) = build_tree(src2.path(), &v2_files);
+    store.push(&m2, src2.path()).expect("push v2");
+
+    // RACE ISOLATION: the impl's swap scratch (`.snapdir-staging*` /
+    // `.snapdir-dest-old*`, file_store.rs:326,345) is created as a sibling of
+    // `dest` under `dest.parent()` and is named by a GLOBAL counter (NOT the
+    // dest basename), so `swap_scratch_siblings` (generic-prefix scan) cannot
+    // filter it by name. Cargo runs this file's tests in PARALLEL; if `dest`
+    // sat directly under the shared `coloc_parent()`, this assertion would
+    // catch a CONCURRENT sibling test's transient scratch. Give `dest` its OWN
+    // private parent (`outer`) so `swap_scratch_siblings(dest)` only ever lists
+    // THIS test's scratch. Linked mode needs no reflink, so a private parent is
+    // fine even on the Btrfs CI leg.
+    let outer = TempDir::under(&parent, "cleanup-isolated");
+    let dest = TempDir::under(outer.path(), "cleanup-dest");
+    store
+        .fetch_files_atomic(&m1, dest.path(), MaterializeMode::Linked)
+        .expect("initial swap (V1) must succeed");
+    // After the FIRST swap (over an existing — but freshly created — dest) there
+    // must already be no scratch sibling.
+    assert!(
+        swap_scratch_siblings(dest.path()).is_empty(),
+        "no scratch sibling may survive the first successful swap: {:?}",
+        swap_scratch_siblings(dest.path())
+    );
+
+    // A SECOND swap over the now-populated dest exercises the rename-aside arm
+    // (rename dest -> dest.old, rename staging -> dest, remove old).
+    store
+        .fetch_files_atomic(&m2, dest.path(), MaterializeMode::Linked)
+        .expect("second swap (V2) over existing dest must succeed");
+    assert_eq!(
+        fs::read(dest.path().join("data.bin")).unwrap(),
+        b"V2-content\n",
+        "the second swap must have installed V2"
+    );
+
+    // KEYSTONE: no `.snapdir-dest-old*` and no `.snapdir-staging*` sibling
+    // survives a SUCCESSFUL swap — the old tree was removed and staging consumed.
+    let leftovers = swap_scratch_siblings(dest.path());
+    assert!(
+        leftovers.is_empty(),
+        "a successful swap must remove the renamed-aside old tree AND consume staging \
+         — found leftover scratch sibling(s): {leftovers:?}"
+    );
+}
+
+// ===========================================================================
+// CASE R2 — LINKED IS NEVER REFUSED ON A NON-CoW TARGET. The impl guard is
+// `matches!(mode, Auto) && !cow_reflink_supported(dest)`. With SNAPDIR_CLONEFILE=0
+// (probe reports false) an Auto swap hard-errors (case 1b above), but a Linked
+// swap MUST still SUCCEED — symlinks are zero-copy on any FS. Pins that the
+// refusal is the Auto path ONLY. (Impl branch: the mode-aware guard.)
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn linked_swap_is_never_refused_on_non_cow_target() {
+    let files_owned = mixed_files();
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let _g = env_lock();
+    let _e = CloneEnv::set(Some("0")); // force non-CoW everywhere
+
+    let parent = std::env::temp_dir();
+    let (store, store_dir, manifest, _id, _src) = staged_store(&parent, "linked-noncow", &files);
+    let dest = TempDir::under(&parent, "linked-noncow-dest");
+
+    // Precondition: the probe reports false (same condition that makes Auto error).
+    assert!(
+        !cow_reflink_supported(dest.path()).expect("probe must not error"),
+        "precondition: SNAPDIR_CLONEFILE=0 must make cow_reflink_supported report false"
+    );
+
+    // Linked mode MUST succeed despite the probe being false — symlinks copy
+    // zero bytes on ANY filesystem, so the zero-copy guard must NOT fire here.
+    store
+        .fetch_files_atomic(&manifest, dest.path(), MaterializeMode::Linked)
+        .expect(
+            "Linked atomic swap must SUCCEED on a non-CoW target (symlinks are zero-copy on \
+             any FS) — only the Auto path may refuse",
+        );
+
+    // The swapped-in entries are symlinks (zero-copy), proving no byte-copy.
+    let hasher = Blake3Hasher::new();
+    for (rel, content, _mode) in &files_owned {
+        let link = dest.path().join(rel);
+        let md = fs::symlink_metadata(&link).unwrap_or_else(|e| panic!("entry {rel}: {e}"));
+        assert!(
+            md.file_type().is_symlink(),
+            "Linked swap on a non-CoW target must still produce a SYMLINK for {rel}, not a copy"
+        );
+        assert_eq!(&fs::read(&link).unwrap(), content, "content for {rel}");
+    }
+    // No object duplicated into the store (zero-copy).
+    let distinct: std::collections::HashSet<String> = files_owned
+        .iter()
+        .map(|(_, c, _)| hasher.hash_hex(c))
+        .collect();
+    assert_eq!(
+        count_objects(store_dir.path()),
+        distinct.len(),
+        "Linked swap on non-CoW must not duplicate objects into the store"
+    );
+}
+
+// ===========================================================================
+// CASE R3 — EXISTING DEST WITH EXTRANEOUS FILES → EXACT MIRROR, EXTRANEOUS GONE.
+// The impl builds staging FRESH from the manifest then swaps it in wholesale, so
+// any extraneous file present in the old dest (not in the new manifest) must be
+// ABSENT afterward. Pins the swap is a wholesale replacement, not an in-place
+// merge. (Impl branch: rename-aside + fresh staging.)
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn swap_replaces_dest_wholesale_extraneous_files_are_gone() {
+    let parent = coloc_parent();
+
+    let files: Vec<(&str, &[u8], &str)> = vec![
+        ("keep.txt", b"manifest-content\n".as_slice(), "644"),
+        ("sub/inner.bin", b"inner\n".as_slice(), "600"),
+    ];
+    let (store, store_dir, manifest, _id, _src) = staged_store(&parent, "wholesale", &files);
+
+    // RACE ISOLATION (same rationale as R1): this test ends with a
+    // `swap_scratch_siblings(dest)` generic-prefix scan, which would otherwise
+    // catch a concurrent sibling test's transient `.snapdir-staging*` /
+    // `.snapdir-dest-old*` scratch if `dest` sat directly under the shared
+    // `coloc_parent()`. Give `dest` its own private parent so the scan only
+    // ever lists THIS test's scratch.
+    let outer = TempDir::under(&parent, "wholesale-isolated");
+    // Pre-populate dest with EXTRANEOUS entries NOT in the manifest.
+    let dest = TempDir::under(outer.path(), "wholesale-dest");
+    fs::write(dest.path().join("EXTRANEOUS_TOP.txt"), b"stale-top").unwrap();
+    fs::create_dir_all(dest.path().join("stale_dir")).unwrap();
+    fs::write(dest.path().join("stale_dir/junk.bin"), b"stale-nested").unwrap();
+    fs::write(dest.path().join("keep.txt"), b"OLD-different-content").unwrap();
+
+    store
+        .fetch_files_atomic(&manifest, dest.path(), MaterializeMode::Linked)
+        .expect("wholesale swap must succeed");
+
+    // The manifest entries are present with the NEW content ...
+    assert_eq!(
+        fs::read(dest.path().join("keep.txt")).unwrap(),
+        b"manifest-content\n",
+        "keep.txt must hold the NEW manifest content, not the stale dest content"
+    );
+    assert_eq!(
+        fs::read(dest.path().join("sub/inner.bin")).unwrap(),
+        b"inner\n",
+        "nested manifest entry must be present"
+    );
+    // ... and EVERY extraneous entry is GONE (wholesale replacement).
+    assert!(
+        !dest.path().join("EXTRANEOUS_TOP.txt").exists(),
+        "extraneous top-level file must be GONE after a wholesale swap"
+    );
+    assert!(
+        !dest.path().join("stale_dir").exists(),
+        "extraneous directory must be GONE after a wholesale swap"
+    );
+    assert!(
+        swap_scratch_siblings(dest.path()).is_empty(),
+        "no scratch sibling may survive: {:?}",
+        swap_scratch_siblings(dest.path())
+    );
+    let _ = store_dir;
+}
+
+// ===========================================================================
+// CASE R4 — THE SWAP IS A REAL RENAME (SAME-FS, ATOMIC): the dest DIRECTORY's
+// identity (device+inode) changes WHOLESALE across the swap. A real `rename` of
+// a freshly-built sibling staging dir into place gives the dest a brand-new
+// inode; an in-place mutation (merge / byte-copy into the existing dir) would
+// KEEP the same inode. This proves the swap is rename-based, not a copy-merge.
+// (Impl: staging is a same-parent temp_sibling renamed into place.)
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn swap_is_a_real_rename_dest_inode_changes_wholesale() {
+    let parent = coloc_parent();
+
+    let v1_files: Vec<(&str, &[u8], &str)> = vec![("f.bin", b"v1\n".as_slice(), "644")];
+    let v2_files: Vec<(&str, &[u8], &str)> = vec![("f.bin", b"v2\n".as_slice(), "644")];
+
+    let store_dir = TempDir::under(&parent, "inode-store");
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    let src1 = TempDir::under(&parent, "inode-src1");
+    let (m1, _i1) = build_tree(src1.path(), &v1_files);
+    store.push(&m1, src1.path()).expect("push v1");
+    let src2 = TempDir::under(&parent, "inode-src2");
+    let (m2, _i2) = build_tree(src2.path(), &v2_files);
+    store.push(&m2, src2.path()).expect("push v2");
+
+    let dest = TempDir::under(&parent, "inode-dest");
+    store
+        .fetch_files_atomic(&m1, dest.path(), MaterializeMode::Linked)
+        .expect("first swap must succeed");
+
+    let before = fs::metadata(dest.path()).expect("stat dest after V1");
+    let (dev_before, ino_before) = (before.dev(), before.ino());
+
+    store
+        .fetch_files_atomic(&m2, dest.path(), MaterializeMode::Linked)
+        .expect("second swap must succeed");
+
+    let after = fs::metadata(dest.path()).expect("stat dest after V2");
+    let (dev_after, ino_after) = (after.dev(), after.ino());
+
+    // Same filesystem (a real rename never crosses devices) ...
+    assert_eq!(
+        dev_before, dev_after,
+        "the swap must stay on one filesystem (staging is a same-FS sibling)"
+    );
+    // ... but the dest directory inode changed WHOLESALE — the swap renamed a
+    // freshly-built tree into place rather than mutating the old dir in place.
+    assert_ne!(
+        ino_before, ino_after,
+        "KEYSTONE: an atomic rename-swap must give the dest a NEW directory inode \
+         (wholesale replacement); an unchanged inode would mean an in-place merge/copy"
+    );
+    assert_eq!(
+        fs::read(dest.path().join("f.bin")).unwrap(),
+        b"v2\n",
+        "the swapped-in dest must hold V2 content"
+    );
+}

--- a/crates/snapdir-stores/tests/mirror_feasibility.rs
+++ b/crates/snapdir-stores/tests/mirror_feasibility.rs
@@ -1,0 +1,333 @@
+//! Per-backend MIRROR-capability matrix (phase 32, gate
+//! `mirror-feasibility-matrix`).
+//!
+//! The `sync --delete` manifest-set mirror (the prune half of
+//! [`sync_snapshot_mirror`]) is supported ONLY where deleting a manifest is safe
+//! and efficient: the local [`FileStore`]. Every object/remote backend must
+//! report `supports_mirror() == false` and a mirror targeting it must be refused
+//! up front, leaving the destination untouched.
+//!
+//! This suite PINS that matrix against the SHIPPED code (it must PASS). It is a
+//! black-box capability check over the public API:
+//!
+//!   * `FileStore::supports_mirror() == true`  — the one supported backend.
+//!   * `S3Store` / `GcsStore` / `B2Store` `supports_mirror() == false` — each
+//!     constructed OFFLINE via its public `connect` constructor (the capability
+//!     method needs no live connection/creds).
+//!   * `ssh://` / `sftp://` / any third-party `<proto>://` resolve to the
+//!     EXTERNAL adapter and are served by [`ExternalStore`], which does NOT
+//!     implement [`StreamStore`] at all — so it can never be a mirror `to`
+//!     (capability "false by exclusion": there is no `supports_mirror()` to
+//!     return true). Pinned via the router + the shim's typed construction.
+//!   * `sync_snapshot_mirror` into a REAL non-`FileStore` dest (a live-offline
+//!     `S3Store`) returns the documented typed error and changes NOTHING.
+//!
+//! If a backend here INCORRECTLY reported `supports_mirror() == true` (or failed
+//! to refuse), that is a REAL BUG in `src` — the failing assertion stays, it is
+//! NOT weakened to hide it.
+
+#![allow(clippy::doc_markdown)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
+use snapdir_core::merkle::{directory_checksum, Blake3Hasher, Hasher};
+use snapdir_core::snapshot_id;
+use snapdir_core::store::{Store, StoreError};
+
+use snapdir_stores::router::{resolve_adapter, Adapter};
+use snapdir_stores::{
+    sync_snapshot_mirror, B2Store, ExternalStore, FileStore, GcsStore, S3Store, StreamStore,
+    TransferConfig,
+};
+
+// ---------------------------------------------------------------------------
+// Scaffolding (no dev-dependencies; mirrors the sibling sync/mirror suites).
+// ---------------------------------------------------------------------------
+
+/// A unique temp dir removed on drop.
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "snapdir-mirror-feasibility-{}-{tag}-{n}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).expect("create temp dir");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn cfg() -> TransferConfig {
+    TransferConfig::new(4, None)
+}
+
+/// Builds a real source tree under `src` and returns its `Manifest` + snapshot
+/// id (real BLAKE3 addressing + a `D ./` root entry, sorted), matching the
+/// `mirror_sync.rs` fixture shape.
+fn build_tree(src: &Path, files: &[(&str, &[u8])]) -> (Manifest, String) {
+    let hasher = Blake3Hasher::new();
+    let mut manifest = Manifest::new();
+
+    let mut file_sums: Vec<String> = Vec::new();
+    for (rel, content) in files {
+        let target = src.join(rel);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&target, content).unwrap();
+        let sum = hasher.hash_hex(content);
+        file_sums.push(sum.clone());
+        manifest.push(ManifestEntry::new(
+            PathType::File,
+            "600",
+            sum,
+            content.len() as u64,
+            format!("./{rel}"),
+        ));
+    }
+
+    let root_sum = directory_checksum(file_sums.iter().map(String::as_str), &hasher);
+    let root_size: u64 = files.iter().map(|(_, c)| c.len() as u64).sum();
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        root_size,
+        "./",
+    ));
+
+    manifest.sort();
+    let id = snapshot_id(&manifest, &hasher);
+    (manifest, id)
+}
+
+/// File-object checksums referenced by a manifest (deduped, sorted).
+fn object_checksums(manifest: &Manifest) -> Vec<String> {
+    let mut v: Vec<String> = manifest
+        .entries()
+        .iter()
+        .filter(|e| e.path_type == PathType::File)
+        .map(|e| e.checksum.clone())
+        .collect();
+    v.sort();
+    v.dedup();
+    v
+}
+
+// ===========================================================================
+// 1. THE ONE SUPPORTED BACKEND — local FileStore
+// ===========================================================================
+
+#[test]
+fn filestore_is_the_one_backend_that_supports_mirror() {
+    // The local file:// store can delete a manifest atomically/efficiently, so it
+    // is the ONLY backend whose supports_mirror() is true.
+    let dir = TempDir::new("file-cap");
+    let store = FileStore::from_root(dir.path().to_path_buf());
+    assert!(
+        store.supports_mirror(),
+        "FileStore (local file:// dest) MUST report supports_mirror() == true"
+    );
+}
+
+// ===========================================================================
+// 2. EVERY OTHER OFFLINE-CONSTRUCTABLE BACKEND — supports_mirror() == false
+//
+//    S3 / GCS / B2 are built via their public `connect` constructors. The
+//    capability method is pure (no live connection/creds), so building the
+//    adapter from an s3:///gs:///b2:// URI offline and calling supports_mirror()
+//    works and must return false (no atomic/efficient manifest delete on an
+//    object/remote store).
+// ===========================================================================
+
+#[test]
+fn s3_store_does_not_support_mirror() {
+    let store = S3Store::connect("s3://bucket/prefix", None)
+        .expect("S3Store::connect must build offline (capability is creds-free)");
+    assert!(
+        !store.supports_mirror(),
+        "S3Store (object/remote) MUST report supports_mirror() == false"
+    );
+}
+
+#[test]
+fn gcs_store_does_not_support_mirror() {
+    let store = GcsStore::connect("gs://bucket/prefix")
+        .expect("GcsStore::connect must build offline (capability is creds-free)");
+    assert!(
+        !store.supports_mirror(),
+        "GcsStore (object/remote) MUST report supports_mirror() == false"
+    );
+}
+
+#[test]
+fn b2_store_does_not_support_mirror() {
+    let store = B2Store::connect("b2://bucket/prefix", None, None)
+        .expect("B2Store::connect must build offline (capability is creds-free)");
+    assert!(
+        !store.supports_mirror(),
+        "B2Store (object/remote) MUST report supports_mirror() == false"
+    );
+}
+
+// ===========================================================================
+// 3. SSH / SFTP / EXTERNAL — served by the shim, NOT a StreamStore at all
+//
+//    ssh:// + sftp:// (and any unknown <proto>://) route to Adapter::External
+//    and are served out-of-process by ExternalStore. ExternalStore does NOT
+//    implement StreamStore, so it has no supports_mirror() to return — it can
+//    NEVER be a mirror `to`. We pin the capability "false by exclusion" via the
+//    router resolution + the shim's typed construction.
+// ===========================================================================
+
+#[test]
+fn ssh_sftp_and_external_uris_route_to_the_external_shim_not_a_streamstore() {
+    // ssh:// + sftp:// + a generic third-party scheme all resolve to the EXTERNAL
+    // adapter (no built-in in-process StreamStore exists for them).
+    for uri in [
+        "ssh://host/base/dir",
+        "sftp://host/base/dir",
+        "mock://bucket/base",
+    ] {
+        let adapter = resolve_adapter(uri).unwrap_or_else(|e| panic!("resolve {uri}: {e}"));
+        let scheme = uri.split(':').next().unwrap();
+        assert_eq!(
+            adapter,
+            Adapter::External {
+                name: scheme.to_owned(),
+            },
+            "{uri} must route to the external adapter '{scheme}'"
+        );
+        assert!(
+            !adapter.is_builtin(),
+            "{uri} is an external (out-of-process) store, not a built-in StreamStore"
+        );
+
+        // The shim builds for these external URIs; it is the ONLY thing serving
+        // them, and it is NOT a StreamStore (see the compile-time note below), so
+        // it can never be a mirror destination — capability false by exclusion.
+        let shim = ExternalStore::new(uri)
+            .unwrap_or_else(|e| panic!("ExternalStore::new({uri}) should build: {e:?}"));
+        assert_eq!(
+            shim.binary(),
+            Path::new(&format!("snapdir-{scheme}-store")),
+            "{uri} dispatches to the snapdir-{scheme}-store binary"
+        );
+    }
+}
+
+#[test]
+fn external_shim_is_not_a_streamstore_so_cannot_be_a_mirror_destination() {
+    // COMPILE-TIME PROOF that the external shim is NOT a StreamStore: a generic
+    // helper that only accepts `&dyn StreamStore` can take FileStore but the line
+    // for ExternalStore is left commented because it would NOT compile (the trait
+    // is unimplemented). sync_snapshot_mirror's `to: &dyn StreamStore` therefore
+    // can never be handed an ExternalStore, so ssh/sftp/external are excluded from
+    // mirroring by the type system itself.
+    fn assert_is_stream_store(_s: &dyn StreamStore) {}
+
+    let dir = TempDir::new("file-is-stream");
+    let file = FileStore::from_root(dir.path().to_path_buf());
+    assert_is_stream_store(&file); // FileStore IS a StreamStore.
+
+    let shim = ExternalStore::new("ssh://host/base").expect("build ssh shim");
+    // The next line MUST NOT compile if uncommented — ExternalStore is not a
+    // StreamStore. Keeping it commented documents the exclusion as code:
+    //   assert_is_stream_store(&shim); // ← compile error: trait not implemented
+    //
+    // We still exercise the shim's public surface so it is not dead: it resolves
+    // to the ssh store binary (not an in-process mirror-capable adapter).
+    assert_eq!(shim.binary(), Path::new("snapdir-ssh-store"));
+}
+
+// ===========================================================================
+// 4. THE REFUSAL PATH — sync_snapshot_mirror to a REAL unsupported dest
+//
+//    Real local FileStore `from` + a REAL offline-constructed S3Store `to`
+//    (supports_mirror() == false). The mirror must return the documented typed
+//    StoreError and change NOTHING (no copy-in, no delete) in the destination.
+// ===========================================================================
+
+#[test]
+fn mirror_to_a_real_s3_dest_is_refused_with_a_clear_error_and_touches_nothing() {
+    let src_dir = TempDir::new("refuse-src");
+    let source = FileStore::from_root(src_dir.path().to_path_buf());
+
+    // Stage a real snapshot into the source so the copy-in WOULD have work to do
+    // were the refusal not to fire first.
+    let staging = TempDir::new("refuse-staging");
+    let (manifest, id) = build_tree(staging.path(), &[("x", b"payload to mirror\n")]);
+    source
+        .push(&manifest, staging.path())
+        .expect("stage source");
+
+    // A REAL object/remote dest built offline. Its supports_mirror() is false, so
+    // the mirror must refuse BEFORE any copy-in or delete.
+    let dest =
+        S3Store::connect("s3://bucket/prefix", None).expect("S3Store::connect must build offline");
+    assert!(
+        !dest.supports_mirror(),
+        "precondition: the S3 dest does not support mirroring"
+    );
+
+    let err = sync_snapshot_mirror(&source, &dest, &id, &cfg(), false, None)
+        .expect_err("a mirror to an object/remote dest MUST be a typed error, not a panic/Ok");
+
+    // Typed, non-panic StoreError whose Display names the unsupported/non-local/
+    // mirror/--delete condition — actionable for the CLI.
+    let display = err.to_string().to_lowercase();
+    match &err {
+        StoreError::Backend { message, .. } => {
+            let m = message.to_lowercase();
+            assert!(
+                m.contains("mirror")
+                    || m.contains("unsupported")
+                    || m.contains("delete")
+                    || m.contains("not support")
+                    || m.contains("local"),
+                "the refusal must explain mirror/--delete is unsupported on this dest; got: {message}"
+            );
+        }
+        // Tolerate a future dedicated variant; the hard requirements are: it is an
+        // Err, and the Display still names the condition.
+        other => {
+            let _ = other;
+            assert!(
+                display.contains("mirror")
+                    || display.contains("unsupported")
+                    || display.contains("delete")
+                    || display.contains("local"),
+                "the refusal Display must name the mirror/delete/local condition; got: {display}"
+            );
+        }
+    }
+
+    // The source is untouched and still readable (the refusal does not corrupt the
+    // input either): every object of the staged snapshot is still present.
+    source.get_manifest(&id).expect("source manifest intact");
+    for sum in object_checksums(&manifest) {
+        assert!(
+            source.has_object(&sum).expect("source has_object"),
+            "the refused mirror must leave the source untouched"
+        );
+    }
+}

--- a/crates/snapdir-stores/tests/mirror_materialize_modes.rs
+++ b/crates/snapdir-stores/tests/mirror_materialize_modes.rs
@@ -1,0 +1,1339 @@
+//! Adversarial integration suite for **materialization modes** (phase 32, gate
+//! `mirror-materialize-modes-spec-tests`).
+//!
+//! BLACK-BOX: authored from the gate SPEC alone, with NO visibility into the
+//! `--linked` / linked-materialization implementation (it does NOT exist yet —
+//! `fetch_files` is copy/reflink-only today). It will NOT compile/pass until the
+//! stores-impl teammate moves this file into
+//! `crates/snapdir-stores/tests/mirror_materialize_modes.rs`, lands the
+//! materialization-mode API + `0444` object hardening + the local-source guard,
+//! and wires the staged cases. Do NOT weaken any assertion to make it green — if
+//! a behavior here fails against the landed impl, that is a real bug in the impl,
+//! not in this test.
+//!
+//! ## SPEC under test (Phase 32 materialization modes)
+//!
+//! `fetch_files` gains an explicit **materialization mode** for how a manifest is
+//! written into a destination. Two modes compose with `--delete`:
+//!
+//!   1. **auto (default)** — reflink (clonefile/FICLONE) where the dest fs
+//!      supports it, else plain copy. INDEPENDENT, EDITABLE inodes; open-fd-safe.
+//!      A write to an editable reflinked dest file (a CoW break) must leave the
+//!      SOURCE store object byte-identical.
+//!   2. **`--linked`** — dest entries are **symlinks into the LOCAL store
+//!      objects** (`.objects/<h0:3>/<h3:6>/<h6:9>/<h9:>`); zero-copy on any fs;
+//!      **read-only-enforced** by making store/cache objects mode `0444`. The
+//!      thin store-view, NOT editable. Hard-errors if the object source is
+//!      non-local (cannot symlink to a remote object).
+//!
+//! ## HARD INVARIANTS this suite pins (must be PREVENTED, not discouraged)
+//!
+//!   (a) `--linked` produces SYMLINKS whose target is the LOCAL store object for
+//!       that entry's checksum (the sharded `.objects/...` path); reading through
+//!       the link yields the correct content.
+//!   (b) Linked objects are `0444`; a write THROUGH a symlinked dest file FAILS
+//!       (EACCES / permission error) and leaves the store object's bytes
+//!       UNCHANGED. `--linked` must NEVER re-chmod the object to a writable mode.
+//!   (c) `--linked` to a NON-LOCAL object source is a HARD ERROR (clear, typed,
+//!       non-panic) — you cannot symlink to a remote object.
+//!   (d) auto mode reflinks on CoW (`CopyMethod::Cloned`) and copies otherwise;
+//!       the dest inodes are INDEPENDENT and EDITABLE; a write to an editable
+//!       reflinked dest file leaves the SOURCE store object byte-identical (the
+//!       CoW break does not corrupt the shared object).
+//!
+//! ## Assumed (contracted) public API — impl lane MUST honor or re-point
+//!
+//! The exact mode-selection API does NOT exist yet. This suite is authored
+//! against a PLAUSIBLE shape; the impl may RE-POINT the type names only (NOT
+//! weaken the contract):
+//!
+//!   * `snapdir_stores::MaterializeMode` — an enum with at least:
+//!       - `MaterializeMode::Auto`   (reflink-or-copy; editable; today's default)
+//!       - `MaterializeMode::Linked` (symlink into local objects; 0444; read-only)
+//!   * `FileStore::fetch_files_with_mode(&self, manifest: &Manifest, dest: &Path,
+//!        mode: MaterializeMode) -> Result<(), StoreError>` — the mode-carrying
+//!     fetch. `Auto` MUST be byte-for-byte today's `fetch_files`.
+//!   * Non-local-source linked refusal surfaces as a TYPED, non-panic
+//!     `StoreError` — assumed `StoreError::Unsupported { .. }` (a plausible new
+//!     `#[non_exhaustive]` variant). The suite tolerates ANY non-`Io`/non-panic
+//!     typed error there via `is_unsupported_like`, and FLAGS the layer question
+//!     in the handoff (the refusal may live at the CLI layer; if the stores API
+//!     cannot express a non-local object source, the impl/design must resolve it
+//!     at the right layer and re-point `linked_remote_source_is_hard_error`).
+//!
+//! ## Env / parallelism note
+//!
+//! `SNAPDIR_CLONEFILE` is process-global and Rust runs `#[test]`s multithreaded
+//! in one binary, so every test that toggles the knob or compares a
+//! `clonefile_hits()` delta holds a single process-wide `ENV_LOCK` for its whole
+//! body and RESTORES the prior value on drop. Mirrors `apfs_clone.rs` /
+//! `reflink.rs` / `clone_skip.rs`.
+//!
+//! ## CoW gating
+//!
+//! CI / dev hosts vary: macOS dev is APFS (clone fires), Linux CI runs both an
+//! ext4 leg (NO reflink) and a Btrfs loopback leg (real FICLONE). So the
+//! "reflink actually fired" assertions are GATED: on macOS we assert the clone
+//! fired; on Linux we assert it fired ONLY when a reflink root
+//! (`SNAPDIR_REFLINK_TEST_DIR`) is provided, else we exercise the copy fallback
+//! (which must STILL yield independent editable inodes). The
+//! independence/correctness invariants are asserted on EVERY host, clone or copy.
+
+// Wiring (shape only, no assertion change): silence workspace `-D warnings`
+// clippy lints on this adversary-authored suite. The mode enum / new method are
+// contracted-symbol presence checks; the round-trip tuples and skip matches are
+// intentional in the adversary's style.
+#![allow(
+    unused_imports,
+    clippy::type_complexity,
+    clippy::single_match_else,
+    clippy::single_match,
+    clippy::manual_let_else,
+    clippy::too_many_lines,
+    clippy::doc_markdown,
+    clippy::similar_names,
+    clippy::map_unwrap_or,
+    clippy::manual_assert,
+    clippy::cast_possible_truncation,
+    clippy::unnested_or_patterns,
+    dead_code
+)]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Mutex, MutexGuard, OnceLock};
+
+#[cfg(unix)]
+use std::os::unix::fs::{MetadataExt, PermissionsExt};
+
+use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
+use snapdir_core::merkle::{directory_checksum, Blake3Hasher, Hasher};
+use snapdir_core::snapshot_id;
+use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
+
+// CONTRACTED new symbols (assumed; impl lane may re-point the type names only):
+//   * `MaterializeMode` enum (Auto | Linked)
+//   * `FileStore::fetch_files_with_mode(manifest, dest, mode)`
+use snapdir_stores::{FileStore, MaterializeMode, StreamStore};
+
+// ---------------------------------------------------------------------------
+// Test scaffolding (no dev-dependencies; mirrors apfs_clone.rs / reflink.rs).
+// ---------------------------------------------------------------------------
+
+/// A unique temp dir removed on drop. `new` places it under the system temp dir;
+/// `under` places it under an explicit parent (used to co-locate src + store on
+/// a reflink root so FICLONE can actually fire — same-FS co-location).
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        Self::under(&std::env::temp_dir(), tag)
+    }
+
+    fn under(parent: &Path, tag: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = parent.join(format!(
+            "snapdir-materialize-test-{}-{tag}-{n}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).expect("create temp dir");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        // Best-effort cleanup. A linked checkout makes objects 0444 and dest
+        // entries symlinks; both still remove cleanly (perms on the link's
+        // PARENT dir, not the 0444 target, govern unlink), so a plain
+        // remove_dir_all suffices, but we restore writability defensively in
+        // case a future impl hardens parent dirs too.
+        restore_writable(&self.path);
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+/// Recursively restore u+w on every dir/file under `root` so a hardened
+/// (`0444`) tree can be torn down by the TempDir drop without leaking temp dirs.
+#[cfg(unix)]
+fn restore_writable(root: &Path) {
+    if let Ok(md) = fs::symlink_metadata(root) {
+        if md.file_type().is_symlink() {
+            return; // never chase a symlink during cleanup
+        }
+        let mut perms = md.permissions();
+        let mode = perms.mode();
+        perms.set_mode(mode | 0o700);
+        let _ = fs::set_permissions(root, perms);
+        if md.is_dir() {
+            if let Ok(rd) = fs::read_dir(root) {
+                for e in rd.flatten() {
+                    restore_writable(&e.path());
+                }
+            }
+        }
+    }
+}
+#[cfg(not(unix))]
+fn restore_writable(_root: &Path) {}
+
+/// Process-global lock guarding `SNAPDIR_CLONEFILE` + the process-global
+/// `clonefile_hits()` counter. Any test that reads/sets the knob or compares a
+/// counter delta MUST hold this for its whole body.
+fn env_lock() -> MutexGuard<'static, ()> {
+    static ENV_LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+    ENV_LOCK
+        .get_or_init(|| Mutex::new(()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+}
+
+/// RAII guard that sets/clears `SNAPDIR_CLONEFILE` and restores the prior value
+/// on drop. The caller must already hold `env_lock()`.
+struct CloneEnv {
+    prev: Option<String>,
+}
+
+impl CloneEnv {
+    /// `Some("0")` disables the clone fast-path (forces `fs::copy`); `None`
+    /// leaves it default-enabled.
+    fn set(value: Option<&str>) -> Self {
+        let prev = std::env::var("SNAPDIR_CLONEFILE").ok();
+        match value {
+            Some(v) => std::env::set_var("SNAPDIR_CLONEFILE", v),
+            None => std::env::remove_var("SNAPDIR_CLONEFILE"),
+        }
+        Self { prev }
+    }
+}
+
+impl Drop for CloneEnv {
+    fn drop(&mut self) {
+        match &self.prev {
+            Some(v) => std::env::set_var("SNAPDIR_CLONEFILE", v),
+            None => std::env::remove_var("SNAPDIR_CLONEFILE"),
+        }
+    }
+}
+
+/// Writes a real source tree under `src` and returns the matching `Manifest`
+/// plus its snapshot id. `files` is `(relative path, content, octal-mode-str)`.
+/// A `D ./` root entry is synthesized so the manifest is a valid snapshot.
+/// Object addressing uses the NON-keyed `Blake3Hasher` (the content-address
+/// hasher the file store files objects under), exactly as the shipped tests do.
+fn build_tree(src: &Path, files: &[(&str, &[u8], &str)]) -> (Manifest, String) {
+    let hasher = Blake3Hasher::new();
+    let mut manifest = Manifest::new();
+
+    let mut file_sums: Vec<String> = Vec::new();
+    for (rel, content, mode) in files {
+        let target = src.join(rel);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&target, content).unwrap();
+        #[cfg(unix)]
+        {
+            let perms = fs::Permissions::from_mode(u32::from_str_radix(mode, 8).unwrap());
+            fs::set_permissions(&target, perms).unwrap();
+        }
+        let sum = hasher.hash_hex(content);
+        file_sums.push(sum.clone());
+        manifest.push(ManifestEntry::new(
+            PathType::File,
+            *mode,
+            sum,
+            content.len() as u64,
+            format!("./{rel}"),
+        ));
+    }
+
+    let root_sum = directory_checksum(file_sums.iter().map(String::as_str), &hasher);
+    let root_size: u64 = files.iter().map(|(_, c, _)| c.len() as u64).sum();
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        root_size,
+        "./",
+    ));
+
+    manifest.sort();
+    let id = snapshot_id(&manifest, &hasher);
+    (manifest, id)
+}
+
+/// Counts the regular files under `<root>/.objects`.
+fn count_objects(root: &Path) -> usize {
+    fn walk(dir: &Path, acc: &mut usize) {
+        if let Ok(rd) = fs::read_dir(dir) {
+            for e in rd.flatten() {
+                let p = e.path();
+                if p.is_dir() {
+                    walk(&p, acc);
+                } else if p.is_file() {
+                    *acc += 1;
+                }
+            }
+        }
+    }
+    let mut n = 0;
+    walk(&root.join(".objects"), &mut n);
+    n
+}
+
+/// On-disk sharded path of an object blob under `root`.
+fn object_disk(root: &Path, checksum: &str) -> PathBuf {
+    root.join(object_path(checksum))
+}
+
+/// On-disk sharded path of a manifest under `root`.
+fn manifest_disk(root: &Path, id: &str) -> PathBuf {
+    root.join(manifest_path(id))
+}
+
+/// The unix mode bits (permission portion) of `path`, or `None` off-unix.
+#[cfg(unix)]
+fn mode_bits(path: &Path) -> Option<u32> {
+    Some(fs::metadata(path).ok()?.permissions().mode() & 0o7777)
+}
+#[cfg(not(unix))]
+fn mode_bits(_path: &Path) -> Option<u32> {
+    None
+}
+
+/// `true` iff `e` is a typed, non-`Io` refusal (the kind the impl must use for
+/// the "`--linked` to a non-local object source" hard error). Tolerant of the
+/// exact variant name so the impl may re-point to `Unsupported`/`Backend`/a new
+/// variant — but a bare `Io` or a panic is NOT acceptable. `ObjectNotFound` is
+/// also acceptable shape for "can't materialize a non-local object".
+fn is_unsupported_like(e: &StoreError) -> bool {
+    matches!(
+        e,
+        StoreError::Backend { .. } | StoreError::ObjectNotFound { .. }
+    ) || {
+        // Future `StoreError::Unsupported { .. }` (or similar) — match on the
+        // Display text so this stays robust to the precise variant name.
+        let s = e.to_string().to_lowercase();
+        !matches!(e, StoreError::Io(_))
+            && (s.contains("unsupported")
+                || s.contains("not supported")
+                || s.contains("non-local")
+                || s.contains("remote")
+                || s.contains("local")
+                || s.contains("symlink"))
+    }
+}
+
+/// A representative tree exercising the boundary sizes + path shapes the SPEC
+/// calls out: a file LARGER than 256 KiB, a tiny file, a 0-byte file, a nested
+/// deep path, and a unicode/space path. Contents are deterministic.
+fn mixed_files() -> Vec<(&'static str, Vec<u8>, &'static str)> {
+    let big: Vec<u8> = (0..(300 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    vec![
+        ("big.bin", big, "644"),
+        ("tiny.txt", b"hello\n".to_vec(), "644"),
+        ("empty", Vec::new(), "644"),
+        (
+            "nested/deep/leaf.bin",
+            vec![0u8, 1, 2, 3, 255, 254, 0],
+            "600",
+        ),
+        (
+            "uni \u{2728}/space name.txt",
+            "snowman \u{2603}\n".as_bytes().to_vec(),
+            "644",
+        ),
+    ]
+}
+
+/// Pushes `files` into a fresh local store rooted under `parent` and returns
+/// `(store, store_dir, manifest, id, src_dir)`. `src_dir`/`store_dir` are kept
+/// alive by the caller (they own the temp roots).
+fn staged_store(
+    parent: &Path,
+    tag: &str,
+    files: &[(&str, &[u8], &str)],
+) -> (FileStore, TempDir, Manifest, String, TempDir) {
+    let store_dir = TempDir::under(parent, &format!("{tag}-store"));
+    let src = TempDir::under(parent, &format!("{tag}-src"));
+    let (manifest, id) = build_tree(src.path(), files);
+    let store = FileStore::from_root(store_dir.path().to_path_buf());
+    store
+        .push(&manifest, src.path())
+        .expect("push to local store");
+    (store, store_dir, manifest, id, src)
+}
+
+/// Resolves a reflink-capable root for the Linux Btrfs CI leg, honoring the same
+/// env contract `reflink.rs` uses: `SNAPDIR_REFLINK_TEST_DIR` set => `Some`,
+/// unset => `None` (caller falls back to a plain temp root + copy path). The
+/// macOS dev host needs no such root (APFS clones under the system temp dir).
+fn reflink_root() -> Option<PathBuf> {
+    match std::env::var("SNAPDIR_REFLINK_TEST_DIR") {
+        Ok(dir) if !dir.is_empty() => {
+            let p = PathBuf::from(dir);
+            if p.is_dir() {
+                Some(p)
+            } else {
+                None
+            }
+        }
+        _ => None,
+    }
+}
+
+/// Whether THIS run can actually exercise the reflink fast-path: macOS (APFS) is
+/// always clone-capable; Linux only when a reflink root is provided.
+fn reflink_capable() -> bool {
+    cfg!(target_os = "macos") || reflink_root().is_some()
+}
+
+/// The parent dir under which to co-locate src+store+dest so a clone can fire.
+/// On Linux with a reflink root, everything must live UNDER it (FICLONE returns
+/// EXDEV across filesystems). Elsewhere the system temp dir is fine.
+fn coloc_parent() -> PathBuf {
+    reflink_root().unwrap_or_else(std::env::temp_dir)
+}
+
+// ===========================================================================
+// CASE (a) — `--linked` produces SYMLINKS into the LOCAL store objects, and
+// reading THROUGH the link returns the correct content.
+// Spec clause (a): "--linked produces symlinks to LOCAL store objects" + the
+// symlinked file READS correct content + the link target is the right object key.
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn linked_mode_creates_symlinks_into_local_objects_with_correct_targets() {
+    // Spec clause (a): every regular-file dest entry under --linked is a SYMLINK
+    // whose canonical target is the sharded local-store object for that entry's
+    // checksum, and reading through the link yields the source content.
+    let files_owned = mixed_files();
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let parent = coloc_parent();
+    let (store, store_dir, manifest, _id, _src) = staged_store(&parent, "linked-targets", &files);
+    let dest = TempDir::under(&parent, "linked-targets-dest");
+
+    store
+        .fetch_files_with_mode(&manifest, dest.path(), MaterializeMode::Linked)
+        .expect("linked checkout must succeed against a LOCAL store");
+
+    let hasher = Blake3Hasher::new();
+    for (rel, content, _mode) in &files_owned {
+        let link = dest.path().join(rel);
+        let lmeta = fs::symlink_metadata(&link)
+            .unwrap_or_else(|e| panic!("linked dest entry {rel} must exist: {e}"));
+        assert!(
+            lmeta.file_type().is_symlink(),
+            "linked dest entry {rel} MUST be a symlink (the thin store-view), not a regular file"
+        );
+
+        // The link's canonical target must be the LOCAL store object for this
+        // content's checksum (the sharded .objects/... path).
+        let sum = hasher.hash_hex(content);
+        let want_obj = object_disk(store_dir.path(), &sum)
+            .canonicalize()
+            .expect("store object must exist on disk to be symlinked");
+        let got_target = fs::canonicalize(&link)
+            .unwrap_or_else(|e| panic!("symlink {rel} must resolve to an existing object: {e}"));
+        assert_eq!(
+            got_target, want_obj,
+            "the symlink for {rel} must point at the LOCAL store object \
+             (.objects/<sharded checksum>), not a copy"
+        );
+
+        // Reading THROUGH the link returns the correct content.
+        let read = fs::read(&link).unwrap_or_else(|e| panic!("read-through {rel} failed: {e}"));
+        assert_eq!(
+            &read, content,
+            "reading through the symlink for {rel} must return the source content"
+        );
+    }
+
+    // KEYSTONE: zero-copy — no object was DUPLICATED into the dest tree; the
+    // .objects pool still holds exactly the distinct objects (+ the dest holds
+    // only links, which carry no object bytes of their own).
+    let distinct: std::collections::HashSet<String> = files_owned
+        .iter()
+        .map(|(_, c, _)| Blake3Hasher::new().hash_hex(c))
+        .collect();
+    assert_eq!(
+        count_objects(store_dir.path()),
+        distinct.len(),
+        "linked mode is zero-copy: it must NOT duplicate objects into the store"
+    );
+}
+
+// ===========================================================================
+// CASE (b) — Linked objects are 0444 and a WRITE THROUGH the symlinked dest
+// file FAILS, leaving the store object byte-identical (no shared-object
+// corruption; --linked never re-chmods the object writable).
+// Spec clause (b): "objects are 0444 so a write through a link FAILS (store
+// uncorrupted)" + "--linked must never re-chmod the object to a writable mode".
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn linked_objects_are_0444_and_write_through_link_fails_leaving_object_intact() {
+    // Spec clause (b): the store objects a linked checkout points at are mode
+    // 0444; an in-place write THROUGH a symlinked dest file is REJECTED
+    // (permission error) and the underlying store object's bytes are UNCHANGED.
+    let content = b"shared-object-must-not-be-corruptible\n".to_vec();
+    let files: Vec<(&str, &[u8], &str)> = vec![("doc.txt", content.as_slice(), "644")];
+
+    let parent = coloc_parent();
+    let (store, store_dir, manifest, _id, _src) = staged_store(&parent, "ro-link", &files);
+    let dest = TempDir::under(&parent, "ro-link-dest");
+
+    store
+        .fetch_files_with_mode(&manifest, dest.path(), MaterializeMode::Linked)
+        .expect("linked checkout must succeed");
+
+    let sum = Blake3Hasher::new().hash_hex(&content);
+    let obj = object_disk(store_dir.path(), &sum);
+
+    // (1) The store object is hardened to 0444 (read-only for everyone).
+    assert_eq!(
+        mode_bits(&obj),
+        Some(0o444),
+        "linked mode must harden the store object to 0444 (read-only-enforced)"
+    );
+
+    // (2) A write THROUGH the symlinked dest file must FAIL (the link resolves to
+    // the 0444 object; opening it for write is EACCES). The exact error kind may
+    // vary, but it MUST be an error — never a silent success.
+    let link = dest.path().join("doc.txt");
+    assert!(
+        fs::symlink_metadata(&link)
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "dest entry must be a symlink for the write-through to target the object"
+    );
+    let write_res = fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(&link)
+        .and_then(|mut f| {
+            use std::io::Write as _;
+            f.write_all(b"CORRUPTION")
+        });
+    assert!(
+        write_res.is_err(),
+        "writing through a linked (0444) dest file MUST fail — the store object \
+         must not be corruptible through the link; got Ok(())"
+    );
+    if let Err(e) = &write_res {
+        assert_eq!(
+            e.kind(),
+            std::io::ErrorKind::PermissionDenied,
+            "the write-through failure must be a permission error (0444 object), got {e:?}"
+        );
+    }
+
+    // (3) The store object's bytes are UNCHANGED after the failed write.
+    assert_eq!(
+        fs::read(&obj).expect("object still readable"),
+        content,
+        "the store object bytes must be byte-identical after a failed write-through"
+    );
+    // And the object still verifies through the read-time BLAKE3 backstop.
+    assert_eq!(
+        store.get_object(&sum).expect("object verifies"),
+        content,
+        "the store object must still verify (get_object) after the blocked write"
+    );
+
+    // (4) --linked must NOT have re-chmod'd the object to a writable manifest
+    // mode (the source file was 0644; the object must be 0444, not 0644).
+    assert_ne!(
+        mode_bits(&obj),
+        Some(0o644),
+        "linked mode must NOT re-chmod the object to the writable manifest mode"
+    );
+}
+
+// ===========================================================================
+// CASE (c) — `--linked` against a NON-LOCAL object source is a HARD ERROR.
+// Spec clause (c): "--linked to a NON-LOCAL object source is a HARD ERROR"
+// (clear, typed, non-panic). You cannot symlink to a remote object.
+//
+// NOTE TO IMPL LANE (flagged in handoff): the meaningful "non-local source"
+// distinction may only be expressible at the CLI layer (the stores `FileStore`
+// is inherently local). We encode the INTENDED contract two ways so at least one
+// is exercisable at the stores API:
+//   (c1) a linked checkout whose required object is simply ABSENT locally (the
+//        closest the stores API can get to "can't reach the object source")
+//        MUST be a typed, non-panic error — never a dangling symlink.
+//   (c2) IF the impl exposes a way to attempt a linked materialization from a
+//        non-`FileStore` (remote) source through the stores API, that MUST be a
+//        typed Unsupported-like error. If it does not, the impl must encode and
+//        enforce this at the CLI layer and re-point this case there.
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn linked_missing_local_object_is_typed_error_not_a_dangling_symlink() {
+    // Spec clause (c1): a linked checkout that cannot resolve a required object
+    // to a real LOCAL store object must HARD-ERROR (typed, non-panic) and must
+    // NOT leave a dangling symlink in the dest (a dangling link is the failure
+    // mode "symlink to a non-local/absent object" must never silently produce).
+    let content = b"object-will-be-missing\n".to_vec();
+    let files: Vec<(&str, &[u8], &str)> = vec![("ghost.bin", content.as_slice(), "644")];
+
+    let parent = coloc_parent();
+    let (store, store_dir, manifest, _id, _src) = staged_store(&parent, "missing-obj", &files);
+
+    // Remove the backing object so the linked materialization has nothing local
+    // to point at (the stores-API analogue of a non-local/unreachable source).
+    let sum = Blake3Hasher::new().hash_hex(&content);
+    let obj = object_disk(store_dir.path(), &sum);
+    let _ = fs::set_permissions(&obj, fs::Permissions::from_mode(0o644)); // in case a prior run hardened it
+    fs::remove_file(&obj).expect("remove the backing object");
+
+    let dest = TempDir::under(&parent, "missing-obj-dest");
+    let res = store.fetch_files_with_mode(&manifest, dest.path(), MaterializeMode::Linked);
+
+    let err = res.expect_err(
+        "a linked checkout with no resolvable LOCAL object MUST hard-error \
+         (never silently create a dangling symlink)",
+    );
+    assert!(
+        is_unsupported_like(&err),
+        "the linked-no-local-object failure must be a typed, non-panic StoreError \
+         (ObjectNotFound / Unsupported-like), got {err:?}"
+    );
+
+    // No dangling symlink may have been left in the dest.
+    let link = dest.path().join("ghost.bin");
+    if let Ok(meta) = fs::symlink_metadata(&link) {
+        if meta.file_type().is_symlink() {
+            assert!(
+                fs::metadata(&link).is_err(),
+                "internal: a leftover link to a present object would invalidate \
+                 the precondition"
+            );
+            panic!("FORBIDDEN: a dangling symlink to a missing/non-local object was created");
+        }
+    }
+}
+
+// ===========================================================================
+// CASE (d) — auto mode reflinks on CoW (CopyMethod::Cloned) and copies
+// otherwise; dest inodes are INDEPENDENT + EDITABLE; a write to an editable
+// reflinked dest file leaves the SOURCE store object byte-identical.
+// Spec clause (d): "auto mode reflinks on CoW and copies otherwise, independent
+// editable inodes" + "a write to an editable reflinked file leaves the source
+// object byte-identical".
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn auto_mode_independent_editable_inode_write_does_not_corrupt_source_object() {
+    // Spec clause (d): an auto-mode dest file is a real, INDEPENDENT, EDITABLE
+    // inode (reflink-CoW or copy). Writing to it (a CoW break on reflink fs) must
+    // leave the SOURCE store object byte-identical — no shared-object corruption.
+    // A >256 KiB payload so a reflink shares real extents and a CoW-break bug
+    // would surface.
+    let content: Vec<u8> = (0..(300 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    let files: Vec<(&str, &[u8], &str)> = vec![("editable.bin", content.as_slice(), "644")];
+
+    let parent = coloc_parent();
+
+    let _g = env_lock();
+    let _e = CloneEnv::set(None); // clone fast-path enabled (reflink where supported)
+
+    let (store, store_dir, manifest, _id, _src) = staged_store(&parent, "auto-edit", &files);
+    let dest = TempDir::under(&parent, "auto-edit-dest");
+
+    let before = snapdir_stores::clonefile_hits();
+    store
+        .fetch_files_with_mode(&manifest, dest.path(), MaterializeMode::Auto)
+        .expect("auto checkout must succeed");
+    let after = snapdir_stores::clonefile_hits();
+
+    let dest_file = dest.path().join("editable.bin");
+    let dest_meta = fs::symlink_metadata(&dest_file).expect("dest file metadata");
+
+    // (1) The dest entry is a REGULAR FILE (NOT a symlink) — auto mode is the
+    // editable mode, never the thin link view.
+    assert!(
+        dest_meta.file_type().is_file(),
+        "auto-mode dest entry must be a regular file (editable), never a symlink"
+    );
+
+    // (2) It is an INDEPENDENT inode from the store object (reflink or copy both
+    // yield a distinct inode; a hardlink/symlink to the object would NOT).
+    let sum = Blake3Hasher::new().hash_hex(&content);
+    let obj = object_disk(store_dir.path(), &sum);
+    let obj_meta = fs::symlink_metadata(&obj).expect("object metadata");
+    assert_ne!(
+        (dest_meta.dev(), dest_meta.ino()),
+        (obj_meta.dev(), obj_meta.ino()),
+        "auto-mode dest file must be an INDEPENDENT inode, not the store object itself"
+    );
+
+    // (3) On a clone-capable host the reflink fast-path MUST have fired (so the
+    // CoW-break invariant below is not vacuously over a plain copy). On a
+    // copy-only host the copy path is exercised instead.
+    if reflink_capable() {
+        assert!(
+            after > before,
+            "auto mode on a CoW-capable host must reflink (CopyMethod::Cloned) — \
+             clonefile_hits must advance: {before} -> {after}"
+        );
+    }
+
+    // (4) The dest file is EDITABLE: writing to it must SUCCEED (manifest mode
+    // 0644). This is the editable-inode contract.
+    let mut new_bytes = content.clone();
+    new_bytes[0] ^= 0xff;
+    new_bytes[content.len() - 1] ^= 0xff;
+    fs::write(&dest_file, &new_bytes).expect("auto-mode dest file must be writable/editable");
+
+    // (5) KEYSTONE: after editing the dest file (a CoW break on reflink fs), the
+    // SOURCE store object's bytes are UNCHANGED — independent inodes, no shared-
+    // object corruption.
+    assert_eq!(
+        fs::read(&obj).expect("object still readable"),
+        content,
+        "editing the reflinked/copied dest file must NOT change the source store \
+         object bytes (CoW break / independent inode)"
+    );
+    assert_eq!(
+        store.get_object(&sum).expect("object verifies"),
+        content,
+        "the store object must still verify after the dest file was edited"
+    );
+
+    // (6) And the edited dest file actually holds the NEW bytes (the write landed
+    // on the dest inode, proving independence in the other direction).
+    assert_eq!(
+        fs::read(&dest_file).expect("read edited dest"),
+        new_bytes,
+        "the edit must have landed on the independent dest inode"
+    );
+}
+
+// ===========================================================================
+// CASE (d2) — auto mode with the clone fast-path FORCED OFF (SNAPDIR_CLONEFILE=0)
+// still yields an EDITABLE, INDEPENDENT inode (plain copy fallback), and editing
+// it leaves the source object intact. Pins the "copies otherwise" half of clause
+// (d) on EVERY host (no reflink fs required).
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn auto_mode_copy_fallback_is_independent_and_editable() {
+    // Spec clause (d, copy half): with SNAPDIR_CLONEFILE=0 auto mode plain-copies;
+    // the dest is still an independent editable inode and an edit does not touch
+    // the source object. Asserts the counter does NOT advance (no clone fired).
+    let content: Vec<u8> = (0..(128 * 1024u32)).map(|i| (i % 197) as u8).collect();
+    let files: Vec<(&str, &[u8], &str)> = vec![("copy.bin", content.as_slice(), "600")];
+
+    let _g = env_lock();
+    let _e = CloneEnv::set(Some("0")); // force the plain fs::copy path
+
+    let parent = std::env::temp_dir();
+    let (store, store_dir, manifest, _id, _src) = staged_store(&parent, "auto-copy", &files);
+    let dest = TempDir::under(&parent, "auto-copy-dest");
+
+    let before = snapdir_stores::clonefile_hits();
+    store
+        .fetch_files_with_mode(&manifest, dest.path(), MaterializeMode::Auto)
+        .expect("auto (copy) checkout must succeed");
+    let after = snapdir_stores::clonefile_hits();
+    assert_eq!(
+        after, before,
+        "SNAPDIR_CLONEFILE=0 must force the copy path; no clone may fire: {before} -> {after}"
+    );
+
+    let dest_file = dest.path().join("copy.bin");
+    let sum = Blake3Hasher::new().hash_hex(&content);
+    let obj = object_disk(store_dir.path(), &sum);
+
+    let d = fs::symlink_metadata(&dest_file).unwrap();
+    let o = fs::symlink_metadata(&obj).unwrap();
+    assert!(d.file_type().is_file(), "copy dest must be a regular file");
+    assert_ne!(
+        (d.dev(), d.ino()),
+        (o.dev(), o.ino()),
+        "the copied dest file must be an independent inode"
+    );
+
+    // Restored content correct + restored mode honors the manifest (0600).
+    assert_eq!(
+        fs::read(&dest_file).unwrap(),
+        content,
+        "copied content must match"
+    );
+    assert_eq!(
+        mode_bits(&dest_file),
+        Some(0o600),
+        "auto-mode restored file must carry the manifest-recorded mode 0600"
+    );
+
+    // Edit the copy; the source object stays byte-identical.
+    let mut edited = content.clone();
+    edited[10] ^= 0xa5;
+    fs::write(&dest_file, &edited).expect("copied dest must be editable");
+    assert_eq!(
+        fs::read(&obj).unwrap(),
+        content,
+        "editing the copied dest file must not change the source object"
+    );
+}
+
+// ===========================================================================
+// CASE (e) — auto mode is byte-for-byte today's `fetch_files`. The mode-carrying
+// fetch with Auto must produce restored content + perms identical to the legacy
+// `fetch_files` (the impl must not regress the additive default).
+// Spec clause: auto (default, no flag) == today's reflink-or-copy materialize.
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn auto_mode_equals_legacy_fetch_files() {
+    // Spec clause (auto == today): fetch_files_with_mode(.., Auto) must restore
+    // the exact same content and permission bits as the legacy fetch_files for
+    // the same manifest — proving Auto is the unchanged additive default.
+    let files_owned = mixed_files();
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let parent = coloc_parent();
+    let (store, _store_dir, manifest, _id, _src) = staged_store(&parent, "auto-eq", &files);
+
+    let dest_legacy = TempDir::under(&parent, "auto-eq-legacy");
+    let dest_auto = TempDir::under(&parent, "auto-eq-auto");
+
+    store
+        .fetch_files(&manifest, dest_legacy.path())
+        .expect("legacy fetch_files");
+    store
+        .fetch_files_with_mode(&manifest, dest_auto.path(), MaterializeMode::Auto)
+        .expect("auto fetch_files_with_mode");
+
+    for (rel, content, mode) in &files_owned {
+        let lp = dest_legacy.path().join(rel);
+        let ap = dest_auto.path().join(rel);
+        assert_eq!(
+            fs::read(&lp).unwrap(),
+            fs::read(&ap).unwrap(),
+            "auto-mode content for {rel} must equal legacy fetch_files"
+        );
+        assert_eq!(
+            fs::read(&ap).unwrap(),
+            *content,
+            "auto-mode content for {rel} must equal the source"
+        );
+        assert_eq!(
+            mode_bits(&lp),
+            mode_bits(&ap),
+            "auto-mode perms for {rel} must equal legacy fetch_files"
+        );
+        let want = u32::from_str_radix(mode, 8).unwrap();
+        assert_eq!(
+            mode_bits(&ap),
+            Some(want),
+            "auto-mode restored {rel} must carry the manifest-recorded mode {mode}"
+        );
+        // Neither path may be a symlink (auto is editable).
+        assert!(
+            fs::symlink_metadata(&ap).unwrap().file_type().is_file(),
+            "auto-mode {rel} must be a regular file, not a symlink"
+        );
+    }
+}
+
+// ===========================================================================
+// CASE (f) — Mixed tree under --linked: directories are real dirs, files are
+// links, nested + unicode/space paths handled, 0-byte object links read empty.
+// Spec clause (adversary exhaustiveness): mixed manifests (files + dirs +
+// nested); symlinked file reads correct content for every entry including the
+// degenerate 0-byte object.
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn linked_mode_mixed_tree_dirs_real_files_links_zero_byte_ok() {
+    // Spec clause (mixed tree): under --linked, directory entries are REAL
+    // directories (not links), every regular-file entry is a symlink to its
+    // object, nested + unicode/space paths resolve, and the 0-byte object links
+    // to an empty object that reads back empty.
+    let files_owned = mixed_files();
+    let files: Vec<(&str, &[u8], &str)> = files_owned
+        .iter()
+        .map(|(p, c, m)| (*p, c.as_slice(), *m))
+        .collect();
+
+    let parent = coloc_parent();
+    let (store, store_dir, manifest, _id, _src) = staged_store(&parent, "linked-mixed", &files);
+    let dest = TempDir::under(&parent, "linked-mixed-dest");
+
+    store
+        .fetch_files_with_mode(&manifest, dest.path(), MaterializeMode::Linked)
+        .expect("linked mixed checkout must succeed");
+
+    // Directory entries from the manifest are real directories in the dest.
+    for entry in manifest.entries() {
+        if entry.path_type != PathType::Directory {
+            continue;
+        }
+        let rel = entry.path.strip_prefix("./").unwrap_or(entry.path.as_str());
+        let rel = rel.strip_suffix('/').unwrap_or(rel);
+        if rel.is_empty() {
+            continue; // the root "./" entry maps to dest itself
+        }
+        let d = dest.path().join(rel);
+        let m =
+            fs::symlink_metadata(&d).unwrap_or_else(|e| panic!("dir entry {rel} must exist: {e}"));
+        assert!(
+            m.file_type().is_dir(),
+            "directory entry {rel} must be a real directory under --linked, not a symlink"
+        );
+    }
+
+    // Every file (incl. nested + unicode/space + 0-byte) is a link reading
+    // back its source content.
+    for (rel, content, _mode) in &files_owned {
+        let link = dest.path().join(rel);
+        assert!(
+            fs::symlink_metadata(&link)
+                .unwrap()
+                .file_type()
+                .is_symlink(),
+            "file entry {rel} must be a symlink under --linked"
+        );
+        assert_eq!(
+            &fs::read(&link).unwrap(),
+            content,
+            "read-through {rel} must equal source content"
+        );
+    }
+
+    // The 0-byte object exists, is 0444, and the link reads back empty.
+    let empty_sum = Blake3Hasher::new().hash_hex(b"");
+    let empty_obj = object_disk(store_dir.path(), &empty_sum);
+    assert!(empty_obj.is_file(), "0-byte object must exist");
+    assert_eq!(
+        mode_bits(&empty_obj),
+        Some(0o444),
+        "the 0-byte object must also be hardened to 0444 under --linked"
+    );
+    assert!(
+        fs::read(dest.path().join("empty")).unwrap().is_empty(),
+        "the link to the 0-byte object must read back empty"
+    );
+}
+
+// ===========================================================================
+// CASE (g) — Linked checkout is IDEMPOTENT: a second linked checkout into a
+// dest already linked succeeds and the links/objects are unchanged (objects
+// stay 0444, links still resolve). Re-running must not error or corrupt.
+// Spec clause (adversary exhaustiveness): idempotency / re-runs.
+// ===========================================================================
+
+#[cfg(unix)]
+#[test]
+fn linked_mode_second_run_is_idempotent() {
+    // Spec clause (idempotency): a repeated linked checkout into the same dest
+    // must succeed, leave the objects 0444, and leave the links resolving to the
+    // same objects (no duplication, no corruption, no error).
+    let content = b"idempotent-linked-content\n".to_vec();
+    let files: Vec<(&str, &[u8], &str)> = vec![("a/b/c.txt", content.as_slice(), "644")];
+
+    let parent = coloc_parent();
+    let (store, store_dir, manifest, _id, _src) = staged_store(&parent, "linked-idem", &files);
+    let dest = TempDir::under(&parent, "linked-idem-dest");
+
+    store
+        .fetch_files_with_mode(&manifest, dest.path(), MaterializeMode::Linked)
+        .expect("first linked checkout");
+    store
+        .fetch_files_with_mode(&manifest, dest.path(), MaterializeMode::Linked)
+        .expect("second linked checkout must be idempotent (no error)");
+
+    let sum = Blake3Hasher::new().hash_hex(&content);
+    let obj = object_disk(store_dir.path(), &sum);
+    assert_eq!(
+        mode_bits(&obj),
+        Some(0o444),
+        "object must remain 0444 after an idempotent re-run"
+    );
+    let link = dest.path().join("a/b/c.txt");
+    assert!(
+        fs::symlink_metadata(&link)
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "the dest entry must still be a symlink after the second run"
+    );
+    assert_eq!(
+        fs::read(&link).unwrap(),
+        content,
+        "the link must still read the correct content after the second run"
+    );
+    assert_eq!(
+        count_objects(store_dir.path()),
+        1,
+        "an idempotent re-run must not duplicate objects"
+    );
+}
+
+// ===========================================================================
+// REVIEW-ADDED CASES (impl now visible). These pin branches the landed impl
+// in `src/file_store.rs` exposes: `harden_object_readonly` idempotency, the
+// `atomic_symlink` canonical target, the `cow_reflink_supported` public probe
+// (residue + SNAPDIR_CLONEFILE=0 + non-CoW path), and the no-corruption depth
+// invariant via the public `get_object`. NONE of these weaken the contract;
+// they strengthen it against the revealed implementation.
+// ===========================================================================
+
+// ---------------------------------------------------------------------------
+// REVIEW (h) — 0444 idempotency / RE-hardening. A SECOND linked checkout over an
+// already-0444 object stays 0444 and succeeds (the atomic-symlink replace path),
+// and writing THROUGH the (now re-checked-out) link still fails. Pins the
+// `harden_object_readonly` idempotent no-op branch (`mode & 0o7777 == 0o444`) +
+// `atomic_symlink`'s rename-over-existing-link replace, distinctly from the
+// first-run hardening exercised in case (g).
+// ---------------------------------------------------------------------------
+#[cfg(unix)]
+#[test]
+fn linked_rehardening_second_checkout_stays_0444_and_write_still_fails() {
+    let content = b"re-harden-must-stay-0444\n".to_vec();
+    let files: Vec<(&str, &[u8], &str)> = vec![("re.txt", content.as_slice(), "644")];
+
+    let parent = coloc_parent();
+    let (store, store_dir, manifest, _id, _src) = staged_store(&parent, "reharden", &files);
+    let dest = TempDir::under(&parent, "reharden-dest");
+
+    let sum = Blake3Hasher::new().hash_hex(&content);
+    let obj = object_disk(store_dir.path(), &sum);
+
+    // First linked checkout hardens the object to 0444.
+    store
+        .fetch_files_with_mode(&manifest, dest.path(), MaterializeMode::Linked)
+        .expect("first linked checkout");
+    assert_eq!(
+        mode_bits(&obj),
+        Some(0o444),
+        "first linked checkout must harden the object to 0444"
+    );
+
+    // A SECOND linked checkout, with the object ALREADY 0444, must succeed (the
+    // `harden_object_readonly` idempotent no-op branch + the atomic-symlink
+    // rename-over-existing-link replace) and leave the object 0444 — never
+    // re-chmod it writable.
+    store
+        .fetch_files_with_mode(&manifest, dest.path(), MaterializeMode::Linked)
+        .expect("second linked checkout over an already-0444 object must succeed (idempotent)");
+    assert_eq!(
+        mode_bits(&obj),
+        Some(0o444),
+        "re-hardening an already-0444 object must keep it 0444 (idempotent no-op)"
+    );
+
+    // The dest entry is still a symlink and writing THROUGH it still fails.
+    let link = dest.path().join("re.txt");
+    assert!(
+        fs::symlink_metadata(&link)
+            .unwrap()
+            .file_type()
+            .is_symlink(),
+        "after the re-checkout the dest entry must still be a symlink"
+    );
+    let write_res = fs::OpenOptions::new()
+        .write(true)
+        .truncate(true)
+        .open(&link)
+        .and_then(|mut f| {
+            use std::io::Write as _;
+            f.write_all(b"CORRUPTION")
+        });
+    assert!(
+        write_res.is_err(),
+        "writing through the re-hardened (0444) link MUST still fail"
+    );
+    if let Err(e) = &write_res {
+        assert_eq!(
+            e.kind(),
+            std::io::ErrorKind::PermissionDenied,
+            "the re-hardened write-through failure must be a permission error, got {e:?}"
+        );
+    }
+
+    // The object's bytes are still intact + still verify through get_object.
+    assert_eq!(
+        store.get_object(&sum).expect("object verifies after re-checkout"),
+        content,
+        "the object must still verify (get_object) after the idempotent re-checkout + blocked write"
+    );
+    assert_eq!(
+        count_objects(store_dir.path()),
+        1,
+        "the re-checkout must not duplicate the object"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// REVIEW (i) — Symlink-chain / canonicalization. The created link's canonical
+// target is EXACTLY the sharded `.objects/<h0:3>/<h3:6>/<h6:9>/<h9:>` object —
+// no `..`/double-indirection surprise, no chain-of-links — and the link's
+// immediate readlink target is NOT itself another symlink. Pins
+// `atomic_symlink(object, target)`'s single-hop link to the object_disk_path.
+// ---------------------------------------------------------------------------
+#[cfg(unix)]
+#[test]
+fn linked_target_is_single_hop_canonical_sharded_object_no_chain() {
+    let content = b"single-hop-canonical-target\n".to_vec();
+    let files: Vec<(&str, &[u8], &str)> = vec![("only.bin", content.as_slice(), "644")];
+
+    let parent = coloc_parent();
+    let (store, store_dir, manifest, _id, _src) = staged_store(&parent, "canon", &files);
+    let dest = TempDir::under(&parent, "canon-dest");
+
+    store
+        .fetch_files_with_mode(&manifest, dest.path(), MaterializeMode::Linked)
+        .expect("linked checkout");
+
+    let sum = Blake3Hasher::new().hash_hex(&content);
+    let link = dest.path().join("only.bin");
+
+    // The link's IMMEDIATE readlink target must itself be a regular file (the
+    // object), i.e. a SINGLE hop — not another symlink (no link-to-link chain).
+    let immediate = fs::read_link(&link).expect("dest entry must be a symlink");
+    let immediate_meta =
+        fs::symlink_metadata(&immediate).expect("the link's immediate target must exist");
+    assert!(
+        immediate_meta.file_type().is_file(),
+        "the symlink must point DIRECTLY at the object file (single hop, not a chain to another link)"
+    );
+
+    // The canonical resolution of the link equals the canonical sharded object
+    // path — confirming no `..`/double-indirection produced a different inode.
+    let want_obj = object_disk(store_dir.path(), &sum)
+        .canonicalize()
+        .expect("object must exist");
+    let got = fs::canonicalize(&link).expect("link must resolve");
+    assert_eq!(
+        got, want_obj,
+        "the link's canonical target must be exactly the sharded .objects/<...> object"
+    );
+
+    // The canonical target path actually lives under the store's .objects pool
+    // (defends against a future regression pointing links elsewhere).
+    let objects_root = store_dir
+        .path()
+        .join(".objects")
+        .canonicalize()
+        .expect(".objects must exist");
+    assert!(
+        got.starts_with(&objects_root),
+        "the resolved target {got:?} must live under the store .objects pool {objects_root:?}"
+    );
+
+    // And reading through the (single-hop) link returns the right content.
+    assert_eq!(
+        fs::read(&link).expect("read through link"),
+        content,
+        "reading through the single-hop link must return the source content"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// REVIEW (j) — `cow_reflink_supported(dest)` public probe. Returns a bool
+// WITHOUT corrupting/leaving probe temps in dest's parent; honors
+// `SNAPDIR_CLONEFILE=0` (=> false). On a clone-capable host the default probe
+// reports true. Black-box against the public crate-root fn.
+// ---------------------------------------------------------------------------
+#[cfg(unix)]
+#[test]
+fn cow_reflink_probe_reports_bool_leaves_no_residue_and_honors_clonefile_off() {
+    let _g = env_lock();
+
+    let parent = coloc_parent();
+    let dir = TempDir::under(&parent, "cow-probe");
+    // The eventual dest need not exist; use a child path under our temp dir so
+    // the probe runs in `dir` (its parent).
+    let dest = dir.path().join("would-be-dest");
+
+    let snapshot_entries = |d: &Path| -> Vec<String> {
+        let mut v: Vec<String> = fs::read_dir(d)
+            .map(|rd| {
+                rd.flatten()
+                    .map(|e| e.file_name().to_string_lossy().into_owned())
+                    .collect()
+            })
+            .unwrap_or_default();
+        v.sort();
+        v
+    };
+    let before = snapshot_entries(dir.path());
+
+    // (1) Default knob (clone enabled where the FS supports it).
+    {
+        let _e = CloneEnv::set(None);
+        let supported = snapdir_stores::cow_reflink_supported(&dest)
+            .expect("probe must not error on a writable dir");
+        // On a clone-capable host (macOS APFS, or a Linux reflink root) the
+        // probe MUST report true; elsewhere it may legitimately be false. Either
+        // way it returns a bool (no panic, no error).
+        if reflink_capable() {
+            assert!(
+                supported,
+                "cow_reflink_supported must report true on a clone-capable host (default knob)"
+            );
+        }
+    }
+
+    // (2) SNAPDIR_CLONEFILE=0 forces the probe to report false (it routes
+    // through the same copy_file machinery, which honors the knob).
+    {
+        let _e = CloneEnv::set(Some("0"));
+        let forced_off = snapdir_stores::cow_reflink_supported(&dest)
+            .expect("probe must not error with the clone knob forced off");
+        assert!(
+            !forced_off,
+            "SNAPDIR_CLONEFILE=0 must make cow_reflink_supported report false"
+        );
+    }
+
+    // (3) No residue: the probe must clean up BOTH its probe temps; the dir
+    // holds exactly what it held before (the would-be dest itself is never
+    // created as a file — only its parent is touched).
+    let after = snapshot_entries(dir.path());
+    assert_eq!(
+        before, after,
+        "cow_reflink_supported must leave NO probe temp files behind in the dest parent: \
+         before={before:?} after={after:?}"
+    );
+    // Belt-and-suspenders: no stray probe-named entries.
+    for name in &after {
+        assert!(
+            !name.contains("snapdir-cow-probe"),
+            "a probe temp file leaked into the dest parent: {name}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// REVIEW (k) — `cow_reflink_supported` on a NON-CoW path reports false without
+// residue. We force the copy fallback via SNAPDIR_CLONEFILE=0 (the
+// host-independent way to exercise the "not CoW" branch: copy_file returns
+// CopyMethod::Copied, so the probe must report false) and confirm no temp file
+// is left. (A genuinely non-CoW filesystem is not portably mountable in a unit
+// test; the forced-off knob exercises the identical `!Cloned => false` branch.)
+// ---------------------------------------------------------------------------
+#[cfg(unix)]
+#[test]
+fn cow_reflink_probe_false_on_non_cow_path_no_residue() {
+    let _g = env_lock();
+    let _e = CloneEnv::set(Some("0")); // force the non-CoW (copy) branch
+
+    let dir = TempDir::new("cow-probe-noncow");
+    let dest = dir.path().join("nested/created/on/demand/dest");
+
+    // The probe creates `dest`'s parent if missing; confirm it still reports
+    // false (copy path) and errors on nothing.
+    let supported = snapdir_stores::cow_reflink_supported(&dest)
+        .expect("probe must succeed (creating the parent) and not error");
+    assert!(
+        !supported,
+        "the non-CoW (copy) path must make cow_reflink_supported report false"
+    );
+
+    // The parent was created; it must hold NO probe residue.
+    let probe_parent = dest.parent().unwrap();
+    let leaked: Vec<String> = fs::read_dir(probe_parent)
+        .map(|rd| {
+            rd.flatten()
+                .map(|e| e.file_name().to_string_lossy().into_owned())
+                .filter(|n| n.contains("snapdir-cow-probe"))
+                .collect()
+        })
+        .unwrap_or_default();
+    assert!(
+        leaked.is_empty(),
+        "the non-CoW probe must leave no probe temps behind, found: {leaked:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// REVIEW (l) — No-corruption DEPTH after an auto-mode CoW/copy edit. The
+// keystone in case (d) checks the object after editing a >256KiB reflinked
+// file; this case additionally drives the full BLAKE3 verify path (get_object)
+// AND a second auto re-fetch into a fresh dest to prove the object remained a
+// faithful source after the edit (no shared-extent CoW-break leakage). Pins
+// the verify-on-fetch backstop interacting with an auto edit.
+// ---------------------------------------------------------------------------
+#[cfg(unix)]
+#[test]
+fn auto_edit_then_object_still_verifies_and_refetches_clean() {
+    let content: Vec<u8> = (0..(300 * 1024u32)).map(|i| (i % 251) as u8).collect();
+    let files: Vec<(&str, &[u8], &str)> = vec![("v.bin", content.as_slice(), "644")];
+
+    let parent = coloc_parent();
+
+    let _g = env_lock();
+    let _e = CloneEnv::set(None);
+
+    let (store, store_dir, manifest, _id, _src) = staged_store(&parent, "verify-depth", &files);
+    let dest1 = TempDir::under(&parent, "verify-depth-d1");
+
+    store
+        .fetch_files_with_mode(&manifest, dest1.path(), MaterializeMode::Auto)
+        .expect("first auto checkout");
+
+    // Edit the (possibly reflinked) dest file — a CoW break.
+    let dest_file = dest1.path().join("v.bin");
+    let mut edited = content.clone();
+    edited[0] ^= 0xff;
+    edited[content.len() / 2] ^= 0xff;
+    edited[content.len() - 1] ^= 0xff;
+    fs::write(&dest_file, &edited).expect("auto dest must be editable");
+
+    let sum = Blake3Hasher::new().hash_hex(&content);
+
+    // (1) The object still verifies via the public get_object BLAKE3 backstop.
+    assert_eq!(
+        store
+            .get_object(&sum)
+            .expect("object verifies after the edit"),
+        content,
+        "after a CoW-break edit the source object must still BLAKE3-verify (get_object)"
+    );
+
+    // (2) A SECOND auto fetch into a FRESH dest restores the ORIGINAL content,
+    // proving the edit never leaked into the shared object via reflinked extents.
+    let dest2 = TempDir::under(&parent, "verify-depth-d2");
+    store
+        .fetch_files_with_mode(&manifest, dest2.path(), MaterializeMode::Auto)
+        .expect("second auto checkout into a fresh dest");
+    assert_eq!(
+        fs::read(dest2.path().join("v.bin")).expect("read re-fetched file"),
+        content,
+        "a re-fetch after a CoW-break edit must restore the ORIGINAL (uncorrupted) content"
+    );
+    assert_eq!(
+        count_objects(store_dir.path()),
+        1,
+        "the edit + re-fetch must not have duplicated/added objects"
+    );
+}

--- a/crates/snapdir-stores/tests/mirror_sync.rs
+++ b/crates/snapdir-stores/tests/mirror_sync.rs
@@ -1,0 +1,1114 @@
+//! Adversarial integration suite for `sync --delete` — the manifest-set MIRROR
+//! (phase 32, gate `mirror-sync-spec-tests`).
+//!
+//! BLACK-BOX: authored from the gate SPEC + the operator-approved plan ALONE,
+//! with NO visibility into any sync-mirror/`--delete` implementation (none
+//! exists yet). The ONLY existing code consulted was the public sync /
+//! `StreamStore` API (`sync_snapshot`, `SyncReport`, `StreamStore`'s object /
+//! manifest / listing primitives) for types and harness patterns. It will NOT
+//! compile/pass until the stores-impl teammate moves this file into
+//! `crates/snapdir-stores/tests/mirror_sync.rs` and wires the assumed symbols.
+//! Do NOT weaken any assertion to make it green — if a behavior here fails
+//! against the landed impl, that is a real bug in the impl, not in this test.
+//!
+//! ---------------------------------------------------------------------------
+//! SPEC under test — `sync --delete` = a MANIFEST-SET MIRROR
+//! ---------------------------------------------------------------------------
+//! Today `sync_snapshot` is ADDITIVE: it copies ONE snapshot (its manifest +
+//! every referenced object) from a source store to a dest store, objects-then-
+//! manifest (manifest-LAST), skipping objects the dest already has. Phase 32
+//! adds `--delete`: AFTER copying the snapshot in, DELETE the destination's
+//! manifests that are NOT present in the SOURCE store's manifest set — making
+//! the dest manifest set a mirror of the source's.
+//!
+//! HARD-SCOPED INVARIANTS (the failure modes this suite targets):
+//!   1. MANIFEST-SET MIRROR: dest manifests absent from the source set are
+//!      DELETED; manifests present in the source set are KEPT; the synced id is
+//!      present after.
+//!   2. NEVER DELETE AN OBJECT (shared-pool safety): GC is OUT OF SCOPE. No
+//!      object is ever deleted — not a shared object a retained manifest still
+//!      references, and not even an ORPHAN object referenced only by a pruned
+//!      manifest. Only manifests are pruned.
+//!   3. COPY-IN BEFORE DELETE: the synced snapshot (objects + manifest) is fully
+//!      present after `--delete`; a healthy mirror is byte-identical to a plain
+//!      sync followed by the prune (manifest-last preserved, no torn state).
+//!   4. UNSUPPORTED DEST = HARD ERROR: `--delete` to a `to` store whose
+//!      `supports_mirror()` is false (object/remote: s3/gcs/b2/ssh/sftp/external)
+//!      returns a typed, non-panic error and DELETES/CHANGES NOTHING.
+//!   5. `--dryrun` + `--delete`: reports what WOULD be pruned, deletes nothing.
+//!   6. IDEMPOTENCY / NO-OP: `--delete` when the dest set already equals the
+//!      source set performs no deletions; a healthy round-trip is unchanged.
+//!   7. NEVER DELETE THE JUST-SYNCED ID, even if some edge would classify it.
+//!
+//! ---------------------------------------------------------------------------
+//! ASSUMED API (the impl may re-point NAMES only; behavior is the contract)
+//! ---------------------------------------------------------------------------
+//! * Mirror entry point — a NEW variant of `sync_snapshot` that, in addition to
+//!   the additive copy-in, prunes dest manifests absent from the source set:
+//!
+//!       pub fn sync_snapshot_mirror(
+//!           from: &(dyn StreamStore + Sync),
+//!           to:   &(dyn StreamStore + Sync),
+//!           id:   &str,
+//!           config: &TransferConfig,
+//!           dry_run: bool,
+//!           meter: Option<&Meter>,
+//!       ) -> Result<MirrorReport, StoreError>;
+//!
+//!   The impl MAY instead express this as a `delete: bool` (or `mirror: bool`)
+//!   parameter added to the existing `sync_snapshot`, and/or fold the pruned-id
+//!   accounting into the existing `SyncReport`. If so, fix ONLY the call shape +
+//!   the report field names below; NEVER the asserted behavior. `MirrorReport`
+//!   is assumed to expose at least: the underlying sync counters (objects copied/
+//!   skipped) AND `manifests_pruned: usize` plus the concrete pruned id set
+//!   `pruned_ids: Vec<String>` (so `--dryrun` can be asserted exactly). If the
+//!   report only exposes a count, drop to count-only assertions but keep them.
+//!
+//! * `StreamStore::supports_mirror(&self) -> bool` — DEFAULT `false`; overridden
+//!   to `true` ONLY by `FileStore` (a local `file://` dest that can delete a
+//!   manifest atomically/efficiently). S3/GCS/B2/SSH/external stay `false`.
+//!
+//! * `StreamStore::delete_manifest(&self, id: &str) -> Result<(), StoreError>` —
+//!   deletes the manifest filed under `id` (NO object touched). Deleting an
+//!   absent id is assumed idempotent (`Ok(())`), matching the listing/dedup
+//!   discipline elsewhere; if the impl makes absent-delete an error instead, that
+//!   is a behavior choice the review can pin — this suite does not depend on it.
+//!
+//! The unsupported-dest refusal is asserted at the STORES layer via
+//! `supports_mirror()` returning false (a non-`FileStore` double). Whether the
+//! refusal is *also* enforced at the CLI/router layer for a literal
+//! `s3://`/`gs://` URI is FLAGGED in the handoff — this file encodes the
+//! stores-level contract.
+
+// Mirror the style allowances used by the sibling adversarial suites so every
+// assertion stays byte-for-byte as authored under the crate's `-D warnings`.
+#![allow(
+    clippy::manual_contains,
+    clippy::explicit_auto_deref,
+    clippy::cloned_ref_to_slice_refs,
+    clippy::doc_markdown,
+    clippy::items_after_statements
+)]
+
+use std::collections::HashSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Mutex;
+
+use snapdir_core::manifest::{Manifest, ManifestEntry, PathType};
+use snapdir_core::merkle::{directory_checksum, Blake3Hasher, Hasher};
+use snapdir_core::snapshot_id;
+use snapdir_core::store::{manifest_path, object_path, Store, StoreError};
+
+use snapdir_stores::{FileStore, StreamStore, TransferConfig};
+
+// The mirror entry point + its report. If the impl folds the mirror into
+// `sync_snapshot` with a `delete: bool` (and reuses `SyncReport` with added
+// `manifests_pruned`/`pruned_ids` fields), re-point these `use`s (and the call
+// sites) to that shape ONLY — never the asserted behavior.
+use snapdir_stores::{sync_snapshot_mirror, MirrorReport};
+
+// ---------------------------------------------------------------------------
+// Test scaffolding (no dev-dependencies; mirrors the existing sync/split tests).
+// ---------------------------------------------------------------------------
+
+/// A unique temp dir removed on drop.
+struct TempDir {
+    path: PathBuf,
+}
+
+impl TempDir {
+    fn new(tag: &str) -> Self {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let path = std::env::temp_dir().join(format!(
+            "snapdir-mirror-sync-test-{}-{tag}-{n}",
+            std::process::id()
+        ));
+        let _ = fs::remove_dir_all(&path);
+        fs::create_dir_all(&path).expect("create temp dir");
+        Self { path }
+    }
+
+    fn path(&self) -> &Path {
+        &self.path
+    }
+}
+
+impl Drop for TempDir {
+    fn drop(&mut self) {
+        let _ = fs::remove_dir_all(&self.path);
+    }
+}
+
+fn cfg() -> TransferConfig {
+    TransferConfig::new(4, None)
+}
+
+/// Builds a real source tree under `src` and returns the matching `Manifest`
+/// plus its snapshot id. Distinct `files` content => distinct snapshot id, so
+/// callers can mint as many independent snapshots as they need. Mirrors the
+/// `manifest_list.rs` fixture: NON-keyed `Blake3Hasher` addressing + a `D ./`
+/// root entry + `snapshot_id` over the sorted manifest.
+fn build_tree(src: &Path, files: &[(&str, &[u8])]) -> (Manifest, String) {
+    let hasher = Blake3Hasher::new();
+    let mut manifest = Manifest::new();
+
+    let mut file_sums: Vec<String> = Vec::new();
+    for (rel, content) in files {
+        let target = src.join(rel);
+        if let Some(parent) = target.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&target, content).unwrap();
+        let sum = hasher.hash_hex(content);
+        file_sums.push(sum.clone());
+        manifest.push(ManifestEntry::new(
+            PathType::File,
+            "600",
+            sum,
+            content.len() as u64,
+            format!("./{rel}"),
+        ));
+    }
+
+    let root_sum = directory_checksum(file_sums.iter().map(String::as_str), &hasher);
+    let root_size: u64 = files.iter().map(|(_, c)| c.len() as u64).sum();
+    manifest.push(ManifestEntry::new(
+        PathType::Directory,
+        "700",
+        root_sum,
+        root_size,
+        "./",
+    ));
+
+    manifest.sort();
+    let id = snapshot_id(&manifest, &hasher);
+    (manifest, id)
+}
+
+/// Stages a real source tree into a store via the full `Store::push` path
+/// (objects + manifest land on disk), returning the `(manifest, id)`.
+fn push_tree(store: &FileStore, tag: &str, files: &[(&str, &[u8])]) -> (Manifest, String) {
+    let src = TempDir::new(tag);
+    let (manifest, id) = build_tree(src.path(), files);
+    store.push(&manifest, src.path()).expect("push tree");
+    (manifest, id)
+}
+
+/// The File-object checksums referenced by a manifest (deduped, sorted).
+fn object_checksums(manifest: &Manifest) -> Vec<String> {
+    let mut v: Vec<String> = manifest
+        .entries()
+        .iter()
+        .filter(|e| e.path_type == PathType::File)
+        .map(|e| e.checksum.clone())
+        .collect();
+    v.sort();
+    v.dedup();
+    v
+}
+
+/// Sorts + dedups a list of ids so order-unspecified results compare as a set.
+fn sorted_set(mut v: Vec<String>) -> Vec<String> {
+    v.sort();
+    v.dedup();
+    v
+}
+
+/// Asserts the store's `list_manifest_ids` SET equals `expected` exactly.
+fn assert_manifest_set(store: &FileStore, expected: &[String]) {
+    let got = sorted_set(store.list_manifest_ids().expect("list_manifest_ids"));
+    let want = sorted_set(expected.to_vec());
+    assert_eq!(
+        got, want,
+        "dest manifest set must equal the expected mirror set"
+    );
+}
+
+/// Absolute on-disk path of a manifest under a FileStore root.
+fn manifest_disk_path(root: &Path, id: &str) -> PathBuf {
+    root.join(manifest_path(id))
+}
+
+/// Absolute on-disk path of an object under a FileStore root.
+fn object_disk_path(root: &Path, checksum: &str) -> PathBuf {
+    root.join(object_path(checksum))
+}
+
+// ===========================================================================
+// 1. MANIFEST-SET MIRROR — dest manifests absent from the source are pruned
+// ===========================================================================
+
+#[test]
+fn mirror_prunes_dest_manifests_absent_from_source_and_keeps_the_synced_id() {
+    // SPEC invariant 1 (manifest-set mirror): seed the DEST with extra manifests
+    // {A,B} NOT in the source; the SOURCE set is {X,Y}; sync --id X with
+    // --delete. Afterwards the dest manifest set == the SOURCE set {X,Y}: A,B
+    // pruned, X copied-in, Y... — the mirror prunes dest manifests absent from
+    // the source set, so Y (in source, never in dest) is NOT magically created
+    // by a single-id sync, but A,B (in dest, absent from source) MUST be gone
+    // and X present. So the dest ends as: source ∩ (dest ∪ {X}) with absent-from-
+    // source dropped => exactly {X}. We pin the two HARD facts the spec names:
+    // (a) A,B are DELETED; (b) the synced id X is PRESENT.
+    let src_store_dir = TempDir::new("mirror-src-store");
+    let dst_store_dir = TempDir::new("mirror-dst-store");
+    let source = FileStore::from_root(src_store_dir.path().to_path_buf());
+    let dest = FileStore::from_root(dst_store_dir.path().to_path_buf());
+
+    // SOURCE manifest set {X, Y}.
+    let (_mx, id_x) = push_tree(&source, "src-x", &[("x", b"snapshot X content\n")]);
+    let (_my, id_y) = push_tree(&source, "src-y", &[("y", b"snapshot Y content\n")]);
+    assert_ne!(id_x, id_y);
+
+    // DEST seeded with EXTRA manifests {A, B} absent from the source.
+    let (_ma, id_a) = push_tree(&dest, "dst-a", &[("a", b"extra A only in dest\n")]);
+    let (_mb, id_b) = push_tree(&dest, "dst-b", &[("b", b"extra B only in dest\n")]);
+    assert_manifest_set(&dest, &[id_a.clone(), id_b.clone()]);
+
+    // Mirror-sync ONLY id X from source into dest.
+    sync_snapshot_mirror(&source, &dest, &id_x, &cfg(), false, None).expect("mirror sync ok");
+
+    // (a) A and B (absent from the source set) are DELETED.
+    assert!(
+        !dest.list_manifest_ids().unwrap().iter().any(|i| *i == id_a),
+        "dest manifest A (absent from source) must be pruned"
+    );
+    assert!(
+        !dest.list_manifest_ids().unwrap().iter().any(|i| *i == id_b),
+        "dest manifest B (absent from source) must be pruned"
+    );
+    // (b) The synced id X is PRESENT.
+    assert!(
+        dest.list_manifest_ids().unwrap().iter().any(|i| *i == id_x),
+        "the just-synced id X must be present in the dest"
+    );
+    dest.get_manifest(&id_x).expect("dest has manifest X");
+    // The dest set is now exactly {X} (Y is in source but was never synced; a
+    // single-id mirror copies X in and prunes everything absent from source).
+    assert_manifest_set(&dest, &[id_x]);
+    // Y was never in the dest and a single-id sync does not fabricate it.
+    assert!(
+        !dest.list_manifest_ids().unwrap().iter().any(|i| *i == id_y),
+        "an un-synced source id Y is not created in the dest by a single-id sync"
+    );
+}
+
+#[test]
+fn mirror_keeps_a_dest_manifest_that_is_also_in_the_source_set() {
+    // SPEC invariant 1: a dest manifest that IS present in the source set must be
+    // KEPT (not pruned). Seed dest with {X, B}; source set {X}; sync X --delete.
+    // X is in source -> kept; B absent from source -> pruned. Result == {X}.
+    let src_dir = TempDir::new("keep-src");
+    let dst_dir = TempDir::new("keep-dst");
+    let source = FileStore::from_root(src_dir.path().to_path_buf());
+    let dest = FileStore::from_root(dst_dir.path().to_path_buf());
+
+    let (mx, id_x) = push_tree(&source, "keep-x", &[("x", b"kept snapshot\n")]);
+    // Put the SAME X into the dest already (so it is a dest manifest that is also
+    // in the source set), plus an extra B.
+    let s = TempDir::new("keep-x-redo");
+    let (_m2, id2) = build_tree(s.path(), &[("x", b"kept snapshot\n")]);
+    assert_eq!(id2, id_x, "rebuilt X must hash to the same id");
+    dest.push(&mx, s.path()).expect("seed dest with X");
+    let (_mb, id_b) = push_tree(&dest, "keep-b", &[("b", b"prune me\n")]);
+    assert_manifest_set(&dest, &[id_x.clone(), id_b.clone()]);
+
+    sync_snapshot_mirror(&source, &dest, &id_x, &cfg(), false, None).expect("mirror ok");
+
+    // X kept (in source set), B pruned (absent from source set).
+    assert_manifest_set(&dest, &[id_x.clone()]);
+    assert!(
+        !dest.list_manifest_ids().unwrap().iter().any(|i| *i == id_b),
+        "B absent from source must be pruned"
+    );
+    dest.get_manifest(&id_x).expect("X retained");
+}
+
+// ===========================================================================
+// 2. NEVER DELETE AN OBJECT — shared-pool safety + orphan survival
+// ===========================================================================
+
+#[test]
+fn mirror_never_deletes_a_shared_object_a_retained_manifest_still_references() {
+    // SPEC invariant 2 (shared-object safety, the KEYSTONE): a to-be-PRUNED dest
+    // manifest references an object that a RETAINED manifest ALSO references.
+    // After mirror-sync, that shared object MUST still exist AND still verify —
+    // deleting it would corrupt the retained snapshot. GC is out of scope; NO
+    // object is ever deleted.
+    let src_dir = TempDir::new("shared-src");
+    let dst_dir = TempDir::new("shared-dst");
+    let source = FileStore::from_root(src_dir.path().to_path_buf());
+    let dest = FileStore::from_root(dst_dir.path().to_path_buf());
+
+    // The shared blob, referenced by BOTH a pruned and a retained dest manifest.
+    let shared_bytes: &[u8] = b"shared-object-bytes-referenced-by-two-snapshots\n";
+    let shared_sum = Blake3Hasher::new().hash_hex(shared_bytes);
+
+    // Source set = {X} where X references the shared blob (so X is retained and
+    // its object must survive).
+    let (_mx, id_x) = push_tree(
+        &source,
+        "shared-x",
+        &[("shared", shared_bytes), ("xonly", b"x distinct\n")],
+    );
+
+    // Dest seeded with PRUNED manifest P that ALSO references the shared blob,
+    // plus the eventual X (we'll sync X in). P is absent from the source -> it
+    // will be pruned, but the shared object it shares with X must survive.
+    let (_mp, id_p) = push_tree(
+        &dest,
+        "shared-p",
+        &[("shared", shared_bytes), ("ponly", b"p distinct\n")],
+    );
+    assert!(
+        dest.has_object(&shared_sum).expect("has shared"),
+        "precondition: dest holds the shared object via P"
+    );
+
+    sync_snapshot_mirror(&source, &dest, &id_x, &cfg(), false, None).expect("mirror ok");
+
+    // P pruned, X present.
+    assert_manifest_set(&dest, &[id_x.clone()]);
+    assert!(
+        !dest.list_manifest_ids().unwrap().iter().any(|i| *i == id_p),
+        "P (absent from source) is pruned"
+    );
+    // The SHARED object MUST still exist AND still verify (no object deletion).
+    assert!(
+        dest.has_object(&shared_sum)
+            .expect("has_object after mirror"),
+        "the shared object referenced by retained X must NOT be deleted"
+    );
+    assert!(
+        object_disk_path(dst_dir.path(), &shared_sum).exists(),
+        "the shared object file must still be on disk"
+    );
+    let blob = dest
+        .get_object(&shared_sum)
+        .expect("shared object must still read + BLAKE3-verify after mirror");
+    assert_eq!(blob, shared_bytes, "shared object bytes intact");
+}
+
+#[test]
+fn mirror_does_not_delete_an_orphan_object_referenced_only_by_a_pruned_manifest() {
+    // SPEC invariant 2 (GC out of scope, orphan survival): an object referenced
+    // ONLY by a PRUNED dest manifest becomes an ORPHAN after the prune — and it
+    // MUST STILL EXIST afterward. Reclaiming orphans is a FUTURE `snapdir gc`
+    // job, never `sync --delete`. Pin: the orphan object is NOT deleted.
+    let src_dir = TempDir::new("orphan-src");
+    let dst_dir = TempDir::new("orphan-dst");
+    let source = FileStore::from_root(src_dir.path().to_path_buf());
+    let dest = FileStore::from_root(dst_dir.path().to_path_buf());
+
+    // Source set = {X} (its own objects, NOT shared with the orphan).
+    let (_mx, id_x) = push_tree(&source, "orphan-x", &[("x", b"x snapshot only\n")]);
+
+    // Dest seeded with a pruned manifest P whose object is UNIQUE to P (an
+    // orphan-to-be). After P is pruned, this object is referenced by nothing.
+    let orphan_bytes: &[u8] = b"object referenced only by the pruned manifest P\n";
+    let orphan_sum = Blake3Hasher::new().hash_hex(orphan_bytes);
+    let (_mp, id_p) = push_tree(&dest, "orphan-p", &[("orphan", orphan_bytes)]);
+    assert!(
+        dest.has_object(&orphan_sum)
+            .expect("has orphan precondition"),
+        "precondition: dest holds the orphan object via P"
+    );
+
+    sync_snapshot_mirror(&source, &dest, &id_x, &cfg(), false, None).expect("mirror ok");
+
+    // P pruned.
+    assert!(
+        !dest.list_manifest_ids().unwrap().iter().any(|i| *i == id_p),
+        "P pruned"
+    );
+    // The now-orphan object MUST still exist (GC out of scope).
+    assert!(
+        dest.has_object(&orphan_sum)
+            .expect("has_object after mirror"),
+        "an orphan object (only referenced by a pruned manifest) must NOT be deleted"
+    );
+    assert!(
+        object_disk_path(dst_dir.path(), &orphan_sum).exists(),
+        "the orphan object file must still be on disk after the mirror prune"
+    );
+    // STRONGER (review): the now-orphan object must still READ + BLAKE3-verify
+    // through the store API (a corrupted-but-present file would still satisfy the
+    // on-disk/has_object checks; get_object proves the bytes are intact).
+    let orphan_blob = dest
+        .get_object(&orphan_sum)
+        .expect("orphan object must still read + BLAKE3-verify after the prune");
+    assert_eq!(
+        orphan_blob, orphan_bytes,
+        "the orphan object bytes must be intact after the prune"
+    );
+    let _ = id_x;
+}
+
+#[test]
+fn mirror_deletes_no_object_at_all_object_pool_byte_identical() {
+    // SPEC invariant 2 (strongest form): across a mirror that PRUNES several dest
+    // manifests, the dest's `.objects/` pool is BYTE-IDENTICAL before vs after
+    // EXCEPT for objects newly copied-in by the synced snapshot. Nothing is ever
+    // removed from the object pool. We snapshot the full set of object files on
+    // disk before and after and assert before ⊆ after (no deletions; only
+    // additions from the copy-in).
+    let src_dir = TempDir::new("pool-src");
+    let dst_dir = TempDir::new("pool-dst");
+    let source = FileStore::from_root(src_dir.path().to_path_buf());
+    let dest = FileStore::from_root(dst_dir.path().to_path_buf());
+
+    let (_mx, id_x) = push_tree(&source, "pool-x", &[("x", b"X new content\n")]);
+
+    // Several extra dest manifests, each with unique objects -> all become
+    // orphans after prune; none may be deleted.
+    let (_p1, _) = push_tree(&dest, "pool-p1", &[("p1", b"p1 unique\n")]);
+    let (_p2, _) = push_tree(&dest, "pool-p2", &[("p2", b"p2 unique\n")]);
+    let (_p3, _) = push_tree(&dest, "pool-p3", &[("p3", b"p3 unique\n")]);
+
+    let before = object_files_on_disk(dst_dir.path());
+    assert!(!before.is_empty(), "precondition: dest has objects");
+
+    sync_snapshot_mirror(&source, &dest, &id_x, &cfg(), false, None).expect("mirror ok");
+
+    let after = object_files_on_disk(dst_dir.path());
+    // EVERY object present before MUST still be present after (no deletion).
+    for o in &before {
+        assert!(
+            after.contains(o),
+            "object file {o:?} was deleted by the mirror prune — objects must NEVER be deleted"
+        );
+    }
+    // STRONGER (review): `before` is a strict SUBSET of `after` and the pool only
+    // ever GREW — a single new object (X's `x` blob) was copied in, the three
+    // orphaned p1/p2/p3 blobs survived. So `after.len() == before.len() + 1` and
+    // nothing was removed. This rules out a "delete one, copy one" wash that the
+    // subset check alone would miss.
+    assert!(
+        before.is_subset(&after),
+        "the whole .objects/ pool before must be a subset of after (no object removed)"
+    );
+    assert_eq!(
+        after.len(),
+        before.len() + 1,
+        "the pool must grow by exactly the one new copied-in object and lose none"
+    );
+}
+
+/// Collects the set of object FILE leaf paths (relative to root) under
+/// `.objects/`, so before/after pool comparisons can detect any deletion.
+fn object_files_on_disk(root: &Path) -> HashSet<PathBuf> {
+    let mut out = HashSet::new();
+    let objects = root.join(".objects");
+    fn walk(dir: &Path, base: &Path, out: &mut HashSet<PathBuf>) {
+        let Ok(rd) = fs::read_dir(dir) else { return };
+        for entry in rd.flatten() {
+            let p = entry.path();
+            if p.is_dir() {
+                walk(&p, base, out);
+            } else if let Ok(rel) = p.strip_prefix(base) {
+                out.insert(rel.to_path_buf());
+            }
+        }
+    }
+    walk(&objects, root, &mut out);
+    out
+}
+
+// ===========================================================================
+// 3. COPY-IN BEFORE DELETE — synced snapshot fully present; byte-identical
+// ===========================================================================
+
+#[test]
+fn mirror_copies_the_snapshot_in_before_pruning() {
+    // SPEC invariant 3 (ordering: copy-in BEFORE delete): after a mirror-sync the
+    // synced snapshot's manifest AND every referenced object are present in the
+    // dest (the copy-in fully happened), AND the prune happened (extra manifest
+    // gone) — proving copy-in completed before/independent of the prune.
+    let src_dir = TempDir::new("order-src");
+    let dst_dir = TempDir::new("order-dst");
+    let source = FileStore::from_root(src_dir.path().to_path_buf());
+    let dest = FileStore::from_root(dst_dir.path().to_path_buf());
+
+    let (mx, id_x) = push_tree(
+        &source,
+        "order-x",
+        &[("a", b"alpha\n"), ("b", b"bravo\n"), ("c", b"charlie\n")],
+    );
+    let (_mp, id_p) = push_tree(&dest, "order-p", &[("p", b"prune target\n")]);
+
+    sync_snapshot_mirror(&source, &dest, &id_x, &cfg(), false, None).expect("mirror ok");
+
+    // Copy-in: manifest X + every object present.
+    dest.get_manifest(&id_x).expect("dest has X manifest");
+    for sum in object_checksums(&mx) {
+        assert!(
+            dest.has_object(&sum).expect("has_object"),
+            "object {sum} of the synced snapshot must be present (copy-in before delete)"
+        );
+        // And it must verify (manifest-last invariant: a present manifest implies
+        // present, valid objects).
+        dest.get_object(&sum).expect("synced object verifies");
+    }
+    // Prune: P gone.
+    assert!(
+        !dest.list_manifest_ids().unwrap().iter().any(|i| *i == id_p),
+        "P pruned after copy-in"
+    );
+}
+
+#[test]
+fn mirror_into_a_set_equal_dest_is_byte_identical_to_plain_sync() {
+    // SPEC invariant 3 (byte-identical): a healthy mirror where the dest set
+    // already == the source set ∪ {X} produces a dest byte-identical to a plain
+    // (additive) `sync_snapshot` over the same inputs — same manifest bytes, same
+    // object bytes, manifest-last preserved, no torn state. Compare two dests:
+    // one built by plain sync, one by mirror-sync, when there's nothing to prune.
+    let src_dir = TempDir::new("bi-src");
+    let plain_dir = TempDir::new("bi-plain");
+    let mirror_dir = TempDir::new("bi-mirror");
+    let source = FileStore::from_root(src_dir.path().to_path_buf());
+    let plain = FileStore::from_root(plain_dir.path().to_path_buf());
+    let mirrored = FileStore::from_root(mirror_dir.path().to_path_buf());
+
+    let (mx, id_x) = push_tree(
+        &source,
+        "bi-x",
+        &[("a", b"aaa\n"), ("b", b"bbb\n"), ("c", b"ccc\n")],
+    );
+
+    // Plain additive sync into an empty dest.
+    snapdir_stores::sync_snapshot(&source, &plain, &id_x, &cfg(), false, None)
+        .expect("plain sync ok");
+    // Mirror sync into another empty dest (nothing to prune -> additive only).
+    sync_snapshot_mirror(&source, &mirrored, &id_x, &cfg(), false, None).expect("mirror sync ok");
+
+    // Manifest bytes identical (both stores file X; raw on-disk bytes match).
+    let p_man = fs::read(manifest_disk_path(plain_dir.path(), &id_x)).expect("plain manifest");
+    let m_man = fs::read(manifest_disk_path(mirror_dir.path(), &id_x)).expect("mirror manifest");
+    assert_eq!(
+        p_man, m_man,
+        "mirror dest manifest bytes must equal plain sync"
+    );
+    // Every object byte-identical.
+    for sum in object_checksums(&mx) {
+        let p = fs::read(object_disk_path(plain_dir.path(), &sum)).expect("plain object");
+        let m = fs::read(object_disk_path(mirror_dir.path(), &sum)).expect("mirror object");
+        assert_eq!(p, m, "object {sum} bytes must match plain sync");
+    }
+    // Same manifest set.
+    assert_manifest_set(&mirrored, &[id_x]);
+}
+
+// ===========================================================================
+// 4. UNSUPPORTED DEST = HARD ERROR (object/remote store), changes NOTHING
+// ===========================================================================
+
+/// A `StreamStore` double whose `supports_mirror()` is FALSE, standing in for an
+/// object/remote backend (S3/GCS/B2/SSH/external) that cannot atomically/
+/// efficiently delete a manifest. It wraps a real `FileStore` so the copy-in
+/// part *would* succeed — the point is that `--delete` must HARD-ERROR on it
+/// BEFORE deleting anything, because pruning is unsupported here. It records
+/// every mutating op so we can assert NOTHING was deleted.
+struct RemoteLikeDest {
+    inner: FileStore,
+    deletes_attempted: Mutex<Vec<String>>,
+}
+
+impl RemoteLikeDest {
+    fn new(root: PathBuf) -> Self {
+        Self {
+            inner: FileStore::from_root(root),
+            deletes_attempted: Mutex::new(Vec::new()),
+        }
+    }
+}
+
+impl Store for RemoteLikeDest {
+    fn get_manifest(&self, id: &str) -> Result<Manifest, StoreError> {
+        self.inner.get_manifest(id)
+    }
+    fn fetch_files(&self, manifest: &Manifest, dest: &Path) -> Result<(), StoreError> {
+        self.inner.fetch_files(manifest, dest)
+    }
+    fn push(&self, manifest: &Manifest, source: &Path) -> Result<(), StoreError> {
+        self.inner.push(manifest, source)
+    }
+}
+
+impl StreamStore for RemoteLikeDest {
+    fn has_object(&self, checksum: &str) -> Result<bool, StoreError> {
+        self.inner.has_object(checksum)
+    }
+    fn get_object(&self, checksum: &str) -> Result<Vec<u8>, StoreError> {
+        self.inner.get_object(checksum)
+    }
+    fn put_object(&self, checksum: &str, bytes: Vec<u8>) -> Result<(), StoreError> {
+        self.inner.put_object(checksum, bytes)
+    }
+    fn put_manifest(&self, id: &str, manifest: &Manifest) -> Result<(), StoreError> {
+        self.inner.put_manifest(id, manifest)
+    }
+    fn list_manifest_ids(&self) -> Result<Vec<String>, StoreError> {
+        self.inner.list_manifest_ids()
+    }
+    // The ASSUMED capability gate: a remote/object backend cannot mirror-prune.
+    fn supports_mirror(&self) -> bool {
+        false
+    }
+    // If `--delete` ever reached here it would be a bug (the capability gate must
+    // refuse first). Record the attempt so the test can prove it never happened.
+    fn delete_manifest(&self, id: &str) -> Result<(), StoreError> {
+        self.deletes_attempted.lock().unwrap().push(id.to_owned());
+        self.inner.delete_manifest(id)
+    }
+}
+
+#[test]
+fn mirror_to_unsupported_dest_is_a_hard_error_and_deletes_nothing() {
+    // SPEC invariant 4 (unsupported dest = hard error): `--delete` to a `to`
+    // store whose `supports_mirror()` is false (object/remote) returns a typed,
+    // NON-PANIC error and DELETES/CHANGES NOTHING. The capability gate must fire
+    // BEFORE any prune (and arguably before/without the copy-in mutating the
+    // dest). We assert: (a) Err, not a panic; (b) NO delete_manifest was ever
+    // attempted; (c) the pre-existing extra manifest is still present.
+    let src_dir = TempDir::new("unsup-src");
+    let dst_dir = TempDir::new("unsup-dst");
+    let source = FileStore::from_root(src_dir.path().to_path_buf());
+    let dest = RemoteLikeDest::new(dst_dir.path().to_path_buf());
+
+    let (mx, id_x) = push_tree(&source, "unsup-x", &[("x", b"x to sync\n")]);
+    // A pre-existing extra manifest in the (file-backed) remote-like dest.
+    let (_mp, id_p) = push_tree(&dest.inner, "unsup-p", &[("p", b"must survive\n")]);
+
+    // Snapshot the FULL dest state (manifest set + object pool) before the refused
+    // mirror, so we can prove the refusal changed NOTHING — not just that no delete
+    // was attempted, but that no copy-in mutated the dest either.
+    let manifests_before = sorted_set(dest.inner.list_manifest_ids().unwrap());
+    let objects_before = object_files_on_disk(dst_dir.path());
+
+    let err = sync_snapshot_mirror(&source, &dest, &id_x, &cfg(), false, None)
+        .expect_err("mirror to an unsupported (non-mirror) dest must be a hard error");
+
+    // A typed StoreError (not a panic). We don't over-constrain the exact
+    // variant, but it must NOT be a silent success path. A Backend("unsupported"
+    // / "mirror") message is the natural shape.
+    match &err {
+        StoreError::Backend { message, .. } => {
+            let m = message.to_lowercase();
+            assert!(
+                m.contains("mirror")
+                    || m.contains("unsupported")
+                    || m.contains("delete")
+                    || m.contains("not support"),
+                "the refusal message should explain mirror/delete is unsupported here; got: {message}"
+            );
+        }
+        // Tolerate the impl choosing a future dedicated variant; the only hard
+        // requirement is that it is an Err and NOTHING was deleted.
+        other => {
+            let _ = other;
+        }
+    }
+
+    // NOTHING was deleted: delete_manifest must never have been called.
+    assert!(
+        dest.deletes_attempted.lock().unwrap().is_empty(),
+        "no manifest may be deleted on an unsupported dest: {:?}",
+        dest.deletes_attempted.lock().unwrap()
+    );
+    // The pre-existing extra manifest survives.
+    assert!(
+        dest.inner
+            .list_manifest_ids()
+            .unwrap()
+            .iter()
+            .any(|i| *i == id_p),
+        "the pre-existing dest manifest P must survive a refused mirror"
+    );
+    // STRONGER (review): the refusal must change NOTHING. The capability gate fires
+    // BEFORE the copy-in, so the dest's manifest SET and the entire `.objects/`
+    // pool are byte-identical to before — no copy-in, no delete, no torn state.
+    assert_eq!(
+        manifests_before,
+        sorted_set(dest.inner.list_manifest_ids().unwrap()),
+        "a refused mirror must leave the dest manifest set byte-identical"
+    );
+    assert_eq!(
+        objects_before,
+        object_files_on_disk(dst_dir.path()),
+        "a refused mirror must leave the dest object pool byte-identical (no copy-in)"
+    );
+    // X's manifest was NOT copied in (the refusal preceded any copy).
+    assert!(
+        dest.inner.get_manifest(&id_x).is_err(),
+        "a refused mirror must NOT have copied the synced manifest in"
+    );
+    // None of X's objects were copied in either.
+    for sum in object_checksums(&mx) {
+        assert!(
+            !dest.inner.has_object(&sum).expect("has_object"),
+            "a refused mirror must NOT have copied any object of X in"
+        );
+    }
+}
+
+#[test]
+fn filestore_supports_mirror_is_true() {
+    // SPEC invariant 4 (capability): a local `FileStore` dest DOES support the
+    // mirror (it can delete a manifest locally), so its `supports_mirror()` is
+    // true. This pins the FileStore side of the capability gate the refusal test
+    // relies on.
+    let dir = TempDir::new("cap-true");
+    let store = FileStore::from_root(dir.path().to_path_buf());
+    assert!(
+        store.supports_mirror(),
+        "FileStore (local file:// dest) must report supports_mirror() == true"
+    );
+}
+
+// ===========================================================================
+// 5. --dryrun + --delete — reports what WOULD be pruned, deletes nothing
+// ===========================================================================
+
+#[test]
+fn mirror_dry_run_reports_pruned_set_but_deletes_nothing() {
+    // SPEC invariant 5 (--dryrun + --delete): a dry-run mirror reports what WOULD
+    // be pruned and copied, but writes/deletes NOTHING. Seed dest with extras
+    // {A,B}; dry-run mirror id X. After: A,B still present, X NOT copied in, no
+    // object written. The report (if it exposes the set) names A,B as the prune
+    // candidates.
+    let src_dir = TempDir::new("dry-src");
+    let dst_dir = TempDir::new("dry-dst");
+    let source = FileStore::from_root(src_dir.path().to_path_buf());
+    let dest = FileStore::from_root(dst_dir.path().to_path_buf());
+
+    let (mx, id_x) = push_tree(&source, "dry-x", &[("x", b"x dryrun\n")]);
+    let (_ma, id_a) = push_tree(&dest, "dry-a", &[("a", b"A extra\n")]);
+    let (_mb, id_b) = push_tree(&dest, "dry-b", &[("b", b"B extra\n")]);
+    let before = sorted_set(dest.list_manifest_ids().unwrap());
+    // Also snapshot the object pool: a dry run must leave it byte-identical too.
+    let objects_before = object_files_on_disk(dst_dir.path());
+
+    let report =
+        sync_snapshot_mirror(&source, &dest, &id_x, &cfg(), true, None).expect("dry-run mirror ok");
+
+    // NOTHING deleted: A and B still present.
+    assert!(
+        dest.list_manifest_ids().unwrap().iter().any(|i| *i == id_a),
+        "dry-run must not delete A"
+    );
+    assert!(
+        dest.list_manifest_ids().unwrap().iter().any(|i| *i == id_b),
+        "dry-run must not delete B"
+    );
+    // The dest manifest set is UNCHANGED (X not copied in, nothing pruned).
+    assert_eq!(
+        before,
+        sorted_set(dest.list_manifest_ids().unwrap()),
+        "dry-run must leave the dest manifest set unchanged"
+    );
+    // No object of X written.
+    for sum in object_checksums(&mx) {
+        assert!(
+            !dest.has_object(&sum).expect("has_object"),
+            "dry-run must not copy in any object"
+        );
+    }
+    // X manifest not written.
+    assert!(
+        dest.get_manifest(&id_x).is_err(),
+        "dry-run must not write the synced manifest"
+    );
+    // STRONGER (review): the entire object pool is byte-identical — a dry run
+    // neither copies a new object in nor (ever) removes one.
+    assert_eq!(
+        objects_before,
+        object_files_on_disk(dst_dir.path()),
+        "dry-run must leave the dest object pool byte-identical"
+    );
+
+    // The report names what WOULD be pruned. If the impl exposes `pruned_ids`,
+    // it must list exactly {A,B}; if only a count, it must be 2. We assert via a
+    // helper that tolerates either shape.
+    assert_pruned_report(&report, &[id_a, id_b]);
+}
+
+/// Asserts a mirror report's "would prune / did prune" set. Written against the
+/// ASSUMED `MirrorReport { manifests_pruned: usize, pruned_ids: Vec<String>, .. }`
+/// (alongside the underlying sync counters). If the landed report exposes only a
+/// count (no `pruned_ids`), the impl teammate should reduce the second assertion
+/// to the count check (NEVER drop it). `expected` is the exact id set.
+fn assert_pruned_report(report: &MirrorReport, expected: &[String]) {
+    let want = sorted_set(expected.to_vec());
+    assert_eq!(
+        report.manifests_pruned,
+        want.len(),
+        "pruned count must equal the number of dest manifests absent from source"
+    );
+    let got = sorted_set(report.pruned_ids.clone());
+    assert_eq!(
+        got, want,
+        "pruned id set must be exactly the absent-from-source manifests"
+    );
+}
+
+// ===========================================================================
+// 6. IDEMPOTENCY / NO-OP — dest already equals source set
+// ===========================================================================
+
+#[test]
+fn mirror_is_a_no_op_when_dest_set_already_equals_source_set() {
+    // SPEC invariant 6 (idempotency / no-op): mirror-syncing into a dest whose
+    // manifest set already == the source set (just {X}) performs NO deletions and
+    // a healthy round-trip is unchanged. Run mirror once to converge, then again
+    // and assert the second run prunes nothing and the object pool is unchanged.
+    let src_dir = TempDir::new("noop-src");
+    let dst_dir = TempDir::new("noop-dst");
+    let source = FileStore::from_root(src_dir.path().to_path_buf());
+    let dest = FileStore::from_root(dst_dir.path().to_path_buf());
+
+    let (mx, id_x) = push_tree(&source, "noop-x", &[("x", b"x noop\n")]);
+
+    // First mirror: empty dest -> just copies X in (nothing to prune).
+    sync_snapshot_mirror(&source, &dest, &id_x, &cfg(), false, None).expect("first mirror");
+    assert_manifest_set(&dest, &[id_x.clone()]);
+    let pool_after_first = object_files_on_disk(dst_dir.path());
+
+    // Second mirror over the converged dest: NO-OP. Nothing pruned, set + pool
+    // unchanged.
+    let report =
+        sync_snapshot_mirror(&source, &dest, &id_x, &cfg(), false, None).expect("second mirror");
+    assert_manifest_set(&dest, &[id_x.clone()]);
+    assert_eq!(
+        pool_after_first,
+        object_files_on_disk(dst_dir.path()),
+        "a converged second mirror must not change the object pool"
+    );
+    // If the report exposes a pruned count, it must be 0 on the no-op run.
+    assert_eq!(
+        report.manifests_pruned, 0,
+        "a converged mirror prunes nothing"
+    );
+    // X still verifies end-to-end.
+    for sum in object_checksums(&mx) {
+        dest.get_object(&sum).expect("object still verifies");
+    }
+}
+
+// ===========================================================================
+// 7. NEVER DELETE THE JUST-SYNCED ID
+// ===========================================================================
+
+#[test]
+fn mirror_never_deletes_the_just_synced_id_even_when_it_is_new_to_the_dest() {
+    // SPEC invariant 7: `--delete` must NEVER delete the just-synced id, even
+    // though X did not exist in the dest before this run (an edge that a naive
+    // "delete everything absent from <dest's prior set>" could misclassify). X is
+    // copied in AND retained; only the unrelated extra is pruned.
+    let src_dir = TempDir::new("self-src");
+    let dst_dir = TempDir::new("self-dst");
+    let source = FileStore::from_root(src_dir.path().to_path_buf());
+    let dest = FileStore::from_root(dst_dir.path().to_path_buf());
+
+    let (_mx, id_x) = push_tree(&source, "self-x", &[("x", b"the synced id\n")]);
+    let (_mq, id_q) = push_tree(&dest, "self-q", &[("q", b"unrelated extra\n")]);
+    // Precondition: X is NOT yet in the dest.
+    assert!(
+        dest.get_manifest(&id_x).is_err(),
+        "precondition: X absent from dest before sync"
+    );
+
+    sync_snapshot_mirror(&source, &dest, &id_x, &cfg(), false, None).expect("mirror ok");
+
+    // X present (never deleted), Q pruned.
+    assert!(
+        dest.list_manifest_ids().unwrap().iter().any(|i| *i == id_x),
+        "the just-synced id X must never be deleted"
+    );
+    dest.get_manifest(&id_x).expect("X readable after mirror");
+    assert!(
+        !dest.list_manifest_ids().unwrap().iter().any(|i| *i == id_q),
+        "the unrelated extra Q is pruned"
+    );
+    assert_manifest_set(&dest, &[id_x]);
+}
+
+#[test]
+fn mirror_with_empty_dest_only_copies_in_prunes_nothing() {
+    // SPEC invariant 1 + 7 edge: an EMPTY dest has nothing to prune — the mirror
+    // is purely additive (copy X in), prunes zero manifests, and the synced id is
+    // present. Pins that "prune set absent from source" is empty when the dest
+    // starts empty (no spurious deletion of the just-copied X).
+    let src_dir = TempDir::new("empty-src");
+    let dst_dir = TempDir::new("empty-dst");
+    let source = FileStore::from_root(src_dir.path().to_path_buf());
+    let dest = FileStore::from_root(dst_dir.path().to_path_buf());
+
+    let (_mx, id_x) = push_tree(&source, "empty-x", &[("x", b"only snapshot\n")]);
+    assert!(
+        dest.list_manifest_ids().unwrap().is_empty(),
+        "precondition: empty dest"
+    );
+
+    let report =
+        sync_snapshot_mirror(&source, &dest, &id_x, &cfg(), false, None).expect("mirror ok");
+
+    assert_manifest_set(&dest, &[id_x.clone()]);
+    assert_eq!(report.manifests_pruned, 0, "empty dest prunes nothing");
+    dest.get_manifest(&id_x).expect("X present");
+}
+
+// ===========================================================================
+// 8. IMPL-REVEALED cases (review gate, implementation now visible)
+// ===========================================================================
+
+#[test]
+fn mirror_prunes_every_one_of_many_extraneous_manifests_and_report_matches_exactly() {
+    // SPEC invariant 1 + report contract (review-added): a dest seeded with MANY
+    // extraneous manifests {A,B,C,D} (none in the source set) must have ALL of
+    // them pruned by a single mirror, and `MirrorReport.pruned_ids` must be
+    // EXACTLY that set (+ `manifests_pruned == 4`). Pins that the prune loop does
+    // not stop early and that the report's id set is precise, not approximate.
+    let src_dir = TempDir::new("many-src");
+    let dst_dir = TempDir::new("many-dst");
+    let source = FileStore::from_root(src_dir.path().to_path_buf());
+    let dest = FileStore::from_root(dst_dir.path().to_path_buf());
+
+    let (_mx, id_x) = push_tree(&source, "many-x", &[("x", b"the synced one\n")]);
+
+    let (_ma, id_a) = push_tree(&dest, "many-a", &[("a", b"extra A\n")]);
+    let (_mb, id_b) = push_tree(&dest, "many-b", &[("b", b"extra B\n")]);
+    let (_mc, id_c) = push_tree(&dest, "many-c", &[("c", b"extra C\n")]);
+    let (_md, id_d) = push_tree(&dest, "many-d", &[("d", b"extra D\n")]);
+    assert_manifest_set(
+        &dest,
+        &[id_a.clone(), id_b.clone(), id_c.clone(), id_d.clone()],
+    );
+
+    let report =
+        sync_snapshot_mirror(&source, &dest, &id_x, &cfg(), false, None).expect("mirror ok");
+
+    // ALL four extraneous manifests pruned; only X remains.
+    assert_manifest_set(&dest, &[id_x.clone()]);
+    // The report's pruned id set is EXACTLY {A,B,C,D} (the just-synced X excluded).
+    assert_eq!(report.manifests_pruned, 4, "all four extras pruned");
+    assert_eq!(
+        sorted_set(report.pruned_ids.clone()),
+        sorted_set(vec![id_a, id_b, id_c, id_d]),
+        "pruned_ids must be exactly the four absent-from-source manifests"
+    );
+    assert!(
+        !report.pruned_ids.iter().any(|i| *i == id_x),
+        "the just-synced id must never appear in pruned_ids"
+    );
+}
+
+#[test]
+fn filestore_delete_manifest_of_absent_id_is_idempotent() {
+    // delete_manifest contract (review-added, impl-revealed): deleting a manifest
+    // id that is NOT present is idempotent — returns Ok(()), matching the
+    // listing/dedup discipline elsewhere. This underpins the mirror's prune loop
+    // tolerating concurrent/duplicate deletes without erroring. Also confirm it
+    // leaves an unrelated existing manifest + its object untouched.
+    let dir = TempDir::new("idem-del");
+    let store = FileStore::from_root(dir.path().to_path_buf());
+
+    let (mx, id_x) = push_tree(&store, "idem-x", &[("x", b"keep me\n")]);
+    let x_obj = object_checksums(&mx);
+
+    // Deleting a never-existed id: Ok, no panic, nothing changed.
+    store
+        .delete_manifest("ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff")
+        .expect("deleting an absent manifest id must be idempotent (Ok)");
+    assert_manifest_set(&store, &[id_x.clone()]);
+
+    // Delete X, then delete X AGAIN — the second delete is still Ok (idempotent).
+    store.delete_manifest(&id_x).expect("first delete ok");
+    assert!(
+        store.get_manifest(&id_x).is_err(),
+        "X manifest gone after delete"
+    );
+    store
+        .delete_manifest(&id_x)
+        .expect("re-deleting the now-absent id must be idempotent (Ok)");
+
+    // delete_manifest NEVER touches objects: X's object still exists on disk and
+    // reads back even though its manifest is gone (it is now an orphan).
+    for sum in &x_obj {
+        assert!(
+            object_disk_path(dir.path(), sum).exists(),
+            "delete_manifest must never remove an object file"
+        );
+        assert!(
+            store.has_object(sum).expect("has_object"),
+            "the object of a deleted manifest must survive (no object GC)"
+        );
+    }
+}
+
+#[test]
+fn default_streamstore_delete_manifest_and_supports_mirror_refuse() {
+    // SPEC invariant 4 (capability default, impl-revealed): a StreamStore that does
+    // NOT override the mirror capability inherits supports_mirror() == false and a
+    // delete_manifest() that HARD-ERRORS (typed StoreError, no silent success).
+    // Our RemoteLikeDest forwards delete to its FileStore inner, so build a pure
+    // default-impl double that overrides NOTHING to pin the trait defaults.
+    let dir = TempDir::new("default-cap");
+    let inner = FileStore::from_root(dir.path().to_path_buf());
+
+    struct DefaultsOnly {
+        inner: FileStore,
+    }
+    impl Store for DefaultsOnly {
+        fn get_manifest(&self, id: &str) -> Result<Manifest, StoreError> {
+            self.inner.get_manifest(id)
+        }
+        fn fetch_files(&self, manifest: &Manifest, dest: &Path) -> Result<(), StoreError> {
+            self.inner.fetch_files(manifest, dest)
+        }
+        fn push(&self, manifest: &Manifest, source: &Path) -> Result<(), StoreError> {
+            self.inner.push(manifest, source)
+        }
+    }
+    impl StreamStore for DefaultsOnly {
+        fn has_object(&self, checksum: &str) -> Result<bool, StoreError> {
+            self.inner.has_object(checksum)
+        }
+        fn get_object(&self, checksum: &str) -> Result<Vec<u8>, StoreError> {
+            self.inner.get_object(checksum)
+        }
+        fn put_object(&self, checksum: &str, bytes: Vec<u8>) -> Result<(), StoreError> {
+            self.inner.put_object(checksum, bytes)
+        }
+        fn put_manifest(&self, id: &str, manifest: &Manifest) -> Result<(), StoreError> {
+            self.inner.put_manifest(id, manifest)
+        }
+        fn list_manifest_ids(&self) -> Result<Vec<String>, StoreError> {
+            self.inner.list_manifest_ids()
+        }
+        // supports_mirror + delete_manifest deliberately NOT overridden -> defaults.
+    }
+
+    let store = DefaultsOnly { inner };
+    // Default supports_mirror() is false (only FileStore opts in).
+    assert!(
+        !store.supports_mirror(),
+        "the default StreamStore must NOT support mirroring"
+    );
+    // Default delete_manifest() hard-errors (typed, not a panic, not a silent Ok).
+    let err = store
+        .delete_manifest("anything")
+        .expect_err("the default delete_manifest must hard-error, not silently succeed");
+    match &err {
+        StoreError::Backend { message, .. } => {
+            let m = message.to_lowercase();
+            assert!(
+                m.contains("delete") || m.contains("mirror") || m.contains("unsupported"),
+                "the default refusal should explain delete/mirror is unsupported; got: {message}"
+            );
+        }
+        other => panic!("default delete_manifest should be a Backend error, got {other:?}"),
+    }
+}

--- a/crates/snapdir/Cargo.toml
+++ b/crates/snapdir/Cargo.toml
@@ -19,7 +19,7 @@ path = "src/main.rs"
 # is the flagship-named shim so `cargo install snapdir` installs the binary.
 # Path+version dep (not [workspace.dependencies]): only this crate consumes
 # it, and an unused workspace-level entry would be flagged by cargo-shear.
-snapdir-cli = { path = "../snapdir-cli", version = "1.9.0" }
+snapdir-cli = { path = "../snapdir-cli", version = "1.10.0" }
 
 [lints]
 workspace = true

--- a/docs/rust-port/CHANGELOG.md
+++ b/docs/rust-port/CHANGELOG.md
@@ -7,6 +7,53 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.10.0] - 2026-06-21
+
+### Added
+
+- **Exact-mirror `--delete` on `checkout` and `pull`.** With `--delete`, the
+  destination becomes an exact mirror of the snapshot: files and directories
+  present in the destination but absent from the manifest are pruned
+  (deepest-first). Pruning is literal-exact and content-free (no hashing). Use
+  `--exclude <regex>` to protect destination paths from pruning, and `--dryrun`
+  to list the exact deletion set without removing anything. The operation
+  hard-refuses dangerous destinations (`/`, `$HOME`, the cache dir, a store
+  path) with no `--force` bypass, never deletes outside the destination root,
+  and removes — never follows — a symlink that escapes the destination.
+- **`--linked` read-only materialization (the flag is now real).** `checkout`
+  can now materialize the destination as `0444` symlinks into the local store's
+  content-addressed objects — a zero-copy, read-only "thin" view that works on
+  any filesystem. Writing through a link fails (objects stay `0444`), so the
+  shared store can never be corrupted. `--linked` against a non-local object
+  source (a remote store/cache) is a hard error. The default (auto) mode is
+  unchanged: reflink (copy-on-write) where the destination filesystem supports
+  it, else a plain copy — independent, editable inodes either way.
+- **Linked-mode checksum-reuse fast path.** Running `snapdir id`/`manifest` over
+  a `--linked` tree recovers each object's BLAKE3 checksum directly from the
+  object path without reading or re-hashing the bytes. The fast path is
+  checksum-only and strictly gated: plain non-keyed BLAKE3 + a known local store
+  only; a non-default `--checksum-bin` or a keyed manifest context falls back to
+  a normal re-hash, as does `SNAPDIR_VERIFY_COPIES=1` (which additionally errors
+  on any mismatch). A dangling object link is reported as a typed error.
+- **`snapdir sync --delete` — manifest-set mirror.** After copying the snapshot,
+  `sync --delete` deletes destination manifests that are not in the source
+  store's manifest set (copy-in always happens before any delete). Objects are
+  **never** deleted — garbage collection is out of scope, so orphaned objects
+  are left harmless and reclaimable. `--delete` is supported on local `file://`
+  destinations only and is a clear hard error against object/remote stores
+  (s3/gcs/b2/ssh).
+
+### Changed
+
+- **Whole-operation atomicity where it is free.** When materialization is
+  zero-copy (reflink on a copy-on-write filesystem, or `--linked` symlinks), a
+  mirror is applied as an atomic staged swap (build a sibling tree, then
+  `rename`) so the destination is never observed in a torn state. On non-CoW
+  plain-copy destinations an atomic swap would duplicate bytes, so it is a hard
+  error and the mirror runs in-place (per-file atomic) instead. In every mode, a
+  process holding a pruned or swapped-out file open keeps reading the old bytes
+  until it closes the descriptor (POSIX inode semantics).
+
 ## [1.9.0] - 2026-06-17
 
 ### Added
@@ -547,7 +594,8 @@ Bash-written caches and remote buckets stay mutually readable.
   `gcloud`) in the shipped binary. External tools are used only by the test/oracle
   harness.
 
-[Unreleased]: https://github.com/snapdir/snapdir/compare/v1.9.0...HEAD
+[Unreleased]: https://github.com/snapdir/snapdir/compare/v1.10.0...HEAD
+[1.10.0]: https://github.com/snapdir/snapdir/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/snapdir/snapdir/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/snapdir/snapdir/compare/v1.7.0...v1.8.0
 [1.7.0]: https://github.com/snapdir/snapdir/compare/v1.6.0...v1.7.0


### PR DESCRIPTION
## [1.10.0] - 2026-06-21

### Added

- **Exact-mirror `--delete` on `checkout` and `pull`.** With `--delete`, the
  destination becomes an exact mirror of the snapshot: files and directories
  present in the destination but absent from the manifest are pruned
  (deepest-first). Pruning is literal-exact and content-free (no hashing). Use
  `--exclude <regex>` to protect destination paths from pruning, and `--dryrun`
  to list the exact deletion set without removing anything. The operation
  hard-refuses dangerous destinations (`/`, `$HOME`, the cache dir, a store
  path) with no `--force` bypass, never deletes outside the destination root,
  and removes — never follows — a symlink that escapes the destination.
- **`--linked` read-only materialization (the flag is now real).** `checkout`
  can now materialize the destination as `0444` symlinks into the local store's
  content-addressed objects — a zero-copy, read-only "thin" view that works on
  any filesystem. Writing through a link fails (objects stay `0444`), so the
  shared store can never be corrupted. `--linked` against a non-local object
  source (a remote store/cache) is a hard error. The default (auto) mode is
  unchanged: reflink (copy-on-write) where the destination filesystem supports
  it, else a plain copy — independent, editable inodes either way.
- **Linked-mode checksum-reuse fast path.** Running `snapdir id`/`manifest` over
  a `--linked` tree recovers each object's BLAKE3 checksum directly from the
  object path without reading or re-hashing the bytes. The fast path is
  checksum-only and strictly gated: plain non-keyed BLAKE3 + a known local store
  only; a non-default `--checksum-bin` or a keyed manifest context falls back to
  a normal re-hash, as does `SNAPDIR_VERIFY_COPIES=1` (which additionally errors
  on any mismatch). A dangling object link is reported as a typed error.
- **`snapdir sync --delete` — manifest-set mirror.** After copying the snapshot,
  `sync --delete` deletes destination manifests that are not in the source
  store's manifest set (copy-in always happens before any delete). Objects are
  **never** deleted — garbage collection is out of scope, so orphaned objects
  are left harmless and reclaimable. `--delete` is supported on local `file://`
  destinations only and is a clear hard error against object/remote stores
  (s3/gcs/b2/ssh).

### Changed

- **Whole-operation atomicity where it is free.** When materialization is
  zero-copy (reflink on a copy-on-write filesystem, or `--linked` symlinks), a
  mirror is applied as an atomic staged swap (build a sibling tree, then
  `rename`) so the destination is never observed in a torn state. On non-CoW
  plain-copy destinations an atomic swap would duplicate bytes, so it is a hard
  error and the mirror runs in-place (per-file atomic) instead. In every mode, a
  process holding a pruned or swapped-out file open keeps reading the old bytes
  until it closes the descriptor (POSIX inode semantics).

