### PR TITLE
docs: bindings/README.md index + list bindings in root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,26 @@ cargo add snapdir-core
 > implementation library behind the CLI. Its versions ≤ 1.5.0 still install
 > the binary; from 1.6.0 the binary lives in the `snapdir` crate.
 
+## Language bindings
+
+Use snapdir from your language — every binding produces **bit-identical**
+manifests and snapshot IDs to the CLI. See **[`bindings/`](bindings/)** for the
+full index, per-language APIs, and platform notes.
+
+| Language | Install | Registry |
+|---|---|---|
+| Node.js | `npm install @snapdir/snapdir` | [npm](https://www.npmjs.com/package/@snapdir/snapdir) |
+| Python | `pip install snapdir` | [PyPI](https://pypi.org/project/snapdir/) |
+| Go | `go get github.com/snapdir/snapdir/bindings/go` | GOPROXY |
+| Java | `org.snapdir:snapdir` (Maven / Gradle) | [Maven Central](https://central.sonatype.com/artifact/org.snapdir/snapdir) |
+| C / C++ | [`snapdir-ffi`](https://crates.io/crates/snapdir-ffi) + `snapdir.hpp` | crates.io |
+| Zig | [`snapdir-ffi`](https://crates.io/crates/snapdir-ffi) + Zig wrapper | crates.io |
+| Rust | `cargo add snapdir-api` | [crates.io](https://crates.io/crates/snapdir-api) |
+
+Node/Python/Java install prebuilt (no compiler); C/C++/Zig/Go build the C ABI
+from source. All run on Linux (glibc + Alpine/musl) and macOS — see
+[`bindings/README.md`](bindings/README.md) for the platform matrix.
+
 ## Quick start — 60 seconds, no setup
 
 No cloud account needed: snapshot a directory and round-trip it through a **local** store.

--- a/bindings/README.md
+++ b/bindings/README.md
@@ -1,0 +1,52 @@
+# snapdir language bindings
+
+Use snapdir from your language of choice. Every binding wraps the same Rust core
+(`snapdir-api` → `snapdir-core`), so **manifests and snapshot IDs are
+bit-identical** across all of them and the `snapdir` CLI — content hashed with
+BLAKE3, pushed to and pulled from the same object stores (file, S3, GCS,
+Backblaze B2, SSH).
+
+| Language | Package | Install | Registry |
+|---|---|---|---|
+| **Node.js** | [`@snapdir/snapdir`](node/) | `npm install @snapdir/snapdir` | [npm](https://www.npmjs.com/package/@snapdir/snapdir) |
+| **Python** | [`snapdir`](python/) | `pip install snapdir` | [PyPI](https://pypi.org/project/snapdir/) |
+| **Go** | [`bindings/go`](go/) | `go get github.com/snapdir/snapdir/bindings/go` | GOPROXY |
+| **Java** | [`org.snapdir:snapdir`](java/) | Maven / Gradle coordinate | [Maven Central](https://central.sonatype.com/artifact/org.snapdir/snapdir) |
+| **C / C++** | [`snapdir.hpp` + `snapdir-ffi`](cpp/) | crates.io C ABI + RAII header | [crates.io](https://crates.io/crates/snapdir-ffi) |
+| **Zig** | [`bindings/zig`](zig/) | crates.io C ABI + Zig wrapper | [crates.io](https://crates.io/crates/snapdir-ffi) |
+| **Rust** | [`snapdir-api`](../crates/snapdir-api) · [`snapdir-ffi`](../crates/snapdir-ffi) | `cargo add snapdir-api` | [crates.io](https://crates.io/crates/snapdir-api) |
+
+Each binding exposes the same core surface — `id` / `manifest`, and async
+`push` / `pull` / `fetch` / `diff` / `sync` — in the idiom of its language
+(`bigint`/`int`/`long` sizes, typed error hierarchies, `Promise`/`async`/
+`CompletableFuture`/`context.Context`/`std::future`). See each subdirectory's
+README for the language-specific API and examples.
+
+## Two install shapes
+
+- **Prebuilt, no compiler** — **Node** (`npm`) and **Python** (`pip`) ship native
+  binaries (linux gnu + **musl**, macOS; x64 + arm64) and **Java** ships a jar
+  with the native library embedded. Install and go.
+- **Build from source** — **C/C++**, **Zig**, and **Go** consume the C ABI by
+  building the [`snapdir-ffi`](https://crates.io/crates/snapdir-ffi) crate from
+  crates.io (needs a Rust toolchain + `cbindgen`); the Go module additionally
+  resolves from GOPROXY. See each README for the exact recipe.
+
+## Platform support
+
+All bindings run on Linux (glibc **and Alpine/musl**, x64 + arm64) and macOS.
+**Exception:** the Java jar is currently **glibc-only** — it does not load on
+Alpine/musl yet (planned for 1.11.1). Windows is not supported (snapdir is
+Unix-only).
+
+Every binding is continuously verified **from its live public registry** on
+blank-slate base images by
+[`.github/workflows/verify-published.yml`](../.github/workflows/verify-published.yml):
+each installs the published package, runs the canonical example, and asserts the
+snapshot ID is byte-exact to the reference CLI.
+
+## Examples
+
+Runnable, idiomatic example apps for every language live in
+[`examples/`](../examples) — a tiny `push` / `pull` / `id` / `diff` CLI over each
+binding's API, the same programs the verification workflow runs.

--- a/bindings/cpp/README.md
+++ b/bindings/cpp/README.md
@@ -26,6 +26,25 @@ Python, and Go bindings.
   CMake `FindSnapdir`/`FetchContent` integration are deferred to release CI; this
   package builds with the native toolchain via the included `Makefile`.
 
+### Consuming the published C ABI (outside this repo)
+
+There is no separate C++ package registry — the published artifact is the
+[`snapdir-ffi`](https://crates.io/crates/snapdir-ffi) **source crate** on
+crates.io. An external consumer builds it and generates the header (the crate
+ships `build = false` and no header, so run `cbindgen`):
+
+```sh
+# needs a Rust toolchain + cbindgen (`apk add rust cargo cbindgen` on Alpine)
+# fetch the snapdir-ffi 1.11.0 source, then:
+cargo build --release                       # -> target/release/libsnapdir_ffi.a
+cbindgen --config cbindgen.toml --crate snapdir-ffi --output snapdir.h .
+g++ -std=c++20 app.cpp -I. -L. -lsnapdir_ffi -lpthread -ldl -lm -o app
+```
+
+with `snapdir.hpp` from this binding. This exact flow (on blank-slate
+`alpine:3.20`, musl) is verified by `.github/workflows/verify-published.yml`
+(the `cpp` job).
+
 ## Build & install
 
 ```sh

--- a/bindings/go/README.md
+++ b/bindings/go/README.md
@@ -157,6 +157,30 @@ func main() {
 **`SnapdirError`**: implements `error`; stable `.Code` string (one of: `IO_ERROR`, `HASH_MISMATCH`,
 `STORE_ERROR`, `IN_FLUX`, `CATALOG_ERROR`, `INVALID_ID`, `INVALID_STORE`, `CONFLICT`).
 
+## Install from the published module (GOPROXY)
+
+The module resolves from GOPROXY at the tag `bindings/go/v1.11.0`:
+
+```sh
+go get github.com/snapdir/snapdir/bindings/go@v1.11.0
+```
+
+Because this is a CGo package, the module is **not self-contained** — you must
+supply the native `libsnapdir_ffi.a` + `snapdir.h`. Build them from the published
+`snapdir-ffi` crate (crates.io) and drop them into the module's `lib/` +
+`include/` (the module ships neither — they are gitignored):
+
+```sh
+# build the C ABI staticlib + header from the crates.io source (needs Rust + cbindgen)
+cbindgen --config cbindgen.toml --crate snapdir-ffi --output snapdir.h .
+# place libsnapdir_ffi.a into <module>/lib/ and snapdir.h into <module>/include/
+CGO_ENABLED=1 go build ./...
+```
+
+This exact flow (GOPROXY module + crates.io ffi on blank-slate `golang:1.24-alpine`)
+is verified by `.github/workflows/verify-published.yml` (the `go` job) — on Alpine
+musl and glibc.
+
 ## License
 
 MIT

--- a/bindings/java/README.md
+++ b/bindings/java/README.md
@@ -1,0 +1,45 @@
+# snapdir (Java binding)
+
+Java bindings for [snapdir](https://snapdir.org) — content-addressed directory
+snapshots. Uses the JDK Foreign Function API over the snapdir C ABI
+(`libsnapdir_ffi`), which is embedded in the jar and extracted at runtime by
+`NativeLoader`.
+
+## Install (Maven Central)
+
+```xml
+<dependency>
+  <groupId>org.snapdir</groupId>
+  <artifactId>snapdir</artifactId>
+  <version>1.11.0</version>
+</dependency>
+```
+
+Gradle:
+
+```kotlin
+implementation("org.snapdir:snapdir:1.11.0")
+```
+
+Run with the incubator Foreign Function module enabled (JDK 17):
+
+```sh
+java --add-modules jdk.incubator.foreign --enable-native-access=ALL-UNNAMED ...
+```
+
+## Platform support
+
+The 1.11.0 jar embeds **glibc**-linked native libraries for
+`linux-x86_64`, `linux-aarch64`, `mac-x86_64`, and `mac-aarch64`. It runs on
+standard **glibc** JVMs (e.g. `eclipse-temurin:17-jdk`).
+
+> **Alpine / musl is not yet supported.** The embedded native library is
+> glibc-linked and `NativeLoader` has no musl detection, so the jar cannot load
+> on a musl JVM (`UnsatisfiedLinkError`). Alpine/musl support is planned for
+> 1.11.1 (musl `java-native` build legs + a libc probe in `NativeLoader`). Every
+> other snapdir binding (npm, PyPI, crates.io, cpp, zig, go) runs on Alpine musl
+> today.
+
+Verified end-to-end from Maven Central by `.github/workflows/verify-published.yml`
+(the `java` job installs this coordinate on `eclipse-temurin:17-jdk` and runs the
+canonical example, asserting the golden snapshot id).

--- a/bindings/node/README.md
+++ b/bindings/node/README.md
@@ -8,6 +8,11 @@ Node.js bindings for [snapdir](https://snapdir.org) — a content-addressed dire
 npm install @snapdir/snapdir
 ```
 
+Ships prebuilt native binaries for linux (gnu + **musl**) and macOS on x64 +
+arm64 — no compiler needed, and it runs on **Alpine** out of the box (the loader
+selects the musl `.node`). Verified from npm on `node:22-alpine` by
+`.github/workflows/verify-published.yml`.
+
 ## Usage
 
 ### ESM

--- a/bindings/python/README.md
+++ b/bindings/python/README.md
@@ -9,6 +9,9 @@ pip install snapdir
 ```
 
 Requires Python 3.10+ (abi3 wheel — one wheel covers all CPython ≥ 3.10).
+Prebuilt manylinux + **musllinux** wheels (x64 + arm64) and macOS — runs on
+**Alpine** with no compiler. Verified from PyPI on `python:3.12-alpine` by
+`.github/workflows/verify-published.yml`.
 
 Supported platforms: Linux (x86-64, aarch64), macOS (x86-64, arm64).
 

--- a/bindings/zig/README.md
+++ b/bindings/zig/README.md
@@ -27,6 +27,25 @@ at build time (they are gitignored, not checked in). Because that library is bui
 for one CPU arch, `build.zig` links it with the matching target (see the build.zig
 NOTE). Per-OS/arch prebuilt libraries are deferred to credited release CI.
 
+### Building the C ABI from the published crate (crates.io)
+
+There is no separate Zig package registry blob for the native lib — the published
+artifact is the [`snapdir-ffi`](https://crates.io/crates/snapdir-ffi) **source
+crate**. Build it and generate the header (the crate ships `build = false` + no
+header, so run `cbindgen`), then place them in `include/` + `lib/`:
+
+```sh
+# needs a Rust toolchain + cbindgen; on Alpine also: apk add libgcc
+cargo build --release                       # -> libsnapdir_ffi.a
+cbindgen --config cbindgen.toml --crate snapdir-ffi --output include/snapdir.h .
+```
+
+> **Alpine/musl note:** the Rust staticlib links `libgcc_s`; Alpine ships only
+> the versioned `libgcc_s.so.1`, so `ln -sf /usr/lib/libgcc_s.so.1
+> /usr/lib/libgcc_s.so` and build **native** (no `-Dtarget`, since the container
+> is already the musl target). Verified by the `zig` job in
+> `.github/workflows/verify-published.yml`.
+
 ## Consume as a Zig package
 
 `build.zig.zon` declares the package; consumers reference it by content hash:


### PR DESCRIPTION
Adds a `bindings/README.md` index and a **Language bindings** section to the root `README.md`, so the 6 language bindings are discoverable from the repo root and `bindings/` renders an overview on GitHub.

- `bindings/README.md` — index table (install command + registry per language), the two install shapes (prebuilt vs source-build), the platform/libc matrix (all run on Linux glibc + Alpine musl and macOS; Java is glibc-only for now), and a pointer to `verify-published.yml` + `examples/`.
- `README.md` — a **Language bindings** section right after Install.

Also bundles the verified-recipe README grounding so every link resolves: a new `bindings/java/README.md` (Maven coord + glibc/musl note), and the cpp/zig/go crates.io+cbindgen recipes + node/python musl notes (matching exactly what `verify-published.yml` runs).