### PR TITLE
fix(release): Maven 401 env-name + plugin false-fail (so future releases from main publish Maven)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -759,9 +759,12 @@ jobs:
   # ---------------------------------------------------------------------------
   maven-publish:
     name: Publish Maven Central (org.snapdir:snapdir)
-    needs: [release, java-native]
-    # Publish ONLY on a real `v*` tag push; a workflow_dispatch dry-run stops here.
-    if: ${{ github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v') }}
+    # Only needs the native libs; the GitHub-release job is a parallel concern.
+    # (Dropping `release` from needs lets a workflow_dispatch re-run deploy Maven
+    # alone — e.g. to recover a failed Maven leg without a tag force-move.)
+    needs: [java-native]
+    # Publish on a real `v*` tag push OR a manual workflow_dispatch (Maven-only re-run).
+    if: ${{ (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')) || github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -817,8 +820,12 @@ jobs:
           mvn --batch-mode -f bindings/java/pom.xml deploy \
             -Dgpg.keyname=${{ secrets.GPG_KEY_FINGERPRINT }}
         env:
-          MAVEN_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
-          MAVEN_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
+          # These names MUST match setup-java's server-username/server-password
+          # (SONATYPE_USERNAME/SONATYPE_PASSWORD), which are the placeholders it
+          # wrote into ~/.m2/settings.xml as ${env.SONATYPE_USERNAME}/${env.SONATYPE_PASSWORD}.
+          # (Previously MAVEN_USERNAME/MAVEN_PASSWORD → placeholders resolved empty → Bearer base64(:) → 401.)
+          SONATYPE_USERNAME: ${{ secrets.SONATYPE_USERNAME }}
+          SONATYPE_PASSWORD: ${{ secrets.SONATYPE_PASSWORD }}
           MAVEN_GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
 
   # ---------------------------------------------------------------------------

--- a/bindings/java/pom.xml
+++ b/bindings/java/pom.xml
@@ -179,7 +179,11 @@
       <plugin>
         <groupId>org.sonatype.central</groupId>
         <artifactId>central-publishing-maven-plugin</artifactId>
-        <version>0.6.0</version>
+        <!-- 0.11.0 (not 0.6.0): 0.6.0's DeploymentApiResponse model can't
+             deserialize the Portal's `warnings` field → UnrecognizedPropertyException
+             false-FAILS the build AFTER a successful upload while polling validation.
+             Newer plugins handle the current API response. -->
+        <version>0.11.0</version>
         <extensions>true</extensions>
         <configuration>
           <publishingServerId>central</publishingServerId>


### PR DESCRIPTION
Brings the two post-1.11.0 Maven fixes to `main` so a future release cut from `main` publishes to Maven Central correctly. Both were proven during the 1.11.0 publish (Maven Central `org.snapdir:snapdir:1.11.0` is live).

**1. `release.yml` — the 401.** `setup-java` writes `settings.xml` with `${env.SONATYPE_USERNAME}`/`${env.SONATYPE_PASSWORD}` placeholders, but the deploy step exported `MAVEN_USERNAME`/`MAVEN_PASSWORD` → the placeholders resolved empty → `Bearer base64(:)` → **HTTP 401**. Renamed the deploy-step env to `SONATYPE_USERNAME`/`SONATYPE_PASSWORD`. Also dropped the tag-only `release` job from `maven-publish`'s `needs` and allowed `workflow_dispatch`, so a failed Maven leg can be re-run alone without a tag force-move.

**2. `pom.xml` — the false BUILD FAILURE.** `central-publishing-maven-plugin:0.6.0` can't deserialize the Portal's newer `warnings` field (`UnrecognizedPropertyException`) and fails the build *after* a successful upload. Bumped to `0.11.0` (released 2026-06-16).

Verified during the real 1.11.0 publish: with these, the bundle uploads, validates clean, and the deployment publishes. actionlint clean.